### PR TITLE
Remove `failure`, `derive_more` in favour of `thiserror`. Update `syn`, `cargo`, `quote`, `petgraph`, `proc-macro2`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
-/examples/foo
+/gantz/examples/foo

--- a/gantz/Cargo.toml
+++ b/gantz/Cargo.toml
@@ -11,17 +11,17 @@ homepage = "https://github.com/nannou-org/gantz"
 edition = "2018"
 
 [dependencies]
-cargo = "0.34"
-derive_more = "0.14"
-failure = "0.1"
+anyhow = "1"
+cargo = "0.44"
 gantz_core = { path = "../gantz_core", version = "0.1" }
 libloading = "0.5"
-petgraph = { version = "0.4", features = ["serde-1"] }
-proc-macro2 = "0.4"
-quote = "0.6"
+petgraph = { version = "0.5", features = ["serde-1"] }
+proc-macro2 = "1"
+quote = "1"
 serde = "1"
 serde_json = "1"
 slug = "0.1"
-syn = "0.15"
+syn = "1"
+thiserror = "1"
 toml = "0.5"
 typetag = "0.1"

--- a/gantz/src/lib.rs
+++ b/gantz/src/lib.rs
@@ -21,10 +21,6 @@
 //!
 //! ## Current Questions
 
-use derive_more::From;
-use failure::Fail;
-use serde::{self, Deserialize, Serialize};
-
 pub mod project;
 
 pub use gantz_core::{self as core, graph, node, Edge, Node};

--- a/gantz_core/Cargo.toml
+++ b/gantz_core/Cargo.toml
@@ -11,11 +11,10 @@ homepage = "https://github.com/nannou-org/gantz"
 edition = "2018"
 
 [dependencies]
-derive_more = "0.14"
-failure = "0.1"
-petgraph = { version = "0.4", features = ["serde-1"] }
-proc-macro2 = "0.4"
-quote = "0.6"
+petgraph = { version = "0.5", features = ["serde-1"] }
+proc-macro2 = "1"
+quote = "1"
 serde = "1"
-syn = "0.15"
+syn = { version = "1", features = ["extra-traits"] }
+thiserror = "1"
 typetag = "0.1"

--- a/gantz_core/src/node/expr.rs
+++ b/gantz_core/src/node/expr.rs
@@ -1,11 +1,10 @@
 use super::{Deserialize, Serialize};
 use crate::node::{self, Node};
-use derive_more::From;
-use failure::Fail;
 use proc_macro2::{TokenStream, TokenTree};
 use quote::{ToTokens, TokenStreamExt};
 use std::fmt;
 use std::str::FromStr;
+use thiserror::Error;
 
 /// A simple node that allows for representing rust expressions as nodes within a gantz graph.
 ///
@@ -35,13 +34,13 @@ pub struct Expr {
 }
 
 /// An error occurred while constructing the `Expr` node.
-#[derive(Debug, Fail, From)]
+#[derive(Debug, Error)]
 pub enum NewExprError {
-    #[fail(display = "failed to parse the `str` as a valid `TokenStream`")]
+    #[error("failed to parse the `str` as a valid `TokenStream`")]
     InvalidTokenStream,
-    #[fail(display = "failed to parse the `str` as a valid expr: {}", err)]
+    #[error("failed to parse the `str` as a valid expr: {err}")]
     InvalidExpr {
-        #[fail(cause)]
+        #[from]
         err: syn::Error,
     },
 }

--- a/gantz_core/src/node/serde.rs
+++ b/gantz_core/src/node/serde.rs
@@ -35,10 +35,10 @@ impl SerdeNode for node::State<node::Expr> {
     }
 }
 
-pub mod fn_decl {
+pub mod signature {
     use serde::{Deserializer, Serializer};
 
-    pub fn serialize<S>(t: &syn::FnDecl, s: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(t: &syn::Signature, s: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -47,12 +47,7 @@ pub mod fn_decl {
             vis: syn::Visibility::Public(syn::VisPublic {
                 pub_token: Default::default(),
             }),
-            constness: None,
-            unsafety: None,
-            asyncness: None,
-            abi: None,
-            ident: syn::Ident::new("foo", proc_macro2::Span::call_site()),
-            decl: Box::new(t.clone()),
+            sig: t.clone(),
             block: Box::new(syn::Block {
                 stmts: vec![],
                 brace_token: <_>::default(),
@@ -61,13 +56,13 @@ pub mod fn_decl {
         super::tts::serialize(&item_fn, s)
     }
 
-    pub fn deserialize<'de, D>(d: D) -> Result<syn::FnDecl, D::Error>
+    pub fn deserialize<'de, D>(d: D) -> Result<syn::Signature, D::Error>
     where
         D: Deserializer<'de>,
     {
         let tts = super::tts::deserialize(d)?;
-        let syn::ItemFn { decl, .. } = syn::parse_quote! { #tts };
-        Ok(*decl)
+        let syn::ItemFn { sig, .. } = syn::parse_quote! { #tts };
+        Ok(sig)
     }
 }
 
@@ -78,18 +73,13 @@ pub mod fn_attrs {
     where
         S: Serializer,
     {
-        let syn::ItemFn { decl, .. } = syn::parse_quote! { fn foo() {} };
+        let syn::ItemFn { sig, .. } = syn::parse_quote! { fn foo() {} };
         let item_fn = syn::ItemFn {
             attrs: t.clone(),
             vis: syn::Visibility::Public(syn::VisPublic {
                 pub_token: Default::default(),
             }),
-            constness: None,
-            unsafety: None,
-            asyncness: None,
-            abi: None,
-            ident: syn::Ident::new("foo", proc_macro2::Span::call_site()),
-            decl: decl,
+            sig,
             block: Box::new(syn::Block {
                 stmts: vec![],
                 brace_token: <_>::default(),

--- a/gantz_derive/README.md
+++ b/gantz_derive/README.md
@@ -1,5 +1,7 @@
 # gantz-derive [![Crates.io](https://img.shields.io/crates/v/gantz-derive.svg)](https://crates.io/crates/gantz-derive) [![Crates.io](https://img.shields.io/crates/l/gantz-derive.svg)](https://github.com/nannou-org/gantz/blob/master/LICENSE-MIT) [![docs.rs](https://docs.rs/gantz-derive/badge.svg)](https://docs.rs/gantz-derive/)
 
+# NOTE: This crate was an old approach that no longer seems to be the best way forward. It may be repurposed for the new direction in the future.
+
 A suite of procedural macros for the gantz crate.
 
 Currently includes:


### PR DESCRIPTION
Also:

- Simplifies `#[no_mangle]` attr creation.
- Adds `#![allow(unused_braces)]` to generated file.
- Adds a deprecation notice to `gantz_derive` README as it is a remnant
  of an older design of gantz.

Closes #47
Closes #48