### PR TITLE
Codegen for stateless gantz graph push evaluation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ cargo = "0.34"
 derive_more = "0.14"
 failure = "0.1"
 petgraph = { version = "0.4", features = ["serde-1"] }
+proc-macro2 = "0.4"
+quote = "0.6"
 slug = "0.1"
 serde = "1"
 serde_json = "1"

--- a/examples/open_project.rs
+++ b/examples/open_project.rs
@@ -1,9 +1,114 @@
+#[macro_use]
+extern crate serde;
+
+#[derive(Deserialize, Serialize)]
+struct One;
+
+#[derive(Deserialize, Serialize)]
+struct Add;
+
+#[derive(Deserialize, Serialize)]
+struct Debug;
+
+impl gantz::Node for One {
+    fn n_inputs(&self) -> u32 {
+        0
+    }
+
+    fn n_outputs(&self) -> u32 {
+        1
+    }
+
+    fn expr(&self, args: Vec<syn::Expr>) -> syn::Expr {
+        assert!(args.is_empty());
+        syn::parse_quote! { 1 }
+    }
+
+    fn push_eval(&self) -> Option<gantz::node::PushEval> {
+        let item_fn: syn::ItemFn = syn::parse_quote! { fn one() {} };
+        Some(item_fn.into())
+    }
+}
+
+impl gantz::Node for Add {
+    fn n_inputs(&self) -> u32 {
+        2
+    }
+
+    fn n_outputs(&self) -> u32 {
+        1
+    }
+
+    fn expr(&self, args: Vec<syn::Expr>) -> syn::Expr {
+        assert_eq!(args.len(), 2);
+        let l = &args[0];
+        let r = &args[1];
+        syn::parse_quote! { #l + #r }
+    }
+}
+
+impl gantz::Node for Debug {
+    fn n_inputs(&self) -> u32 {
+        1
+    }
+
+    fn n_outputs(&self) -> u32 {
+        0
+    }
+
+    fn expr(&self, args: Vec<syn::Expr>) -> syn::Expr {
+        assert_eq!(args.len(), 1);
+        let input = &args[0];
+        syn::parse_quote! { println!("{:?}", #input) }
+    }
+}
+
+#[typetag::serde]
+impl gantz::node::SerdeNode for One {
+    fn node(&self) -> &gantz::Node { self }
+}
+
+#[typetag::serde]
+impl gantz::node::SerdeNode for Add {
+    fn node(&self) -> &gantz::Node { self }
+}
+
+#[typetag::serde]
+impl gantz::node::SerdeNode for Debug {
+    fn node(&self) -> &gantz::Node { self }
+}
+
 fn main() {
-    let path = format!("{}/examples/foo", env!("CARGO_MANIFEST_DIR"));
-    let project = gantz::Project::open(path.into()).unwrap();
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("examples").join("foo");
+    let mut project = gantz::Project::open(path.into()).unwrap();
 
-    // project.root_node(
+    // Instantiate the core nodes.
+    let one = Box::new(One) as Box<gantz::node::SerdeNode>;
+    let add = Box::new(Add) as Box<_>;
+    let debug = Box::new(Debug) as Box<_>;
 
-    // // Add nodes to the
-    // project.add_node(
+    // Add nodes to the project.
+    let one = project.add_core_node(one);
+    let add = project.add_core_node(add);
+    let debug = project.add_core_node(debug);
+
+    // Update the root graph.
+    let root = project.root_node_id();
+    project.update_graph(&root, |g| {
+        let one = g.add_node(one);
+        let add = g.add_node(add);
+        let debug = g.add_node(debug);
+        g.add_edge(one, add, gantz::Edge {
+            output: gantz::node::Output(0),
+            input: gantz::node::Input(0),
+        });
+        g.add_edge(one, add, gantz::Edge {
+            output: gantz::node::Output(0),
+            input: gantz::node::Input(1),
+        });
+        g.add_edge(add, debug, gantz::Edge {
+            output: gantz::node::Output(0),
+            input: gantz::node::Input(0),
+        });
+    }).unwrap();
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,4 +1,4 @@
-use crate::node;
+use crate::node::{self, Node};
 
 /// The type used to represent node and edge indices.
 pub type Index = usize;
@@ -16,74 +16,393 @@ pub struct Edge {
 }
 
 /// The petgraph type used to represent the **Graph**.
-pub type Petgraph<N> = petgraph::stable_graph::StableGraph<N, Edge, petgraph::Directed, Index>;
+pub type StableGraph<N> = petgraph::stable_graph::StableGraph<N, Edge, petgraph::Directed, Index>;
 
-/// The graph type used to represent evaluation.
-#[derive(Debug)]
-pub struct Graph<N> {
-    graph: Petgraph<N>,
+impl<N> Node for StableGraph<N>
+where
+    N: Node,
+{
+    fn n_inputs(&self) -> u32 {
+        unimplemented!("requires implementing graph inlet nodes")
+    }
+
+    fn n_outputs(&self) -> u32 {
+        unimplemented!("requires implementing graph outlet nodes")
+    }
+
+    fn expr(&self, _args: Vec<syn::Expr>) -> syn::Expr {
+        unimplemented!("requires implementing graph inlet and outlet nodes")
+    }
 }
 
 pub mod codegen {
     use crate::node::{self, Node};
-    use super::{Graph, NodeIndex};
+    use petgraph::visit::{Data, EdgeRef, GraphRef, IntoEdgesDirected, IntoNodeReferences,
+                          NodeIndexable, NodeRef, Visitable};
+    use std::collections::HashMap;
+    use std::hash::Hash;
+    use super::Edge;
+    use syn::punctuated::Punctuated;
 
     /// An evaluation step ready for translation to rust code.
-    pub struct EvalStep {
+    #[derive(Debug)]
+    pub struct EvalStep<NI> {
         /// The node to be evaluated.
-        pub node: NodeIndex,
+        pub node: NI,
         /// Arguments to the node's function call.
-        pub args: Vec<FnCallArg>,
+        ///
+        /// The `len` of the outer vec will always be equal to the number of inputs on `node`.
+        pub args: Vec<Option<ExprInput<NI>>>,
     }
 
-    /// An argument ot a node's function call.
-    pub struct FnCallArg {
+    /// An argument to a node's function call.
+    #[derive(Debug)]
+    pub struct ExprInput<NI> {
         /// The node from which the value was generated.
-        pub node: NodeIndex,
-        /// The outlet on the source node associated with the generated value.
-        pub outlet: node::Output,
+        pub node: NI,
+        /// The output on the source node associated with the generated value.
+        pub output: node::Output,
         /// Whether or not using the value in this argument requires cloning.
         pub requires_clone: bool,
     }
 
-    impl<N> Graph<N>
+    /// Given a graph with of gantz nodes, return `NodeId`s of those that require push evaluation.
+    ///
+    /// Expects any graph type whose nodes implement `Node`.
+    pub fn push_nodes<G>(g: G) -> Vec<(G::NodeId, node::PushEval)>
     where
-        N: Node,
+        G: IntoNodeReferences,
+        <G::NodeRef as NodeRef>::Weight: Node,
     {
-        /// Push evaluation steps starting from the specified outlets on the given node.
-        /// 
-        /// 1. For each outlet on the given node, evaluate the output and use it to evaluate the
-        ///    input for each child inlet connected to this outlet.
-        /// 2. Repeat this for each child in BFS order.
-        pub fn push_eval_steps(&self, node: NodeIndex) -> Vec<EvalStep> {
-            // let mut bfs = petgraph::visit::Bfs::new(&self.graph, node);
-            // while let Some(parent) = bfs.next(&self.graph) {
-            //     let n_outlets = self.graph[parent].n_outlets();
-            //     for outlet in (0..n_outlets).map(node::Outlet) {
-            //         // For every outgoing neighbour of the parent, if it has an input that is
-            //         // connected to this outlet, process it.
-            //         self.graph[parent].state.proc_outlet_at_index(outlet);
-            //         let mut children = self.graph.neighbors(parent).detach();
-            //         while let Some((e, child)) = children.next(&self.graph) {
-            //             let edge = self.graph[e];
-            //             if edge.outlet == outlet {
-            //                 let (parent, child) = self.graph.index_twice_mut(parent, child);
-            //                 child.proc_inlet_at_index(edge.inlet, parent.outlet_ref(outlet));
-            //             }
-            //         }
-            //     }
-            // }
-            unimplemented!();
-        }
+        g.node_references()
+            .filter_map(|n| n.weight().push_eval().map(|eval| (n.id(), eval)))
+            .collect()
+    }
 
-        /// Pull evaluation steps starting from the specified outlets on the given node.
-        ///
-        /// This causes the graph to performa DFS through each of the inlets to find the deepest
-        /// nodes. Evaluation occurs as though a "push" was sent simultaneously to each of the
-        /// deepest nodes. Outlets are only calculated once per node. If an outlet value is
-        /// required more than once, it will be borrowed accordingly.
-        pub fn pull_eval_steps(&self, node: NodeIndex) -> Vec<EvalStep> {
-            unimplemented!();
+    /// Given a graph with of gantz nodes, return `NodeId`s of those that require pull evaluation.
+    ///
+    /// Expects any graph type whose nodes implement `Node`.
+    pub fn pull_nodes<G>(g: G) -> Vec<(G::NodeId, node::PullEval)>
+    where
+        G: IntoNodeReferences,
+        <G::NodeRef as NodeRef>::Weight: Node,
+    {
+        g.node_references()
+            .filter_map(|n| n.weight().pull_eval().map(|eval| (n.id(), eval)))
+            .collect()
+    }
+
+    /// Push evaluation from the specified node.
+    ///
+    /// Evaluation order is equivalent to depth-first-search post order.
+    ///
+    /// Expects any directed graph whose edges are of type `Edge` and whose nodes implement `Node`.
+    /// Direction of edges indicate the flow of data through the graph.
+    pub fn push_eval_steps<G>(g: G, n: G::NodeId) -> Vec<EvalStep<G::NodeId>>
+    where
+        G: GraphRef + IntoEdgesDirected + IntoNodeReferences + NodeIndexable + Visitable,
+        G: Data<EdgeWeight = Edge>,
+        <G::NodeRef as NodeRef>::Weight: Node,
+    {
+        // The order of evaluation is DFS post order.
+        let mut dfs_post_order = petgraph::visit::Dfs::new(g, n);
+
+        // Track the evaluation steps.
+        let mut eval_steps = vec![];
+
+        // // The first node cannot have any inputs.
+        // match dfs_post_order.next(g) {
+        //     None => return vec![],
+        //     Some(node) => eval_steps.push(EvalStep { node, args: vec![] }),
+        // };
+
+        // Step through each of the nodes.
+        while let Some(node) = dfs_post_order.next(g) {
+            // Fetch the node reference.
+            let child = g.node_references()
+                .nth(g.to_index(node))
+                .expect("no node for index");
+
+            // Initialise the arguments to `None` for each input.
+            let mut args: Vec<_> = (0..child.weight().n_inputs()).map(|_| None).collect();
+
+            // Create an argument for each input to this child. 
+            // TODO: Need some way of caching previously evaluated inputs to use as defaults.
+            // TODO: Need some way of deciding what to use as an argument in the case of
+            //       multiple input connections.
+            for e_ref in g.edges_directed(node, petgraph::Incoming) {
+                let w = e_ref.weight();
+
+                // Check how many connections their are from the parent's output and see if the
+                // value will need to be cloned when passed to this input.
+                let requires_clone = {
+                    let parent = e_ref.source();
+                    // TODO: Connection order should match 
+                    let mut connection_ix = 0;
+                    let mut total_connections_from_output = 0;
+                    for (i, pe_ref) in g.edges_directed(parent, petgraph::Outgoing).enumerate() {
+                        let pw = pe_ref.weight();
+                        if pw == w {
+                            connection_ix = i;
+                        }
+                        if pw.output == w.output {
+                            total_connections_from_output += 1;
+                        }
+                    }
+                    total_connections_from_output > 1
+                        && connection_ix < (total_connections_from_output - 1)
+                };
+
+                // Assign the expression argument for this input.
+                let arg = ExprInput {
+                    node: e_ref.source(),
+                    output: w.output,
+                    requires_clone,
+                };
+                args[w.input.0 as usize] = Some(arg);
+            }
+
+            // Add the step.
+            eval_steps.push(EvalStep { node, args });
+        }
+        eval_steps
+    }
+
+    /// Given a function argument, return its type if known.
+    pub fn ty_from_fn_arg(arg: &syn::FnArg) -> Option<syn::Type> {
+        match arg {
+            syn::FnArg::Captured(cap) => Some(cap.ty.clone()),
+            syn::FnArg::Ignored(ty) => Some(ty.clone()),
+            _ => None,
         }
     }
+
+    /// Generate a function for performing push evaluation from the given node with the given
+    /// evaluation steps.
+    pub fn push_eval_fn<G>(
+        g: G,
+        push_eval: node::PushEval,
+        steps: &[EvalStep<G::NodeId>],
+    ) -> syn::ItemFn
+    where
+        G: GraphRef + IntoNodeReferences + NodeIndexable,
+        G::NodeId: Eq + Hash,
+        <G::NodeRef as NodeRef>::Weight: Node,
+    {
+        // For each evaluation step, generate a statement where the expression for the node at that
+        // evaluation step is evaluated and the outputs are destructured from a tuple.
+        let mut stmts: Vec<syn::Stmt> = vec![];
+
+        // Keep track of each of the lvalues for each of the statements. These are used to pass
+        let mut lvalues: HashMap<(G::NodeId, node::Output), syn::Ident> = Default::default();
+
+        type LValues<NI> = HashMap<(NI, node::Output), syn::Ident>;
+
+        // A function for constructing a variable name.
+        fn var_name(node_ix: usize, out_ix: u32) -> String {
+            format!("_node{}_output{}", node_ix, out_ix)
+        }
+
+        // Insert the lvalue for the node output with the given name into the given map.
+        fn insert_lvalue<NI>(node_id: NI, out_ix: u32, name: &str, lvals: &mut LValues<NI>)
+        where
+            NI: Eq + Hash,
+        {
+            let output = node::Output(out_ix);
+            let ident = syn::Ident::new(name, proc_macro2::Span::call_site());
+            lvals.insert((node_id, output), ident);
+        };
+
+        // Construct a pattern for a function argument.
+        fn var_pat(name: &str) -> syn::Pat {
+            let ident = syn::Ident::new(name, proc_macro2::Span::call_site());
+            let pat_ident = syn::PatIdent {
+                by_ref: None,
+                mutability: None,
+                subpat: None,
+                ident,
+            };
+            syn::Pat::Ident(pat_ident)
+        }
+
+        // Retrieve the expr for the input to the function.
+        fn input_expr<G>(
+            g: G,
+            arg: Option<&ExprInput<G::NodeId>>,
+            lvals: &LValues<G::NodeId>,
+        ) -> syn::Expr
+        where
+            G: NodeIndexable,
+            G::NodeId: Eq + Hash,
+        {
+            match arg {
+                None => syn::parse_quote! { Default::default() },
+                Some(arg) => {
+                    let ident = lvals.get(&(arg.node, arg.output)).unwrap_or_else(|| {
+                        panic!(
+                            "no lvalue for expected arg (node {}, output {})",
+                            g.to_index(arg.node),
+                            arg.output.0,
+                        );
+                    });
+                    match arg.requires_clone {
+                        false => syn::parse_quote! { { #ident } },
+                        true => syn::parse_quote! { { #ident.clone() } },
+                    }
+                }
+            }
+        }
+
+        for (si, step) in steps.iter().enumerate() {
+            let n_ref = g.node_references().nth(g.to_index(step.node)).expect("no node for index");
+
+            // Retrieve an expression for each argument to the current node's expression.
+            //
+            // E.g. `_n1_v0`, `_n3_v1.clone()` or `Default::default()`.
+            let args: Vec<syn::Expr> = step.args.iter()
+                .map(|arg| input_expr(g, arg.as_ref(), &lvalues))
+                .collect();
+
+            let nw = n_ref.weight();
+            let n_outputs = nw.n_outputs();
+            let expr: syn::Expr = nw.expr(args);
+
+            // Create the lvals pattern, either `PatWild` for no outputs, `Ident` for single output
+            // or `Tuple` for multiple. Keep track of each the lvalue ident for each output of the
+            // node so that they may be passed to following node exprs.
+            let lvals: syn::Pat = {
+                let v_name = |vi| var_name(si, vi);
+                let mut insert_lval = |vi, name: &str| {
+                    insert_lvalue(step.node, vi, name, &mut lvalues);
+                };
+                match n_outputs {
+                    0 => syn::parse_quote! { () },
+                    1 => {
+                        let vi = 0;
+                        let v = v_name(vi);
+                        insert_lval(vi, &v);
+                        var_pat(&v)
+                    }
+                    vs => {
+                        let punct = (0..vs)
+                            .map(|vi| {
+                                let v = v_name(vi);
+                                insert_lval(vi, &v);
+                                var_pat(&v)
+                            })
+                            .collect::<Punctuated<syn::Pat, syn::Token![,]>>();
+                        syn::parse_quote! { (#punct) }
+                    }
+                }
+            };
+
+            let stmt: syn::Stmt = syn::parse_quote!{
+                let #lvals = #expr;
+            };
+
+            stmts.push(stmt);
+        }
+
+        // Construct the final function item.
+        let block = Box::new(syn::Block { stmts, brace_token: Default::default() });
+        let node::PushEval { fn_decl, fn_name, fn_attrs } = push_eval;
+        let decl = Box::new(fn_decl);
+        let ident = syn::Ident::new(&fn_name, proc_macro2::Span::call_site());
+        let vis = syn::Visibility::Public(syn::VisPublic { pub_token: Default::default() });
+        let item_fn = syn::ItemFn {
+            attrs: fn_attrs,
+            vis,
+            constness: None,
+            unsafety: None,
+            asyncness: None,
+            abi: None,
+            ident,
+            decl,
+            block,
+        };
+
+        item_fn
+    }
+
+    /// Given a list of push evaluation nodes and their evaluation steps, generate a function for
+    /// performing push evaluation for each node.
+    pub fn push_eval_fns<'a, G, I>( g: G, push_eval_nodes: I,) -> Vec<syn::ItemFn>
+    where
+        G: GraphRef + IntoNodeReferences + NodeIndexable,
+        G::NodeId: 'a + Eq + Hash,
+        <G::NodeRef as NodeRef>::Weight: Node,
+        I: IntoIterator<Item = (G::NodeId, node::PushEval, &'a [EvalStep<G::NodeId>])>,
+    {
+        push_eval_nodes
+            .into_iter()
+            .map(|(_n, eval, steps)| push_eval_fn(g, eval, steps))
+            .collect()
+    }
+
+    /// Given a gantz graph, generate the rust code src file with all the necessary functions for
+    /// executing it.
+    pub fn file<G>(g: G) -> syn::File
+    where
+        G: GraphRef + IntoEdgesDirected + IntoNodeReferences + NodeIndexable + Visitable,
+        G: Data<EdgeWeight = Edge>,
+        G::NodeId: Eq + Hash,
+        <G::NodeRef as NodeRef>::Weight: Node,
+    {
+        let push_nodes = push_nodes(g);
+        let items = push_nodes
+            .into_iter()
+            .map(|(n, eval)| {
+                let steps = push_eval_steps(g, n);
+                let item_fn = push_eval_fn(g, eval, &steps);
+                syn::Item::Fn(item_fn)
+            })
+            .collect();
+        let file = syn::File { shebang: None, attrs: vec![], items };
+        file
+    }
+
+    // impl<N> Graph<N>
+    // where
+    //     N: Node,
+    // {
+    //     /// Push evaluation from the specified node.
+    //     ///
+    //     /// Evaluation order is equivalent to depth-first-search post order.
+    //     pub fn push_eval_steps(&self, node: NodeIndex) -> Vec<EvalStep> {
+    //         let mut eval_steps = vec![];
+    //         let mut dfs_post_order = petgraph::visit::DfsPostOrder::new(&self.graph, node);
+    //         match dfs_post_order.next(&self.graph) {
+    //             None => return vec![],
+    //             Some(node) => eval_steps.push(EvalStep { node, args: vec![] }),
+    //         };
+    //         while let Some(node) = dfs_post_order.next(&self.graph) {
+    //             let child = &self.graph[node];
+    //             let mut args: Vec<_> = (0..child.n_inputs()).map(|_| None).collect();
+    //             // TODO: Need some way of caching previously evaluated inputs to use as defaults.
+    //             // TODO: Need some way of deciding what to use as an argument in the case of
+    //             //       multiple input connections.
+    //             for e_ref in self.graph.edges_directed(node, petgraph::Incoming) {
+    //                 let w = e_ref.weight();
+    //                 let arg = ExprInput {
+    //                     node: petgraph::visit::EdgeRef::source(&e_ref),
+    //                     output: w.output,
+    //                     requires_clone: false, // TODO: calculate properly.
+    //                 };
+    //                 args[w.input.0 as usize] = Some(arg);
+    //             }
+    //             eval_steps.push(EvalStep { node, args });
+    //         }
+    //         eval_steps
+    //     }
+
+    //     /// Pull evaluation steps starting from the specified outputs on the given node.
+    //     ///
+    //     /// This causes the graph to performa DFS through each of the inlets to find the deepest
+    //     /// nodes. Evaluation occurs as though a "push" was sent simultaneously to each of the
+    //     /// deepest nodes. Outlets are only calculated once per node. If an output value is
+    //     /// required more than once, it will be borrowed accordingly.
+    //     pub fn pull_eval_steps(&self, _node: NodeIndex) -> Vec<EvalStep> {
+    //         unimplemented!();
+    //     }
+    // }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,5 +32,6 @@ pub mod graph;
 pub mod node;
 pub mod project;
 
+pub use graph::Edge;
 pub use node::Node;
 pub use project::Project;

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1,0 +1,119 @@
+// Tests for the graph module.
+
+struct One;
+
+struct Add;
+
+struct Debug;
+
+impl gantz::Node for One {
+    fn n_inputs(&self) -> u32 {
+        0
+    }
+
+    fn n_outputs(&self) -> u32 {
+        1
+    }
+
+    fn expr(&self, args: Vec<syn::Expr>) -> syn::Expr {
+        assert!(args.is_empty());
+        syn::parse_quote! { 1 }
+    }
+
+    fn push_eval(&self) -> Option<gantz::node::PushEval> {
+        let item_fn: syn::ItemFn = syn::parse_quote! { fn one() {} };
+        Some(item_fn.into())
+    }
+}
+
+impl gantz::Node for Add {
+    fn n_inputs(&self) -> u32 {
+        2
+    }
+
+    fn n_outputs(&self) -> u32 {
+        1
+    }
+
+    fn expr(&self, args: Vec<syn::Expr>) -> syn::Expr {
+        assert_eq!(args.len(), 2);
+        let l = &args[0];
+        let r = &args[1];
+        syn::parse_quote! { #l + #r }
+    }
+}
+
+impl gantz::Node for Debug {
+    fn n_inputs(&self) -> u32 {
+        1
+    }
+
+    fn n_outputs(&self) -> u32 {
+        0
+    }
+
+    fn expr(&self, args: Vec<syn::Expr>) -> syn::Expr {
+        assert_eq!(args.len(), 1);
+        let input = &args[0];
+        syn::parse_quote! { println!("{:?}", #input) }
+    }
+}
+
+// A simple test graph that adds two "one"s and outputs the result to stdout.
+//
+//    -------
+//    | One |
+//    -+-----
+//     |\
+//     | \
+//     |  \
+//    -+---+-
+//    | Add |
+//    -+-----
+//     |
+//     |
+//    -+-----
+//    |Debug|
+//    -------
+#[test]
+fn test_graph1() {
+    // Instantiate the nodes.
+    let one = Box::new(One) as Box<gantz::Node>;
+    let add = Box::new(Add) as Box<_>;
+    let debug = Box::new(Debug) as Box<_>;
+
+    // Compose the graph.
+    let mut g = petgraph::Graph::new();
+    let one = g.add_node(one);
+    let add = g.add_node(add);
+    let debug = g.add_node(debug);
+    g.add_edge(one, add, gantz::Edge {
+        output: gantz::node::Output(0),
+        input: gantz::node::Input(0),
+    });
+    g.add_edge(one, add, gantz::Edge {
+        output: gantz::node::Output(0),
+        input: gantz::node::Input(1),
+    });
+    g.add_edge(add, debug, gantz::Edge {
+        output: gantz::node::Output(0),
+        input: gantz::node::Input(0),
+    });
+
+    // Find all push evaluation enabled nodes. This should just be our `One` node.
+    let mut push_ns = gantz::graph::codegen::push_nodes(&g);
+    assert_eq!(push_ns.len(), 1);
+    let (push_n, fn_decl) = push_ns.pop().unwrap();
+
+    // Generate the push evaluation steps. There should be three, one for each node instance.
+    let eval_steps = gantz::graph::codegen::push_eval_steps(&g, push_n);
+    assert_eq!(eval_steps.len(), 3);
+
+    // Ensure the order was correct.
+    let eval_order: Vec<_> = eval_steps.iter().map(|step| step.node).collect();
+    assert_eq!(eval_order, vec![one, add, debug]);
+
+    // Generate the push evaluation function.
+    let push_eval_fn = gantz::graph::codegen::push_eval_fn(&g, fn_decl, &eval_steps);
+    println!("{}", quote::ToTokens::into_token_stream(push_eval_fn));
+}


### PR DESCRIPTION
This adds some significant progress to the graph::codegen module -
namely the ability to generate a rust file from a gantz graph. A test
has been added to a new tests directory and the Project API has been
updated accordingly.

The role of serialization has been separated from **Node** into a
**SerdeNode** trait. This should probably moved to the project.rs module
eventually. It seems like it might be useful to separate the project.rs
module into a separate crate at some point as it is quite a high-level
API around the lower-level graph and node code.

The open_project.rs example now creates a graph, generates the src and
updates the root graph node's crate with the new src. The next step will
be attempting to dynamically build, load and execute the generated code.