### PR TITLE
Add support for pull evaluation

### DIFF
--- a/examples/project.rs
+++ b/examples/project.rs
@@ -22,7 +22,7 @@ impl gantz::Node for One {
         }
     }
 
-    fn push_eval(&self) -> Option<gantz::node::PushEval> {
+    fn push_eval(&self) -> Option<gantz::node::EvalFn> {
         let item_fn: syn::ItemFn = syn::parse_quote! { fn one_push_eval() {} };
         Some(item_fn.into())
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -517,7 +517,7 @@ pub mod codegen {
     /// Direction of edges indicate the flow of data through the graph.
     pub fn push_eval_order<G>(g: G, n: G::NodeId) -> impl Iterator<Item = G::NodeId>
     where
-        G: GraphRef + IntoEdgesDirected + IntoNodeReferences + NodeIndexable + Visitable,
+        G: IntoEdgesDirected + IntoNodeReferences + Visitable,
         G::NodeId: Eq + Hash,
     {
         // First, find all nodes reachable by a `DFS` from this node.
@@ -538,7 +538,7 @@ pub mod codegen {
     /// Direction of edges indicate the flow of data through the graph.
     pub fn pull_eval_order<G>(g: G, n: G::NodeId) -> impl Iterator<Item = G::NodeId>
     where
-        G: GraphRef + IntoEdgesDirected + IntoNodeReferences + NodeIndexable + Visitable,
+        G: IntoEdgesDirected + IntoNodeReferences + Visitable,
         G::NodeId: Eq + Hash,
     {
         // First, find all nodes reachable by a `DFS` from this node.
@@ -558,7 +558,7 @@ pub mod codegen {
         eval_order: I,
     ) -> Vec<EvalStep<G::NodeId>>
     where
-        G: GraphRef + IntoEdgesDirected + IntoNodeReferences + NodeIndexable + Visitable,
+        G: GraphRef + IntoEdgesDirected + IntoNodeReferences + NodeIndexable,
         G: Data<EdgeWeight = Edge>,
         G::NodeId: Eq + Hash,
         <G::NodeRef as NodeRef>::Weight: Node,

--- a/src/node/pull.rs
+++ b/src/node/pull.rs
@@ -1,0 +1,73 @@
+use super::{Deserialize, Serialize};
+use crate::node::{self, Node};
+
+/// A wrapper around a `Node` that enables pull evaluation.
+///
+/// The implementation of `Node` will match the inner node type `N`, but with a unique
+/// implementation of `Node::pull_eval`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Pull<N> {
+    node: N,
+    pull_eval: node::EvalFn,
+}
+
+/// A trait implemented for all `Node` types allowing to enable pull evaluation.
+pub trait WithPullEval: Sized + Node {
+    /// Consume `self` and return a `Node` that has pull evaluation enabled.
+    fn with_pull_eval(self, pull_eval: node::EvalFn) -> Pull<Self>;
+
+    /// Enable pull evaluation using the given pull evaluation function.
+    ///
+    /// Internally, this calls `with_pull_eval`.
+    ///
+    /// Note: Only the name, function declaration and attributes are used - the function definition
+    /// is ignored.
+    fn with_pull_eval_fn(self, item_fn: syn::ItemFn) -> Pull<Self> {
+        self.with_pull_eval(item_fn.into())
+    }
+
+    /// Enable pull evaluation.
+    ///
+    /// Internally, this calls `with_pull_eval_fn` with a function that looks like `fn #name() {}`.
+    fn with_pull_eval_name(self, fn_name: &str) -> Pull<Self> {
+        let fn_ident = syn::Ident::new(fn_name, proc_macro2::Span::call_site());
+        self.with_pull_eval_fn(syn::parse_quote! { fn #fn_ident() {} })
+    }
+}
+
+impl<N> Pull<N>
+where
+    N: Node,
+{
+    /// Given some node, return a `Pull` node enabling pull evaluation.
+    pub fn new(node: N, pull_eval: node::EvalFn) -> Self {
+        Pull { node, pull_eval }
+    }
+}
+
+impl<N> WithPullEval for N
+where
+    N: Node,
+{
+    /// Consume `self` and return an equivalent node with pull evaluation enabled.
+    fn with_pull_eval(self, pull_eval: node::EvalFn) -> Pull<Self> {
+        Pull::new(self, pull_eval)
+    }
+}
+
+impl<N> Node for Pull<N>
+where
+    N: Node,
+{
+    fn evaluator(&self) -> node::Evaluator {
+        self.node.evaluator()
+    }
+
+    fn push_eval(&self) -> Option<node::EvalFn> {
+        self.node.push_eval()
+    }
+
+    fn pull_eval(&self) -> Option<node::EvalFn> {
+        Some(self.pull_eval.clone())
+    }
+}

--- a/src/node/push.rs
+++ b/src/node/push.rs
@@ -8,13 +8,13 @@ use crate::node::{self, Node};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Push<N> {
     node: N,
-    push_eval: node::PushEval,
+    push_eval: node::EvalFn,
 }
 
 /// A trait implemented for all `Node` types allowing to enable push evaluation.
 pub trait WithPushEval: Sized + Node {
     /// Consume `self` and return a `Node` that has push evaluation enabled.
-    fn with_push_eval(self, push_eval: node::PushEval) -> Push<Self>;
+    fn with_push_eval(self, push_eval: node::EvalFn) -> Push<Self>;
 
     /// Enable push evaluation using the given push evaluation function.
     ///
@@ -40,7 +40,7 @@ where
     N: Node,
 {
     /// Given some node, return a `Push` node enabling push evaluation.
-    pub fn new(node: N, push_eval: node::PushEval) -> Self {
+    pub fn new(node: N, push_eval: node::EvalFn) -> Self {
         Push { node, push_eval }
     }
 }
@@ -50,7 +50,7 @@ where
     N: Node,
 {
     /// Consume `self` and return an equivalent node with push evaluation enabled.
-    fn with_push_eval(self, push_eval: node::PushEval) -> Push<Self> {
+    fn with_push_eval(self, push_eval: node::EvalFn) -> Push<Self> {
         Push::new(self, push_eval)
     }
 }
@@ -63,11 +63,11 @@ where
         self.node.evaluator()
     }
 
-    fn push_eval(&self) -> Option<node::PushEval> {
+    fn push_eval(&self) -> Option<node::EvalFn> {
         Some(self.push_eval.clone())
     }
 
-    fn pull_eval(&self) -> Option<node::PullEval> {
+    fn pull_eval(&self) -> Option<node::EvalFn> {
         self.node.pull_eval()
     }
 }

--- a/src/node/serde.rs
+++ b/src/node/serde.rs
@@ -21,6 +21,13 @@ impl SerdeNode for node::Push<node::Expr> {
     }
 }
 
+#[typetag::serde]
+impl SerdeNode for node::Pull<node::Expr> {
+    fn node(&self) -> &dyn Node {
+        self
+    }
+}
+
 pub mod fn_decl {
     use serde::{Deserializer, Serializer};
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -550,14 +550,14 @@ impl<'a> Node for NodeRef<'a> {
         }
     }
 
-    fn push_eval(&self) -> Option<node::PushEval> {
+    fn push_eval(&self) -> Option<node::EvalFn> {
         match self {
             NodeRef::Core(node) => node.push_eval(),
             NodeRef::Graph(graph) => graph.push_eval(),
         }
     }
 
-    fn pull_eval(&self) -> Option<node::PullEval> {
+    fn pull_eval(&self) -> Option<node::EvalFn> {
         match self {
             NodeRef::Core(node) => node.pull_eval(),
             NodeRef::Graph(graph) => graph.pull_eval(),


### PR DESCRIPTION
This was easier than expected as I realised that, other than the order of the node evaluation steps, most of the code could be shared with push evaluation.

Also improves a lot of the documentation and adds a single simple test.

Closes #16.