### PR TITLE
feat: Add a control `Flow` graph

### DIFF
--- a/crates/gantz_core/src/compile.rs
+++ b/crates/gantz_core/src/compile.rs
@@ -10,6 +10,8 @@ pub(crate) use codegen::eval_stmts;
 #[doc(inline)]
 pub use codegen::{pull_eval_fn_name, push_eval_fn_name};
 #[doc(inline)]
+pub use flow::Flow;
+#[doc(inline)]
 pub use meta::{EdgeKind, Meta};
 use petgraph::visit::{
     Data, Dfs, EdgeRef, GraphBase, GraphRef, IntoEdgesDirected, IntoNeighbors, IntoNodeReferences,
@@ -456,7 +458,12 @@ where
     // Create a `Meta` for each graph (including nested) in a tree.
     let mut meta_tree = RoseTree::<Meta>::default();
     crate::graph::visit(g, &[], &mut meta_tree);
+    dbg!(&meta_tree);
     let eval_tree = meta_tree.map_ref(&mut eval_plan);
+
+    // Derive control flow graphs from the meta graphs.
+    let flow_tree = meta_tree.map_ref(&mut Flow::from_meta);
+    dbg!(&flow_tree);
 
     // Collect node fns.
     let node_confs_tree = codegen::node_confs_tree(&eval_tree);

--- a/crates/gantz_core/src/compile.rs
+++ b/crates/gantz_core/src/compile.rs
@@ -23,6 +23,7 @@ use std::{
 use steel::parser::ast::ExprKind;
 
 mod codegen;
+mod flow;
 mod meta;
 mod rosetree;
 

--- a/crates/gantz_core/src/compile.rs
+++ b/crates/gantz_core/src/compile.rs
@@ -47,13 +47,6 @@ struct EvalPlan<'a> {
     /// The gantz graph `Meta` from which this `EvalPlan` was produced.
     meta: &'a Meta,
 
-    /// Order of evaluation from all inlets to all outlets.
-    ///
-    /// Empty in the case that the graph has no inlets or outlets (i.e. is not
-    /// nested).
-    // TODO: Knowing the connectedness of the inlets/outlets would be useful
-    // for generating only the necessary node configs.
-    nested_steps: Vec<EvalStep>,
     /// The order of node evaluation for each push_eval node.
     push_steps: BTreeMap<node::Id, Vec<EvalStep>>,
     /// The order of node evaluation for each pull_eval node.
@@ -420,25 +413,10 @@ fn eval_plan(meta: &Meta) -> EvalPlan {
         })
         .collect();
 
-    let nested_steps = {
-        let order = eval_order(
-            &meta.graph,
-            // FIXME: shouldn't hardcode these `Conns` counts...
-            meta.inlets
-                .iter()
-                .map(|&n| (n, node::Conns::connected(1).unwrap())),
-            meta.outlets
-                .iter()
-                .map(|&n| (n, node::Conns::connected(1).unwrap())),
-        );
-        eval_steps(meta, order).collect()
-    };
-
     EvalPlan {
         meta,
         push_steps,
         pull_steps,
-        nested_steps,
     }
 }
 

--- a/crates/gantz_core/src/compile.rs
+++ b/crates/gantz_core/src/compile.rs
@@ -6,11 +6,10 @@ use crate::{
     node::{self, Node},
 };
 // FIXME: Make these private, expose easier way to call entry points.
-pub(crate) use codegen::eval_stmts;
 #[doc(inline)]
-pub use codegen::{pull_eval_fn_name, push_eval_fn_name};
+pub use codegen::{eval_fn_body, pull_eval_fn_name, push_eval_fn_name};
 #[doc(inline)]
-pub use flow::{Flow, NodeConf, NodeConns};
+pub use flow::{Block, Flow, FlowGraph, NodeConf, NodeConns, flow_graph};
 #[doc(inline)]
 pub use meta::{EdgeKind, Meta, MetaGraph};
 use petgraph::visit::{
@@ -18,10 +17,7 @@ use petgraph::visit::{
     NodeIndexable, Topo, Visitable, Walker,
 };
 pub(crate) use rosetree::RoseTree;
-use std::{
-    collections::{BTreeMap, HashSet},
-    hash::Hash,
-};
+use std::{collections::HashSet, hash::Hash};
 use steel::parser::ast::ExprKind;
 
 mod codegen;
@@ -37,45 +33,6 @@ mod rosetree;
 pub trait Edges {
     /// Produce an iterator yielding all the [`Edge`]s.
     fn edges(&self) -> impl Iterator<Item = Edge>;
-}
-
-/// A representation of how to evaluate a graph.
-///
-/// Produced via [`eval_plan`].
-#[derive(Debug)]
-struct EvalPlan<'a> {
-    /// The gantz graph `Meta` from which this `EvalPlan` was produced.
-    meta: &'a Meta,
-
-    /// The order of node evaluation for each push_eval node.
-    push_steps: BTreeMap<node::Id, Vec<EvalStep>>,
-    /// The order of node evaluation for each pull_eval node.
-    pull_steps: BTreeMap<node::Id, Vec<EvalStep>>,
-}
-
-/// An evaluation step ready for translation to code.
-///
-/// Represents evaluation of a node with some set of the inputs connected.
-#[derive(Debug)]
-pub(crate) struct EvalStep {
-    /// The node to be evaluated.
-    pub(crate) node: node::Id,
-    /// Arguments to the node's function call.
-    ///
-    /// The `len` of the outer vec will always be equal to the number of inputs
-    /// on `node`.
-    pub(crate) inputs: Vec<Option<ExprInput>>,
-    /// The set of connected outputs.
-    pub(crate) outputs: Vec<bool>,
-}
-
-/// An argument to a node's function call.
-#[derive(Debug)]
-pub(crate) struct ExprInput {
-    /// The node from which the value was generated.
-    pub(crate) node: node::Id,
-    /// The output on the source node associated with the generated value.
-    pub(crate) output: node::Output,
 }
 
 impl Edges for Edge {
@@ -267,48 +224,6 @@ where
     reachable(rev_g, n, nbs)
 }
 
-/// Push evaluation from the specified node.
-///
-/// Evaluation order is equivalent to a topological ordering of the connected
-/// component starting from the given node.
-///
-/// Expects any directed graph whose edges are of type `Edge` and whose nodes
-/// implement `Node`. Direction of edges indicate the flow of data through the
-/// graph.
-fn push_eval_order<G>(
-    g: G,
-    n: G::NodeId,
-    nbs: &HashSet<G::NodeId>,
-) -> impl Iterator<Item = G::NodeId>
-where
-    G: IntoEdgesDirected + IntoNodeReferences + Visitable,
-    G::NodeId: Eq + Hash,
-{
-    let dfs: HashSet<G::NodeId> = push_reachable(g, n, nbs).collect();
-    Topo::new(g).iter(g).filter(move |node| dfs.contains(&node))
-}
-
-/// Pull evaluation from the specified node.
-///
-/// Evaluation order is equivalent to a topological ordering of the connected
-/// component that ends at the given node.
-///
-/// Expects any directed graph whose edges are of type `Edge` and whose nodes
-/// implement `Node`. Direction of edges indicate the flow of data through the
-/// graph.
-fn pull_eval_order<G>(
-    g: G,
-    n: G::NodeId,
-    nbs: &HashSet<G::NodeId>,
-) -> impl Iterator<Item = G::NodeId>
-where
-    G: IntoEdgesDirected + IntoNodeReferences + Visitable,
-    G::NodeId: Eq + Hash,
-{
-    let dfs: HashSet<G::NodeId> = pull_reachable(g, n, nbs).collect();
-    Topo::new(g).iter(g).filter(move |node| dfs.contains(&node))
-}
-
 /// The evaluation order given any number of simultaneously pushing and pulling
 /// nodes.
 ///
@@ -339,87 +254,6 @@ where
     Topo::new(g).iter(g).filter(move |n| reachable.contains(&n))
 }
 
-/// Given a node evaluation order, produce the series of evaluation steps
-/// required.
-pub(crate) fn eval_steps<I>(meta: &Meta, eval_order: I) -> impl Iterator<Item = EvalStep>
-where
-    I: IntoIterator<Item = node::Id>,
-{
-    // Step through each of the nodes.
-    let mut visited = HashSet::new();
-    eval_order.into_iter().map(move |n| {
-        visited.insert(n);
-
-        // Collect the inputs, initialising the set to `None`.
-        let n_inputs = meta.inputs.get(&n).copied().unwrap_or(0);
-        let mut inputs: Vec<_> = (0..n_inputs).map(|_| None).collect();
-        for e_ref in meta.graph.edges_directed(n, petgraph::Incoming) {
-            // Only consider edges to nodes that we have already visited.
-            if !visited.contains(&e_ref.source()) {
-                continue;
-            }
-            for (edge, _kind) in e_ref.weight() {
-                // Assign the expression argument for this input.
-                let arg = ExprInput {
-                    node: e_ref.source(),
-                    output: edge.output,
-                };
-                inputs[edge.input.0 as usize] = Some(arg);
-            }
-        }
-
-        // Collect the set of connected outputs.
-        let n_outputs = meta.outputs.get(&n).copied().unwrap_or(0);
-        let mut outputs: Vec<_> = (0..n_outputs).map(|_| false).collect();
-        for e_ref in meta.graph.edges_directed(n, petgraph::Outgoing) {
-            for (edge, _kind) in e_ref.weight() {
-                outputs[edge.output.0 as usize] |= true;
-            }
-        }
-
-        EvalStep {
-            node: n,
-            inputs,
-            outputs,
-        }
-    })
-}
-
-/// Create the evaluation plan for the graph associated with the given meta.
-fn eval_plan(meta: &Meta) -> EvalPlan {
-    let pull_steps = meta
-        .pull
-        .iter()
-        .flat_map(|(&n, confs)| {
-            confs.iter().map(move |conns| {
-                let nbs = pull_eval_neighbors(&meta.graph, n, conns);
-                let order = pull_eval_order(&meta.graph, n, &nbs);
-                let steps = eval_steps(meta, order).collect();
-                (n, steps)
-            })
-        })
-        .collect();
-
-    let push_steps = meta
-        .push
-        .iter()
-        .flat_map(|(&n, confs)| {
-            confs.iter().map(move |conns| {
-                let nbs = push_eval_neighbors(&meta.graph, n, conns);
-                let order = push_eval_order(&meta.graph, n, &nbs);
-                let steps = eval_steps(meta, order).collect();
-                (n, steps)
-            })
-        })
-        .collect();
-
-    EvalPlan {
-        meta,
-        push_steps,
-        pull_steps,
-    }
-}
-
 /// Given a root gantz graph, generate the full module with all the necessary
 /// functions for executing it.
 ///
@@ -438,15 +272,13 @@ where
     crate::graph::visit(g, &[], &mut meta_tree);
 
     // Derive control flow graphs from the meta graphs.
-    let flow_tree = meta_tree.map_ref(&mut Flow::from_meta);
+    let flow_tree = meta_tree.map_ref(&mut |meta| (meta, Flow::from_meta(meta)));
 
     // Collect node fns.
-    let node_confs_tree = flow_tree.map_ref(&mut codegen::unique_node_confs);
+    let node_confs_tree = flow_tree.map_ref(&mut |(_, flow)| codegen::unique_node_confs(flow));
     let node_fns = codegen::node_fns(g, &node_confs_tree);
 
     // Collect eval fns.
-    let eval_tree = meta_tree.map_ref(&mut eval_plan);
-    let eval_fns = codegen::eval_fns(&eval_tree);
-
+    let eval_fns = codegen::eval_fns(&flow_tree);
     node_fns.into_iter().chain(eval_fns).collect()
 }

--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -5,7 +5,7 @@ use crate::{
     compile::{EvalPlan, EvalStep, RoseTree},
     node,
 };
-pub(crate) use node_fn::{node_confs_tree, node_fns};
+pub(crate) use node_fn::{node_fns, unique_node_confs};
 use std::collections::{BTreeSet, HashMap};
 use steel::{parser::ast::ExprKind, steel_vm::engine::Engine};
 

--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -2,11 +2,15 @@
 
 use crate::{
     GRAPH_STATE, ROOT_STATE,
-    compile::{EvalPlan, EvalStep, RoseTree},
+    compile::{Block, Flow, FlowGraph, Meta, MetaGraph, RoseTree},
     node,
 };
 pub(crate) use node_fn::{node_fns, unique_node_confs};
-use std::collections::{BTreeSet, HashMap};
+use petgraph::{
+    graph::NodeIndex,
+    visit::{EdgeRef, IntoNodeReferences, NodeRef},
+};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use steel::{parser::ast::ExprKind, steel_vm::engine::Engine};
 
 mod node_fn;
@@ -150,50 +154,6 @@ fn eval_stmt(
     (stmt, output_vars)
 }
 
-/// Generate a sequence of evaluation statements for an eval function, one
-/// statement for each given evaluation step.
-///
-/// The given `path`, `outputs` and `stateful` are associated with the graph
-/// in which the eval fn is invoked.
-pub(crate) fn eval_stmts(
-    path: &[node::Id],
-    steps: &[EvalStep],
-    stateful: &BTreeSet<node::Id>,
-) -> Vec<ExprKind> {
-    // Track output variables
-    let mut output_vars: HashMap<(node::Id, node::Output), String> = HashMap::new();
-    let mut stmts = Vec::new();
-    for step in steps {
-        // Prepare input expressions for this node
-        let inputs: Vec<_> = step
-            .inputs
-            .iter()
-            .map(|arg_opt| {
-                arg_opt.as_ref().map(|arg| {
-                    let var_name = output_vars.get(&(arg.node, arg.output)).unwrap();
-                    var_name.to_string()
-                })
-            })
-            .collect();
-
-        let node_path: Vec<_> = path.iter().copied().chain(Some(step.node)).collect();
-        let stateful = stateful.contains(&step.node);
-
-        // Produce the statement.
-        let outputs = node::Conns::try_from_slice(&step.outputs).unwrap();
-        let (stmt, stmt_outputs) = eval_stmt(&node_path, &inputs, &outputs, stateful);
-
-        // Keep track of the output bindings.
-        for (out_ix, out_var) in stmt_outputs.into_iter().enumerate() {
-            let output = node::Output(out_ix.try_into().unwrap());
-            output_vars.insert((step.node, output), out_var);
-        }
-
-        stmts.push(stmt);
-    }
-    stmts
-}
-
 /// Generate a function for performing evaluation of the given statements.
 ///
 /// The given `Vec<ExprKind>` should be generated via the `eval_stmts` function.
@@ -242,26 +202,152 @@ pub fn push_eval_fn_name(path: &[node::Id]) -> String {
     format!("push-fn-{}", path_string(path))
 }
 
+/// The names of the arguments for a call to the node with the given ID with the
+/// given connected inputs.
+fn node_fn_call_arg_srcs(
+    g: &MetaGraph,
+    reachable: &HashSet<node::Id>,
+    n: node::Id,
+    inputs: &node::Conns,
+) -> Vec<Option<(node::Id, node::Output)>> {
+    let mut args = vec![None; inputs.len()];
+    for e_ref in g.edges_directed(n, petgraph::Incoming) {
+        for (edge, _kind) in e_ref.weight() {
+            if inputs.get(edge.input.0 as usize).unwrap() && reachable.contains(&e_ref.source()) {
+                args[edge.input.0 as usize] = Some((e_ref.source(), edge.output));
+            }
+        }
+    }
+    assert_eq!(
+        inputs.iter().filter(|&b| b).count(),
+        args.iter().filter(|opt| opt.is_some()).count(),
+    );
+    args
+}
+
+/// Generate a sequence of node fn call statements from the given flow graph
+/// basic block.
+pub(crate) fn eval_fn_block_stmts(
+    path: &[node::Id],
+    mg: &MetaGraph,
+    stateful: &BTreeSet<node::Id>,
+    reachable: &HashSet<node::Id>,
+    block: &Block,
+) -> Vec<ExprKind> {
+    // Track output variables
+    let mut output_vars: HashMap<(node::Id, node::Output), String> = HashMap::new();
+    let mut stmts = Vec::new();
+    for conf in &block.0 {
+        // Determine the arg names for the fn call..
+        let input_srcs = node_fn_call_arg_srcs(mg, reachable, conf.id, &conf.conns.inputs);
+        let inputs: Vec<Option<String>> = input_srcs
+            .iter()
+            .map(|src_opt| {
+                src_opt.as_ref().map(|&(node, output)| {
+                    let var_name = output_vars.get(&(node, output)).unwrap();
+                    var_name.to_string()
+                })
+            })
+            .collect();
+
+        let node_path: Vec<_> = path.iter().copied().chain(Some(conf.id)).collect();
+        let stateful = stateful.contains(&conf.id);
+
+        // Produce the statement.
+        let outputs = conf.conns.outputs;
+        let (stmt, stmt_outputs) = eval_stmt(&node_path, &inputs, &outputs, stateful);
+
+        // Keep track of the output bindings.
+        for (out_ix, out_var) in stmt_outputs.into_iter().enumerate() {
+            let output = node::Output(out_ix.try_into().unwrap());
+            output_vars.insert((conf.id, output), out_var);
+        }
+
+        stmts.push(stmt);
+    }
+
+    stmts
+}
+
+/// Find the entrypoint to the flow graph.
+fn flow_graph_entry(fg: &FlowGraph) -> Option<NodeIndex<u32>> {
+    let mut iter = fg
+        .node_references()
+        .map(|n_ref| n_ref.id())
+        .filter(|&n| fg.edges_directed(n, petgraph::Incoming).next().is_none());
+    let entry = iter.next();
+    assert!(
+        iter.next().is_none(),
+        "flow graph should have only one entry"
+    );
+    entry
+}
+
+/// The set of unique nodes in the flow graph.
+fn flow_graph_nodes(fg: &FlowGraph) -> HashSet<node::Id> {
+    let mut set = HashSet::new();
+    for n_ref in fg.node_references() {
+        set.extend(n_ref.weight().iter().map(|conf| conf.id));
+    }
+    set
+}
+
+/// Given the flow graph for an entry point eval fn, generate the body for the
+/// fn. as a list of statements.
+pub fn eval_fn_body(
+    path: &[node::Id],
+    mg: &MetaGraph,
+    stateful: &BTreeSet<node::Id>,
+    fg: &FlowGraph,
+) -> Vec<ExprKind> {
+    // Find the entry node. Collect the set of reachable nodes to filter out
+    // unreachable nodes from the meta graph.
+    let entry = flow_graph_entry(fg).unwrap();
+    let reachable = flow_graph_nodes(fg);
+
+    // Walk the CFG depth-first generating all stmts for blocks and branches.
+    // FIXME: do DFS manually and handle branches.
+    let mut dfs = petgraph::visit::Dfs::new(fg, entry.id());
+    let mut stmts = vec![];
+    while let Some(n) = dfs.next(fg) {
+        let block = &fg[n];
+        stmts.extend(eval_fn_block_stmts(path, mg, stateful, &reachable, block));
+    }
+    stmts
+}
+
+//// Generate all push and pull fns for the given control flow graph.
+pub(crate) fn eval_fns_from_flow(
+    path: &[node::Id],
+    mg: &MetaGraph,
+    stateful: &BTreeSet<node::Id>,
+    flow: &Flow,
+) -> Vec<ExprKind> {
+    let pull_fgs = flow.pull.iter().map(|(&(id, _conns), fg)| {
+        let node_path: Vec<_> = path.iter().copied().chain(Some(id)).collect();
+        let name = pull_eval_fn_name(&node_path);
+        (name, fg)
+    });
+    let push_fgs = flow.push.iter().map(|(&(id, _conns), fg)| {
+        let node_path: Vec<_> = path.iter().copied().chain(Some(id)).collect();
+        let name = push_eval_fn_name(&node_path);
+        (name, fg)
+    });
+    pull_fgs
+        .chain(push_fgs)
+        .map(|(name, fg)| {
+            let stmts = eval_fn_body(path, mg, stateful, fg);
+            eval_fn(&name, stmts)
+        })
+        .collect()
+}
+
 /// Given a tree of eval plans for a gantz graph (and its nested graphs),
 /// generate all push, pull and nested eval fns for the graph.
-pub(crate) fn eval_fns(eval_tree: &RoseTree<EvalPlan>) -> Vec<ExprKind> {
+pub(crate) fn eval_fns(flow_tree: &RoseTree<(&Meta, Flow)>) -> Vec<ExprKind> {
     let mut eval_fns = vec![];
-    eval_tree.visit(&[], &mut |path, eval| {
-        let pull_steps = eval.pull_steps.iter().map(|(&id, steps)| {
-            let node_path: Vec<_> = path.iter().copied().chain(Some(id)).collect();
-            let name = pull_eval_fn_name(&node_path);
-            (name, steps)
-        });
-        let push_steps = eval.push_steps.iter().map(|(&id, steps)| {
-            let node_path: Vec<_> = path.iter().copied().chain(Some(id)).collect();
-            let name = push_eval_fn_name(&node_path);
-            (name, steps)
-        });
-        let fns = pull_steps.chain(push_steps).map(|(name, steps)| {
-            let stmts = eval_stmts(path, &steps, &eval.meta.stateful);
-            eval_fn(&name, stmts)
-        });
-        eval_fns.extend(fns);
+    flow_tree.visit(&[], &mut |path, (meta, flow)| {
+        eval_fns.extend(eval_fns_from_flow(path, &meta.graph, &meta.stateful, flow));
     });
     eval_fns
 }

--- a/crates/gantz_core/src/compile/flow.rs
+++ b/crates/gantz_core/src/compile/flow.rs
@@ -2,8 +2,11 @@
 
 use super::{EdgeKind, Meta};
 use crate::node;
-use petgraph::visit::EdgeRef;
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use petgraph::visit::{EdgeRef, IntoEdgeReferences};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    fmt,
+};
 
 /// Represents all control flow graphs for all entrypoints in a single gantz graph.
 ///
@@ -20,23 +23,39 @@ pub struct Flow {
     pub pull: BTreeMap<(node::Id, node::Conns), FlowGraph>,
 }
 
+/// Represents a basic, linear block of node function calls.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct Block(pub Vec<NodeConf>);
+
 /// The control flow graph.
-pub type FlowGraph = petgraph::graphmap::DiGraphMap<NodeConf, BranchConns>;
+///
+/// Nodes represent basic blocks of node function calls, edges represent the
+/// unique output branching that leads between blocks.
+pub type FlowGraph = petgraph::stable_graph::StableDiGraph<Block, BranchConns>;
 
 /// One of the
 type BranchConns = node::Conns;
 
+/// A control flow graph describing indifidual node function call dependency.
+///
+/// Each `NodeConf` node represents a node function call statement that should
+/// be made.
+///
+/// This is derived from the `Meta` graph and is used to construct the
+/// `FlowGraph` via edge contraction.
+pub type NodeConfGraph = petgraph::graphmap::DiGraphMap<NodeConf, BranchConns>;
+
 /// A node within the control flow graph.
 ///
 /// Maps directly to a node function.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
 struct NodeConf {
     id: node::Id,
     conns: NodeConns,
 }
 
 /// The connectedness of a node for a particular evaluation step.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub(super) struct NodeConns {
     /// The active inputs (conditional connections may or may not be active).
     inputs: node::Conns,
@@ -44,8 +63,20 @@ pub(super) struct NodeConns {
     outputs: node::Conns,
 }
 
+impl fmt::Debug for NodeConf {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "({:?}: {:?})", self.id, self.conns)
+    }
+}
+
+impl fmt::Debug for NodeConns {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "([{}], [{}])", self.inputs, self.outputs)
+    }
+}
+
 impl Flow {
-    fn from_meta(meta: &Meta) -> Self {
+    pub fn from_meta(meta: &Meta) -> Self {
         // Create the push eval entrypoint control flow graphs.
         let push = meta
             .push
@@ -57,8 +88,31 @@ impl Flow {
             })
             .collect();
 
-        let pull = todo!();
-        let nested = todo!();
+        let pull = meta
+            .pull
+            .iter()
+            .flat_map(|(&n, connss)| {
+                connss
+                    .iter()
+                    .map(move |conns| ((n, *conns), pull_eval_flow_graph(meta, n, conns)))
+            })
+            .collect();
+
+        let nested = {
+            let order: Vec<_> = super::eval_order(
+                &meta.graph,
+                meta.inlets
+                    .iter()
+                    .map(|&n| (n, node::Conns::connected(1).unwrap())),
+                meta.outlets
+                    .iter()
+                    .map(|&n| (n, node::Conns::connected(1).unwrap())),
+            )
+            .collect();
+            let included: HashSet<_> = order.iter().copied().collect();
+            let conf_graph = node_conf_graph(meta, order, &included);
+            flow_graph(&conf_graph)
+        };
 
         Self { nested, push, pull }
     }
@@ -69,18 +123,111 @@ impl Flow {
 fn push_eval_flow_graph(meta: &Meta, n: node::Id, conns: &node::Conns) -> FlowGraph {
     use super::{push_eval_neighbors, push_eval_order};
 
-    let mut g = FlowGraph::new();
-
     // Iterate over the meta nodes that are included in topo order.
     let nbs = push_eval_neighbors(&meta.graph, n, conns);
     let order: Vec<_> = push_eval_order(&meta.graph, n, &nbs).collect();
     let included: HashSet<_> = order.iter().copied().collect();
+    let conf_graph = node_conf_graph(meta, order, &included);
+    dbg!(&conf_graph);
+    flow_graph(&conf_graph)
+}
 
+/// Given the meta graph and a node registered as a `pull_eval` entrypoint,
+/// produce the control flow graph.
+fn pull_eval_flow_graph(meta: &Meta, n: node::Id, conns: &node::Conns) -> FlowGraph {
+    use super::{pull_eval_neighbors, pull_eval_order};
+
+    // Iterate over the meta nodes that are included in topo order.
+    let nbs = pull_eval_neighbors(&meta.graph, n, conns);
+    let order: Vec<_> = pull_eval_order(&meta.graph, n, &nbs).collect();
+    let included: HashSet<_> = order.iter().copied().collect();
+    let conf_graph = node_conf_graph(meta, order, &included);
+    flow_graph(&conf_graph)
+}
+
+/// Given a node configuration flow graph, return the reduced control flow graph
+/// of basic blocks.
+fn flow_graph(cg: &NodeConfGraph) -> FlowGraph {
+    // Initialise the flow graph with the same nodes and edges.
+    let mut g = FlowGraph::with_capacity(cg.node_count(), cg.edge_count());
+    let mut visited = HashMap::with_capacity(cg.node_count());
+    for (a, b, &branch) in cg.all_edges() {
+        let na = *visited
+            .entry(a)
+            .or_insert_with(|| g.add_node(Block(vec![a])));
+        let nb = *visited
+            .entry(b)
+            .or_insert_with(|| g.add_node(Block(vec![b])));
+        g.add_edge(na, nb, branch);
+    }
+    flow_graph_edge_contraction(&mut g);
+    g
+}
+
+/// For the given flow graph, contract all edges into basic blocks where
+/// possible.
+///
+/// Ie for each edge, if that edge is the only output for the source node, and
+/// the only input for the destination node, remove the edge and merge the src
+/// and dst nodes.
+fn flow_graph_edge_contraction(g: &mut FlowGraph) {
+    // Maintain a stack of all edges that require reducing.
+    let mut edges: Vec<_> = g.edge_references().map(|e_ref| e_ref.id()).collect();
+    while let Some(e) = edges.pop() {
+        let (src, dst) = g.edge_endpoints(e).unwrap();
+
+        // Check whether or not this is the only edge between src and dst.
+        let mergeable = g.edges_directed(src, petgraph::Outgoing).take(2).count() == 1
+            && g.edges_directed(dst, petgraph::Incoming).take(2).count() == 1;
+        if !mergeable {
+            continue;
+        }
+
+        // Merge the src and dst blocks.
+        let (src_blk, dst_blk) = g.index_twice_mut(src, dst);
+        src_blk.0.append(&mut dst_blk.0);
+
+        // Re-attach the dst output edges to the src.
+        let new_edges: Vec<_> = g
+            .edges_directed(dst, petgraph::Outgoing)
+            .map(|e_ref| (e_ref.target(), *e_ref.weight()))
+            .collect();
+        for (new_dst, w) in new_edges {
+            let new_e = g.add_edge(src, new_dst, w);
+            // Add the edges to the stack in case they need to be re-checked.
+            // FIXME: Shouldn't be necessary to re-add edges to the stack if we
+            // check all edges in reverse topo order? I think we are but we
+            // don't explicitly assert this anywhere.
+            edges.push(new_e);
+        }
+
+        // Remove the dst node now that it's been merged.
+        g.remove_node(dst);
+    }
+}
+
+/// Given the topological order of
+fn node_conf_graph(
+    meta: &Meta,
+    order: impl IntoIterator<Item = node::Id>,
+    included: &HashSet<node::Id>,
+) -> NodeConfGraph {
+    let mut g = NodeConfGraph::new();
+    let mut visited: BTreeMap<node::Id, Vec<NodeConf>> = Default::default();
     // For each node, add a `NodeConf` for every permutation of inputs/outputs
     // required, and an edge for each input node's branches.
-    let mut visited: BTreeMap<node::Id, Vec<NodeConf>> = Default::default();
     for n in order {
-        for (a, b, branch) in node_input_edges(meta, n, &included, &visited) {
+        // Retrieve all possible configuration permutations for this node.
+        let confs = node_conf_perms(meta, n, |n| included.contains(&n));
+
+        // Track the permutations for each node.
+        let vconfs = visited.entry(n).or_default();
+        for conf in &confs {
+            vconfs.push(*conf);
+        }
+
+        let input_edges = node_input_edges(meta, n, &confs, &included, &visited);
+        for (a, b, branch) in input_edges {
             g.add_edge(a, b, branch);
             visited.entry(n).or_default().push(b);
         }
@@ -94,13 +241,11 @@ fn push_eval_flow_graph(meta: &Meta, n: node::Id, conns: &node::Conns) -> FlowGr
 fn node_input_edges(
     meta: &Meta,
     dst: node::Id,
+    dst_conf_perms: &[NodeConf],
     included: &HashSet<node::Id>,
     visited: &BTreeMap<node::Id, Vec<NodeConf>>,
 ) -> BTreeSet<(NodeConf, NodeConf, BranchConns)> {
     let mut input_edges = BTreeSet::new();
-
-    // Retrieve all possible configuration permutations for this node.
-    let dst_confs = node_conf_perms(meta, dst, |n| included.contains(&n));
 
     // For each configuragion of each source node, determine all branching edges
     // to each relevant configuration of this node.
@@ -122,16 +267,18 @@ fn node_input_edges(
                     continue;
                 }
 
-                for &dst_conf in &dst_confs {
+                for &dst_conf in dst_conf_perms {
                     // Skip dst confs that don't touch this input.
                     if !dst_conf.conns.inputs.get(dst_in).unwrap() {
                         continue;
                     }
 
-                    // TODO: need to include
-                    // For each of the src branches that touch this
+                    // For each of the src branches that touch this, add an
+                    // edge. If the src declares no branching, there is only a
+                    // single edge from all outputs connected on the src.
                     let src_branches = meta.branches.get(&src).cloned().unwrap_or_else(|| {
-                        todo!("node::Conns with all connected src outputs")
+                        let n_outputs = meta.outputs.get(&src).copied().unwrap_or(0);
+                        vec![node::Conns::connected(n_outputs).unwrap()]
                     });
                     for src_branch in src_branches {
                         if src_branch.get(src_out).unwrap() {
@@ -177,7 +324,7 @@ fn node_conf_perms(meta: &Meta, n: node::Id, included: impl Fn(node::Id) -> bool
             continue;
         }
         for (edge, _kind) in e_ref.weight() {
-            outputs.set(edge.output.0 as usize, true);
+            outputs.set(edge.output.0 as usize, true).unwrap();
         }
     }
 

--- a/crates/gantz_core/src/compile/flow.rs
+++ b/crates/gantz_core/src/compile/flow.rs
@@ -1,0 +1,335 @@
+//! Items related to constructing a view of the control flow of a gantz graph.
+
+use super::{EdgeKind, Meta};
+use crate::node;
+use petgraph::visit::EdgeRef;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+/// Represents all control flow graphs for all entrypoints in a single gantz graph.
+///
+/// This includes all branches on the edges, and unique node configurations as
+/// nodes.
+#[derive(Debug)]
+pub struct Flow {
+    /// Control flow graph from all inlets to all outlets, or empty in the case
+    /// that the graph has no inlets or outlets (i.e. is not nested).
+    pub nested: FlowGraph,
+    /// The control flow graph for each `push_eval` configuration for each node.
+    pub push: BTreeMap<(node::Id, node::Conns), FlowGraph>,
+    /// The control flow graph for each `pull_eval` configuration for each node.
+    pub pull: BTreeMap<(node::Id, node::Conns), FlowGraph>,
+}
+
+/// The control flow graph.
+pub type FlowGraph = petgraph::graphmap::DiGraphMap<NodeConf, BranchConns>;
+
+/// One of the
+type BranchConns = node::Conns;
+
+/// A node within the control flow graph.
+///
+/// Maps directly to a node function.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+struct NodeConf {
+    id: node::Id,
+    conns: NodeConns,
+}
+
+/// The connectedness of a node for a particular evaluation step.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub(super) struct NodeConns {
+    /// The active inputs (conditional connections may or may not be active).
+    inputs: node::Conns,
+    /// Includes all connected outputs (whether conditional or not).
+    outputs: node::Conns,
+}
+
+impl Flow {
+    fn from_meta(meta: &Meta) -> Self {
+        // Create the push eval entrypoint control flow graphs.
+        let push = meta
+            .push
+            .iter()
+            .flat_map(|(&n, connss)| {
+                connss
+                    .iter()
+                    .map(move |conns| ((n, *conns), push_eval_flow_graph(meta, n, conns)))
+            })
+            .collect();
+
+        let pull = todo!();
+        let nested = todo!();
+
+        Self { nested, push, pull }
+    }
+}
+
+/// Given the meta graph and a node registered as a `push_eval` entrypoint,
+/// produce the control flow graph.
+fn push_eval_flow_graph(meta: &Meta, n: node::Id, conns: &node::Conns) -> FlowGraph {
+    use super::{push_eval_neighbors, push_eval_order};
+
+    let mut g = FlowGraph::new();
+
+    // Iterate over the meta nodes that are included in topo order.
+    let nbs = push_eval_neighbors(&meta.graph, n, conns);
+    let order: Vec<_> = push_eval_order(&meta.graph, n, &nbs).collect();
+    let included: HashSet<_> = order.iter().copied().collect();
+
+    // For each node, add a `NodeConf` for every permutation of inputs/outputs
+    // required, and an edge for each input node's branches.
+    let mut visited: BTreeMap<node::Id, Vec<NodeConf>> = Default::default();
+    for n in order {
+        for (a, b, branch) in node_input_edges(meta, n, &included, &visited) {
+            g.add_edge(a, b, branch);
+            visited.entry(n).or_default().push(b);
+        }
+    }
+    g
+}
+
+/// The input edges of all configurations of this node.
+///
+/// All connected outputs (whether conditional or not).
+fn node_input_edges(
+    meta: &Meta,
+    dst: node::Id,
+    included: &HashSet<node::Id>,
+    visited: &BTreeMap<node::Id, Vec<NodeConf>>,
+) -> BTreeSet<(NodeConf, NodeConf, BranchConns)> {
+    let mut input_edges = BTreeSet::new();
+
+    // Retrieve all possible configuration permutations for this node.
+    let dst_confs = node_conf_perms(meta, dst, |n| included.contains(&n));
+
+    // For each configuragion of each source node, determine all branching edges
+    // to each relevant configuration of this node.
+    for e_ref in meta.graph.edges_directed(dst, petgraph::Incoming) {
+        let src = e_ref.source();
+        let Some(src_confs) = visited.get(&src) else {
+            continue;
+        };
+
+        // For every edge between this pair, create an edge for each conf
+        // permutation. Doubles will automatically be deduped.
+        for (edge, kind) in e_ref.weight() {
+            let src_out = edge.output.0 as usize;
+            let dst_in = edge.input.0 as usize;
+
+            for &src_conf in src_confs {
+                // Skip src confs that don't touch this output.
+                if !src_conf.conns.outputs.get(src_out).unwrap() {
+                    continue;
+                }
+
+                for &dst_conf in &dst_confs {
+                    // Skip dst confs that don't touch this input.
+                    if !dst_conf.conns.inputs.get(dst_in).unwrap() {
+                        continue;
+                    }
+
+                    // TODO: need to include
+                    // For each of the src branches that touch this
+                    let src_branches = meta.branches.get(&src).cloned().unwrap_or_else(|| {
+                        todo!("node::Conns with all connected src outputs")
+                    });
+                    for src_branch in src_branches {
+                        if src_branch.get(src_out).unwrap() {
+                            input_edges.insert((src_conf, dst_conf, src_branch));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    input_edges
+}
+
+/// Retrieve all possible configuration permutations for this node.
+///
+/// This will include:
+///
+/// - All `inputs` permutations over its conditional input edges.
+/// - One `outputs` for all connected output edges (conditional or not).
+fn node_conf_perms(meta: &Meta, n: node::Id, included: impl Fn(node::Id) -> bool) -> Vec<NodeConf> {
+    // 1. Collect all permutations of inputs as `Vec<node::Conns>`.
+    let n_inputs = meta.inputs.get(&n).copied().unwrap_or(0);
+    let mut input_kinds: Vec<Option<EdgeKind>> = vec![None; n_inputs];
+    for e_ref in meta.graph.edges_directed(n, petgraph::Incoming) {
+        // Only consider edges to nodes included in the traversal.
+        if !included(e_ref.source()) {
+            continue;
+        }
+        for (edge, kind) in e_ref.weight() {
+            input_kinds[edge.input.0 as usize] = Some(kind.clone());
+        }
+    }
+    let inputs = conns_permutations(&input_kinds);
+
+    // 2. The only output should include all connected output edges.
+    // Note: Branches are handled at runtime, so we omit those until adding edges.
+    let n_outputs = meta.outputs.get(&n).copied().unwrap_or(0);
+    let mut outputs = node::Conns::unconnected(n_outputs).unwrap();
+    for e_ref in meta.graph.edges_directed(n, petgraph::Outgoing) {
+        // Only consider edges to nodes included in the traversal.
+        if !included(e_ref.target()) {
+            continue;
+        }
+        for (edge, _kind) in e_ref.weight() {
+            outputs.set(edge.output.0 as usize, true);
+        }
+    }
+
+    // 3. Create a conf for each input permutation with the output.
+    inputs
+        .iter()
+        .map(move |&inputs| {
+            let conns = NodeConns { inputs, outputs };
+            NodeConf { id: n, conns }
+        })
+        .collect()
+}
+
+/// For the given edge kinds, produce all conditional permutations.
+fn conns_permutations(edges: &[Option<EdgeKind>]) -> Vec<node::Conns> {
+    // Find all conditional edge positions.
+    let cond_positions: Vec<usize> = edges
+        .iter()
+        .enumerate()
+        .filter_map(|(i, edge)| match edge {
+            Some(EdgeKind::Conditional) => Some(i),
+            _ => None,
+        })
+        .collect();
+
+    let num_conds = cond_positions.len();
+    let num_perms = 1 << num_conds;
+    let mut perms = Vec::with_capacity(num_perms);
+
+    // Generate all 2^n permutations.
+    for perm_ix in 0..num_perms {
+        let mut perm = node::Conns::unconnected(edges.len()).unwrap();
+        for (i, edge) in edges.iter().enumerate() {
+            let Some(kind) = edge else {
+                continue;
+            };
+            let value = match kind {
+                EdgeKind::Static => true,
+                EdgeKind::Conditional => {
+                    // Find which conditional this is and check the corresponding bit.
+                    let cond_ix = cond_positions.iter().position(|&pos| pos == i).unwrap();
+                    (perm_ix >> cond_ix) & 1 == 1
+                }
+            };
+            perm.set(i, value);
+        }
+        perms.push(perm);
+    }
+
+    perms
+}
+
+mod tests {
+    use super::*;
+
+    // Meta:
+    //
+    // -----
+    // | 0 | // push
+    // -+---
+    //  |
+    // -+---
+    // | 1 |
+    // -+-+-
+    //  | |
+    //  | -----  // both edges conditional
+    //  |     |
+    // -+--- -+---
+    // | 2 | | 3 |
+    // ----- -----
+    //
+    // Flow:
+    //
+    // -----
+    // | 0 |
+    // -+---
+    //  |
+    // -----
+    // | 1 |
+    // -----
+    //
+    //
+    //
+    //
+    #[test]
+    fn flow_graph() {
+        // let meta = Meta {
+        // graph:
+        // };
+    }
+
+    #[test]
+    fn test_generate_edge_permutations() {
+        // Test case: [Static, Conditional, None, Conditional]
+        let edges = vec![
+            Some(EdgeKind::Static),
+            Some(EdgeKind::Conditional),
+            None,
+            Some(EdgeKind::Conditional),
+        ];
+
+        let permutations = conns_permutations(&edges);
+
+        // Should have 2^2 = 4 permutations (2 conditional edges)
+        assert_eq!(permutations.len(), 4);
+
+        // Expected permutations:
+        // [true, false, false, false] - both conditionals false
+        // [true, true, false, false]  - first conditional true, second false
+        // [true, false, false, true]  - first conditional false, second true
+        // [true, true, false, true]   - both conditionals true
+
+        let expected = vec![
+            node::Conns::try_from([true, false, false, false]).unwrap(),
+            node::Conns::try_from([true, true, false, false]).unwrap(),
+            node::Conns::try_from([true, false, false, true]).unwrap(),
+            node::Conns::try_from([true, true, false, true]).unwrap(),
+        ];
+
+        assert_eq!(permutations, expected);
+    }
+
+    #[test]
+    fn test_no_conditionals() {
+        let edges = vec![Some(EdgeKind::Static), None, Some(EdgeKind::Static)];
+
+        let permutations = conns_permutations(&edges);
+
+        // Should have exactly 1 permutation
+        assert_eq!(permutations.len(), 1);
+        assert_eq!(
+            permutations[0],
+            node::Conns::try_from([true, false, true]).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_all_conditionals() {
+        let edges = vec![Some(EdgeKind::Conditional), Some(EdgeKind::Conditional)];
+
+        let permutations = conns_permutations(&edges);
+
+        // Should have 2^2 = 4 permutations
+        assert_eq!(permutations.len(), 4);
+
+        let expected = vec![
+            node::Conns::try_from([false, false]).unwrap(),
+            node::Conns::try_from([true, false]).unwrap(),
+            node::Conns::try_from([false, true]).unwrap(),
+            node::Conns::try_from([true, true]).unwrap(),
+        ];
+
+        assert_eq!(permutations, expected);
+    }
+}

--- a/crates/gantz_core/src/compile/meta.rs
+++ b/crates/gantz_core/src/compile/meta.rs
@@ -51,7 +51,7 @@ pub enum EdgeKind {
 ///
 /// Note that we use a `Vec<Edge>` in order to represent multiple edges
 /// between the same two nodes.
-type MetaGraph = petgraph::graphmap::DiGraphMap<node::Id, Vec<(Edge, EdgeKind)>>;
+pub type MetaGraph = petgraph::graphmap::DiGraphMap<node::Id, Vec<(Edge, EdgeKind)>>;
 
 impl Meta {
     /// Construct a `Meta` for a single gantz graph.

--- a/crates/gantz_core/src/node.rs
+++ b/crates/gantz_core/src/node.rs
@@ -180,7 +180,7 @@ pub struct ExprCtx<'a> {
     ///
     /// If the input is connected, it is `Some(name)` where `name` is a binding
     /// to the incoming value.
-    outputs: &'a [bool],
+    outputs: &'a Conns,
 }
 
 /// Represents a function that can be called to begin evaluation of the graph
@@ -197,7 +197,7 @@ pub struct Input(pub u16);
 pub struct Output(pub u16);
 
 impl<'a> ExprCtx<'a> {
-    pub(crate) fn new(path: &'a [Id], inputs: &'a [Option<String>], outputs: &'a [bool]) -> Self {
+    pub(crate) fn new(path: &'a [Id], inputs: &'a [Option<String>], outputs: &'a Conns) -> Self {
         Self {
             path,
             inputs,
@@ -235,7 +235,7 @@ impl<'a> ExprCtx<'a> {
     /// Note that even if
     ///
     /// If the output is connected, it is `true`.
-    pub fn outputs(&self) -> &[bool] {
+    pub fn outputs(&self) -> &Conns {
         self.outputs
     }
 }

--- a/crates/gantz_core/src/node/conns.rs
+++ b/crates/gantz_core/src/node/conns.rs
@@ -65,6 +65,14 @@ impl Conns {
         Ok(conns)
     }
 
+    /// Creates a new empty `Conns`.
+    pub fn empty() -> Self {
+        Self {
+            bytes: [0u8; Self::MAX_BYTES],
+            len: 0,
+        }
+    }
+
     /// Creates a new `Conns` with the given slice of connection states.
     ///
     /// Returns `Err` if `len` is out of range of [`MAX`].

--- a/crates/gantz_core/src/node/graph.rs
+++ b/crates/gantz_core/src/node/graph.rs
@@ -337,18 +337,16 @@ where
     // Use compile to create the evaluation order, steps, and statements
     let meta = compile::Meta::from_graph(g);
     let outlets: Vec<_> = outlets(g).map(|n_ref| n_ref.id()).collect();
-    let order = compile::eval_order(
-        g,
+    let flow_graph = compile::flow_graph(
+        &meta,
         inlets
             .iter()
-            .map(|&n| (n, node::Conns::connected(1).unwrap())),
+            .map(|&n| (g.to_index(n), node::Conns::connected(1).unwrap())),
         outlets
             .iter()
-            .map(|&n| (n, node::Conns::connected(1).unwrap())),
-    )
-    .map(|id| g.to_index(id));
-    let steps: Vec<_> = compile::eval_steps(&meta, order).collect();
-    let stmts = compile::eval_stmts(path, &steps, &meta.stateful);
+            .map(|&n| (g.to_index(n), node::Conns::connected(1).unwrap())),
+    );
+    let stmts = compile::eval_fn_body(path, &meta.graph, &meta.stateful, &flow_graph);
 
     // Combine inlet bindings with graph evaluation steps
     let all_stmts = inlet_bindings

--- a/crates/gantz_core/tests/graph.rs
+++ b/crates/gantz_core/tests/graph.rs
@@ -211,7 +211,7 @@ fn test_graph_push_cond_eval() {
             let x = ctx.inputs()[0].as_deref().expect("must have one input");
             let expr = format!(
                 r#"
-                (if (equals? 0 {x})
+                (if (equal? 0 {x})
                   (list 0 '())  ; 0 index for left branch, '() for empty value
                   (list 1 '())) ; 1 index for right branch, '() for empty value
             "#
@@ -258,7 +258,6 @@ fn test_graph_push_cond_eval() {
 
     // Register the functions, then call push_eval.
     for f in module {
-        println!("{}\n", f.to_pretty(100));
         vm.run(format!("{f}")).unwrap();
     }
 
@@ -402,7 +401,6 @@ fn test_graph_push_eval_subset() {
 
     // Register all functions
     for f in module {
-        println!("{}\n", f.to_pretty(100));
         vm.run(f.to_pretty(100)).unwrap();
     }
 

--- a/crates/gantz_core/tests/graph.rs
+++ b/crates/gantz_core/tests/graph.rs
@@ -192,6 +192,10 @@ fn test_graph_push_cond_eval() {
     struct Select;
 
     impl Node for Select {
+        fn n_inputs(&self) -> usize {
+            1
+        }
+
         fn n_outputs(&self) -> usize {
             2
         }
@@ -360,11 +364,12 @@ fn test_graph_push_eval_subset() {
 
         fn expr(&self, ctx: node::ExprCtx) -> ExprKind {
             let Src(a, b) = *self;
-            let expr = match ctx.outputs() {
+            let outputs = ctx.outputs();
+            let expr = match (outputs.get(0).unwrap(), outputs.get(1).unwrap()) {
                 // Only return left if only left is connected.
-                &[true, false] => format!("(begin {a})"),
+                (true, false) => format!("(begin {a})"),
                 // Only return right if only right is connected.
-                &[false, true] => format!("(begin {b})"),
+                (false, true) => format!("(begin {b})"),
                 // Otherwise return both in a list.
                 _ => format!("(list {a} {b})"),
             };


### PR DESCRIPTION
**WIP**

Part of #21, #82.

Derive a control flow graph from the `Meta` graph in order to enable branching on the node outputs.

## Motivation

Previously, in order to work out what node config functions should be called in what order, we could simply do a toposort of all the nodes. We could do this because we assumed that a node would always output a value for every connected output.

However, in order to support branching on the node outputs, we can no longer rely on a simple toposort as the nodes we execute will depend on the selected branch of its predecessor.

Instead, we likely need to represent the possible execution paths with a control flow graph, from which we can later derive the necessary branching steel code.