### PR TITLE
Update the nested test as a proof of concept

### DIFF
--- a/gantz_core/src/node/expr.rs
+++ b/gantz_core/src/node/expr.rs
@@ -54,7 +54,7 @@ impl Expr {
     ///
     /// ```rust
     /// fn main() {
-    ///     let _node = gantz::node::Expr::new("#foo + #bar").unwrap();
+    ///     let _node = gantz_core::node::Expr::new("#foo + #bar").unwrap();
     /// }
     /// ```
     pub fn new(expr: &str) -> Result<Self, NewExprError> {


### PR DESCRIPTION
This is a quick hack to get the nested graph working as a proof of
concept. The test successfully calls the root graph which in turn calls
into the inner nested graph to produce the correct result for the
following assertion. #44 should be addressed next.

Closes #20.