### PR TITLE
feat: Derive branching code from control `FlowGraph` 

### DIFF
--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -15,8 +15,44 @@ use steel::{parser::ast::ExprKind, steel_vm::engine::Engine};
 
 mod node_fn;
 
+/// Specifies whether the argument for a node fn call comes directly from
+/// another node output, or if it has a dedicated binding name.
+#[derive(Clone, Debug)]
+enum NodeFnCallArg {
+    /// The arg comes directly from another node's output.
+    /// E.g. `node-4-o2`.
+    Output(node::Id, node::Output),
+    /// The arg has a dedicated name (named after the node input) for
+    /// disambiguation as the node is a part of a "join" in the flow graph.
+    /// E.g. `node-6-i2`.
+    DedicatedBinding,
+}
+
 /// Binding used for `state` local to each node fn.
 const STATE: &str = "state";
+/// Binding used for the current branch index.
+const BRANCH_IX: &str = "branch-ix";
+
+/// Whether or not the given node input requires a dedicated binding name.
+///
+/// This is required in the case that the node is within or following a "join"
+/// control flow node, and the input has more than one incoming edge.
+///
+/// Disambiguation only requires generating one extra binding, so we just check
+/// if there's more than one edge and don't worry about checking the flow graph.
+fn node_input_needs_binding(mg: &MetaGraph, n: node::Id, input: usize) -> bool {
+    let mut count = 0;
+    for e_ref in mg.edges_directed(n, petgraph::Incoming) {
+        for (edge, _kind) in e_ref.weight() {
+            let ix = edge.input.0 as usize;
+            count += (ix == input).then_some(1).unwrap_or(0);
+            if count > 1 {
+                return true;
+            }
+        }
+    }
+    false
+}
 
 /// The expression for a call to a node function.
 fn node_fn_call(
@@ -42,27 +78,47 @@ fn node_fn_call(
         .unwrap()
 }
 
+/// Function to generate node input variable names for disambiguation.
+fn node_input_var(node_ix: node::Id, in_ix: usize) -> String {
+    format!("node-{}-i{}", node_ix, in_ix)
+}
+
 /// Function to generate node output variable names.
-fn output_var_name(node_ix: node::Id, out_ix: u16) -> String {
+fn node_output_var(node_ix: node::Id, out_ix: usize) -> String {
     format!("node-{}-o{}", node_ix, out_ix)
 }
 
-/// The names of the arguments for a call to the node with the given ID with the
-/// given connected inputs.
-fn node_fn_call_arg_srcs(
-    g: &MetaGraph,
+/// The binding name given to the node's output.
+fn node_outputs_var(node_ix: node::Id) -> String {
+    format!("node-{node_ix}")
+}
+
+/// Find the arguments for a call to the node with the given ID with the given
+/// connected inputs.
+fn node_fn_call_args(
+    mg: &MetaGraph,
     reachable: &HashSet<node::Id>,
     n: node::Id,
     inputs: &node::Conns,
-) -> Vec<Option<(node::Id, node::Output)>> {
+) -> Vec<Option<NodeFnCallArg>> {
     let mut args = vec![None; inputs.len()];
-    for e_ref in g.edges_directed(n, petgraph::Incoming) {
+    for e_ref in mg.edges_directed(n, petgraph::Incoming) {
         for (edge, _kind) in e_ref.weight() {
-            if inputs.get(edge.input.0 as usize).unwrap() && reachable.contains(&e_ref.source()) {
-                args[edge.input.0 as usize] = Some((e_ref.source(), edge.output));
+            let input_ix = edge.input.0 as usize;
+            if inputs.get(input_ix).unwrap() && reachable.contains(&e_ref.source()) {
+                args[input_ix] = match args[input_ix] {
+                    // If there's no arg for this index yet, assign the output.
+                    None => Some(NodeFnCallArg::Output(e_ref.source(), edge.output)),
+                    // Otherwise if there's already an arg, that means there's
+                    // more than one node output connected to this input
+                    // (potentially from different branches) so this arg will
+                    // have a dedicated binding name.
+                    Some(_) => Some(NodeFnCallArg::DedicatedBinding),
+                };
             }
         }
     }
+    // Sanity check the connected inputs all have an arg.
     assert_eq!(
         inputs.iter().filter(|&b| b).count(),
         args.iter().filter(|opt| opt.is_some()).count(),
@@ -126,27 +182,18 @@ fn eval_stmt(
             .unwrap()
     }
 
-    // Helper to create a define-values expression for multiple outputs.
-    // E.g. (define-values (foo bar) expr)
-    fn create_define_values_expr(var_names: Vec<String>, value_expr: ExprKind) -> ExprKind {
-        let s = format!("(define-values ({}) {})", var_names.join(" "), value_expr);
-        Engine::emit_ast(&s)
-            .expect("failed to emit AST")
-            .into_iter()
-            .next()
-            .unwrap()
-    }
-
     // The node index is the last element of the path.
     let node_ix = *node_path.last().expect("node_path must not be empty");
 
     // Determine the input arg names.
-    let input_args: Vec<_> = node_fn_call_arg_srcs(mg, reachable, node_ix, inputs)
+    let input_args: Vec<_> = node_fn_call_args(mg, reachable, node_ix, inputs)
         .into_iter()
-        .map(|src_opt| {
-            src_opt
-                .as_ref()
-                .map(|&(node, output)| output_var_name(node, output.0))
+        .enumerate()
+        .map(|(ix, src_opt)| {
+            src_opt.as_ref().map(|arg| match arg {
+                NodeFnCallArg::Output(n, out) => node_output_var(*n, out.0.into()),
+                NodeFnCallArg::DedicatedBinding => node_input_var(node_ix, ix),
+            })
         })
         .collect();
 
@@ -164,24 +211,48 @@ fn eval_stmt(
         .next()
         .unwrap();
 
-    // Create a binding statement for each output
+    // Create a binding statement for the node's output.
     let stmt = match outputs.len() {
         0 => node_fn_call_expr,
-        1 => {
-            let output_var = output_var_name(node_ix, 0);
+        _ => {
+            let output_var = node_outputs_var(node_ix);
             let define_expr = create_define_expr(output_var, node_fn_call_expr);
             define_expr
-        }
-        _ => {
-            let output_vars: Vec<String> = (0..outputs.len())
-                .map(|i| output_var_name(node_ix, i as u16))
-                .collect();
-            let define_values_expr = create_define_values_expr(output_vars, node_fn_call_expr);
-            define_values_expr
         }
     };
 
     stmt
+}
+
+/// Create a statement that binds a var for each value in the node's outputs.
+fn destructure_node_outputs_stmt(n: node::Id, outputs: node::Conns) -> ExprKind {
+    // Collect the names of the outputs.
+    let vars: Vec<_> = outputs
+        .iter()
+        .enumerate()
+        .filter_map(|(ix, b)| b.then(|| node_output_var(n, ix)))
+        .collect();
+    let outputs_var = node_outputs_var(n);
+    let stmt = match vars.len() {
+        1 => format!("(define {} {outputs_var})", vars.join(" ")),
+        _ => format!("(define-values ({}) {outputs_var})", vars.join(" ")),
+    };
+    Engine::emit_ast(&stmt)
+        .expect("failed to emit AST")
+        .into_iter()
+        .next()
+        .unwrap()
+}
+
+/// Create a statement that destructures the node
+fn destructure_node_branch_stmt(n: node::Id) -> ExprKind {
+    let outputs_var = node_outputs_var(n);
+    let stmt = format!("(define-values (branch-ix {outputs_var}) {outputs_var})");
+    Engine::emit_ast(&stmt)
+        .expect("failed to emit AST")
+        .into_iter()
+        .next()
+        .unwrap()
 }
 
 /// Generate a function for performing evaluation of the given statements.
@@ -232,6 +303,52 @@ pub fn push_eval_fn_name(path: &[node::Id]) -> String {
     format!("push-fn-{}", path_string(path))
 }
 
+/// The set of outputs on the given node that require dedicated bindings due to
+/// being connected to an input on a node that has multiple incoming edges.
+fn node_outputs_that_need_bindings(
+    mg: &MetaGraph,
+    n: node::Id,
+) -> BTreeSet<(node::Output, (node::Id, node::Input))> {
+    let mut need_bindings = BTreeSet::default();
+    for e_ref in mg.edges_directed(n, petgraph::Outgoing) {
+        for (edge, _kind) in e_ref.weight() {
+            if node_input_needs_binding(mg, e_ref.target(), edge.input.0 as usize) {
+                need_bindings.insert((edge.output, (e_ref.target(), edge.input)));
+            }
+        }
+    }
+    need_bindings
+}
+
+/// Generate a statement that creates a node input binding for `dst` to the
+/// given `src` node's output.
+fn define_node_input_binding(
+    (src, src_out): (node::Id, node::Output),
+    (dst, dst_in): (node::Id, node::Input),
+) -> ExprKind {
+    let s = format!(
+        "(define {} {})",
+        node_input_var(dst, dst_in.0 as usize),
+        node_output_var(src, src_out.0 as usize),
+    );
+    Engine::emit_ast(&s)
+        .expect("failed to emit AST")
+        .into_iter()
+        .next()
+        .unwrap()
+}
+
+// For the given node's outputs that connect to node inputs that have more than
+// one incoming edge, create dedicated bindings for those inputs.
+fn define_necessary_node_input_bindings(
+    g: &MetaGraph,
+    n: node::Id,
+) -> impl Iterator<Item = ExprKind> {
+    node_outputs_that_need_bindings(g, n)
+        .into_iter()
+        .map(move |(output, dst)| define_node_input_binding((n, output), dst))
+}
+
 /// Generate a sequence of node fn call statements from the given flow graph
 /// basic block.
 pub(crate) fn eval_fn_block_stmts(
@@ -242,12 +359,25 @@ pub(crate) fn eval_fn_block_stmts(
     block: &Block,
 ) -> Vec<ExprKind> {
     let mut stmts = Vec::new();
-    for conf in &block.0 {
+    let mut iter = block.0.iter().peekable();
+    while let Some(conf) = iter.next() {
         let node_path: Vec<_> = path.iter().copied().chain(Some(conf.id)).collect();
         let stateful = stateful.contains(&conf.id);
         let NodeConns { inputs, outputs } = conf.conns;
         let stmt = eval_stmt(mg, reachable, &node_path, &inputs, &outputs, stateful);
         stmts.push(stmt);
+
+        // If this is the last node fn call in the block, it must be either
+        // branching or terminal, so there's no need to destructure here.
+        if iter.peek().is_none() {
+            continue;
+        }
+
+        // Destructure the node's outputs.
+        stmts.push(destructure_node_outputs_stmt(conf.id, conf.conns.outputs));
+        // For outputs connected to node inputs that have more than one incoming
+        // edge, we create dedicated bindings for those inputs.
+        stmts.extend(define_necessary_node_input_bindings(mg, conf.id));
     }
     stmts
 }
@@ -275,6 +405,78 @@ fn flow_graph_nodes(fg: &FlowGraph) -> HashSet<node::Id> {
     set
 }
 
+/// The eval fn statements for the control flow block at the given `flow_ix`.
+fn flow_node_stmts(
+    path: &[node::Id],
+    flow_ix: NodeIndex,
+    mg: &MetaGraph,
+    stateful: &BTreeSet<node::Id>,
+    reachable: &HashSet<node::Id>,
+    fg: &FlowGraph,
+) -> Vec<ExprKind> {
+    // Add the block.
+    let block = &fg[flow_ix];
+    let mut stmts = eval_fn_block_stmts(path, mg, stateful, &reachable, block);
+
+    // Collect the output branching edges.
+    let mut edges: Vec<_> = fg
+        .edges_directed(flow_ix, petgraph::Outgoing)
+        .map(|e_ref| (*e_ref.weight(), e_ref.target()))
+        .collect();
+    edges.sort();
+
+    // If there are no edges, we're done.
+    if edges.is_empty() {
+        return stmts;
+
+    // If there is one edge, this must be part of a join.
+    // FIXME: For now, just continue generating stmts. We should handle joins
+    // properly though.
+    } else if edges.len() == 1 {
+        let (_branch, dst) = edges.pop().unwrap();
+
+        // Destructure the last node's output.
+        let conf = *block.last().unwrap();
+        stmts.push(destructure_node_outputs_stmt(conf.id, conf.conns.outputs));
+        stmts.extend(define_necessary_node_input_bindings(mg, conf.id));
+
+        // Continue generating...
+        stmts.extend(flow_node_stmts(path, dst, mg, stateful, reachable, fg));
+        return stmts;
+    }
+
+    // Otherwise, add a statement to destructure the branch index.
+    let conf = *block.last().unwrap();
+    stmts.push(destructure_node_branch_stmt(conf.id));
+    stmts.extend(define_necessary_node_input_bindings(mg, conf.id));
+
+    // Add the branches.
+    // FIXME: This doesn't properly handle joins.
+    let mut expr = "'()".to_string();
+    while let Some((branch, dst)) = edges.pop() {
+        let dst_stmts = flow_node_stmts(path, dst, mg, stateful, reachable, fg);
+        let dst_expr = format!(
+            "(begin {} {} '())",
+            destructure_node_outputs_stmt(conf.id, branch.conns),
+            dst_stmts
+                .into_iter()
+                .map(|expr| format!("{expr}"))
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        expr = format!("(if (= {} {BRANCH_IX}) {dst_expr} {expr})", branch.ix);
+    }
+
+    let expr = Engine::emit_ast(&expr)
+        .expect("Failed to emit AST for function")
+        .into_iter()
+        .next()
+        .unwrap();
+
+    stmts.push(expr);
+    stmts
+}
+
 /// Given the flow graph for an entry point eval fn, generate the body for the
 /// fn. as a list of statements.
 pub fn eval_fn_body(
@@ -285,18 +487,11 @@ pub fn eval_fn_body(
 ) -> Vec<ExprKind> {
     // Find the entry node. Collect the set of reachable nodes to filter out
     // unreachable nodes from the meta graph.
-    let entry = flow_graph_entry(fg).unwrap();
+    let Some(entry) = flow_graph_entry(fg) else {
+        return vec![];
+    };
     let reachable = flow_graph_nodes(fg);
-
-    // Walk the CFG depth-first generating all stmts for blocks and branches.
-    // FIXME: do DFS manually and handle branches.
-    let mut dfs = petgraph::visit::Dfs::new(fg, entry.id());
-    let mut stmts = vec![];
-    while let Some(n) = dfs.next(fg) {
-        let block = &fg[n];
-        stmts.extend(eval_fn_block_stmts(path, mg, stateful, &reachable, block));
-    }
-    stmts
+    flow_node_stmts(path, entry.id(), mg, stateful, &reachable, fg)
 }
 
 //// Generate all push and pull fns for the given control flow graph.

--- a/crates/gantz_core/tests/graph.rs
+++ b/crates/gantz_core/tests/graph.rs
@@ -186,7 +186,6 @@ fn test_graph_pull_eval() {
 //    | number |
 //    ----------
 #[test]
-#[ignore = "Requires handling node output branching"]
 fn test_graph_push_cond_eval() {
     #[derive(Debug)]
     struct Select;


### PR DESCRIPTION
Follow-up to #87.

Part of https://github.com/nannou-org/gantz/issues/21, https://github.com/nannou-org/gantz/issues/82.

Currently this generates branching correctly, but doesn't yet handle joins, so branching can currently generate massive eval fns. The plan is to handle joins properly using continuation passing style in a follow-up PR.