### PR TITLE
 Add support for dynamically compiling gantz node dylibs. Move `SerdeNode` trait into project module.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ serde_json = "1"
 syn = "0.15"
 toml = "0.5"
 typetag = "0.1"
+
+[dev-dependencies]
+libloading = "0.5"

--- a/examples/open_project.rs
+++ b/examples/open_project.rs
@@ -64,17 +64,17 @@ impl gantz::Node for Debug {
 }
 
 #[typetag::serde]
-impl gantz::node::SerdeNode for One {
+impl gantz::project::SerdeNode for One {
     fn node(&self) -> &gantz::Node { self }
 }
 
 #[typetag::serde]
-impl gantz::node::SerdeNode for Add {
+impl gantz::project::SerdeNode for Add {
     fn node(&self) -> &gantz::Node { self }
 }
 
 #[typetag::serde]
-impl gantz::node::SerdeNode for Debug {
+impl gantz::project::SerdeNode for Debug {
     fn node(&self) -> &gantz::Node { self }
 }
 

--- a/examples/open_project.rs
+++ b/examples/open_project.rs
@@ -25,7 +25,7 @@ impl gantz::Node for One {
     }
 
     fn push_eval(&self) -> Option<gantz::node::PushEval> {
-        let item_fn: syn::ItemFn = syn::parse_quote! { fn one() {} };
+        let item_fn: syn::ItemFn = syn::parse_quote! { fn one_push_eval() {} };
         Some(item_fn.into())
     }
 }
@@ -83,7 +83,7 @@ fn main() {
     let mut project = gantz::Project::open(path.into()).unwrap();
 
     // Instantiate the core nodes.
-    let one = Box::new(One) as Box<gantz::node::SerdeNode>;
+    let one = Box::new(One) as Box<gantz::project::SerdeNode>;
     let add = Box::new(Add) as Box<_>;
     let debug = Box::new(Debug) as Box<_>;
 
@@ -111,4 +111,15 @@ fn main() {
             input: gantz::node::Input(0),
         });
     }).unwrap();
+
+    // Retrieve the path to the compiled library.
+    let dylib_path = project.graph_node_dylib(&root).unwrap().expect("no dylib or node");
+    let lib = libloading::Library::new(&dylib_path).expect("failed to load library");
+    let symbol_name = "one_push_eval".as_bytes();
+    unsafe {
+        let foo_one_push_eval_fn: libloading::Symbol<fn()> =
+            lib.get(symbol_name).expect("failed to load symbol");
+        // Execute the gantz graph (prints `2` to stdout).
+        foo_one_push_eval_fn();
+    }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -48,13 +48,6 @@ pub trait Node {
     }
 }
 
-/// A wrapper around the **Node** trait that allows for serializing and deserializing node trait
-/// objects.
-#[typetag::serde(tag = "type")]
-pub trait SerdeNode {
-    fn node(&self) -> &Node;
-}
-
 /// Items that need to be known in order to generate a push evaluation function for a node.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct PushEval {

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,5 +1,5 @@
 use crate::graph;
-use crate::node::{self, Node, SerdeNode};
+use crate::node::{self, Node};
 use quote::ToTokens;
 use std::{fs, io, ops};
 use std::collections::BTreeMap;
@@ -24,6 +24,13 @@ pub struct Project {
     directory: PathBuf,
     /// All nodes that have been imported into the project ready for use.
     nodes: NodeCollection,
+}
+
+/// A wrapper around the **Node** trait that allows for serializing and deserializing node trait
+/// objects.
+#[typetag::serde(tag = "type")]
+pub trait SerdeNode {
+    fn node(&self) -> &Node;
 }
 
 /// A unique identifier representing an imported node.

--- a/src/project.rs
+++ b/src/project.rs
@@ -2,7 +2,7 @@ use crate::graph;
 use crate::node::{self, Node};
 use quote::ToTokens;
 use std::{fs, io, ops};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 /// A gantz **Project** represents the context in which the user composes their gantz graph
@@ -54,10 +54,14 @@ pub type NodeIdGraph = graph::StableGraph<NodeId>;
 #[derive(Deserialize, Serialize)]
 pub enum NodeKind {
     Core(Box<SerdeNode>),
-    Graph {
-        graph: NodeIdGraph,
-        package_id: cargo::core::PackageId,
-    },
+    Graph(GraphNode),
+}
+
+/// A node composed of a graph of other nodes.
+#[derive(Deserialize, Serialize)]
+pub struct GraphNode {
+    pub graph: NodeIdGraph,
+    pub package_id: cargo::core::PackageId,
 }
 
 // A **Node** type constructed as a reference to some other node.
@@ -79,16 +83,11 @@ pub enum OpenNodePackageError {
         #[fail(cause)]
         err: failure::Error,
     },
-    #[fail(display = "failed to deserialize the manifest toml: {}", err)]
-    ManifestDeserialize {
+    #[fail(display = "failed to update the manifest toml: {}", err)]
+    UpdateTomlFile {
         #[fail(cause)]
-        err: toml::de::Error,
+        err: UpdateTomlFileError,
     },
-    #[fail(display = "failed to serialize the manifest toml: {}", err)]
-    ManifestSerialize {
-        #[fail(cause)]
-        err: toml::ser::Error,
-    }
 }
 
 /// Errors that may occur while checking an existing workspace or creating a new one.
@@ -144,6 +143,11 @@ pub enum ProjectOpenError {
         #[fail(cause)]
         err: AddGraphNodeToCollectionError,
     },
+    #[fail(display = "failed to compile the root graph node: {}", err)]
+    GraphNodeCompile {
+        #[fail(cause)]
+        err: GraphNodeCompileError,
+    }
 }
 
 /// Errors that might occur when saving or loading JSON from a file.
@@ -193,8 +197,65 @@ pub enum AddGraphNodeToCollectionError {
     },
 }
 
+/// Errors that might occur while updating the contents of a toml file.
+#[derive(Debug, Fail, From)]
+pub enum UpdateTomlFileError {
+    #[fail(display = "an IO error occurred: {}", err)]
+    Io {
+        #[fail(cause)]
+        err: io::Error,
+    },
+    #[fail(display = "failed to deserialize the toml: {}", err)]
+    TomlDeserialize {
+        #[fail(cause)]
+        err: toml::de::Error,
+    },
+    #[fail(display = "failed to serialize the toml: {}", err)]
+    TomlSerialize {
+        #[fail(cause)]
+        err: toml::ser::Error,
+    }
+}
+
+/// Errors that might occur while compiling the project workspace.
+#[derive(Debug, Fail, From)]
+pub enum WorkspaceCompileError {
+    #[fail(display = "a cargo error occurred: {}", err)]
+    Cargo {
+        #[fail(cause)]
+        err: failure::Error,
+    },
+}
+
+/// Errors that might occur while compiling a graph node.
+#[derive(Debug, Fail, From)]
+pub enum GraphNodeCompileError {
+    #[fail(display = "a cargo error occurred: {}", err)]
+    Cargo {
+        #[fail(cause)]
+        err: failure::Error,
+    },
+    #[fail(display = "no matching `package_id` in workspace that matches graph node `package_id`")]
+    NoMatchingPackageId,
+}
+
+/// Errors that might occur while updating a `GraphNode`'s graph.
+#[derive(Debug, Fail, From)]
+pub enum UpdateGraphError {
+    #[fail(display = "failed to replace graph node src: {}", err)]
+    GraphNodeReplaceSrc {
+        #[fail(cause)]
+        err: GraphNodeReplaceSrcError,
+    },
+    #[fail(display = "failed to compile graph node: {}", err)]
+    GraphNodeCompile {
+        #[fail(cause)]
+        err: GraphNodeCompileError,
+    },
+}
+
 /// Node crates within the project workspace are prefixed with this.
-pub const NODE_CRATE_PREFIX: &'static str = "gantz-node-";
+pub const NODE_CRATE_PREFIX: &'static str = "gantz_node_";
 
 impl Project {
     /// Open a project at the given directory path.
@@ -235,7 +296,11 @@ impl Project {
                 let graph = NodeIdGraph::default();
                 let ws_dir = workspace_dir(&directory);
                 let proj_name = project_name(&directory);
-                add_graph_node_to_collection(ws_dir, proj_name, &cargo_config, graph, &mut nodes)?;
+                let node_id =
+                    add_graph_node_to_collection(&ws_dir, proj_name, &cargo_config, graph, &mut nodes)?;
+                if let Some(NodeKind::Graph(ref node)) = nodes.get(&node_id) {
+                    graph_node_compile(&ws_dir, &cargo_config, node)?;
+                }
                 nodes
             }
         };
@@ -292,26 +357,60 @@ impl Project {
     ///
     /// Returns `None` if there are no nodes for the given **NodeId** or if a node exists but it is
     /// not a **Graph** node.
-    pub fn graph_node(&self, id: &NodeId) -> Option<(&NodeIdGraph, &cargo::core::PackageId)> {
+    pub fn graph_node(&self, id: &NodeId) -> Option<&GraphNode> {
         self.nodes.get(id).and_then(|kind| match kind {
-            NodeKind::Graph { ref graph, ref package_id } => Some((graph, package_id)),
+            NodeKind::Graph(ref graph) => Some(graph),
             _ => None,
         })
     }
 
     /// Update the graph associated with the graph node at the given **NodeId**.
-    pub fn update_graph<F>(&mut self, id: &NodeId, update: F) -> Result<(), GraphNodeReplaceSrcError>
+    pub fn update_graph<F>(&mut self, id: &NodeId, update: F) -> Result<(), UpdateGraphError>
     where
         F: FnOnce(&mut NodeIdGraph),
     {
         match self.nodes.map.get_mut(id) {
-            Some(NodeKind::Graph { ref mut graph, .. }) => update(graph),
+            Some(NodeKind::Graph(ref mut node)) => update(&mut node.graph),
             _ => return Ok(()),
         }
         let file = graph_node_src(id, &self.nodes).expect("no graph node for NodeId");
         let ws_dir = self.workspace_dir();
-        graph_node_replace_src(ws_dir, &self.cargo_config, id, &self.nodes, file)?;
+        graph_node_replace_src(&ws_dir, &self.cargo_config, id, &self.nodes, file)?;
+        let node = self.graph_node(id).expect("no graph node for NodeId");
+        let _compilation = graph_node_compile(&ws_dir, &self.cargo_config, &node)?;
         Ok(())
+    }
+
+    /// The path to the generated dynamic library for the graph node at the given `id`.
+    ///
+    /// Returns `None` if there is no dynamic library or no graph node for the given `id`.
+    pub fn graph_node_dylib(&self, id: &NodeId) -> cargo::CargoResult<Option<PathBuf>> {
+        let node = match self.graph_node(id) {
+            None => return Ok(None),
+            Some(n) => n,
+        };
+        let ws_dir = self.workspace_dir();
+        let ws_manifest_path = manifest_path(&ws_dir);
+        let ws = cargo::core::Workspace::new(&ws_manifest_path, &self.cargo_config)?;
+        let target_dir = ws.target_dir().into_path_unlocked();
+        let pkg = match ws.members().find(|pkg| pkg.package_id() == node.package_id) {
+            Some(pkg) => pkg,
+            None => return Ok(None),
+        };
+        let target = match pkg.targets().iter().find(|target| target.is_dylib()) {
+            Some(t) => t,
+            None => return Ok(None),
+        };
+        let target_filestem = format!("lib{}", target.name());
+        let target_path = target_dir
+            .join("release")
+            .join(target_filestem)
+            .with_extension(dylib_ext());
+        if target_path.exists() {
+            Ok(Some(target_path))
+        } else {
+            Ok(None)
+        }
     }
 
     /// The project directory.
@@ -402,6 +501,28 @@ impl ops::Deref for NodeCollection {
     }
 }
 
+// Get the dylib extension for this platform.
+//
+// TODO: This should be exposed from cargo.
+fn dylib_ext() -> &'static str {
+    #[cfg(target_os = "linux")]
+    {
+        return "so";
+    }
+    #[cfg(target_os = "macos")]
+    {
+        return "dylib";
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return "dll";
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        panic!("unknown dynamic library for this platform")
+    }
+}
+
 /// Given the project directory, retrieve the project name from the file stem.
 pub fn project_name(project_dir: &Path) -> &str {
     project_dir
@@ -419,12 +540,12 @@ where
     project_dir.as_ref().join("workspace")
 }
 
-/// Given a project's workspace directory, return a path to its `Cargo.toml` file.
-pub fn workspace_manifest_path<P>(workspace_dir: P) -> PathBuf
+/// Given a crate directory, return a path to its `Cargo.toml` file.
+pub fn manifest_path<P>(crate_dir: P) -> PathBuf
 where
     P: AsRef<Path>,
 {
-    workspace_dir.as_ref().join("Cargo.toml")
+    crate_dir.as_ref().join("Cargo.toml")
 }
 
 /// The path at which the project's node collection JSON is stored.
@@ -509,7 +630,7 @@ where
     }
 
     // Create the workspace cargo toml.
-    let workspace_manifest_path = workspace_manifest_path(&workspace_dir);
+    let workspace_manifest_path = manifest_path(&workspace_dir);
     create_workspace_cargo_toml(&workspace_manifest_path)?;
 
     // Verify the workspace.
@@ -536,6 +657,30 @@ where
     fs::write(toml_path, toml_str)
 }
 
+// Update the toml at the given file.
+fn update_toml_file<P, F>(toml_path: P, update: F) -> Result<(), UpdateTomlFileError>
+where
+    P: AsRef<Path>,
+    F: FnOnce(&mut toml::Value),
+{
+    let bytes = fs::read(&toml_path)?;
+    let mut toml: toml::Value = toml::from_slice(&bytes)?;
+    update(&mut toml);
+    let toml_string = toml::to_string_pretty(&toml)?;
+    fs::write(&toml_path, &toml_string)?;
+    Ok(())
+}
+
+fn node_crate_new_options(dir_path: PathBuf) -> cargo::CargoResult<cargo::ops::NewOptions> {
+    let version_ctrl = None;
+    let bin = false;
+    let lib = true;
+    let name = None;
+    let edition = None;
+    let registry = None;
+    cargo::ops::NewOptions::new(version_ctrl, bin, lib, dir_path, name, edition, registry)
+}
+
 // Create a node crate within the given workspace directory with the given name.
 //
 // The crate name will be slugified before being used within the path.
@@ -550,44 +695,46 @@ where
     // Check to see if the node exists within `workspace.members` yet. If not, add it.
     let workspace_dir = workspace_dir.as_ref();
     let node_crate_name = node_crate_name(node_name);
-    let workspace_manifest_path = workspace_manifest_path(workspace_dir);
+    let workspace_manifest_path = manifest_path(workspace_dir);
     let exists = {
         let workspace = cargo::core::Workspace::new(&workspace_manifest_path, &cargo_config)?;
         workspace.members().any(|pkg| format!("{}", pkg.name()) == node_crate_name)
     };
     if !exists {
-        let bytes = fs::read(&workspace_manifest_path)?;
-        let mut toml: toml::Value = toml::from_slice(&bytes)?;
-        if let toml::Value::Table(ref mut table) = toml {
-            if let Some(toml::Value::Table(ref mut workspace)) = table.get_mut("workspace") {
-                if let Some(toml::Value::Array(ref mut members)) = workspace.get_mut("members") {
-                    members.push(node_crate_name.clone().into());
-                }
+        update_toml_file(&workspace_manifest_path, |toml| {
+            let table = match toml {
+                toml::Value::Table(ref mut table) => table,
+                _ => return,
+            };
+            let ws = match table.get_mut("workspace") {
+                Some(toml::Value::Table(ref mut ws)) => ws,
+                _ => return,
+            };
+            if let Some(toml::Value::Array(ref mut members)) = ws.get_mut("members") {
+                members.push(node_crate_name.clone().into());
             }
-        }
-        let toml_string = toml::to_string_pretty(&toml)?;
-        fs::write(&workspace_manifest_path, &toml_string)?;
+        })?;
     }
 
     // If the directory doesn't exist yet, create it.
     let node_crate_dir_path = node_crate_dir(workspace_dir, node_name);
     if !node_crate_dir_path.exists() {
-        let version_ctrl = None;
-        let bin = false;
-        let lib = true;
-        let name = None;
-        let edition = None;
-        let registry = None;
-        let new_options = cargo::ops::NewOptions::new(
-            version_ctrl,
-            bin,
-            lib,
-            node_crate_dir_path.clone(),
-            name,
-            edition,
-            registry,
-        )?;
+        let new_options = node_crate_new_options(node_crate_dir_path.clone())?;
         cargo::ops::new(&new_options, &cargo_config)?;
+
+        // Add the lib targets.
+        let node_crate_manifest_path = manifest_path(&node_crate_dir_path);
+        update_toml_file(&node_crate_manifest_path, |toml| {
+            let table = match toml {
+                toml::Value::Table(ref mut table) => table,
+                _ => return,
+            };
+            let mut lib_table = HashMap::default();
+            lib_table.insert("name".to_string(), node_crate_name.clone().into());
+            let array = toml::Value::Array(vec!["lib".into(), "dylib".into()]);
+            lib_table.insert("crate-type".to_string(), array);
+            table.insert("lib".to_string(), lib_table.into());
+        })?;
     }
 
     // Verify the package after creation (or if it already exists) by reading it.
@@ -613,13 +760,60 @@ where
     P: AsRef<Path>,
 {
     let package_id = open_node_package(&workspace_dir, node_name, cargo_config)?;
-    let kind = NodeKind::Graph { graph, package_id };
+    let kind = NodeKind::Graph(GraphNode { graph, package_id });
     let node_id = nodes.insert(kind);
     let file = graph_node_src(&node_id, nodes).expect("no graph node for NodeId");
-    graph_node_replace_src(workspace_dir, cargo_config, &node_id, nodes, file)?;
+    graph_node_replace_src(&workspace_dir, cargo_config, &node_id, nodes, file)?;
     Ok(node_id)
 }
 
+// Compile all crates within the workspace.
+fn workspace_compile<P>(
+    workspace_dir: P,
+    cargo_config: &cargo::Config,
+) -> Result<HashMap<cargo::core::PackageId, cargo::core::compiler::Compilation>, WorkspaceCompileError>
+where
+    P: AsRef<Path>,
+{
+    let ws_manifest_path = manifest_path(workspace_dir);
+    let ws = cargo::core::Workspace::new(&ws_manifest_path, &cargo_config)?;
+    let mut compilations = HashMap::default();
+    for pkg in ws.members() {
+        let pkg_manifest_path = pkg.manifest_path();
+        let pkg_ws = cargo::core::Workspace::new(&pkg_manifest_path, &cargo_config)?;
+        let mode = cargo::core::compiler::CompileMode::Build;
+        let mut options = cargo::ops::CompileOptions::new(&cargo_config, mode)?;
+        options.build_config.message_format = cargo::core::compiler::MessageFormat::Json;
+        options.build_config.release = true;
+        let compilation = cargo::ops::compile(&pkg_ws, &options)?;
+        compilations.insert(pkg.package_id(), compilation);
+    }
+    Ok(compilations)
+}
+
+// Compile the graph node associated with the given `NodeId`.
+fn graph_node_compile<'conf, P>(
+    workspace_dir: P,
+    cargo_config: &'conf cargo::Config,
+    node: &GraphNode,
+) -> Result<cargo::core::compiler::Compilation<'conf>, GraphNodeCompileError>
+where
+    P: AsRef<Path>,
+{
+    let ws_manifest_path = manifest_path(workspace_dir);
+    let ws = cargo::core::Workspace::new(&ws_manifest_path, &cargo_config)?;
+    let pkg = ws.members()
+        .find(|pkg| pkg.package_id() == node.package_id)
+        .ok_or(GraphNodeCompileError::NoMatchingPackageId)?;
+    let pkg_manifest_path = pkg.manifest_path();
+    let pkg_ws = cargo::core::Workspace::new(&pkg_manifest_path, &cargo_config)?;
+    let mode = cargo::core::compiler::CompileMode::Build;
+    let mut options = cargo::ops::CompileOptions::new(&cargo_config, mode)?;
+    options.build_config.message_format = cargo::core::compiler::MessageFormat::Json;
+    options.build_config.release = true;
+    let compilation = cargo::ops::compile(&pkg_ws, &options)?;
+    Ok(compilation)
+}
 
 // Given a `NodeIdGraph` and `NodeCollection`, return a graph capable of evaluation.
 fn id_graph_to_node_graph<'a>(g: &NodeIdGraph, ns: &'a NodeCollection) -> graph::StableGraph<NodeRef<'a>> {
@@ -627,8 +821,8 @@ fn id_graph_to_node_graph<'a>(g: &NodeIdGraph, ns: &'a NodeCollection) -> graph:
         |_, n_id| {
             match ns[n_id] {
                 NodeKind::Core(ref node) => NodeRef::Core(node.node()),
-                NodeKind::Graph { ref graph, .. } => {
-                    NodeRef::Graph(id_graph_to_node_graph(graph, ns))
+                NodeKind::Graph(ref node) => {
+                    NodeRef::Graph(id_graph_to_node_graph(&node.graph, ns))
                 }
             }
         },
@@ -642,8 +836,8 @@ fn id_graph_to_node_graph<'a>(g: &NodeIdGraph, ns: &'a NodeCollection) -> graph:
 //
 // Returns `None` if there is no graph node associated with the given `NodeId`.
 fn graph_node_src(id: &NodeId, nodes: &NodeCollection) -> Option<syn::File> {
-    if let Some(NodeKind::Graph { ref graph, .. }) = nodes.get(id) {
-        let graph = id_graph_to_node_graph(graph, nodes);
+    if let Some(NodeKind::Graph(ref node)) = nodes.get(id) {
+        let graph = id_graph_to_node_graph(&node.graph, nodes);
         return Some(graph::codegen::file(&graph));
     }
     None
@@ -661,12 +855,12 @@ fn graph_node_replace_src<P>(
 where
     P: AsRef<Path>,
 {
-    if let Some(NodeKind::Graph { ref package_id, .. }) = nodes.get(id) {
-        let ws_manifest_path = workspace_manifest_path(workspace_dir);
+    if let Some(NodeKind::Graph(ref node)) = nodes.get(id) {
+        let ws_manifest_path = manifest_path(workspace_dir);
         let workspace = cargo::core::Workspace::new(&ws_manifest_path, &cargo_config)?;
         let pkg = workspace
             .members()
-            .find(|pkg| pkg.package_id() == *package_id)
+            .find(|pkg| pkg.package_id() == node.package_id)
             .ok_or(GraphNodeReplaceSrcError::NoMatchingPackageId)?;
         let node_crate_dir = pkg.root();
         let node_crate_lib_rs = node_crate_lib_rs(node_crate_src(node_crate_dir));


### PR DESCRIPTION
This updates the project code to add a `dylib` target and implements
compilation of gantz nodes when added to the project and when updated.

The example has been updated to demonstrate graph manipulation
and execution of the resulting `dylib` all at runtime. :tada: :taco: :balloon: 

Closes #11
Closes #9
Closes #7
Closes #3
Closes #2