### PR TITLE
Add support for optionally typed inputs and outputs

### DIFF
--- a/examples/project.rs
+++ b/examples/project.rs
@@ -11,17 +11,11 @@ struct Add;
 struct Debug;
 
 impl gantz::Node for One {
-    fn n_inputs(&self) -> u32 {
-        0
-    }
-
-    fn n_outputs(&self) -> u32 {
-        1
-    }
-
-    fn expr(&self, args: Vec<syn::Expr>) -> syn::Expr {
-        assert!(args.is_empty());
-        syn::parse_quote! { 1 }
+    fn evaluator(&self) -> gantz::node::Evaluator {
+        let n_inputs = 0;
+        let n_outputs = 1;
+        let gen_expr = Box::new(|_| syn::parse_quote! { 1 });
+        gantz::node::Evaluator::Expr { n_inputs, n_outputs, gen_expr }
     }
 
     fn push_eval(&self) -> Option<gantz::node::PushEval> {
@@ -31,35 +25,28 @@ impl gantz::Node for One {
 }
 
 impl gantz::Node for Add {
-    fn n_inputs(&self) -> u32 {
-        2
-    }
-
-    fn n_outputs(&self) -> u32 {
-        1
-    }
-
-    fn expr(&self, args: Vec<syn::Expr>) -> syn::Expr {
-        assert_eq!(args.len(), 2);
-        let l = &args[0];
-        let r = &args[1];
-        syn::parse_quote! { #l + #r }
+    fn evaluator(&self) -> gantz::node::Evaluator {
+        let n_inputs = 2;
+        let n_outputs = 1;
+        let gen_expr = Box::new(move |args: Vec<syn::Expr>| {
+            let l = &args[0];
+            let r = &args[1];
+            syn::parse_quote! { #l + #r }
+        });
+        gantz::node::Evaluator::Expr { n_inputs, n_outputs, gen_expr }
     }
 }
 
 impl gantz::Node for Debug {
-    fn n_inputs(&self) -> u32 {
-        1
-    }
-
-    fn n_outputs(&self) -> u32 {
-        0
-    }
-
-    fn expr(&self, args: Vec<syn::Expr>) -> syn::Expr {
-        assert_eq!(args.len(), 1);
-        let input = &args[0];
-        syn::parse_quote! { println!("{:?}", #input) }
+    fn evaluator(&self) -> gantz::node::Evaluator {
+        let n_inputs = 1;
+        let n_outputs = 0;
+        let gen_expr = Box::new(move |args: Vec<syn::Expr>| {
+            assert_eq!(args.len(), 1);
+            let input = &args[0];
+            syn::parse_quote! { println!("{:?}", #input) }
+        });
+        gantz::node::Evaluator::Expr { n_inputs, n_outputs, gen_expr }
     }
 }
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -74,7 +74,7 @@ pub enum Evaluator {
     /// outputs. This simplifies the implementation of the `Node` trait for users.
     Expr {
         /// The function for producing an expression given the input expressions.
-        gen_expr: Box<Fn(Vec<syn::Expr>) -> syn::Expr>,
+        gen_expr: Box<dyn Fn(Vec<syn::Expr>) -> syn::Expr>,
         /// The number of inputs to the expression.
         n_inputs: u32,
         /// The number of outputs to the expression.
@@ -154,7 +154,7 @@ where
 
 macro_rules! impl_node_for_ptr {
     ($($Ty:ident)::*) => {
-        impl Node for $($Ty)::*<Node> {
+        impl Node for $($Ty)::*<dyn Node> {
             fn evaluator(&self) -> Evaluator {
                 (**self).evaluator()
             }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -9,31 +9,25 @@ pub use self::push::{Push, WithPushEval};
 pub use self::serde::SerdeNode;
 
 /// Gantz allows for constructing executable directed graphs by composing together **Node**s.
-/// 
+///
 /// **Node**s are a way to allow users to abstract and encapsulate logic into smaller, re-usable
 /// components, similar to a function in a coded programming language.
-/// 
+///
 /// Every Node is made up of the following:
-/// 
+///
 /// - Any number of inputs, where each input is of some rust type or generic type.
 /// - Any number of outputs, where each output is of some rust type or generic type.
 /// - A function that takes the inputs as arguments and returns an Outputs struct containing a
 ///   field for each of the outputs.
 pub trait Node {
-    /// The number of inputs to the node.
-    fn n_inputs(&self) -> u32;
-
-    /// The number of outputs to the node.
-    fn n_outputs(&self) -> u32;
-
-    /// Tokens representing the rust code that will evaluate to a tuple containing all outputs.
+    /// The approach taken for evaluating a nodes inputs to its outputs.
     ///
-    /// TODO: Consider making `args` a `Vec` of `Option`s and returning an `Option` expr to allow
-    /// for generating execution paths where only a certain set of inputs have been triggered.
-    /// Returning `None` could indicate that there is no valid `Expr` for the current set of
-    /// triggered inputs. This would probably be better than than using `default` as is currently
-    /// the case. Would also allow for 
-    fn expr(&self, args: Vec<syn::Expr>) -> syn::Expr;
+    /// This can either be an expression or a function - the key difference being that the types of
+    /// a function's inputs and outputs are known before compilation begins. As a result, functions
+    /// can lead to gantz generating more modular, compiler-friendly code, while raw expressions
+    /// have the benefit of being more ergonomic for the implementer as types aren't resolved until
+    /// the compilation process begins.
+    fn evaluator(&self) -> Evaluator;
 
     /// Specifies whether or not code should be generated to allow for push evaluation from
     /// instances of this node. Enabling push evaluation allows applications to call into
@@ -56,6 +50,36 @@ pub trait Node {
     fn pull_eval(&self) -> Option<PullEval> {
         None
     }
+}
+
+/// The method of evaluation used for a node.
+///
+/// The key distinction between the `Fn` and `Expr` variants is whether or not types of the inputs
+/// and outputs are known before a node is connected to a graph or if instead these types should be
+/// inferred.
+pub enum Evaluator {
+    /// Functions have the benefit of knowing the types of their inputs and outputs.
+    ///
+    /// Knowing the types of a node's inputs and outputs allow us to:
+    ///
+    /// - Generate more modular code for a node.
+    /// - Create better user feedback and error messages.
+    /// - Implement `Node` for `Graph`.
+    Fn {
+        /// A free-standing function, including its name, declaration, the block and other
+        /// attributes.
+        fn_item: syn::ItemFn,
+    },
+    /// Expressions have the benefit of not needing to know the exact types of a node's inputs and
+    /// outputs. This simplifies the implementation of the `Node` trait for users.
+    Expr {
+        /// The function for producing an expression given the input expressions.
+        gen_expr: Box<Fn(Vec<syn::Expr>) -> syn::Expr>,
+        /// The number of inputs to the expression.
+        n_inputs: u32,
+        /// The number of outputs to the expression.
+        n_outputs: u32,
+    },
 }
 
 /// Items that need to be known in order to generate a push evaluation function for a node.
@@ -83,20 +107,40 @@ pub struct Input(pub u32);
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
 pub struct Output(pub u32);
 
+impl Evaluator {
+    /// The number of inputs to the node.
+    pub fn n_inputs(&self) -> u32 {
+        match *self {
+            Evaluator::Fn { ref fn_item } => count_fn_inputs(&fn_item.decl) as _,
+            Evaluator::Expr { n_inputs, .. } => n_inputs as _,
+        }
+    }
+
+    /// The number of outputs to the node.
+    pub fn n_outputs(&self) -> u32 {
+        match *self {
+            Evaluator::Fn { ref fn_item } => count_fn_outputs(&fn_item.decl) as _,
+            Evaluator::Expr { n_outputs, .. } => n_outputs as _,
+        }
+    }
+
+    /// Tokens representing the rust code that will evaluate to a tuple containing all outputs.
+    ///
+    /// TODO: Handle case where only a subset of inputs are connected. See issue #17.
+    pub fn expr(&self, args: Vec<syn::Expr>) -> syn::Expr {
+        match *self {
+            Evaluator::Fn { ref fn_item } => fn_call_expr(fn_item, args),
+            Evaluator::Expr { ref gen_expr, .. } => (*gen_expr)(args),
+        }
+    }
+}
+
 impl<'a, N> Node for &'a N
 where
     N: Node,
 {
-    fn n_inputs(&self) -> u32 {
-        (**self).n_inputs()
-    }
-
-    fn n_outputs(&self) -> u32 {
-        (**self).n_outputs()
-    }
-
-    fn expr(&self, args: Vec<syn::Expr>) -> syn::Expr {
-        (**self).expr(args)
+    fn evaluator(&self) -> Evaluator {
+        (**self).evaluator()
     }
 
     fn push_eval(&self) -> Option<PushEval> {
@@ -111,16 +155,8 @@ where
 macro_rules! impl_node_for_ptr {
     ($($Ty:ident)::*) => {
         impl Node for $($Ty)::*<Node> {
-            fn n_inputs(&self) -> u32 {
-                (**self).n_inputs()
-            }
-
-            fn n_outputs(&self) -> u32 {
-                (**self).n_outputs()
-            }
-
-            fn expr(&self, args: Vec<syn::Expr>) -> syn::Expr {
-                (**self).expr(args)
+            fn evaluator(&self) -> Evaluator {
+                (**self).evaluator()
             }
 
             fn push_eval(&self) -> Option<PushEval> {
@@ -164,4 +200,47 @@ impl From<u32> for Output {
 /// Shorthand for `node::Expr::new`.
 pub fn expr(expr: &str) -> Result<Expr, NewExprError> {
     Expr::new(expr)
+}
+
+// Count the number of arguments to the given function.
+//
+// This is used to determine the number of inputs to the function.
+fn count_fn_inputs(fn_decl: &syn::FnDecl) -> usize {
+    fn_decl.inputs.len()
+}
+
+// Count the number of arguments to the given function.
+//
+// This is used to determine the number of inputs to the function.
+fn count_fn_outputs(fn_decl: &syn::FnDecl) -> usize {
+    match fn_decl.output {
+        syn::ReturnType::Default => 0,
+        syn::ReturnType::Type(ref _r_arrow, ref ty) => match **ty {
+            syn::Type::Tuple(ref tuple) => tuple.elems.len(),
+            _ => 1,
+        }
+    }
+}
+
+// Create a rust expression that calls the given `fn_decl` function with the given `args`
+// expressions as its inputs.
+fn fn_call_expr(fn_item: &syn::ItemFn, args: Vec<syn::Expr>) -> syn::Expr {
+    let n_inputs = count_fn_inputs(&fn_item.decl);
+    assert_eq!(n_inputs, args.len(), "the number of args to a function node must match n_inputs");
+    let ident = fn_item.ident.clone();
+    let arguments = syn::PathArguments::None;
+    let segment = syn::PathSegment { ident, arguments };
+    let segments = std::iter::once(segment).collect();
+    let leading_colon = None;
+    let path = syn::Path { leading_colon, segments };
+    let attrs = vec![];
+    let qself = None;
+    let func_path = syn::ExprPath { attrs, qself, path };
+    let attrs = vec![];
+    let func = Box::new(syn::Expr::Path(func_path));
+    let paren_token = syn::token::Paren { span: proc_macro2::Span::call_site() };
+    let args = args.into_iter().collect();
+    let expr_call = syn::ExprCall { attrs, func, paren_token, args };
+    let expr = syn::Expr::Call(expr_call);
+    expr
 }

--- a/src/node/push.rs
+++ b/src/node/push.rs
@@ -59,16 +59,8 @@ impl<N> Node for Push<N>
 where
     N: Node,
 {
-    fn n_inputs(&self) -> u32 {
-        self.node.n_inputs()
-    }
-
-    fn n_outputs(&self) -> u32 {
-        self.node.n_outputs()
-    }
-
-    fn expr(&self, args: Vec<syn::Expr>) -> syn::Expr {
-        self.node.expr(args)
+    fn evaluator(&self) -> node::Evaluator {
+        self.node.evaluator()
     }
 
     fn push_eval(&self) -> Option<node::PushEval> {

--- a/src/node/serde.rs
+++ b/src/node/serde.rs
@@ -4,17 +4,17 @@ use crate::node::{self, Node};
 /// objects.
 #[typetag::serde(tag = "type")]
 pub trait SerdeNode {
-    fn node(&self) -> &Node;
+    fn node(&self) -> &dyn Node;
 }
 
 #[typetag::serde]
 impl SerdeNode for node::Expr {
-    fn node(&self) -> &Node { self }
+    fn node(&self) -> &dyn Node { self }
 }
 
 #[typetag::serde]
 impl SerdeNode for node::Push<node::Expr> {
-    fn node(&self) -> &Node { self }
+    fn node(&self) -> &dyn Node { self }
 }
 
 pub mod fn_decl {

--- a/src/project.rs
+++ b/src/project.rs
@@ -61,7 +61,7 @@ pub type NodeIdGraphNode = GraphNode<NodeIdGraph>;
 /// **Graph** node, composed entirely of other gantz **Node**s.
 #[derive(Deserialize, Serialize)]
 pub enum NodeKind {
-    Core(Box<SerdeNode>),
+    Core(Box<dyn SerdeNode>),
     Graph(ProjectGraph),
 }
 
@@ -76,7 +76,7 @@ pub struct ProjectGraph {
 
 // A **Node** type constructed as a reference to some other node.
 enum NodeRef<'a> {
-    Core(&'a Node),
+    Core(&'a dyn Node),
     Graph(GraphNode<graph::StableGraph<NodeRef<'a>>>),
 }
 
@@ -327,7 +327,7 @@ impl Project {
     }
 
     /// Add the given core node to the collection and return its unique identifier.
-    pub fn add_core_node(&mut self, node: Box<SerdeNode>) -> NodeId {
+    pub fn add_core_node(&mut self, node: Box<dyn SerdeNode>) -> NodeId {
         let kind = NodeKind::Core(node);
         let node_id = self.nodes.insert(kind);
         node_id
@@ -359,7 +359,7 @@ impl Project {
     ///
     /// Returns `None` if there are no nodes for the given **NodeId** or if a node exists but it is
     /// not a **Core** node.
-    pub fn core_node(&self, id: &NodeId) -> Option<&Box<SerdeNode>> {
+    pub fn core_node(&self, id: &NodeId) -> Option<&Box<dyn SerdeNode>> {
         self.nodes.get(id).and_then(|kind| match kind {
             NodeKind::Core(ref node) => Some(node),
             _ => None,

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,5 +1,5 @@
 use super::{Deserialize, Fail, From, Serialize};
-use crate::graph;
+use crate::graph::{self, GraphNode};
 use crate::node::{self, Node, SerdeNode};
 use quote::ToTokens;
 use std::collections::{BTreeMap, HashMap};
@@ -55,25 +55,29 @@ pub struct NodeCollection {
 /// A graph composed of IDs into the `NodeCollection`.
 pub type NodeIdGraph = graph::StableGraph<NodeId>;
 
+pub type NodeIdGraphNode = GraphNode<NodeIdGraph>;
+
 /// Whether the node is a **Core** node (has no other internal **Node** dependencies) or is a
 /// **Graph** node, composed entirely of other gantz **Node**s.
 #[derive(Deserialize, Serialize)]
 pub enum NodeKind {
     Core(Box<SerdeNode>),
-    Graph(GraphNode),
+    Graph(ProjectGraph),
 }
 
-/// A node composed of a graph of other nodes.
+/// A gantz node graph useful within gantz `Project`s.
+///
+/// This can be thought of as a node that is a graph composed of other nodes.
 #[derive(Deserialize, Serialize)]
-pub struct GraphNode {
-    pub graph: NodeIdGraph,
+pub struct ProjectGraph {
+    pub graph: NodeIdGraphNode,
     pub package_id: cargo::core::PackageId,
 }
 
 // A **Node** type constructed as a reference to some other node.
 enum NodeRef<'a> {
     Core(&'a Node),
-    Graph(graph::StableGraph<NodeRef<'a>>),
+    Graph(GraphNode<graph::StableGraph<NodeRef<'a>>>),
 }
 
 /// Errors that may occur while creating a node crate.
@@ -245,7 +249,7 @@ pub enum GraphNodeCompileError {
     NoMatchingPackageId,
 }
 
-/// Errors that might occur while updating a `GraphNode`'s graph.
+/// Errors that might occur while updating a `ProjectGraph`'s graph.
 #[derive(Debug, Fail, From)]
 pub enum UpdateGraphError {
     #[fail(display = "failed to replace graph node src: {}", err)]
@@ -300,10 +304,13 @@ impl Project {
             Err(_err) => {
                 let mut nodes = NodeCollection::default();
                 let graph = NodeIdGraph::default();
+                let inlets = vec![];
+                let outlets = vec![];
+                let graph_node = GraphNode { graph, inlets, outlets };
                 let ws_dir = workspace_dir(&directory);
                 let proj_name = project_name(&directory);
                 let node_id =
-                    add_graph_node_to_collection(&ws_dir, proj_name, &cargo_config, graph, &mut nodes)?;
+                    add_graph_node_to_collection(&ws_dir, proj_name, &cargo_config, graph_node, &mut nodes)?;
                 if let Some(NodeKind::Graph(ref node)) = nodes.get(&node_id) {
                     graph_node_compile(&ws_dir, &cargo_config, node)?;
                 }
@@ -329,7 +336,7 @@ impl Project {
     /// Add the given node to the collection and return its unique identifier.
     pub fn add_graph_node(
         &mut self,
-        graph: NodeIdGraph,
+        graph: NodeIdGraphNode,
         node_name: &str,
     ) -> Result<NodeId, AddGraphNodeToCollectionError> {
         let ws_dir = self.workspace_dir();
@@ -363,7 +370,7 @@ impl Project {
     ///
     /// Returns `None` if there are no nodes for the given **NodeId** or if a node exists but it is
     /// not a **Graph** node.
-    pub fn graph_node(&self, id: &NodeId) -> Option<&GraphNode> {
+    pub fn graph_node(&self, id: &NodeId) -> Option<&ProjectGraph> {
         self.nodes.get(id).and_then(|kind| match kind {
             NodeKind::Graph(ref graph) => Some(graph),
             _ => None,
@@ -373,7 +380,7 @@ impl Project {
     /// Update the graph associated with the graph node at the given **NodeId**.
     pub fn update_graph<F>(&mut self, id: &NodeId, update: F) -> Result<(), UpdateGraphError>
     where
-        F: FnOnce(&mut NodeIdGraph),
+        F: FnOnce(&mut NodeIdGraphNode),
     {
         match self.nodes.map.get_mut(id) {
             Some(NodeKind::Graph(ref mut node)) => update(&mut node.graph),
@@ -481,24 +488,10 @@ impl NodeCollection {
 }
 
 impl<'a> Node for NodeRef<'a> {
-    fn n_inputs(&self) -> u32 {
+    fn evaluator(&self) -> node::Evaluator {
         match self {
-            NodeRef::Core(node) => node.n_inputs(),
-            NodeRef::Graph(graph) => graph.n_inputs(),
-        }
-    }
-
-    fn n_outputs(&self) -> u32 {
-        match self {
-            NodeRef::Core(node) => node.n_outputs(),
-            NodeRef::Graph(graph) => graph.n_outputs(),
-        }
-    }
-
-    fn expr(&self, args: Vec<syn::Expr>) -> syn::Expr {
-        match self {
-            NodeRef::Core(node) => node.expr(args),
-            NodeRef::Graph(graph) => graph.expr(args),
+            NodeRef::Core(node) => node.evaluator(),
+            NodeRef::Graph(graph) => graph.evaluator(),
         }
     }
 
@@ -797,14 +790,14 @@ fn add_graph_node_to_collection<P>(
     workspace_dir: P,
     node_name: &str,
     cargo_config: &cargo::Config,
-    graph: NodeIdGraph,
+    graph: NodeIdGraphNode,
     nodes: &mut NodeCollection,
 ) -> Result<NodeId, AddGraphNodeToCollectionError>
 where
     P: AsRef<Path>,
 {
     let package_id = open_node_package(&workspace_dir, node_name, cargo_config)?;
-    let kind = NodeKind::Graph(GraphNode { graph, package_id });
+    let kind = NodeKind::Graph(ProjectGraph { graph, package_id });
     let node_id = nodes.insert(kind);
     let file = graph_node_src(&node_id, nodes).expect("no graph node for NodeId");
     graph_node_replace_src(&workspace_dir, cargo_config, &node_id, nodes, file)?;
@@ -839,7 +832,7 @@ where
 fn graph_node_compile<'conf, P>(
     workspace_dir: P,
     cargo_config: &'conf cargo::Config,
-    node: &GraphNode,
+    node: &ProjectGraph,
 ) -> Result<cargo::core::compiler::Compilation<'conf>, GraphNodeCompileError>
 where
     P: AsRef<Path>,
@@ -859,12 +852,14 @@ where
     Ok(compilation)
 }
 
-// Given a `NodeIdGraph` and `NodeCollection`, return a graph capable of evaluation.
+// Given a `NodeIdGraphNode` and `NodeCollection`, return a graph capable of evaluation.
 fn id_graph_to_node_graph<'a>(
-    g: &NodeIdGraph,
+    g: &NodeIdGraphNode,
     ns: &'a NodeCollection,
-) -> graph::StableGraph<NodeRef<'a>> {
-    g.map(
+) -> GraphNode<graph::StableGraph<NodeRef<'a>>> {
+    let inlets = g.inlets.clone();
+    let outlets = g.outlets.clone();
+    let graph = g.graph.map(
         |_, n_id| {
             match ns[n_id] {
                 NodeKind::Core(ref node) => NodeRef::Core(node.node()),
@@ -876,7 +871,8 @@ fn id_graph_to_node_graph<'a>(
         |_, edge| {
             edge.clone()
         },
-    )
+    );
+    GraphNode { graph, inlets, outlets }
 }
 
 // Generate a src file for the graph node associated with the given `NodeId`.
@@ -885,7 +881,7 @@ fn id_graph_to_node_graph<'a>(
 fn graph_node_src(id: &NodeId, nodes: &NodeCollection) -> Option<syn::File> {
     if let Some(NodeKind::Graph(ref node)) = nodes.get(id) {
         let graph = id_graph_to_node_graph(&node.graph, nodes);
-        return Some(graph::codegen::file(&graph));
+        return Some(graph::codegen::file(&graph.graph, &graph.inlets, &graph.outlets));
     }
     None
 }

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -56,7 +56,7 @@ fn test_graph1() {
     let assert_eq = node_assert_eq();
 
     // Add the nodes to the project.
-    let push = project.add_core_node(Box::new(push) as Box<SerdeNode>);
+    let push = project.add_core_node(Box::new(push) as Box<dyn SerdeNode>);
     let one = project.add_core_node(Box::new(one) as Box<_>);
     let add = project.add_core_node(Box::new(add) as Box<_>);
     let two = project.add_core_node(Box::new(two) as Box<_>);
@@ -110,7 +110,7 @@ impl gantz::Node for Mul {
 
 #[typetag::serde]
 impl gantz::node::SerdeNode for Mul {
-    fn node(&self) -> &gantz::Node { self }
+    fn node(&self) -> &dyn gantz::Node { self }
 }
 
 // A simple test graph that multiplies two "two"s and checks that it equals "two".
@@ -154,7 +154,7 @@ fn test_graph2_evaluator_fn() {
     assert_eq!(mul_eval.n_outputs(), 1);
 
     // Add the nodes to the project.
-    let push = project.add_core_node(Box::new(push) as Box<SerdeNode>);
+    let push = project.add_core_node(Box::new(push) as Box<dyn SerdeNode>);
     let two = project.add_core_node(Box::new(two) as Box<_>);
     let mul = project.add_core_node(Box::new(mul) as Box<_>);
     let four = project.add_core_node(Box::new(four) as Box<_>);

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -2,6 +2,7 @@
 
 use gantz::Edge;
 use gantz::node::{self, SerdeNode, WithPushEval};
+use serde::{Deserialize, Serialize};
 
 fn node_push() -> node::Push<node::Expr> {
     node::expr("()").unwrap().with_push_eval_name("push")
@@ -75,6 +76,104 @@ fn test_graph1() {
         g.add_edge(one, add, Edge::from((0, 1)));
         g.add_edge(add, assert_eq, Edge::from((0, 0)));
         g.add_edge(two, assert_eq, Edge::from((0, 1)));
+    }).unwrap();
+
+    // Retrieve the path to the compiled library.
+    let dylib_path = project.graph_node_dylib(&root).unwrap().expect("no dylib or node");
+    let lib = libloading::Library::new(&dylib_path).expect("failed to load library");
+    let symbol_name = "push".as_bytes();
+    unsafe {
+        let push_eval_fn: libloading::Symbol<fn()> =
+            lib.get(symbol_name).expect("failed to load symbol");
+        // Execute the gantz graph.
+        push_eval_fn();
+    }
+}
+
+// Create a Node for testing the `Fn` evaluator variant.
+#[derive(Deserialize, Serialize)]
+struct Mul;
+
+impl gantz::Node for Mul {
+    fn evaluator(&self) -> gantz::node::Evaluator {
+        let fn_item = syn::parse_quote! {
+            fn mul<T>(a: T, b: T) -> T
+            where
+                T: std::ops::Mul<T, Output = T>,
+            {
+                a * b
+            }
+        };
+        gantz::node::Evaluator::Fn { fn_item }
+    }
+}
+
+#[typetag::serde]
+impl gantz::node::SerdeNode for Mul {
+    fn node(&self) -> &gantz::Node { self }
+}
+
+// A simple test graph that multiplies two "two"s and checks that it equals "two".
+//
+//    --------
+//    | push | // push_eval
+//    -+------
+//     |
+//     |---------
+//     |        |
+//    -+-----   |
+//    | two |   |
+//    -+-----   |
+//     |\       |
+//     | \      |
+//     |  \     |
+//    -+---+-  -+------
+//    | mul |  | four |
+//    -+-----  -+------
+//     |        |
+//     |       --
+//     |       |
+//    -+-------+-
+//    |assert_eq|
+//    -----------
+#[test]
+fn test_graph2_evaluator_fn() {
+    // Create a temp project.
+    let mut project = gantz::TempProject::open_with_name("test_graph2_evaluator_fn").unwrap();
+
+    // Instantiate the nodes.
+    let push = node_push();
+    let two = node_int(2);
+    let mul = Mul;
+    let four = node_int(4);
+    let assert_eq = node_assert_eq();
+
+    // Check some properties about `Mul`, our fancy Fn node.
+    let mul_eval = gantz::Node::evaluator(&mul);
+    assert_eq!(mul_eval.n_inputs(), 2);
+    assert_eq!(mul_eval.n_outputs(), 1);
+
+    // Add the nodes to the project.
+    let push = project.add_core_node(Box::new(push) as Box<SerdeNode>);
+    let two = project.add_core_node(Box::new(two) as Box<_>);
+    let mul = project.add_core_node(Box::new(mul) as Box<_>);
+    let four = project.add_core_node(Box::new(four) as Box<_>);
+    let assert_eq = project.add_core_node(Box::new(assert_eq) as Box<_>);
+
+    // Compose the graph.
+    let root = project.root_node_id();
+    project.update_graph(&root, |g| {
+        let push = g.add_node(push);
+        let two = g.add_node(two);
+        let mul = g.add_node(mul);
+        let four = g.add_node(four);
+        let assert_eq = g.add_node(assert_eq);
+        g.add_edge(push, two, Edge::from((0, 0)));
+        g.add_edge(push, four, Edge::from((0, 0)));
+        g.add_edge(two, mul, Edge::from((0, 0)));
+        g.add_edge(two, mul, Edge::from((0, 1)));
+        g.add_edge(mul, assert_eq, Edge::from((0, 0)));
+        g.add_edge(four, assert_eq, Edge::from((0, 1)));
     }).unwrap();
 
     // Retrieve the path to the compiled library.


### PR DESCRIPTION
This allows for optionally specifying the full types of the inputs and
outputs of a `Node` during implementation by allowing to specify a full,
freestanding function, rather than only an expression.

The function's arguments and return type will be parsed to produce the
number of inputs and outputs for the node, where the number of arguments
is the number of inputs, and the number of tuple arguments in the output
is the number of outputs (1 if no tuple output type).

Some of this may have to be re-written when addressing a few follow-up
issues including #29, #19, #21 and #22, but I think it's helpful to
break up progress into achievable steps!

Closes #27 and makes #20 much more feasible.