### PR TITLE
Use 2018 Edition conventions for external crates.

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,3 +1,4 @@
+use super::{Deserialize, Serialize};
 use crate::node::{self, Node};
 
 /// The type used to represent node and edge indices.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,12 +21,9 @@
 //!
 //! ## Current Questions
 
-#[macro_use]
-extern crate derive_more;
-#[macro_use]
-extern crate failure;
-#[macro_use]
-extern crate serde;
+use derive_more::From;
+use failure::Fail;
+use serde::{self, Deserialize, Serialize};
 
 pub mod graph;
 pub mod node;

--- a/src/node/expr.rs
+++ b/src/node/expr.rs
@@ -1,7 +1,7 @@
+use super::{Deserialize, Fail, From, Serialize};
 use crate::node::Node;
 use proc_macro2::{TokenStream, TokenTree};
-use quote::{TokenStreamExt, ToTokens};
-use serde::{Deserialize, Serialize};
+use quote::{ToTokens, TokenStreamExt};
 use std::fmt;
 use std::str::FromStr;
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,3 +1,5 @@
+use super::{Deserialize, Fail, From, Serialize};
+
 pub mod expr;
 pub mod push;
 pub mod serde;

--- a/src/node/push.rs
+++ b/src/node/push.rs
@@ -1,3 +1,4 @@
+use super::{Deserialize, Serialize};
 use crate::node::{self, Node};
 
 /// A wrapper around a `Node` that enables push evaluation.

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,9 +1,10 @@
+use super::{Deserialize, Fail, From, Serialize};
 use crate::graph;
 use crate::node::{self, Node, SerdeNode};
 use quote::ToTokens;
-use std::{fs, io, ops};
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
+use std::{fs, io, ops};
 
 /// A gantz **Project** represents the context in which the user composes their gantz graph
 /// together at runtime.


### PR DESCRIPTION
Potentially closes issue #26. Passes test.

There's a tiny bit of import reordering in project.rs and expr.rs due to ```rustfmt``` running on save in my editor, but I'll open a different issue about that if you want ;)