### PR TITLE
 WIP Implementation of `Node` for graph types 

### DIFF
--- a/examples/project.rs
+++ b/examples/project.rs
@@ -52,17 +52,17 @@ impl gantz::Node for Debug {
 
 #[typetag::serde]
 impl gantz::node::SerdeNode for One {
-    fn node(&self) -> &gantz::Node { self }
+    fn node(&self) -> &dyn gantz::Node { self }
 }
 
 #[typetag::serde]
 impl gantz::node::SerdeNode for Add {
-    fn node(&self) -> &gantz::Node { self }
+    fn node(&self) -> &dyn gantz::Node { self }
 }
 
 #[typetag::serde]
 impl gantz::node::SerdeNode for Debug {
-    fn node(&self) -> &gantz::Node { self }
+    fn node(&self) -> &dyn gantz::Node { self }
 }
 
 fn main() {
@@ -71,7 +71,7 @@ fn main() {
     let mut project = gantz::Project::open(path.into()).unwrap();
 
     // Instantiate the core nodes.
-    let one = Box::new(One) as Box<gantz::node::SerdeNode>;
+    let one = Box::new(One) as Box<dyn gantz::node::SerdeNode>;
     let add = Box::new(Add) as Box<_>;
     let debug = Box::new(Debug) as Box<_>;
 

--- a/src/node/serde.rs
+++ b/src/node/serde.rs
@@ -103,3 +103,23 @@ pub mod tts {
         Ok(TokenStream::from_str(&string).expect("failed to parse string as token stream"))
     }
 }
+
+pub mod ty {
+    use serde::{Deserializer, Serializer};
+
+    pub fn serialize<S>(ty: &syn::Type, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        super::tts::serialize(ty, s)
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<syn::Type, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let tts = super::tts::deserialize(d)?;
+        let ty: syn::Type = syn::parse_quote!{ #tts };
+        Ok(ty)
+    }
+}


### PR DESCRIPTION
This is a WIP implementation of the **Node** trait for graph types of
nodes that also implement the **Node** trait. This work goes toward
allowing nesting of graphs within graphs, the primary form of
abstraction for gantz graph projects.

This works by producing an **Evaluator::Fn** from the
**Node::evaluator** method, where the number of inputs to the generated
function declaration match the number of inlets, and the output type
matches the number of outlets. The implementation is generic over all
graph types, so long as they are able to generate a function body for
the generated declaration mentioned above.

This requirement is specified via the **graph::EvaluatorFnBlock** trait.
An implementation exists for the graph type used within the project
module - it is currently incomplete but specifies the necessary steps
for completion once state handling is added.

Progress on #20.