### PR TITLE
Early implementation of support for Node State

### DIFF
--- a/examples/project.rs
+++ b/examples/project.rs
@@ -142,9 +142,9 @@ fn main() {
     let lib = libloading::Library::new(&dylib_path).expect("failed to load library");
     let symbol_name = "one_push_eval".as_bytes();
     unsafe {
-        let foo_one_push_eval_fn: libloading::Symbol<fn()> =
+        let foo_one_push_eval_fn: libloading::Symbol<fn(&mut [&mut dyn std::any::Any])> =
             lib.get(symbol_name).expect("failed to load symbol");
         // Execute the gantz graph (prints `2` to stdout).
-        foo_one_push_eval_fn();
+        foo_one_push_eval_fn(&mut []);
     }
 }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -381,25 +381,10 @@ fn graph_node_evaluator_fn_inputs<Id>(inlets: &[Inlet<Id>]) -> Punctuated<FnArg,
         .enumerate()
         .map(|(i, inlet)| {
             let name = format!("inlet{}", i);
-            let by_ref = None;
-            let mutability = None;
             let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
-            let subpat = None;
-            let pat_ident = syn::PatIdent {
-                by_ref,
-                mutability,
-                ident,
-                subpat,
-            };
-            let pat = pat_ident.into();
-            let colon_token = Default::default();
             let ty = inlet.ty.clone();
-            let arg_captured = syn::ArgCaptured {
-                pat,
-                colon_token,
-                ty,
-            };
-            syn::FnArg::from(arg_captured)
+            let fn_arg: syn::FnArg = syn::parse_quote! { #ident: #ty };
+            fn_arg
         })
         .collect()
 }

--- a/src/node/pull.rs
+++ b/src/node/pull.rs
@@ -70,4 +70,8 @@ where
     fn pull_eval(&self) -> Option<node::EvalFn> {
         Some(self.pull_eval.clone())
     }
+
+    fn state_type(&self) -> Option<syn::Type> {
+        self.node.state_type()
+    }
 }

--- a/src/node/push.rs
+++ b/src/node/push.rs
@@ -70,4 +70,8 @@ where
     fn pull_eval(&self) -> Option<node::EvalFn> {
         self.node.pull_eval()
     }
+
+    fn state_type(&self) -> Option<syn::Type> {
+        self.node.state_type()
+    }
 }

--- a/src/node/serde.rs
+++ b/src/node/serde.rs
@@ -28,6 +28,13 @@ impl SerdeNode for node::Pull<node::Expr> {
     }
 }
 
+#[typetag::serde]
+impl SerdeNode for node::State<node::Expr> {
+    fn node(&self) -> &dyn Node {
+        self
+    }
+}
+
 pub mod fn_decl {
     use serde::{Deserializer, Serializer};
 

--- a/src/node/state.rs
+++ b/src/node/state.rs
@@ -1,0 +1,61 @@
+use super::{Deserialize, Serialize};
+use crate::node::{self, Node};
+
+/// A trait implemented for all **Node** types allowing to add some state accessible to its
+/// expression. This is particularly useful for adding state to **Expr** nodes.
+pub trait WithStateType: Sized + Node {
+    /// Consume `self` and return a `Node` that has state of type `state_type`.
+    fn with_state_type(self, state_type: syn::Type) -> State<Self>;
+
+    /// A short-hand for `with_state_type` - allows for describing the type via a `str`.
+    fn with_state_ty(self, state_type: &str) -> syn::Result<State<Self>> {
+        let ty: syn::Type = syn::parse_str(state_type)?;
+        Ok(self.with_state_type(ty))
+    }
+}
+
+/// A wrapper around a **Node** that adds some persistent state.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct State<N> {
+    pub node: N,
+    /// Attributes for the generated `ItemFn`.
+    #[serde(with = "crate::node::serde::ty")]
+    pub state_type: syn::Type,
+}
+
+impl<N> State<N> {
+    /// Given some node, return a **State** node enabling access to state of the given type.
+    pub fn new(node: N, state_type: syn::Type) -> Self {
+        State { node, state_type }
+    }
+}
+
+impl<N> WithStateType for N
+where
+    N: Node,
+{
+    fn with_state_type(self, state_type: syn::Type) -> State<Self> {
+        State::new(self, state_type)
+    }
+}
+
+impl<N> Node for State<N>
+where
+    N: Node,
+{
+    fn evaluator(&self) -> node::Evaluator {
+        self.node.evaluator()
+    }
+
+    fn push_eval(&self) -> Option<node::EvalFn> {
+        self.node.push_eval()
+    }
+
+    fn pull_eval(&self) -> Option<node::EvalFn> {
+        self.node.pull_eval()
+    }
+
+    fn state_type(&self) -> Option<syn::Type> {
+        Some(self.state_type.clone())
+    }
+}

--- a/src/project.rs
+++ b/src/project.rs
@@ -563,6 +563,13 @@ impl<'a> Node for NodeRef<'a> {
             NodeRef::Graph(graph) => graph.pull_eval(),
         }
     }
+
+    fn state_type(&self) -> Option<syn::Type> {
+        match self {
+            NodeRef::Core(node) => node.state_type(),
+            NodeRef::Graph(graph) => graph.state_type(),
+        }
+    }
 }
 
 impl ops::Deref for TempProject {

--- a/tests/counter.rs
+++ b/tests/counter.rs
@@ -1,0 +1,64 @@
+// Testing a simple counter node, the first stateful node type to be tested.
+
+use gantz::node::{self, SerdeNode, WithPushEval, WithStateType};
+use gantz::Edge;
+
+fn node_push() -> node::Push<node::Expr> {
+    node::expr("()").unwrap().with_push_eval_name("push")
+}
+
+fn node_counter() -> node::State<node::Expr> {
+    node::expr(r#"{ #push; let count = *state; *state += 1; count }"#)
+        .unwrap()
+        .with_state_ty("u32")
+        .unwrap()
+}
+
+#[test]
+fn test_graph_with_counter() {
+    // Create a temp project.
+    let mut project = gantz::TempProject::open_with_name("test_graph_with_counter").unwrap();
+
+    // Instantiate the nodes.
+    let push = node_push();
+    let counter = node_counter();
+
+    // Add the nodes to the project.
+    let push = project.add_core_node(Box::new(push) as Box<dyn SerdeNode>);
+    let counter = project.add_core_node(Box::new(counter) as Box<_>);
+
+    // Compose the graph.
+    let root = project.root_node_id();
+    project
+        .update_graph(&root, |g| {
+            let push = g.add_node(push);
+            let counter = g.add_node(counter);
+            g.add_edge(push, counter, Edge::from((0, 0)));
+        })
+        .unwrap();
+
+    // Initialise the counter state.
+    let mut count = 0u32;
+
+    // Retrieve the path to the compiled library.
+    let dylib_path = project
+        .graph_node_dylib(&root)
+        .unwrap()
+        .expect("no dylib or node");
+
+    // Load the library.
+    let lib = libloading::Library::new(&dylib_path).expect("failed to load library");
+    let symbol_name = "push".as_bytes();
+    unsafe {
+        let push_eval_fn: libloading::Symbol<fn(&mut [&mut dyn std::any::Any])> =
+            lib.get(symbol_name).expect("failed to load symbol");
+        // Prepare the `node_states` and execute the graph.
+        let mut node_states = [&mut count as &mut dyn std::any::Any];
+        push_eval_fn(&mut node_states[..]);
+        push_eval_fn(&mut node_states[..]);
+        push_eval_fn(&mut node_states[..]);
+    }
+
+    // Check the counter was incremented 3 times.
+    assert_eq!(count, 3);
+}

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -88,10 +88,10 @@ fn test_graph1() {
     let lib = libloading::Library::new(&dylib_path).expect("failed to load library");
     let symbol_name = "push".as_bytes();
     unsafe {
-        let push_eval_fn: libloading::Symbol<fn()> =
+        let push_eval_fn: libloading::Symbol<fn(&mut [&mut dyn std::any::Any])> =
             lib.get(symbol_name).expect("failed to load symbol");
         // Execute the gantz graph.
-        push_eval_fn();
+        push_eval_fn(&mut []);
     }
 }
 
@@ -193,10 +193,10 @@ fn test_graph2_evaluator_fn() {
     let lib = libloading::Library::new(&dylib_path).expect("failed to load library");
     let symbol_name = "push".as_bytes();
     unsafe {
-        let push_eval_fn: libloading::Symbol<fn()> =
+        let push_eval_fn: libloading::Symbol<fn(&mut [&mut dyn std::any::Any])> =
             lib.get(symbol_name).expect("failed to load symbol");
         // Execute the gantz graph.
-        push_eval_fn();
+        push_eval_fn(&mut []);
     }
 }
 
@@ -257,10 +257,10 @@ fn test_graph3_pull_eval() {
     let lib = libloading::Library::new(&dylib_path).expect("failed to load library");
     let symbol_name = "assert_eq".as_bytes();
     unsafe {
-        let pull_eval_fn: libloading::Symbol<fn()> =
+        let pull_eval_fn: libloading::Symbol<fn(&mut [&mut dyn std::any::Any])> =
             lib.get(symbol_name).expect("failed to load symbol");
         // Execute the gantz graph.
-        pull_eval_fn();
+        pull_eval_fn(&mut []);
     }
 }
 
@@ -319,9 +319,9 @@ fn test_graph4_should_panic() {
     let lib = libloading::Library::new(&dylib_path).expect("failed to load library");
     let symbol_name = "assert_eq".as_bytes();
     unsafe {
-        let pull_eval_fn: libloading::Symbol<fn()> =
+        let pull_eval_fn: libloading::Symbol<fn(&mut [&mut dyn std::any::Any])> =
             lib.get(symbol_name).expect("failed to load symbol");
         // Execute the gantz graph.
-        pull_eval_fn();
+        pull_eval_fn(&mut []);
     }
 }


### PR DESCRIPTION
This adds rough support for node state that persists between calls to
evaluation functions.

Currently, node state is made available in evaluation functions via an
added `&mut [&mut dyn std::any::Any]`. Eventually, this should be
changed to a friendlier `node::States` type or something along these
lines, however this will first require some way to make such a type
available to the generated crate. This might mean splitting this type
into its own crate so that it may be shared between both gantz,
generated crates and user crates. For now, the `Any` slice only requires
`std` and seems to work as a basic prototype.

A simple counter.rs test has been added in which a small graph
containing a counter node is composed, compiled, loaded, evaluated three
times and the result is asserted at the end.

I'm not sure if Rust's unstable ABI will begin causing more issues with
larger types, but for now this seems to be working consistently OK with
primitive types on Linux.

This should make it possible to finish #20.

Closes #19.