### PR TITLE
[WIP] Work towards impl Node for Graph.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 cargo = "0.34"
 derive_more = "0.14"
 failure = "0.1"
+libloading = "0.5"
 petgraph = { version = "0.4", features = ["serde-1"] }
 proc-macro2 = "0.4"
 quote = "0.6"
@@ -23,6 +24,3 @@ serde_json = "1"
 syn = "0.15"
 toml = "0.5"
 typetag = "0.1"
-
-[dev-dependencies]
-libloading = "0.5"

--- a/src/graph/codegen.rs
+++ b/src/graph/codegen.rs
@@ -163,16 +163,14 @@ where
     I: IntoIterator<Item = G::NodeId>,
     G::NodeWeight: Node,
 {
-    eval_order
-        .into_iter()
-        .filter(move |&n| {
-            g.node_references()
-                .nth(g.to_index(n))
-                .expect("node in `eval_order` does not exist within the given graph")
-                .weight()
-                .state_type()
-                .is_some()
-        })
+    eval_order.into_iter().filter(move |&n| {
+        g.node_references()
+            .nth(g.to_index(n))
+            .expect("node in `eval_order` does not exist within the given graph")
+            .weight()
+            .state_type()
+            .is_some()
+    })
 }
 
 /// Given a node evaluation order, produce the series of evaluation steps required.

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -140,8 +140,15 @@ where
         // This will have to be considered in evaluator expr generation too.
         let name = format!("graph_node_evaluator_fn");
         let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
-        let decl = Box::new(graph_node_evaluator_fn_decl(&self.graph, &self.inlets, &self.outlets));
-        let block = Box::new(self.graph.evaluator_fn_block(&self.inlets, &self.outlets, &decl));
+        let decl = Box::new(graph_node_evaluator_fn_decl(
+            &self.graph,
+            &self.inlets,
+            &self.outlets,
+        ));
+        let block = Box::new(
+            self.graph
+                .evaluator_fn_block(&self.inlets, &self.outlets, &decl),
+        );
         let fn_item = syn::ItemFn {
             attrs,
             vis,
@@ -165,7 +172,11 @@ where
         let graph = Default::default();
         let inlets = Default::default();
         let outlets = Default::default();
-        GraphNode { graph, inlets, outlets }
+        GraphNode {
+            graph,
+            inlets,
+            outlets,
+        }
     }
 }
 
@@ -295,7 +306,10 @@ impl Node for Inlet {
         let n_outputs = 1;
         let ty = self.ty.clone();
         let gen_expr = Box::new(move |args: Vec<syn::Expr>| {
-            assert!(args.is_empty(), "there cannot be any inputs to an inlet node");
+            assert!(
+                args.is_empty(),
+                "there cannot be any inputs to an inlet node"
+            );
             syn::parse_quote! {
                 let state: &mut #ty = state;
                 state.clone()
@@ -383,11 +397,7 @@ where
     }
 }
 
-fn graph_node_evaluator_fn_decl<G>(
-    g: G,
-    inlets: &[G::NodeId],
-    outlets: &[G::NodeId],
-) -> syn::FnDecl
+fn graph_node_evaluator_fn_decl<G>(g: G, inlets: &[G::NodeId], outlets: &[G::NodeId]) -> syn::FnDecl
 where
     G: Graph,
 {

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,5 +1,5 @@
 use super::{Deserialize, Fail, From, Serialize};
-use crate::graph::{self, GraphNode};
+use crate::graph::{self, Edge, GraphNode};
 use crate::node::{self, Node, SerdeNode};
 use petgraph::visit::GraphBase;
 use quote::ToTokens;
@@ -53,8 +53,16 @@ pub struct NodeCollection {
     map: NodeTree,
 }
 
+/// The type used to represent node and edge indices.
+pub type Index = usize;
+pub type EdgeIndex = petgraph::graph::EdgeIndex<Index>;
+pub type NodeIndex = petgraph::graph::NodeIndex<Index>;
+
+/// The petgraph type used to represent a stable gantz graph.
+pub type StableGraph<N> = petgraph::stable_graph::StableGraph<N, Edge, petgraph::Directed, Index>;
+
 /// A graph composed of IDs into the `NodeCollection`.
-pub type NodeIdGraph = graph::StableGraph<NodeId>;
+pub type NodeIdGraph = StableGraph<NodeId>;
 
 /// A **NodeIdGraph** along with its inlets and outlets.
 pub type NodeIdGraphNode = GraphNode<NodeIdGraph>;
@@ -63,7 +71,7 @@ pub type NodeIdGraphNode = GraphNode<NodeIdGraph>;
 ///
 /// This graph is constructed at the time of code generation using the project's **NodeIdGraph**
 /// and the **NodeCollection**.
-type NodeRefGraph<'a> = graph::StableGraph<NodeRef<'a>>;
+type NodeRefGraph<'a> = StableGraph<NodeRef<'a>>;
 
 /// A **NodeRefGraph** along with the cargo **PackageId** for the graph within this project.
 ///
@@ -532,13 +540,27 @@ impl<'a> GraphBase for ProjectNodeRefGraph<'a> {
 }
 
 impl<'a> graph::EvaluatorFnBlock for ProjectNodeRefGraph<'a> {
-    fn evaluator_fn_block(&self, _fn_decl: &syn::FnDecl) -> syn::Block {
+    fn evaluator_fn_block(&self, fn_decl: &syn::FnDecl) -> syn::Block {
+        let mut stmts = vec![];
+
         // TODO: Block should look something like this:
         //
         // - Use the inputs to the `fn_decl` to set the state of the `inlet` nodes.
         // - Call the `push_eval` function from the dynamic library associated with this graph.
         // - Retrievel the state for each `outlet` node and return them at the end of the block.
-        unimplemented!("TODO: generate a block that evaluates the graph")
+        unimplemented!("TODO: generate a block that evaluates the graph");
+
+
+        let brace_token = Default::default();
+        let block = syn::Block { brace_token, stmts };
+        block
+    }
+}
+
+impl<'a> graph::Graph for ProjectNodeRefGraph<'a> {
+    type Node = NodeRef<'a>;
+    fn node(&self, id: Self::NodeId) -> Option<&Self::Node> {
+        self.graph.node_weight(id)
     }
 }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -594,23 +594,17 @@ impl<'a> graph::EvaluatorFnBlock for ProjectNodeRefGraph<'a> {
         println!("state order: {:?}", state_order);
 
         // The order within the state slice for each inlet node.
-        let inlet_state_indices = inlets
-            .iter()
-            .map(|&inlet| state_order[&inlet]);
-        let mut outlet_state_indices = outlets
-            .iter()
-            .map(|&outlet| state_order[&outlet]);
+        let inlet_state_indices = inlets.iter().map(|&inlet| state_order[&inlet]);
+        let mut outlet_state_indices = outlets.iter().map(|&outlet| state_order[&outlet]);
 
         // Retrieve the inlet values from the fn_decl args.
-        let inlet_values = fn_decl.inputs
-            .iter()
-            .map(|arg| match arg {
-                syn::FnArg::Captured(ref arg) => match arg.pat {
-                    syn::Pat::Ident(ref pat) => pat.ident.clone(),
-                    _ => unreachable!("graph eval fn_decl contained non-`Ident` arg pattern"),
-                },
-                _ => unreachable!("graph eval fn_decl should only use captured `FnArg`s"),
-            });
+        let inlet_values = fn_decl.inputs.iter().map(|arg| match arg {
+            syn::FnArg::Captured(ref arg) => match arg.pat {
+                syn::Pat::Ident(ref pat) => pat.ident.clone(),
+                _ => unreachable!("graph eval fn_decl contained non-`Ident` arg pattern"),
+            },
+            _ => unreachable!("graph eval fn_decl should only use captured `FnArg`s"),
+        });
 
         // - `()` for no outlets.
         // - `#outlet` for single outlet.
@@ -620,7 +614,9 @@ impl<'a> graph::EvaluatorFnBlock for ProjectNodeRefGraph<'a> {
                 syn::parse_quote! { () }
             }
             1 => {
-                let outlet_ix = outlet_state_indices.next().expect("expected 1 index, found none");
+                let outlet_ix = outlet_state_indices
+                    .next()
+                    .expect("expected 1 index, found none");
                 syn::parse_quote! { state.node_states[#outlet_ix] }
             }
             _ => {
@@ -666,7 +662,7 @@ pub struct GraphState<'a> {
     /// A reference to the function symbol for running the full graph.
     ///
     /// E.g. `&'a libloading::Symbol<'static, fn(X, Y) -> Z>`
-    pub full_graph_eval_fn_symbol: &'a dyn::std::any::Any,
+    pub full_graph_eval_fn_symbol: &'a dyn ::std::any::Any,
 }
 
 impl<'a> Node for NodeRef<'a> {
@@ -700,7 +696,7 @@ impl<'a> Node for NodeRef<'a> {
                 // - Dynamic library function symbols.
                 let ty = syn::parse_quote!(GraphState<'static>);
                 Some(ty)
-            },
+            }
         }
     }
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -78,13 +78,13 @@ type NodeRefGraph<'a> = StableGraph<NodeRef<'a>>;
 /// This type implements the **EvaluatorFnBlock** implementation, enabling
 /// **ProjectNodeRefGraphNode** to implement the **Node** type.
 // TODO: Implement `GraphBase` and `EvaluatorFnBlock`.
-struct ProjectNodeRefGraph<'a> {
-    graph: NodeRefGraph<'a>,
-    package_id: cargo::core::PackageId,
+pub struct ProjectNodeRefGraph<'a> {
+    pub graph: NodeRefGraph<'a>,
+    pub package_id: cargo::core::PackageId,
 }
 
 /// Shorthand for a **GraphNode** wrapped around a **ProjectNodeRefGraph**.
-type ProjectNodeRefGraphNode<'a> = GraphNode<ProjectNodeRefGraph<'a>>;
+pub type ProjectNodeRefGraphNode<'a> = GraphNode<ProjectNodeRefGraph<'a>>;
 
 /// Whether the node is a **Core** node (has no other internal **Node** dependencies) or is a
 /// **Graph** node, composed entirely of other gantz **Node**s.
@@ -106,7 +106,7 @@ pub struct ProjectGraph {
 /// A **Node** type constructed as a reference to a type implementing **Node**.
 ///
 /// A graph of **NodeRef**s are created at the time of codegen in order to.
-enum NodeRef<'a> {
+pub enum NodeRef<'a> {
     Core(&'a dyn Node),
     Graph(ProjectNodeRefGraphNode<'a>),
 }
@@ -417,11 +417,22 @@ impl Project {
     ///
     /// Returns `None` if there are no nodes for the given **NodeId** or if a node exists but it is
     /// not a **Graph** node.
-    pub fn graph_node(&self, id: &NodeId) -> Option<&ProjectGraph> {
+    pub fn graph_node<'a>(&'a self, id: &NodeId) -> Option<&'a ProjectGraph> {
         self.nodes.get(id).and_then(|kind| match kind {
             NodeKind::Graph(ref graph) => Some(graph),
             _ => None,
         })
+    }
+
+    /// Similar to `graph_node`, but returns a graph containing node references rather than IDs.
+    ///
+    /// The returned graph will also contain information about its inlets and outlets.
+    ///
+    /// Returns `None` if there are no nodes for the given **NodeId** or if a node exists but is
+    /// not a **Graph** node.
+    pub fn ref_graph_node<'a>(&'a self, id: &NodeId) -> Option<ProjectNodeRefGraphNode<'a>> {
+        let g = self.graph_node(id)?;
+        Some(id_graph_to_node_graph(g, &self.nodes))
     }
 
     /// Update the graph associated with the graph node at the given **NodeId**.
@@ -534,34 +545,128 @@ impl NodeCollection {
     }
 }
 
+impl NodeIdGraphNode {
+    /// Adds the given `NodeId` to the graph as an inlet node.
+    ///
+    /// This is the same as `G::add_node`, but also adds the resulting node index to the
+    /// `GraphNode`'s `inlets` list.
+    pub fn add_inlet(&mut self, id: NodeId) -> NodeIndex {
+        let idx = self.add_node(id);
+        self.inlets.push(idx);
+        idx
+    }
+
+    /// Adds the given `NodeId` to the graph as an outlet node.
+    ///
+    /// This is the same as `G::add_node`, but also adds the resulting node index to the
+    /// `GraphNode`'s `outlet` list.
+    pub fn add_outlet(&mut self, id: NodeId) -> NodeIndex {
+        let idx = self.add_node(id);
+        self.outlets.push(idx);
+        idx
+    }
+}
+
 impl<'a> GraphBase for ProjectNodeRefGraph<'a> {
     type EdgeId = <NodeRefGraph<'a> as GraphBase>::EdgeId;
     type NodeId = <NodeRefGraph<'a> as GraphBase>::NodeId;
 }
 
 impl<'a> graph::EvaluatorFnBlock for ProjectNodeRefGraph<'a> {
-    fn evaluator_fn_block(&self, fn_decl: &syn::FnDecl) -> syn::Block {
-        let mut stmts = vec![];
+    fn evaluator_fn_block(
+        &self,
+        inlets: &[Self::NodeId],
+        outlets: &[Self::NodeId],
+        fn_decl: &syn::FnDecl,
+    ) -> syn::Block {
+        println!("evaluator_fn_block");
 
-        // TODO: Block should look something like this:
-        //
-        // - Use the inputs to the `fn_decl` to set the state of the `inlet` nodes.
-        // - Call the `push_eval` function from the dynamic library associated with this graph.
-        // - Retrievel the state for each `outlet` node and return them at the end of the block.
-        unimplemented!("TODO: generate a block that evaluates the graph");
+        let push = inlets.iter().cloned();
+        let pull = outlets.iter().cloned();
+        let eval_order = graph::codegen::eval_order(&self.graph, push, pull);
+        let state_order: HashMap<_, _> = graph::codegen::state_order(&self.graph, eval_order)
+            .enumerate()
+            .map(|(ix, n_id)| (n_id, ix))
+            .collect();
 
+        println!("inlets: {:?}", inlets);
+        println!("outlets: {:?}", outlets);
+        println!("state order: {:?}", state_order);
 
-        let brace_token = Default::default();
-        let block = syn::Block { brace_token, stmts };
+        // The order within the state slice for each inlet node.
+        let inlet_state_indices = inlets
+            .iter()
+            .map(|&inlet| state_order[&inlet]);
+        let mut outlet_state_indices = outlets
+            .iter()
+            .map(|&outlet| state_order[&outlet]);
+
+        // Retrieve the inlet values from the fn_decl args.
+        let inlet_values = fn_decl.inputs
+            .iter()
+            .map(|arg| match arg {
+                syn::FnArg::Captured(ref arg) => match arg.pat {
+                    syn::Pat::Ident(ref pat) => pat.ident.clone(),
+                    _ => unreachable!("graph eval fn_decl contained non-`Ident` arg pattern"),
+                },
+                _ => unreachable!("graph eval fn_decl should only use captured `FnArg`s"),
+            });
+
+        // - `()` for no outlets.
+        // - `#outlet` for single outlet.
+        // - `(#(#outlet),*)` for multiple outlets.
+        let return_outlets: syn::Expr = match outlets.len() {
+            0 => {
+                syn::parse_quote! { () }
+            }
+            1 => {
+                let outlet_ix = outlet_state_indices.next().expect("expected 1 index, found none");
+                syn::parse_quote! { state.node_states[#outlet_ix] }
+            }
+            _ => {
+                syn::parse_quote! {
+                    (#(state.node_states[#outlet_state_indices]),*)
+                }
+            }
+        };
+
+        let block = syn::parse_quote! {{
+            // Assign inlet values.
+            #(
+                state.node_states[#inlet_state_indices] = #inlet_values;
+            )*
+
+            // Evaluate the full graph.
+            type FullGraphEvalFn<'a> = libloading::Symbol<'a, fn(&mut [&mut dyn std::any::Any])>;
+            let eval_fn = state.full_graph_eval_fn_symbol
+                .downcast_ref::<FullGraphEvalFn>()
+                .expect("`full_graph_eval_fn_symbol` did not match the expected type");
+            eval_fn(&mut state.node_states[..]);
+
+            // Retrieve the outlet values.
+            #return_outlets
+        }};
+
         block
     }
 }
 
 impl<'a> graph::Graph for ProjectNodeRefGraph<'a> {
     type Node = NodeRef<'a>;
+
     fn node(&self, id: Self::NodeId) -> Option<&Self::Node> {
         self.graph.node_weight(id)
     }
+}
+
+/// The `State` type expected by the `Project` graph type.
+pub struct GraphState<'a> {
+    /// The list of states necessary for the graph's child stateful nodes.
+    pub node_states: &'a mut [&'a mut dyn std::any::Any],
+    /// A reference to the function symbol for running the full graph.
+    ///
+    /// E.g. `&'a libloading::Symbol<'static, fn(X, Y) -> Z>`
+    pub full_graph_eval_fn_symbol: &'a dyn::std::any::Any,
 }
 
 impl<'a> Node for NodeRef<'a> {
@@ -589,7 +694,13 @@ impl<'a> Node for NodeRef<'a> {
     fn state_type(&self) -> Option<syn::Type> {
         match self {
             NodeRef::Core(node) => node.state_type(),
-            NodeRef::Graph(graph) => graph.state_type(),
+            NodeRef::Graph(_graph) => {
+                // TODO: State type must include:
+                // - Node states.
+                // - Dynamic library function symbols.
+                let ty = syn::parse_quote!(GraphState<'static>);
+                Some(ty)
+            },
         }
     }
 }
@@ -611,6 +722,13 @@ impl ops::Deref for NodeCollection {
     type Target = NodeTree;
     fn deref(&self) -> &Self::Target {
         &self.map
+    }
+}
+
+impl<'a> ops::Deref for ProjectNodeRefGraph<'a> {
+    type Target = NodeRefGraph<'a>;
+    fn deref(&self) -> &Self::Target {
+        &self.graph
     }
 }
 
@@ -895,7 +1013,7 @@ where
 }
 
 // Compile all crates within the workspace.
-fn workspace_compile<P>(
+fn _workspace_compile<P>(
     workspace_dir: P,
     cargo_config: &cargo::Config,
 ) -> Result<
@@ -940,7 +1058,7 @@ where
     let pkg_ws = cargo::core::Workspace::new(&pkg_manifest_path, &cargo_config)?;
     let mode = cargo::core::compiler::CompileMode::Build;
     let mut options = cargo::ops::CompileOptions::new(&cargo_config, mode)?;
-    options.build_config.message_format = cargo::core::compiler::MessageFormat::Json;
+    options.build_config.message_format = cargo::core::compiler::MessageFormat::Human;
     options.build_config.release = true;
     let compilation = cargo::ops::compile(&pkg_ws, &options)?;
     Ok(compilation)

--- a/tests/counter.rs
+++ b/tests/counter.rs
@@ -3,10 +3,15 @@
 use gantz::node::{self, SerdeNode, WithPushEval, WithStateType};
 use gantz::Edge;
 
-fn node_push() -> node::Push<node::Expr> {
-    node::expr("()").unwrap().with_push_eval_name("push")
+fn node_push(push_eval_name: &str) -> node::Push<node::Expr> {
+    node::expr("()")
+        .unwrap()
+        .with_push_eval_name(push_eval_name)
 }
 
+// A simple counter node.
+//
+// Increases its `u32` state by `1` each time it receives an input of any type.
 fn node_counter() -> node::State<node::Expr> {
     node::expr(r#"{ #push; let count = *state; *state += 1; count }"#)
         .unwrap()
@@ -14,13 +19,25 @@ fn node_counter() -> node::State<node::Expr> {
         .unwrap()
 }
 
+// A simple as possible test graph for testing state.
+//
+//    --------
+//    | push | // push_eval
+//    -+------
+//     |
+//    -+---------
+//    | counter |
+//    -+---------
+//
+// The push evaluation enabled `push` node is called three times once loaded.
 #[test]
 fn test_graph_with_counter() {
     // Create a temp project.
     let mut project = gantz::TempProject::open_with_name("test_graph_with_counter").unwrap();
 
     // Instantiate the nodes.
-    let push = node_push();
+    let symbol_name = "push";
+    let push = node_push(symbol_name);
     let counter = node_counter();
 
     // Add the nodes to the project.
@@ -48,10 +65,10 @@ fn test_graph_with_counter() {
 
     // Load the library.
     let lib = libloading::Library::new(&dylib_path).expect("failed to load library");
-    let symbol_name = "push".as_bytes();
     unsafe {
-        let push_eval_fn: libloading::Symbol<fn(&mut [&mut dyn std::any::Any])> =
-            lib.get(symbol_name).expect("failed to load symbol");
+        let push_eval_fn: libloading::Symbol<fn(&mut [&mut dyn std::any::Any])> = lib
+            .get(symbol_name.as_bytes())
+            .expect("failed to load symbol");
         // Prepare the `node_states` and execute the graph.
         let mut node_states = [&mut count as &mut dyn std::any::Any];
         push_eval_fn(&mut node_states[..]);
@@ -61,4 +78,134 @@ fn test_graph_with_counter() {
 
     // Check the counter was incremented 3 times.
     assert_eq!(count, 3);
+}
+
+// A slightly more complex test of state.
+//
+//    --------    --------    --------
+//    | push |    | push |    | push |
+//    -+------    -+------    -+------
+//     |           |           |
+//    -+---------  |           |
+//    | counter |  |           |
+//    -+---------  |           |
+//     |           |           |
+//     -------------           |
+//                 |           |
+//                -+---------  |
+//                | counter |  |
+//                -+---------  |
+//                 |           |
+//                 -------------
+//                             |
+//                            -+---------
+//                            | counter |
+//                            -+---------
+//
+// Calls each of the `push` evaluation functions once from left to right.
+#[test]
+fn test_graph_with_counters() {
+    // Create a temp project.
+    let mut project = gantz::TempProject::open_with_name("test_graph_with_counters").unwrap();
+
+    // Instantiate the nodes.
+    let push_a_name = "push_a";
+    let push_b_name = "push_b";
+    let push_c_name = "push_c";
+    let push_a = node_push(push_a_name);
+    let push_b = node_push(push_b_name);
+    let push_c = node_push(push_c_name);
+    let counter = node_counter();
+
+    // Add the nodes to the project.
+    let push_a = project.add_core_node(Box::new(push_a) as Box<dyn SerdeNode>);
+    let push_b = project.add_core_node(Box::new(push_b) as Box<dyn SerdeNode>);
+    let push_c = project.add_core_node(Box::new(push_c) as Box<dyn SerdeNode>);
+    let counter = project.add_core_node(Box::new(counter) as Box<_>);
+
+    // Compose the graph.
+    let root = project.root_node_id();
+    let mut push_ids = vec![];
+    let mut counter_ids = vec![];
+    project
+        .update_graph(&root, |g| {
+            let p_a = g.add_node(push_a);
+            let p_b = g.add_node(push_b);
+            let p_c = g.add_node(push_c);
+            let c_a = g.add_node(counter);
+            let c_b = g.add_node(counter);
+            let c_c = g.add_node(counter);
+            g.add_edge(p_a, c_a, Edge::from((0, 0)));
+            g.add_edge(c_a, c_b, Edge::from((0, 0)));
+            g.add_edge(p_b, c_b, Edge::from((0, 0)));
+            g.add_edge(c_b, c_c, Edge::from((0, 0)));
+            g.add_edge(p_c, c_c, Edge::from((0, 0)));
+            push_ids = vec![p_a, p_b, p_c];
+            counter_ids = vec![c_a, c_b, c_c];
+        })
+        .unwrap();
+
+    // Check the expected stateful node order.
+    {
+        let g = project
+            .ref_graph_node(&root)
+            .expect("no graph for project root node");
+
+        let (p_a, p_b, p_c) = (push_ids[0], push_ids[1], push_ids[2]);
+        let (c_a, c_b, c_c) = (counter_ids[0], counter_ids[1], counter_ids[2]);
+
+        let eval_order = gantz::graph::codegen::eval_order(&**g, push_ids, vec![]);
+        let state_order = gantz::graph::codegen::state_order(&**g, eval_order).collect::<Vec<_>>();
+        assert_eq!(state_order, counter_ids);
+
+        // Check `a` evaluation and state ordering.
+        let a_eval_order = gantz::graph::codegen::push_eval_order(&**g, p_a).collect::<Vec<_>>();
+        assert_eq!(a_eval_order, vec![p_a, c_a, c_b, c_c]);
+        let a_state_order =
+            gantz::graph::codegen::state_order(&**g, a_eval_order).collect::<Vec<_>>();
+        assert_eq!(a_state_order, vec![c_a, c_b, c_c]);
+
+        // Check `b` evaluation and state ordering.
+        let b_eval_order = gantz::graph::codegen::push_eval_order(&**g, p_b).collect::<Vec<_>>();
+        assert_eq!(b_eval_order, vec![p_b, c_b, c_c]);
+        let b_state_order =
+            gantz::graph::codegen::state_order(&**g, b_eval_order).collect::<Vec<_>>();
+        assert_eq!(b_state_order, vec![c_b, c_c]);
+
+        // Check `c` evaluation and state ordering.
+        let c_eval_order = gantz::graph::codegen::push_eval_order(&**g, p_c).collect::<Vec<_>>();
+        assert_eq!(c_eval_order, vec![p_c, c_c]);
+        let c_state_order =
+            gantz::graph::codegen::state_order(&**g, c_eval_order).collect::<Vec<_>>();
+        assert_eq!(c_state_order, vec![c_c]);
+    }
+
+    // Initialise the counter states.
+    let mut a = 0u32;
+    let mut b = 0u32;
+    let mut c = 0u32;
+
+    // Retrieve the path to the compiled library.
+    let dylib_path = project
+        .graph_node_dylib(&root)
+        .unwrap()
+        .expect("no dylib or node");
+
+    // Load the library.
+    let lib = libloading::Library::new(&dylib_path).expect("failed to load library");
+    unsafe {
+        type PushEvalFn = fn(&mut [&mut dyn std::any::Any]);
+        type PushEvalFnSymbol<'a> = libloading::Symbol<'a, PushEvalFn>;
+        let push_a_fn: PushEvalFnSymbol = lib.get(push_a_name.as_bytes()).unwrap();
+        let push_b_fn: PushEvalFnSymbol = lib.get(push_b_name.as_bytes()).unwrap();
+        let push_c_fn: PushEvalFnSymbol = lib.get(push_c_name.as_bytes()).unwrap();
+
+        // Ensure the order of node states matches the expected state order for each eval function.
+        push_a_fn(&mut [&mut a as _, &mut b as _, &mut c as _]);
+        push_b_fn(&mut [&mut b as _, &mut c as _]);
+        push_c_fn(&mut [&mut c as _]);
+    }
+
+    // Check the counter was incremented 3 times.
+    assert_eq!([a, b, c], [1, 2, 3]);
 }

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -1,0 +1,140 @@
+use gantz::node::{self, SerdeNode, WithPushEval};
+use gantz::Edge;
+
+fn node_push() -> node::Push<node::Expr> {
+    node::expr("()").unwrap().with_push_eval_name("push")
+}
+
+fn node_int(i: i32) -> node::Expr {
+    node::expr(&format!("{{ #push; {} }}", i)).unwrap()
+}
+
+fn node_mul() -> node::Expr {
+    node::expr("#l * #r").unwrap()
+}
+
+fn node_assert_eq() -> node::Expr {
+    node::expr("assert_eq!(#l, #r)").unwrap()
+}
+
+// A simple test for nested graph support.
+//
+// This is the core method of abstraction provided by gantz, so it better work!
+//
+// GRAPH A
+//
+//    --------- ---------
+//    | Inlet | | Inlet |
+//    -+------- -+-------
+//     |         |
+//     |   -------
+//     |   |
+//    -+---+-
+//    | Mul |
+//    -+-----
+//     |
+//    -+--------
+//    | Outlet |
+//    ----------
+//
+// GRAPH B
+//
+//    --------
+//    | push | // push_eval
+//    -+------
+//     |
+//     |------------
+//     |           |
+//     |------     |
+//     |     |     |
+//    -+--- -+---  |
+//    | 6 | | 7 |  |
+//    -+--- -+---  |
+//     |     |     |
+//     |     ---   |
+//     |       |   |
+//    -+-------+- -+----
+//    | GRAPH A | | 42 |
+//    -+--------- -+----
+//     |           |
+//     |         ---
+//     |         |
+//    -+---------+-
+//    | assert_eq |
+//    -------------
+#[test]
+fn test_graph_nested_stateless() {
+    // Create a temp project.
+    let mut project = gantz::TempProject::open_with_name("test_graph_nested_stateless").unwrap();
+
+    // Instantiate the nodes.
+    let push = node_push();
+    let six = node_int(6);
+    let seven = node_int(7);
+    let forty_two = node_int(42);
+    let mul = node_mul();
+    let assert_eq = node_assert_eq();
+    let inlet = gantz::graph::Inlet::parse("i32").unwrap();
+    let outlet = gantz::graph::Outlet::parse("i32").unwrap();
+
+    // Add the nodes to the project.
+    let push = project.add_core_node(Box::new(push) as Box<dyn SerdeNode>);
+    let six = project.add_core_node(Box::new(six) as Box<_>);
+    let seven = project.add_core_node(Box::new(seven) as Box<_>);
+    let forty_two = project.add_core_node(Box::new(forty_two) as Box<_>);
+    let mul = project.add_core_node(Box::new(mul) as Box<_>);
+    let assert_eq = project.add_core_node(Box::new(assert_eq) as Box<_>);
+    let inlet = project.add_core_node(Box::new(inlet) as _);
+    let outlet = project.add_core_node(Box::new(outlet) as _);
+    // We'll use the project root graph as GRAPH B, but we still need to add a node for GRAPH A.
+    let graph_a = project
+        .add_graph_node(Default::default(), "graph_a")
+        .unwrap();
+
+    // Compose the inner GRAPH A first.
+    project
+        .update_graph(&graph_a, |g| {
+            let inlet_a = g.add_inlet(inlet);
+            let inlet_b = g.add_inlet(inlet);
+            let mul = g.add_node(mul);
+            let outlet = g.add_outlet(outlet);
+            g.add_edge(inlet_a, mul, Edge::from((0, 0)));
+            g.add_edge(inlet_b, mul, Edge::from((0, 1)));
+            g.add_edge(mul, outlet, Edge::from((0, 0)));
+        })
+        .unwrap();
+
+    // Now compose the project root graph.
+    let root = project.root_node_id();
+    project
+        .update_graph(&root, |g| {
+            let push = g.add_node(push);
+            let six = g.add_node(six);
+            let seven = g.add_node(seven);
+            let graph_a = g.add_node(graph_a);
+            let forty_two = g.add_node(forty_two);
+            let assert_eq = g.add_node(assert_eq);
+            g.add_edge(push, six, Edge::from((0, 0)));
+            g.add_edge(push, seven, Edge::from((0, 0)));
+            g.add_edge(push, forty_two, Edge::from((0, 0)));
+            g.add_edge(six, graph_a, Edge::from((0, 0)));
+            g.add_edge(seven, graph_a, Edge::from((0, 1)));
+            g.add_edge(graph_a, assert_eq, Edge::from((0, 0)));
+            g.add_edge(forty_two, assert_eq, Edge::from((0, 1)));
+        })
+        .unwrap();
+
+    // Retrieve the path to the compiled library.
+    let root_dylib_path = project
+        .graph_node_dylib(&root)
+        .unwrap()
+        .expect("no dylib or node");
+    let lib = libloading::Library::new(&root_dylib_path).expect("failed to load root library");
+    let symbol_name = "push".as_bytes();
+    unsafe {
+        let push_eval_fn: libloading::Symbol<fn(&mut [&mut dyn std::any::Any])> =
+            lib.get(symbol_name).expect("failed to load symbol");
+        // Execute the gantz graph.
+        push_eval_fn(&mut []);
+    }
+}


### PR DESCRIPTION
This refactors the graph modules in order to more easily allow for
nesting custom graph types recursively within their node types.

Also refactors graph codegen to more easily allow for code generation of
multiple push/pull evaluation sources at once.

**TODO**

- [x] The next step I'm considering is to generate a function for every
graph that has one or more inlets or outlets, where the evaluation steps
are determined by pushing from all inlets and pulling from all outlets
at once. While this might not be the most practical approach in the long
run once conditional evaluation gets involved, it will at least help to
close the loop for the implementation of Node for Graph.
- [x] Specify a graph node's state type as an inner nested slice of
state somehow. We need this in order to set the inlet values before
evaluating the graph and in order to retrieve state from the outlets.