### PR TITLE
feat: Add support for custom node registry along with implementation in `gantz_egui` demo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,6 +936,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "dyn-hash"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,6 +1455,7 @@ dependencies = [
 name = "gantz_egui"
 version = "0.1.0"
 dependencies = [
+ "dyn-clone",
  "dyn-hash",
  "eframe",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 repository = "https://github.com/nannou-org/gantz"
 
 [workspace.dependencies]
+dyn-clone = "1"
 dyn-hash = "0.2.2"
 eframe = { version = "0.32", features = ["persistence"] }
 egui = { version = "0.32", default-features = false }

--- a/crates/gantz_core/src/compile/codegen/node_fn.rs
+++ b/crates/gantz_core/src/compile/codegen/node_fn.rs
@@ -62,7 +62,8 @@ impl<'pl, Env> Visitor<Env> for NodeFns<'pl> {
         let range = (Included(start), Excluded(end));
         let input_confs = tree.elem.range(range);
         for conf in input_confs {
-            self.fns.push(node_fn(ctx.env(), node, node_path, &conf.conns));
+            self.fns
+                .push(node_fn(ctx.env(), node, node_path, &conf.conns));
         }
     }
 }

--- a/crates/gantz_core/src/compile/codegen/node_fn.rs
+++ b/crates/gantz_core/src/compile/codegen/node_fn.rs
@@ -38,9 +38,9 @@ impl<'a> NodeFns<'a> {
     }
 }
 
-impl<'pl> Visitor for NodeFns<'pl> {
+impl<'pl, Env> Visitor<Env> for NodeFns<'pl> {
     // We use `visit_post` so that the nested are generated before parents.
-    fn visit_post(&mut self, ctx: visit::Ctx, node: &dyn Node) {
+    fn visit_post(&mut self, ctx: visit::Ctx<Env>, node: &dyn Node<Env>) {
         use std::ops::Bound::{Excluded, Included};
         let node_path = ctx.path();
         let plan_path = &node_path[..node_path.len() - 1];
@@ -62,7 +62,7 @@ impl<'pl> Visitor for NodeFns<'pl> {
         let range = (Included(start), Excluded(end));
         let input_confs = tree.elem.range(range);
         for conf in input_confs {
-            self.fns.push(node_fn(node, node_path, &conf.conns));
+            self.fns.push(node_fn(ctx.env(), node, node_path, &conf.conns));
         }
     }
 }
@@ -101,7 +101,12 @@ pub(crate) fn name(node_path: &[node::Id], inputs: &node::Conns, outputs: &node:
 }
 
 /// Generate a function for a single node with the given set of connected inputs.
-pub(crate) fn node_fn(node: &dyn Node, node_path: &[node::Id], conns: &NodeConns) -> ExprKind {
+pub(crate) fn node_fn<Env>(
+    env: &Env,
+    node: &dyn Node<Env>,
+    node_path: &[node::Id],
+    conns: &NodeConns,
+) -> ExprKind {
     // The binding used to receive the node's state as an argument, and whose
     // resulting value is returned from the body of the function and used to
     // update the state map.
@@ -128,7 +133,7 @@ pub(crate) fn node_fn(node: &dyn Node, node_path: &[node::Id], conns: &NodeConns
         .collect();
 
     // Get the node's expression
-    let ctx = node::ExprCtx::new(node_path, &input_exprs, &conns.outputs);
+    let ctx = node::ExprCtx::new(env, node_path, &input_exprs, &conns.outputs);
     let node_expr = node.expr(ctx);
 
     // Construct the full function definition
@@ -152,12 +157,16 @@ pub(crate) fn node_fn(node: &dyn Node, node_path: &[node::Id], conns: &NodeConns
 
 /// Given a gantz graph and a rose tree with the associated node configs,
 /// produce a function for every node configuration in the graph.
-pub(crate) fn node_fns<G>(g: G, node_confs_tree: &RoseTree<NodeConfs>) -> Vec<ExprKind>
+pub(crate) fn node_fns<Env, G>(
+    env: &Env,
+    g: G,
+    node_confs_tree: &RoseTree<NodeConfs>,
+) -> Vec<ExprKind>
 where
     G: Data<EdgeWeight = Edge> + IntoEdgesDirected + IntoNodeReferences + NodeIndexable + Visitable,
-    G::NodeWeight: Node,
+    G::NodeWeight: Node<Env>,
 {
     let mut node_fns = NodeFns::new(&node_confs_tree);
-    crate::graph::visit(g, &[], &mut node_fns);
+    crate::graph::visit(env, g, &[], &mut node_fns);
     node_fns.fns
 }

--- a/crates/gantz_core/src/compile/meta.rs
+++ b/crates/gantz_core/src/compile/meta.rs
@@ -55,10 +55,10 @@ pub type MetaGraph = petgraph::graphmap::DiGraphMap<node::Id, Vec<(Edge, EdgeKin
 
 impl Meta {
     /// Construct a `Meta` for a single gantz graph.
-    pub fn from_graph<G>(g: G) -> Self
+    pub fn from_graph<Env, G>(env: &Env, g: G) -> Self
     where
         G: Data<EdgeWeight = Edge> + IntoEdgesDirected + IntoNodeReferences + NodeIndexable,
-        G::NodeWeight: Node,
+        G::NodeWeight: Node<Env>,
     {
         let mut flow = Meta::default();
         for n_ref in g.node_references() {
@@ -68,16 +68,17 @@ impl Meta {
                 .map(|e_ref| (g.to_index(e_ref.source()), e_ref.weight().clone()));
             let id = g.to_index(n);
             let node = n_ref.weight();
-            flow.add_node(id, node, inputs);
+            flow.add_node(env, id, node, inputs);
         }
         flow
     }
 
     /// Add the node with the given ID and inputs to the `Meta`.
-    pub fn add_node(
+    pub fn add_node<Env>(
         &mut self,
+        env: &Env,
         id: node::Id,
-        node: &dyn Node,
+        node: &dyn Node<Env>,
         inputs: impl IntoIterator<Item = (node::Id, Edge)>,
     ) {
         // Add the node.
@@ -98,8 +99,8 @@ impl Meta {
         }
 
         // Register whether the node has inputs or outputs.
-        let inputs = node.n_inputs();
-        let outputs = node.n_outputs();
+        let inputs = node.n_inputs(env);
+        let outputs = node.n_outputs(env);
         if inputs > 0 {
             self.inputs.insert(id, inputs);
         }
@@ -108,7 +109,7 @@ impl Meta {
         }
 
         // Track node branching.
-        let branches = node.branches();
+        let branches = node.branches(env);
         if !branches.is_empty() {
             self.branches.insert(
                 id,
@@ -120,7 +121,7 @@ impl Meta {
         }
 
         // Register push/pull eval for the node if necessary.
-        let push_eval = node.push_eval();
+        let push_eval = node.push_eval(env);
         if !push_eval.is_empty() {
             self.push.insert(
                 id,
@@ -130,7 +131,7 @@ impl Meta {
                     .collect(),
             );
         }
-        let pull_eval = node.pull_eval();
+        let pull_eval = node.pull_eval(env);
         if !pull_eval.is_empty() {
             self.pull.insert(
                 id,
@@ -154,8 +155,8 @@ impl Meta {
 
 /// Allow for constructing a rose-tree of `Meta`s (one for each graph) using
 /// the `Node::visit` implementation.
-impl Visitor for RoseTree<Meta> {
-    fn visit_pre(&mut self, ctx: visit::Ctx, node: &dyn Node) {
+impl<Env> Visitor<Env> for RoseTree<Meta> {
+    fn visit_pre(&mut self, ctx: visit::Ctx<Env>, node: &dyn Node<Env>) {
         let node_path = ctx.path();
 
         // Ensure the plan for the graph owning this node exists, retrieve it.
@@ -164,7 +165,7 @@ impl Visitor for RoseTree<Meta> {
 
         // Insert the node.
         let id = ctx.id();
-        tree.elem.add_node(id, node, ctx.inputs().iter().copied());
+        tree.elem.add_node(ctx.env(), id, node, ctx.inputs().iter().copied());
     }
 }
 

--- a/crates/gantz_core/src/compile/meta.rs
+++ b/crates/gantz_core/src/compile/meta.rs
@@ -165,7 +165,8 @@ impl<Env> Visitor<Env> for RoseTree<Meta> {
 
         // Insert the node.
         let id = ctx.id();
-        tree.elem.add_node(ctx.env(), id, node, ctx.inputs().iter().copied());
+        tree.elem
+            .add_node(ctx.env(), id, node, ctx.inputs().iter().copied());
     }
 }
 

--- a/crates/gantz_core/src/graph.rs
+++ b/crates/gantz_core/src/graph.rs
@@ -36,10 +36,10 @@ where
 
 /// Visit all nodes in the graph in toposort order, and all nested nodes in
 /// depth-first order.
-pub fn visit<G>(g: G, path: &[node::Id], visitor: &mut dyn node::Visitor)
+pub fn visit<Env, G>(env: &Env, g: G, path: &[node::Id], visitor: &mut dyn node::Visitor<Env>)
 where
     G: Data<EdgeWeight = Edge> + IntoEdgesDirected + IntoNodeReferences + NodeIndexable + Visitable,
-    G::NodeWeight: Node,
+    G::NodeWeight: Node<Env>,
 {
     let mut path = path.to_vec();
     let mut topo = Topo::new(g);
@@ -50,7 +50,7 @@ where
             .edges_directed(n, petgraph::Direction::Incoming)
             .map(|e_ref| (g.to_index(e_ref.source()), e_ref.weight().clone()))
             .collect();
-        let ctx = visit::Ctx::new(&path, &inputs);
+        let ctx = visit::Ctx::new(env, &path, &inputs);
 
         // FIXME: index directly.
         let nref = g.node_references().find(|nref| nref.id() == n).unwrap();
@@ -61,10 +61,10 @@ where
 }
 
 /// Register the given graph of nodes, including any nested nodes.
-pub fn register<G>(g: G, path: &[node::Id], vm: &mut Engine)
+pub fn register<Env, G>(env: &Env, g: G, path: &[node::Id], vm: &mut Engine)
 where
     G: Data<EdgeWeight = Edge> + IntoEdgesDirected + IntoNodeReferences + NodeIndexable + Visitable,
-    G::NodeWeight: Node,
+    G::NodeWeight: Node<Env>,
 {
-    visit(g, path, &mut visit::Register(vm));
+    visit(env, g, path, &mut visit::Register(vm));
 }

--- a/crates/gantz_core/src/graph.rs
+++ b/crates/gantz_core/src/graph.rs
@@ -1,15 +1,38 @@
 //! Provides [`visit`](crate::graph::visit) and [`register`] fns for generic
 //! gantz graphs.
 
+use std::hash::{Hash, Hasher};
+
 use crate::{
     Edge,
     node::{self, Node},
     visit,
 };
 use petgraph::visit::{
-    Data, EdgeRef, IntoEdgesDirected, IntoNodeReferences, NodeIndexable, NodeRef, Topo, Visitable,
+    Data, EdgeRef, IntoEdgeReferences, IntoEdgesDirected, IntoNodeReferences, NodeIndexable,
+    NodeRef, Topo, Visitable,
 };
 use steel::steel_vm::engine::Engine;
+
+/// Hash the nodes, edges and their IDs of the given graph.
+pub fn hash<G, H>(g: G, h: &mut H)
+where
+    G: Data + IntoEdgeReferences + IntoNodeReferences,
+    G::EdgeId: Hash,
+    G::EdgeWeight: Hash,
+    G::NodeId: Hash,
+    G::NodeWeight: Hash,
+    H: Hasher,
+{
+    for n in g.node_references() {
+        n.id().hash(h);
+        n.weight().hash(h);
+    }
+    for e in g.edge_references() {
+        e.id().hash(h);
+        e.weight().hash(h);
+    }
+}
 
 /// Visit all nodes in the graph in toposort order, and all nested nodes in
 /// depth-first order.

--- a/crates/gantz_core/src/node/expr.rs
+++ b/crates/gantz_core/src/node/expr.rs
@@ -109,16 +109,16 @@ fn interpolate_tokens(tts: TokenStream, inputs: &[Option<String>]) -> String {
     tokens.collect::<Vec<_>>().join(" ")
 }
 
-impl Node for Expr {
-    fn n_inputs(&self) -> usize {
+impl<Env> Node<Env> for Expr {
+    fn n_inputs(&self, _: &Env) -> usize {
         self.n_inputs
     }
 
-    fn n_outputs(&self) -> usize {
+    fn n_outputs(&self, _: &Env) -> usize {
         self.n_outputs
     }
 
-    fn expr(&self, ctx: node::ExprCtx) -> ExprKind {
+    fn expr(&self, ctx: node::ExprCtx<Env>) -> ExprKind {
         // Create a token stream.
         let skip_comments = true;
         let source_id = None;

--- a/crates/gantz_core/src/node/graph.rs
+++ b/crates/gantz_core/src/node/graph.rs
@@ -306,7 +306,12 @@ where
 }
 
 /// The implementation of the `GraphNode`'s `Node::expr` fn.
-pub fn nested_expr<Env, G>(env: &Env, g: G, path: &[node::Id], inputs: &[Option<String>]) -> ExprKind
+pub fn nested_expr<Env, G>(
+    env: &Env,
+    g: G,
+    path: &[node::Id],
+    inputs: &[Option<String>],
+) -> ExprKind
 where
     G: IntoEdgesDirected + IntoNodeReferences + NodeIndexable + Visitable + Data<EdgeWeight = Edge>,
     G::NodeWeight: Node<Env>,

--- a/crates/gantz_core/src/node/graph.rs
+++ b/crates/gantz_core/src/node/graph.rs
@@ -68,25 +68,25 @@ where
     }
 }
 
-impl<N> Node for GraphNode<N>
+impl<Env, N> Node<Env> for GraphNode<N>
 where
-    N: Node,
+    N: Node<Env>,
 {
-    fn branches(&self) -> Vec<node::EvalConf> {
+    fn n_inputs(&self, _: &Env) -> usize {
+        inlets(&self.graph).count()
+    }
+
+    fn n_outputs(&self, _: &Env) -> usize {
+        outlets(&self.graph).count()
+    }
+
+    fn branches(&self, _: &Env) -> Vec<node::EvalConf> {
         // TODO: generate branches based on inner node branching
         vec![]
     }
 
-    fn expr(&self, ctx: node::ExprCtx) -> ExprKind {
-        nested_expr(&self.graph, ctx.path(), ctx.inputs())
-    }
-
-    fn n_inputs(&self) -> usize {
-        inlets(&self.graph).count()
-    }
-
-    fn n_outputs(&self) -> usize {
-        outlets(&self.graph).count()
+    fn expr(&self, ctx: node::ExprCtx<Env>) -> ExprKind {
+        nested_expr(ctx.env(), &self.graph, ctx.path(), ctx.inputs())
     }
 
     fn stateful(&self) -> bool {
@@ -99,8 +99,8 @@ where
             .expect("failed to register graph hashmap");
     }
 
-    fn visit(&self, ctx: visit::Ctx, visitor: &mut dyn node::Visitor) {
-        crate::graph::visit(&self.graph, ctx.path(), visitor);
+    fn visit(&self, ctx: visit::Ctx<Env>, visitor: &mut dyn node::Visitor<Env>) {
+        crate::graph::visit(ctx.env(), &self.graph, ctx.path(), visitor);
     }
 }
 
@@ -195,9 +195,9 @@ where
     }
 }
 
-impl Node for Inlet {
+impl<Env> Node<Env> for Inlet {
     /// Simply returns the state value as this node's output
-    fn expr(&self, _ctx: node::ExprCtx) -> ExprKind {
+    fn expr(&self, _ctx: node::ExprCtx<Env>) -> ExprKind {
         Engine::emit_ast("state")
             .expect("failed to emit AST")
             .into_iter()
@@ -206,11 +206,11 @@ impl Node for Inlet {
             .into()
     }
 
-    fn n_inputs(&self) -> usize {
+    fn n_inputs(&self, _env: &Env) -> usize {
         0
     }
 
-    fn n_outputs(&self) -> usize {
+    fn n_outputs(&self, _env: &Env) -> usize {
         1
     }
 
@@ -227,9 +227,9 @@ impl Node for Inlet {
     }
 }
 
-impl Node for Outlet {
+impl<Env> Node<Env> for Outlet {
     // Stores the input value in the state.
-    fn expr(&self, ctx: node::ExprCtx) -> ExprKind {
+    fn expr(&self, ctx: node::ExprCtx<Env>) -> ExprKind {
         let input = match &ctx.inputs()[0] {
             Some(expr) => expr.clone(),
             None => "'()".to_string(),
@@ -243,11 +243,11 @@ impl Node for Outlet {
             .into()
     }
 
-    fn n_inputs(&self) -> usize {
+    fn n_inputs(&self, _env: &Env) -> usize {
         1
     }
 
-    fn n_outputs(&self) -> usize {
+    fn n_outputs(&self, _env: &Env) -> usize {
         0
     }
 
@@ -288,28 +288,28 @@ pub fn graph_partial_eq<N: PartialEq>(a: &Graph<N>, b: &Graph<N>) -> bool {
 }
 
 /// Count the number of inlet nodes in the given graph.
-pub fn inlets<G>(g: G) -> impl Iterator<Item = G::NodeRef>
+pub fn inlets<Env, G>(g: G) -> impl Iterator<Item = G::NodeRef>
 where
     G: Data + IntoNodeReferences,
-    G::NodeWeight: Node,
+    G::NodeWeight: Node<Env>,
 {
     g.node_references().filter(|n_ref| n_ref.weight().inlet())
 }
 
 /// Count the number of outlet nodes in the given graph.
-pub fn outlets<G>(g: G) -> impl Iterator<Item = G::NodeRef>
+pub fn outlets<Env, G>(g: G) -> impl Iterator<Item = G::NodeRef>
 where
     G: Data + IntoNodeReferences,
-    G::NodeWeight: Node,
+    G::NodeWeight: Node<Env>,
 {
     g.node_references().filter(|n_ref| n_ref.weight().outlet())
 }
 
 /// The implementation of the `GraphNode`'s `Node::expr` fn.
-pub fn nested_expr<G>(g: G, path: &[node::Id], inputs: &[Option<String>]) -> ExprKind
+pub fn nested_expr<Env, G>(env: &Env, g: G, path: &[node::Id], inputs: &[Option<String>]) -> ExprKind
 where
     G: IntoEdgesDirected + IntoNodeReferences + NodeIndexable + Visitable + Data<EdgeWeight = Edge>,
-    G::NodeWeight: Node,
+    G::NodeWeight: Node<Env>,
     G::NodeId: Eq + Hash,
 {
     use crate::compile;
@@ -330,7 +330,7 @@ where
     }
 
     // Use compile to create the evaluation order, steps, and statements
-    let meta = compile::Meta::from_graph(g);
+    let meta = compile::Meta::from_graph(env, g);
     let outlets: Vec<_> = outlets(g).map(|n_ref| n_ref.id()).collect();
     let flow_graph = compile::flow_graph(
         &meta,

--- a/crates/gantz_core/src/visit.rs
+++ b/crates/gantz_core/src/visit.rs
@@ -9,16 +9,18 @@ use steel::steel_vm::engine::Engine;
 /// For types used to traverse nested graphs of [`Node`]s.
 ///
 /// This is used for both node state registration and code generation.
-pub trait Visitor {
+pub trait Visitor<Env> {
     /// Called prior to traversing nested nodes.
-    fn visit_pre(&mut self, _ctx: Ctx, _node: &dyn Node) {}
+    fn visit_pre(&mut self, _ctx: Ctx<Env>, _node: &dyn Node<Env>) {}
     /// Called following traversal of nested nodes.
-    fn visit_post(&mut self, _ctx: Ctx, _node: &dyn Node) {}
+    fn visit_post(&mut self, _ctx: Ctx<Env>, _node: &dyn Node<Env>) {}
 }
 
 /// The context provided for each node during the traversal.
-#[derive(Clone, Copy, Debug)]
-pub struct Ctx<'a> {
+#[derive(Debug)]
+pub struct Ctx<'a, Env> {
+    /// A reference to the environment provided to the nodes.
+    env: &'a Env,
     /// The path at which this node is nested relative to the root.
     path: &'a [node::Id],
     /// A slice with an element for every input, `Some` if connected.
@@ -33,11 +35,16 @@ pub struct Ctx<'a> {
 /// - `gantz_core::graph::register`
 pub(crate) struct Register<'vm>(pub(crate) &'vm mut Engine);
 
-impl<'a> Ctx<'a> {
+impl<'a, Env> Ctx<'a, Env> {
     /// Create a `Ctx` instance. Exclusively for use by `Visitor`
     /// implementations.
-    pub fn new(path: &'a [node::Id], inputs: &'a [(node::Id, Edge)]) -> Self {
-        Self { path, inputs }
+    pub fn new(env: &'a Env, path: &'a [node::Id], inputs: &'a [(node::Id, Edge)]) -> Self {
+        Self { env, path, inputs }
+    }
+
+    /// Access to the environment provided to the nodes.
+    pub fn env(&self) -> &Env {
+        self.env
     }
 
     /// The path at which this node is nested relative to the root.
@@ -58,10 +65,22 @@ impl<'a> Ctx<'a> {
     }
 }
 
+impl<'a, Env> Clone for Ctx<'a, Env> {
+    fn clone(&self) -> Self {
+        Self {
+            env: self.env,
+            path: self.path,
+            inputs: self.inputs,
+        }
+    }
+}
+
+impl<'a, Env> Copy for Ctx<'a, Env> { }
+
 /// The `Register` visitor just calls `register` for each node, prior to
 /// traversing its nested nodes.
-impl<'vm> Visitor for Register<'vm> {
-    fn visit_pre(&mut self, ctx: Ctx, node: &dyn Node) {
+impl<'vm, Env> Visitor<Env> for Register<'vm> {
+    fn visit_pre(&mut self, ctx: Ctx<Env>, node: &dyn Node<Env>) {
         node.register(ctx.path(), self.0);
     }
 }

--- a/crates/gantz_core/src/visit.rs
+++ b/crates/gantz_core/src/visit.rs
@@ -75,7 +75,7 @@ impl<'a, Env> Clone for Ctx<'a, Env> {
     }
 }
 
-impl<'a, Env> Copy for Ctx<'a, Env> { }
+impl<'a, Env> Copy for Ctx<'a, Env> {}
 
 /// The `Register` visitor just calls `register` for each node, prior to
 /// traversing its nested nodes.

--- a/crates/gantz_core/tests/nested.rs
+++ b/crates/gantz_core/tests/nested.rs
@@ -8,7 +8,7 @@ use gantz_core::{
 use std::fmt::Debug;
 use steel::{SteelVal, steel_vm::engine::Engine};
 
-fn node_push() -> node::Push<node::Expr> {
+fn node_push() -> node::Push<(), node::Expr> {
     node::expr("'()").unwrap().with_push_eval()
 }
 
@@ -36,8 +36,8 @@ fn node_number() -> node::Expr {
 }
 
 // Helper trait for debugging the graph.
-trait DebugNode: Debug + Node {}
-impl<T> DebugNode for T where T: Debug + Node {}
+trait DebugNode: Debug + Node<()> {}
+impl<T> DebugNode for T where T: Debug + Node<()> {}
 
 // A simple test for nested graph support.
 //
@@ -114,15 +114,18 @@ fn test_graph_nested_stateless() {
     gb.add_edge(graph_a, assert_eq, Edge::from((0, 0)));
     gb.add_edge(forty_two, assert_eq, Edge::from((0, 1)));
 
+    // No need to share an environment between nodes for this test.
+    let env = ();
+
     // Generate the module, which should have just one top-level expr for `push`.
-    let module = gantz_core::compile::module(&gb);
+    let module = gantz_core::compile::module(&env, &gb);
 
     // Create the VM.
     let mut vm = Engine::new_base();
 
     // Initialise the node state vars.
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
-    gantz_core::graph::register(&gb, &[], &mut vm);
+    gantz_core::graph::register(&env, &gb, &[], &mut vm);
 
     // Register the fns.
     for f in module {
@@ -196,15 +199,18 @@ fn test_graph_nested_counter() {
     gb.add_edge(push, graph_a, Edge::from((0, 0)));
     gb.add_edge(graph_a, number, Edge::from((0, 0)));
 
+    // No need to share an environment between nodes for this test.
+    let env = ();
+
     // Generate the module.
-    let module = gantz_core::compile::module(&gb);
+    let module = gantz_core::compile::module(&env, &gb);
 
     // Create the VM.
     let mut vm = Engine::new_base();
 
     // Initialise the node state vars.
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
-    gantz_core::graph::register(&gb, &[], &mut vm);
+    gantz_core::graph::register(&env, &gb, &[], &mut vm);
 
     // Register the fns.
     for f in module {
@@ -283,15 +289,18 @@ fn test_graph_nested_push_eval() {
     let number = gb.add_node(Box::new(node_number()) as Box<_>);
     gb.add_edge(graph_a, number, Edge::from((0, 0)));
 
+    // No need to share an environment between nodes for this test.
+    let env = ();
+
     // Generate the module.
-    let module = gantz_core::compile::module(&gb);
+    let module = gantz_core::compile::module(&env, &gb);
 
     // Create the VM.
     let mut vm = Engine::new_base();
 
     // Initialise the node state vars.
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
-    gantz_core::graph::register(&gb, &[], &mut vm);
+    gantz_core::graph::register(&env, &gb, &[], &mut vm);
 
     // Register the fns.
     for f in module {

--- a/crates/gantz_core/tests/state.rs
+++ b/crates/gantz_core/tests/state.rs
@@ -13,14 +13,14 @@ use steel::{
 use steel_derive::Steel;
 
 /// Simple node for pushing evaluation through the graph.
-fn node_push() -> node::Push<node::Expr> {
+fn node_push() -> node::Push<(), node::Expr> {
     node::expr("'()").unwrap().with_push_eval()
 }
 
 // A simple counter node.
 //
 // Increases its `u32` state by `1` each time it receives an input of any type.
-fn node_counter() -> node::State<node::Expr, Counter> {
+fn node_counter() -> node::State<(), node::Expr, Counter> {
     let expr = r#"
         (begin
           $push
@@ -54,8 +54,8 @@ impl NodeState for Counter {
 }
 
 // Helper trait for debugging the graph.
-trait DebugNode: Debug + Node {}
-impl<T> DebugNode for T where T: Debug + Node {}
+trait DebugNode: Debug + Node<()> {}
+impl<T> DebugNode for T where T: Debug + Node<()> {}
 
 // A simple as possible test graph for testing state.
 //
@@ -81,15 +81,18 @@ fn test_graph_with_counter() {
     let counter = g.add_node(Box::new(counter) as Box<_>);
     g.add_edge(push, counter, Edge::from((0, 0)));
 
+    // No need to share an environment between nodes for this test.
+    let env = ();
+
     // Generate the module, which should have just one top-level expr for `push`.
-    let module = gantz_core::compile::module(&g);
+    let module = gantz_core::compile::module(&env, &g);
 
     // Initialise the VM.
     let mut vm = Engine::new_base();
 
     // Initialise the node state.
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
-    gantz_core::graph::register(&g, &[], &mut vm);
+    gantz_core::graph::register(&env, &g, &[], &mut vm);
 
     // Initialise the eval fn.
     for f in module {
@@ -171,15 +174,18 @@ fn test_graph_with_counters() {
     g.add_edge(c_b, c_c, Edge::from((0, 0)));
     g.add_edge(p_c, c_c, Edge::from((0, 0)));
 
+    // No need to share an environment between nodes for this test.
+    let env = ();
+
     // Generate the module, which should have one expr for each `push`.
-    let module = gantz_core::compile::module(&g);
+    let module = gantz_core::compile::module(&env, &g);
 
     // Initialise the VM.
     let mut vm = Engine::new_base();
 
     // Initialise the node state.
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
-    gantz_core::graph::register(&g, &[], &mut vm);
+    gantz_core::graph::register(&env, &g, &[], &mut vm);
 
     // Initialise the eval fns.
     for f in &module {

--- a/crates/gantz_egui/Cargo.toml
+++ b/crates/gantz_egui/Cargo.toml
@@ -22,6 +22,7 @@ steel-core.workspace = true
 sublime_fuzzy.workspace = true
 
 [dev-dependencies]
+dyn-clone.workspace = true
 dyn-hash.workspace = true
 eframe.workspace = true
 ron.workspace = true

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -224,7 +224,12 @@ impl App {
             })
             .unwrap_or_else(|| {
                 log::error!("Unable to access storage");
-                (Default::default(), Default::default(), None, Default::default())
+                (
+                    Default::default(),
+                    Default::default(),
+                    None,
+                    Default::default(),
+                )
             });
 
         // Lookup the active graph or fallback to an empty default.
@@ -490,16 +495,14 @@ fn load_gantz_gui_state(storage: &dyn eframe::Storage) -> gantz_egui::widget::Ga
             log::debug!("No existing gantz GUI state to load");
             None
         })
-        .and_then(|gantz_str| {
-            match ron::de::from_str(&gantz_str) {
-                Ok(gantz) => {
-                    log::debug!("Successfully loaded gantz GUI state from storage");
-                    Some(gantz)
-                }
-                Err(e) => {
-                    log::error!("Failed to deserialize gantz GUI state: {e}");
-                    None
-                }
+        .and_then(|gantz_str| match ron::de::from_str(&gantz_str) {
+            Ok(gantz) => {
+                log::debug!("Successfully loaded gantz GUI state from storage");
+                Some(gantz)
+            }
+            Err(e) => {
+                log::error!("Failed to deserialize gantz GUI state: {e}");
+                None
             }
         })
         .unwrap_or_else(|| {

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -52,6 +52,10 @@ impl Node for gantz_std::Log {}
 #[typetag::serde]
 impl Node for gantz_std::Number {}
 
+// FIXME
+// #[typetag::serde]
+// impl Node for gantz_egui::node::NamedGraph<Box<dyn Node>> {}
+
 #[typetag::serde]
 impl Node for Box<dyn Node> {}
 

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -1,19 +1,17 @@
 //! A simple demonstration of a pure `egui` setup for `gantz`.
 //!
-//! Includes a top-level `Node` trait with a minimal set of nodes, a node
-//! registry, and a minimal default graph to demonstrate how to use these with
-//! the top-level `Gantz` widget in an egui app.
+//! Includes a top-level `Node` trait with a minimal set of nodes, an
+//! environment with a node registry, and a minimal default graph to demonstrate
+//! how to use these with the top-level `Gantz` widget in an egui app.
 
+use dyn_clone::DynClone;
 use dyn_hash::DynHash;
 use eframe::egui;
 use gantz_core::steel::steel_vm::engine::Engine;
-use petgraph::visit::EdgeRef;
-use petgraph::visit::{IntoEdgeReferences, IntoNodeReferences, NodeRef};
-use std::{
-    any::Any,
-    collections::BTreeMap,
-    hash::{Hash, Hasher},
-};
+use gantz_egui::ContentAddr;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::{any::Any, collections::BTreeMap};
 use steel::{SteelVal, parser::ast::ExprKind};
 
 // ----------------------------------------------
@@ -25,13 +23,111 @@ fn main() -> Result<(), eframe::Error> {
 }
 
 // ----------------------------------------------
+// Environment
+// ----------------------------------------------
+
+/// The type used to track mappings between node names, content addresses and
+/// graphs. Also provides access to the node registry. This can be thought of as
+/// a shared immutable input to all nodes.
+struct Environment {
+    /// Constructors for all primitive nodes.
+    primitives: Primitives,
+    /// The registry of all nodes composed from other nodes.
+    registry: NodeTypeRegistry,
+}
+
+/// The registry for all named graphs, i.e. nodes composed from other nodes.
+#[derive(Default, Deserialize, Serialize)]
+struct NodeTypeRegistry {
+    /// A mapping from content addresses to graphs.
+    graphs: HashMap<ContentAddr, Graph>,
+    /// A mapping from names to graph content addresses.
+    names: BTreeMap<String, ContentAddr>,
+}
+
+/// Constructors for all primitive nodes.
+type Primitives = BTreeMap<String, Box<dyn Fn() -> Box<dyn Node>>>;
+
+// Provide the `NodeTypeRegistry` implementation required by `gantz_egui`.
+impl gantz_egui::widget::gantz::NodeTypeRegistry for Environment {
+    type Node = Box<dyn Node>;
+
+    fn node_types(&self) -> impl Iterator<Item = &str> {
+        let mut types = vec![];
+        types.extend(self.primitives.keys().map(|s| &s[..]));
+        types.extend(self.registry.names.keys().map(|s| &s[..]));
+        types.sort();
+        types.into_iter()
+    }
+
+    fn new_node(&self, node_type: &str) -> Option<Self::Node> {
+        self.registry
+            .names
+            .get(node_type)
+            .map(|&ca| {
+                let named = gantz_egui::node::NamedGraph::new(node_type.to_string(), ca);
+                Box::new(named) as Box<_>
+            })
+            .or_else(|| self.primitives.get(node_type).map(|f| (f)()))
+    }
+}
+
+// Provide the `NodeNameRegistry` implementation required by `gantz_egui`.
+impl gantz_egui::node::graph::GraphRegistry for Environment {
+    type Node = Box<dyn Node>;
+    fn graph(&self, ca: ContentAddr) -> Option<&gantz_core::node::graph::Graph<Self::Node>> {
+        self.registry.graphs.get(&ca)
+    }
+}
+
+/// The set of all known node types accessible to gantz.
+fn primitives() -> Primitives {
+    let mut p = Primitives::default();
+    register_primitive(&mut p, "add", || {
+        Box::new(gantz_std::ops::Add::default()) as Box<_>
+    });
+    register_primitive(&mut p, "bang", || {
+        Box::new(gantz_std::Bang::default()) as Box<_>
+    });
+    register_primitive(&mut p, "expr", || {
+        Box::new(gantz_core::node::Expr::new("()").unwrap()) as Box<_>
+    });
+    register_primitive(&mut p, "graph", || Box::new(GraphNode::default()) as Box<_>);
+    register_primitive(&mut p, "inlet", || {
+        Box::new(gantz_core::node::graph::Inlet::default()) as Box<_>
+    });
+    register_primitive(&mut p, "outlet", || {
+        Box::new(gantz_core::node::graph::Outlet::default()) as Box<_>
+    });
+    register_primitive(&mut p, "log", || {
+        Box::new(gantz_std::Log::default()) as Box<_>
+    });
+    register_primitive(&mut p, "number", || {
+        Box::new(gantz_std::Number::default()) as Box<_>
+    });
+    p
+}
+
+fn register_primitive(
+    primitives: &mut Primitives,
+    name: impl Into<String>,
+    new: impl 'static + Fn() -> Box<dyn Node>,
+) -> Option<Box<dyn Fn() -> Box<dyn Node>>> {
+    primitives.insert(name.into(), Box::new(new) as Box<_>)
+}
+
+// ----------------------------------------------
 // Top-level `Node` trait
 // ----------------------------------------------
 
-/// A top-level blanket trait providing trait object serialization.
+/// A top-level blanket trait providing trait object cloning, hashing, and serialization.
 #[typetag::serde(tag = "type")]
-trait Node: Any + DynHash + gantz_core::Node + gantz_egui::NodeUi {}
+trait Node:
+    Any + DynClone + DynHash + gantz_core::Node<Environment> + gantz_egui::NodeUi<Environment>
+{
+}
 
+dyn_clone::clone_trait_object!(Node);
 dyn_hash::hash_trait_object!(Node);
 
 #[typetag::serde]
@@ -52,9 +148,8 @@ impl Node for gantz_std::Log {}
 #[typetag::serde]
 impl Node for gantz_std::Number {}
 
-// FIXME
-// #[typetag::serde]
-// impl Node for gantz_egui::node::NamedGraph<Box<dyn Node>> {}
+#[typetag::serde]
+impl Node for gantz_egui::node::NamedGraph {}
 
 #[typetag::serde]
 impl Node for Box<dyn Node> {}
@@ -66,59 +161,6 @@ impl gantz_egui::widget::graph_scene::ToGraphMut for Box<dyn Node> {
     fn to_graph_mut(&mut self) -> Option<&mut gantz_core::node::GraphNode<Self::Node>> {
         ((&mut **self) as &mut dyn Any).downcast_mut()
     }
-}
-
-// ----------------------------------------------
-// Node Registry
-// ----------------------------------------------
-
-/// The set of all known node types accessible to gantz.
-#[derive(Default)]
-struct NodeTypeRegistry(BTreeMap<String, Box<dyn Fn() -> Box<dyn Node>>>);
-
-impl NodeTypeRegistry {
-    /// A convenience generic method around `NodeTypeRegistry::insert`.
-    fn register(
-        &mut self,
-        name: impl Into<String>,
-        new: impl 'static + Fn() -> Box<dyn Node>,
-    ) -> Option<Box<dyn Fn() -> Box<dyn Node>>> {
-        self.0.insert(name.into(), Box::new(new) as Box<_>)
-    }
-}
-
-impl gantz_egui::widget::gantz::NodeTypeRegistry for NodeTypeRegistry {
-    type Node = Box<dyn Node>;
-
-    fn node_types(&self) -> impl Iterator<Item = &str> {
-        self.0.keys().map(|s| &s[..])
-    }
-
-    fn new_node(&self, node_type: &str) -> Option<Self::Node> {
-        self.0.get(node_type).map(|f| (f)())
-    }
-}
-
-/// The set of all known node types accessible to gantz.
-fn node_type_registry() -> NodeTypeRegistry {
-    let mut reg = NodeTypeRegistry::default();
-    reg.register("add", || Box::new(gantz_std::ops::Add::default()) as Box<_>);
-    reg.register("bang", || Box::new(gantz_std::Bang::default()) as Box<_>);
-    reg.register("expr", || {
-        Box::new(gantz_core::node::Expr::new("()").unwrap()) as Box<_>
-    });
-    reg.register("graph", || Box::new(GraphNode::default()) as Box<_>);
-    reg.register("inlet", || {
-        Box::new(gantz_core::node::graph::Inlet::default()) as Box<_>
-    });
-    reg.register("outlet", || {
-        Box::new(gantz_core::node::graph::Outlet::default()) as Box<_>
-    });
-    reg.register("log", || Box::new(gantz_std::Log::default()) as Box<_>);
-    reg.register("number", || {
-        Box::new(gantz_std::Number::default()) as Box<_>
-    });
-    reg
 }
 
 // ----------------------------------------------
@@ -138,11 +180,11 @@ struct App {
 
 struct State {
     graph: GraphNode,
-    graph_hash: u64,
+    graph_ca: ContentAddr,
     compiled_module: String,
     logger: gantz_egui::widget::log_view::Logger,
     gantz: gantz_egui::widget::GantzState,
-    node_ty_reg: NodeTypeRegistry,
+    env: Environment,
     vm: Engine,
 }
 
@@ -151,10 +193,14 @@ struct State {
 // ----------------------------------------------
 
 impl App {
-    /// The key at which the graph is to be saved/loaded.
-    const GRAPH_KEY: &str = "graph";
     /// The key at which the gantz widget state is to be saved/loaded.
     const GANTZ_GUI_STATE_KEY: &str = "gantz-widget-state";
+    /// All known graph content addresses.
+    const GRAPH_ADDRS_KEY: &str = "graph-addrs";
+    /// The key at which the mapping from names to graph CAs is stored.
+    const GRAPH_NAMES_KEY: &str = "graph-names";
+    /// The key at which the content address of the active graph is stored.
+    const ACTIVE_GRAPH_KEY: &str = "active-graph";
 
     pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
         // Setup logging.
@@ -162,40 +208,46 @@ impl App {
         log::set_boxed_logger(Box::new(logger.clone())).unwrap();
         log::set_max_level(log::LevelFilter::Info);
 
-        // Load the graph or fallback to a default empty one.
-        let graph = cc
+        // Load the graphs and mappings from storage.
+        let (graphs, names, active_graph) = cc
             .storage
             .as_ref()
-            .and_then(|storage| {
-                let Some(graph_str) = storage.get_string(Self::GRAPH_KEY) else {
-                    log::debug!("No existing graph to load");
-                    return None;
-                };
-                match ron::de::from_str(&graph_str) {
-                    Ok(graph) => {
-                        log::debug!("Successfully loaded graph from storage");
-                        Some(graph)
-                    }
-                    Err(e) => {
-                        log::error!("Failed to deserialize graph: {e}");
-                        None
-                    }
-                }
+            .map(|&storage| {
+                let graph_addrs = load_graph_addrs(storage);
+                let graphs = load_graphs(storage, graph_addrs.iter().copied());
+                let graph_names = load_graph_names(storage);
+                let active_graph = load_active_graph(storage);
+                (graphs, graph_names, active_graph)
             })
-            .unwrap_or_else(|| {
-                log::debug!("Initialising default graph");
-                GraphNode::default()
-            });
-        let graph_hash = graph_hash(&graph);
+            .unwrap_or_else(|| (Default::default(), Default::default(), None));
+
+        // Lookup the active graph or fallback to an empty default.
+        let graph = match active_graph {
+            None => GraphNode::default(),
+            Some(ca) => {
+                let graph = graphs.get(&ca).map(|g| clone_graph(g)).unwrap_or_default();
+                GraphNode { graph }
+            }
+        };
+        let graph_ca = gantz_egui::graph_content_addr(&graph);
+
+        // Setup the environment that will be provided to all nodes.
+        let registry = NodeTypeRegistry { graphs, names };
+        let primitives = primitives();
+        let env = Environment {
+            registry,
+            primitives,
+        };
 
         // VM setup
         let mut vm = Engine::new();
+        // TODO: Load state from storage?
         vm.register_value(gantz_core::ROOT_STATE, SteelVal::empty_hashmap());
-        gantz_core::graph::register(&graph.graph, &[], &mut vm);
-        let module = compile_graph(&graph, &mut vm);
+        gantz_core::graph::register(&env, &graph.graph, &[], &mut vm);
+        let module = compile_graph(&env, &graph, &mut vm);
         let compiled_module = fmt_compiled_module(&module);
 
-        // GUI setup
+        // GUI setup.
         let ctx = &cc.egui_ctx;
         ctx.set_fonts(egui::FontDefinitions::default());
 
@@ -228,8 +280,8 @@ impl App {
             logger,
             gantz,
             graph,
-            graph_hash,
-            node_ty_reg: node_type_registry(),
+            graph_ca,
+            env,
             compiled_module,
             vm,
         };
@@ -243,10 +295,12 @@ impl eframe::App for App {
         gui(ctx, &mut self.state);
 
         // Check for changes to the graph.
-        let new_graph_hash = graph_hash(&self.state.graph);
-        if self.state.graph_hash != new_graph_hash {
-            self.state.graph_hash = new_graph_hash;
-            let module = compile_graph(&self.state.graph, &mut self.state.vm);
+        // FIXME: Rather than checking changed CA to monitor changes, ideally
+        // `Gantz` widget can tell us this in a custom response.
+        let new_graph_ca = gantz_egui::graph_content_addr(&self.state.graph);
+        if self.state.graph_ca != new_graph_ca {
+            self.state.graph_ca = new_graph_ca;
+            let module = compile_graph(&self.state.env, &self.state.graph, &mut self.state.vm);
             self.state.compiled_module = fmt_compiled_module(&module);
         }
 
@@ -255,33 +309,201 @@ impl eframe::App for App {
     }
 
     fn save(&mut self, storage: &mut dyn eframe::Storage) {
-        // Save the graph.
-        let graph_str = match ron::to_string(&self.state.graph) {
-            Err(e) => {
-                log::error!("Failed to serialize and save graph: {e}");
-                return;
-            }
-            Ok(s) => s,
-        };
-        storage.set_string(Self::GRAPH_KEY, graph_str);
-        log::debug!("Successfully persisted graph");
+        // Ensure the active graph is registered.
+        let active_ca = gantz_egui::graph_content_addr(&self.state.graph.graph);
+        self.state
+            .env
+            .registry
+            .graphs
+            .entry(active_ca)
+            .or_insert_with(|| clone_graph(&self.state.graph.graph));
+
+        // Save the graph addresses, the graphs and the graph names.
+        let mut addrs: Vec<_> = self.state.env.registry.graphs.keys().copied().collect();
+        addrs.sort();
+        save_graph_addrs(storage, &addrs);
+        save_graphs(storage, &self.state.env.registry.graphs);
+        save_graph_names(storage, &self.state.env.registry.names);
+
+        // Save the active graph.
+        save_active_graph(storage, active_ca);
 
         // Save the gantz GUI state.
-        let gantz_str = match ron::to_string(&self.state.gantz) {
-            Err(e) => {
-                log::error!("Failed to serialize and save gantz GUI state: {e}");
-                return;
-            }
-            Ok(s) => s,
-        };
-        storage.set_string(Self::GANTZ_GUI_STATE_KEY, gantz_str);
-        log::debug!("Successfully persisted gantz GUI state");
+        save_gantz_gui_state(storage, &self.state.gantz);
     }
 
     // Persist GUI state.
     fn persist_egui_memory(&self) -> bool {
         true
     }
+}
+
+/// Short-hand for using `dyn-clone` to clone the graph.
+fn clone_graph(graph: &Graph) -> Graph {
+    graph.map(|_, n| dyn_clone::clone_box(&**n), |_, e| e.clone())
+}
+
+/// Save the list of known content addresses to storage.
+fn save_graph_addrs(storage: &mut dyn eframe::Storage, addrs: &[ContentAddr]) {
+    let graph_addrs_str = match ron::to_string(addrs) {
+        Err(e) => {
+            log::error!("Failed to serialize graph content addresses: {e}");
+            return;
+        }
+        Ok(s) => s,
+    };
+    storage.set_string(App::GRAPH_ADDRS_KEY, graph_addrs_str);
+    log::debug!("Successfully persisted known graph content addresses");
+}
+
+/// Save all graphs to storage, keyed via their content address.
+fn save_graphs(
+    storage: &mut dyn eframe::Storage,
+    graphs: &HashMap<ContentAddr, gantz_core::node::graph::Graph<Box<dyn Node>>>,
+) {
+    for (&ca, graph) in graphs {
+        save_graph(storage, ca, graph);
+    }
+}
+
+/// Save the list of known content addresses to storage.
+fn save_graph(
+    storage: &mut dyn eframe::Storage,
+    ca: ContentAddr,
+    graph: &gantz_core::node::graph::Graph<Box<dyn Node>>,
+) {
+    let key = graph_key(ca);
+    let graph_str = match ron::to_string(graph) {
+        Err(e) => {
+            log::error!("Failed to serialize graph: {e}");
+            return;
+        }
+        Ok(s) => s,
+    };
+    storage.set_string(&key, graph_str);
+    log::debug!("Successfully persisted graph {key}");
+}
+
+/// Save the graph names to storage.
+fn save_graph_names(storage: &mut dyn eframe::Storage, names: &BTreeMap<String, ContentAddr>) {
+    let graph_names_str = match ron::to_string(names) {
+        Err(e) => {
+            log::error!("Failed to serialize graph names: {e}");
+            return;
+        }
+        Ok(s) => s,
+    };
+    storage.set_string(App::GRAPH_NAMES_KEY, graph_names_str);
+    log::debug!("Successfully persisted graph names");
+}
+
+/// Save the gantz GUI state.
+fn save_gantz_gui_state(storage: &mut dyn eframe::Storage, state: &gantz_egui::widget::GantzState) {
+    let gantz_str = match ron::to_string(state) {
+        Err(e) => {
+            log::error!("Failed to serialize and save gantz GUI state: {e}");
+            return;
+        }
+        Ok(s) => s,
+    };
+    storage.set_string(App::GANTZ_GUI_STATE_KEY, gantz_str);
+    log::debug!("Successfully persisted gantz GUI state");
+}
+
+/// Save the active graph to storage.
+fn save_active_graph(storage: &mut dyn eframe::Storage, ca: ContentAddr) {
+    // TODO: Use hex formatter rather than `ron`.
+    let active_graph_str = match ron::to_string(&ca) {
+        Err(e) => {
+            log::error!("Failed to serialize active graph CA: {e}");
+            return;
+        }
+        Ok(s) => s,
+    };
+    storage.set_string(App::ACTIVE_GRAPH_KEY, active_graph_str);
+    log::debug!("Successfully persisted active graph CA");
+}
+
+/// Load the graph addresses from storage.
+fn load_graph_addrs(storage: &dyn eframe::Storage) -> Vec<ContentAddr> {
+    let Some(graph_addrs_str) = storage.get_string(App::GRAPH_ADDRS_KEY) else {
+        log::debug!("No existing graph address list to load");
+        return vec![];
+    };
+    match ron::de::from_str(&graph_addrs_str) {
+        Ok(addrs) => {
+            log::debug!("Successfully loaded graph addresses from storage");
+            addrs
+        }
+        Err(e) => {
+            log::error!("Failed to deserialize graph addresses: {e}");
+            vec![]
+        }
+    }
+}
+
+/// Given access to storage and an iterator yielding known graph content
+/// addresses, load those graphs into memory.
+fn load_graphs(
+    storage: &dyn eframe::Storage,
+    addrs: impl IntoIterator<Item = ContentAddr>,
+) -> HashMap<ContentAddr, gantz_core::node::graph::Graph<Box<dyn Node>>> {
+    addrs
+        .into_iter()
+        .filter_map(|ca| Some((ca, load_graph(storage, ca)?)))
+        .collect()
+}
+
+/// Load the graph with the given content address from storage.
+fn load_graph(
+    storage: &dyn eframe::Storage,
+    ca: ContentAddr,
+) -> Option<gantz_core::node::graph::Graph<Box<dyn Node>>> {
+    let key = graph_key(ca);
+    let Some(graph_str) = storage.get_string(&key) else {
+        log::debug!("No graph found for content address {key}");
+        return None;
+    };
+    match ron::de::from_str(&graph_str) {
+        Ok(graph) => {
+            log::debug!("Successfully loaded graph {key} from storage");
+            Some(graph)
+        }
+        Err(e) => {
+            log::error!("Failed to deserialize graph {key}: {e}");
+            None
+        }
+    }
+}
+
+/// Load the graph names from storage.
+fn load_graph_names(storage: &dyn eframe::Storage) -> BTreeMap<String, ContentAddr> {
+    let Some(graph_names_str) = storage.get_string(App::GRAPH_NAMES_KEY) else {
+        log::debug!("No existing graph names list to load");
+        return BTreeMap::default();
+    };
+    match ron::de::from_str(&graph_names_str) {
+        Ok(names) => {
+            log::debug!("Successfully loaded graph names from storage");
+            names
+        }
+        Err(e) => {
+            log::error!("Failed to deserialize graph names: {e}");
+            BTreeMap::default()
+        }
+    }
+}
+
+/// Load the CA of the active graph if there is one.
+fn load_active_graph(storage: &dyn eframe::Storage) -> Option<ContentAddr> {
+    let active_graph_str = storage.get_string(App::ACTIVE_GRAPH_KEY)?;
+    // TODO: Use from_hex instead of `ron`.
+    ron::de::from_str(&active_graph_str).ok()
+}
+
+/// The key for a particular graph in storage.
+fn graph_key(ca: ContentAddr) -> String {
+    format!("{}", gantz_egui::fmt_content_addr(ca))
 }
 
 // Drain the commands provided by the UI and process them.
@@ -309,9 +531,9 @@ fn process_cmds(state: &mut gantz_egui::widget::GantzState, vm: &mut Engine) {
     }
 }
 
-fn compile_graph(graph: &Graph, vm: &mut Engine) -> Vec<ExprKind> {
+fn compile_graph(env: &Environment, graph: &Graph, vm: &mut Engine) -> Vec<ExprKind> {
     // Generate the steel module.
-    let module = gantz_core::compile::module(graph);
+    let module = gantz_core::compile::module(env, graph);
     // Compile the eval fns.
     for expr in &module {
         if let Err(e) = vm.run(expr.to_pretty(80)) {
@@ -329,26 +551,11 @@ fn fmt_compiled_module(module: &[ExprKind]) -> String {
         .join("\n\n")
 }
 
-/// Determine the graph hash. Used between updates to check for changes.
-// FIXME: Ideally `Gantz` widget can tell us this in a custom response.
-fn graph_hash(g: &Graph) -> u64 {
-    let mut h = std::hash::DefaultHasher::default();
-    for n in g.node_references() {
-        n.id().hash(&mut h);
-        n.weight().hash(&mut h);
-    }
-    for e in g.edge_references() {
-        e.id().hash(&mut h);
-        e.weight().hash(&mut h);
-    }
-    h.finish()
-}
-
 fn gui(ctx: &egui::Context, state: &mut State) {
     egui::containers::CentralPanel::default()
         .frame(egui::Frame::default())
         .show(ctx, |ui| {
-            gantz_egui::widget::Gantz::new(&state.node_ty_reg, &mut state.graph).show(
+            gantz_egui::widget::Gantz::new(&state.env, &mut state.graph).show(
                 &mut state.gantz,
                 &state.logger,
                 &state.compiled_module,

--- a/crates/gantz_egui/src/impls/bang.rs
+++ b/crates/gantz_egui/src/impls/bang.rs
@@ -1,11 +1,11 @@
 use crate::{NodeCtx, NodeUi};
 
-impl NodeUi for gantz_std::Bang {
-    fn name(&self) -> &str {
+impl<Env> NodeUi<Env> for gantz_std::Bang {
+    fn name(&self, _: &Env) -> &str {
         "!"
     }
 
-    fn ui(&mut self, mut ctx: NodeCtx, ui: &mut egui::Ui) -> egui::Response {
+    fn ui(&mut self, mut ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
         let res = ui.add(egui::Button::new(" ! "));
         if res.clicked() {
             ctx.push_eval();

--- a/crates/gantz_egui/src/impls/expr.rs
+++ b/crates/gantz_egui/src/impls/expr.rs
@@ -75,12 +75,12 @@ impl<'a> egui::Widget for ExprEdit<'a> {
     }
 }
 
-impl NodeUi for gantz_core::node::Expr {
-    fn name(&self) -> &str {
+impl<Env> NodeUi<Env> for gantz_core::node::Expr {
+    fn name(&self, _: &Env) -> &str {
         "expr"
     }
 
-    fn ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> egui::Response {
+    fn ui(&mut self, ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
         let id = egui::Id::new("ExprEdit").with(ctx.path());
         ui.add(ExprEdit::new(self, id))
     }

--- a/crates/gantz_egui/src/impls/graph.rs
+++ b/crates/gantz_egui/src/impls/graph.rs
@@ -1,15 +1,15 @@
 use crate::{fmt_content_addr, graph_content_addr, widget::node_inspector, Cmd, NodeCtx, NodeUi};
 use std::hash::Hash;
 
-impl<N> NodeUi for gantz_core::node::GraphNode<N>
+impl<Env, N> NodeUi<Env> for gantz_core::node::GraphNode<N>
 where
     N: Hash,
 {
-    fn name(&self) -> &str {
+    fn name(&self, _: &Env) -> &str {
         "graph"
     }
 
-    fn ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> egui::Response {
+    fn ui(&mut self, ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
         let res = ui.add(egui::Label::new("graph").selectable(false));
         if ui.response().double_clicked() {
             ctx.cmds.push(Cmd::OpenGraph(ctx.path().to_vec()));
@@ -17,7 +17,7 @@ where
         res
     }
 
-    fn inspector_rows(&mut self, _ctx: &NodeCtx, body: &mut egui_extras::TableBody) {
+    fn inspector_rows(&mut self, _ctx: &NodeCtx<Env>, body: &mut egui_extras::TableBody) {
         let row_h = node_inspector::table_row_h(body.ui_mut());
         body.row(row_h, |mut row| {
             row.col(|ui| {

--- a/crates/gantz_egui/src/impls/graph.rs
+++ b/crates/gantz_egui/src/impls/graph.rs
@@ -1,6 +1,5 @@
-use std::hash::{Hash, Hasher};
-
-use crate::{Cmd, ContentAddr, NodeCtx, NodeUi, widget::node_inspector};
+use crate::{fmt_content_addr, graph_content_addr, widget::node_inspector, Cmd, NodeCtx, NodeUi};
+use std::hash::Hash;
 
 impl<N> NodeUi for gantz_core::node::GraphNode<N>
 where
@@ -25,21 +24,10 @@ where
                 ui.label("CA");
             });
             row.col(|ui| {
-                let ca = content_addr(self);
-                let ca_string = format!("{ca:#016x}");
+                let ca = graph_content_addr(self);
+                let ca_string = fmt_content_addr(ca);
                 ui.add(egui::Label::new(egui::RichText::new(ca_string).monospace()));
             });
         });
     }
-}
-
-/// Produce the content address for a given graph node.
-fn content_addr<N>(g: &gantz_core::node::GraphNode<N>) -> ContentAddr
-where
-    N: Hash,
-{
-    // TODO: Use a more stable/reproducible hash method.
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    g.hash(&mut hasher);
-    hasher.finish()
 }

--- a/crates/gantz_egui/src/impls/graph.rs
+++ b/crates/gantz_egui/src/impls/graph.rs
@@ -1,4 +1,4 @@
-use crate::{fmt_content_addr, graph_content_addr, widget::node_inspector, Cmd, NodeCtx, NodeUi};
+use crate::{Cmd, NodeCtx, NodeUi, fmt_content_addr, graph_content_addr, widget::node_inspector};
 use std::hash::Hash;
 
 impl<Env, N> NodeUi<Env> for gantz_core::node::GraphNode<N>

--- a/crates/gantz_egui/src/impls/inlet.rs
+++ b/crates/gantz_egui/src/impls/inlet.rs
@@ -1,11 +1,11 @@
 use crate::{NodeCtx, NodeUi};
 
-impl NodeUi for gantz_core::node::graph::Inlet {
-    fn name(&self) -> &str {
+impl<Env> NodeUi<Env> for gantz_core::node::graph::Inlet {
+    fn name(&self, _: &Env) -> &str {
         "in"
     }
 
-    fn ui(&mut self, _ctx: NodeCtx, ui: &mut egui::Ui) -> egui::Response {
-        ui.add(egui::Label::new(self.name()).selectable(false))
+    fn ui(&mut self, ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
+        ui.add(egui::Label::new(self.name(ctx.env())).selectable(false))
     }
 }

--- a/crates/gantz_egui/src/impls/log.rs
+++ b/crates/gantz_egui/src/impls/log.rs
@@ -1,7 +1,7 @@
 use crate::{NodeCtx, NodeUi};
 
-impl NodeUi for gantz_std::log::Log {
-    fn name(&self) -> &str {
+impl<Env> NodeUi<Env> for gantz_std::log::Log {
+    fn name(&self, _: &Env) -> &str {
         match self.level {
             log::Level::Error => "error",
             log::Level::Warn => "warn",
@@ -11,7 +11,7 @@ impl NodeUi for gantz_std::log::Log {
         }
     }
 
-    fn ui(&mut self, _ctx: NodeCtx, ui: &mut egui::Ui) -> egui::Response {
+    fn ui(&mut self, _ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
         let level = format!("{:?}", self.level).to_lowercase();
         ui.add(egui::Label::new(&level).selectable(false))
     }

--- a/crates/gantz_egui/src/impls/number.rs
+++ b/crates/gantz_egui/src/impls/number.rs
@@ -1,12 +1,12 @@
 use crate::{NodeCtx, NodeUi};
 use steel::SteelVal;
 
-impl NodeUi for gantz_std::number::Number {
-    fn name(&self) -> &str {
+impl<Env> NodeUi<Env> for gantz_std::number::Number {
+    fn name(&self, _: &Env) -> &str {
         "number"
     }
 
-    fn ui(&mut self, mut ctx: NodeCtx, ui: &mut egui::Ui) -> egui::Response {
+    fn ui(&mut self, mut ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
         let mut val = ctx.extract_value().unwrap().unwrap();
         let res = match val {
             SteelVal::NumV(ref mut f) => ui.add(egui::DragValue::new(f)),

--- a/crates/gantz_egui/src/impls/ops.rs
+++ b/crates/gantz_egui/src/impls/ops.rs
@@ -1,11 +1,11 @@
 use crate::{NodeCtx, NodeUi};
 
-impl NodeUi for gantz_std::ops::Add {
-    fn name(&self) -> &str {
+impl<Env> NodeUi<Env> for gantz_std::ops::Add {
+    fn name(&self, _: &Env) -> &str {
         "+"
     }
 
-    fn ui(&mut self, _ctx: NodeCtx, ui: &mut egui::Ui) -> egui::Response {
+    fn ui(&mut self, _ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
         ui.add(egui::Label::new("+").selectable(false))
     }
 }

--- a/crates/gantz_egui/src/impls/outlet.rs
+++ b/crates/gantz_egui/src/impls/outlet.rs
@@ -1,11 +1,11 @@
 use crate::{NodeCtx, NodeUi};
 
-impl NodeUi for gantz_core::node::graph::Outlet {
-    fn name(&self) -> &str {
+impl<Env> NodeUi<Env> for gantz_core::node::graph::Outlet {
+    fn name(&self, _: &Env) -> &str {
         "out"
     }
 
-    fn ui(&mut self, _ctx: NodeCtx, ui: &mut egui::Ui) -> egui::Response {
-        ui.add(egui::Label::new(self.name()).selectable(false))
+    fn ui(&mut self, ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
+        ui.add(egui::Label::new(self.name(ctx.env())).selectable(false))
     }
 }

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -2,7 +2,6 @@
 //! gantz using `egui`.
 
 use std::hash::{Hash, Hasher};
-
 use steel::{
     SteelErr, SteelVal,
     rvals::{FromSteelVal, IntoSteelVal},
@@ -126,8 +125,18 @@ macro_rules! impl_node_ui_for_ptr {
 impl_node_ui_for_ptr!(Box);
 
 impl<'a, Env> NodeCtx<'a, Env> {
-    pub fn new(env: &'a Env, path: &'a [node::Id], vm: &'a mut Engine, cmds: &'a mut Vec<Cmd>) -> Self {
-        Self { env, path, vm, cmds }
+    pub fn new(
+        env: &'a Env,
+        path: &'a [node::Id],
+        vm: &'a mut Engine,
+        cmds: &'a mut Vec<Cmd>,
+    ) -> Self {
+        Self {
+            env,
+            path,
+            vm,
+            cmds,
+        }
     }
 
     /// Provide access to the node's input environment.

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -1,5 +1,8 @@
-#[doc(inline)]
-use gantz_core::node;
+//! A suite of widgets, nodes and implementations for creating a GUI around
+//! gantz using `egui`.
+
+use std::hash::{Hash, Hasher};
+
 use steel::{
     SteelErr, SteelVal,
     rvals::{FromSteelVal, IntoSteelVal},
@@ -7,6 +10,7 @@ use steel::{
 };
 
 mod impls;
+pub mod node;
 pub mod widget;
 
 /// A trait providing an egui `Ui` implementation for gantz nodes.
@@ -164,4 +168,20 @@ impl<'a> NodeCtx<'a> {
     pub fn pull_eval(&mut self) {
         self.cmds.push(Cmd::PullEval(self.path.to_vec()));
     }
+}
+
+/// Produce the content address for a given graph.
+pub fn graph_content_addr<N>(g: &gantz_core::node::graph::Graph<N>) -> ContentAddr
+where
+    N: Hash,
+{
+    // TODO: Use a more stable/reproducible hash method.
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    gantz_core::graph::hash(g, &mut hasher);
+    hasher.finish()
+}
+
+/// Format the given content address into a hex string.
+pub fn fmt_content_addr(ca: ContentAddr) -> String {
+    format!("{ca:#016x}")
 }

--- a/crates/gantz_egui/src/node.rs
+++ b/crates/gantz_egui/src/node.rs
@@ -9,4 +9,4 @@ pub use graph::NamedGraph;
 #[doc(inline)]
 pub use gantz_core::node::{Id, state};
 
-mod graph;
+pub mod graph;

--- a/crates/gantz_egui/src/node.rs
+++ b/crates/gantz_egui/src/node.rs
@@ -4,9 +4,8 @@
 //! Provides new node items, while re-exporting some of the `gantz_core::node`
 //! items for convenience.
 
-pub use graph::NamedGraph;
-
 #[doc(inline)]
 pub use gantz_core::node::{Id, state};
+pub use graph::NamedGraph;
 
 pub mod graph;

--- a/crates/gantz_egui/src/node.rs
+++ b/crates/gantz_egui/src/node.rs
@@ -1,0 +1,12 @@
+//! Provides custom nodes that are commonly useful to egui applications of
+//! gantz.
+//!
+//! Provides new node items, while re-exporting some of the `gantz_core::node`
+//! items for convenience.
+
+pub use graph::NamedGraph;
+
+#[doc(inline)]
+pub use gantz_core::node::{Id, state};
+
+mod graph;

--- a/crates/gantz_egui/src/node/graph.rs
+++ b/crates/gantz_egui/src/node/graph.rs
@@ -1,0 +1,100 @@
+use crate::{fmt_content_addr, widget::node_inspector, Cmd, ContentAddr, NodeCtx, NodeUi};
+use std::{
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
+use steel::{SteelVal, parser::ast::ExprKind, steel_vm::engine::Engine};
+
+/// A node abstraction composed from a graph of other nodes.
+///
+/// A thin wrapper around [`gantz_core::node::Graph`] that allows holding it
+/// via an `Arc`, giving the graph a unique name and provides the content
+/// address pre-computed to avoid hashing the graph on every update.
+///
+/// Similar to [`gantz_core::node::GraphNode`], but with a precalculated CA and
+/// optional name.
+pub struct NamedGraph<N> {
+    name: String,
+    ca: ContentAddr,
+    // FIXME: can't include this and be `Serialize`/`Deserialize`.
+    // Need a way to pass through the node map / registry during `expr`.
+    graph: Arc<gantz_core::node::graph::Graph<N>>,
+}
+
+impl<N> Hash for NamedGraph<N>
+where
+    N: Hash,
+{
+    fn hash<H>(&self, hasher: &mut H)
+    where
+        H: Hasher,
+    {
+        gantz_core::graph::hash(&*self.graph, hasher);
+    }
+}
+
+impl<N> gantz_core::Node for NamedGraph<N>
+where
+    N: gantz_core::Node,
+{
+    fn branches(&self) -> Vec<gantz_core::node::EvalConf> {
+        // TODO: generate branches based on inner node branching
+        vec![]
+    }
+
+    fn expr(&self, ctx: gantz_core::node::ExprCtx) -> ExprKind {
+        gantz_core::node::graph::nested_expr(&*self.graph, ctx.path(), ctx.inputs())
+    }
+
+    fn n_inputs(&self) -> usize {
+        gantz_core::node::graph::inlets(&*self.graph).count()
+    }
+
+    fn n_outputs(&self) -> usize {
+        gantz_core::node::graph::outlets(&*self.graph).count()
+    }
+
+    fn stateful(&self) -> bool {
+        true
+    }
+
+    fn register(&self, path: &[gantz_core::node::Id], vm: &mut Engine) {
+        // Register the graph's state map.
+        gantz_core::node::state::update_value(vm, path, SteelVal::empty_hashmap())
+            .expect("failed to register graph hashmap");
+    }
+
+    fn visit(&self, ctx: gantz_core::visit::Ctx, visitor: &mut dyn gantz_core::node::Visitor) {
+        gantz_core::graph::visit(&*self.graph, ctx.path(), visitor);
+    }
+}
+
+impl<N> NodeUi for NamedGraph<N>
+where
+    N: Hash,
+{
+    fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    fn ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> egui::Response {
+        let res = ui.add(egui::Label::new(&self.name).selectable(false));
+        if ui.response().double_clicked() {
+            ctx.cmds.push(Cmd::OpenGraph(ctx.path().to_vec()));
+        }
+        res
+    }
+
+    fn inspector_rows(&mut self, _ctx: &NodeCtx, body: &mut egui_extras::TableBody) {
+        let row_h = node_inspector::table_row_h(body.ui_mut());
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("CA");
+            });
+            row.col(|ui| {
+                let ca_string = fmt_content_addr(self.ca);
+                ui.add(egui::Label::new(egui::RichText::new(ca_string).monospace()));
+            });
+        });
+    }
+}

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -163,6 +163,12 @@ impl<'a, T> Clone for NodeTyCmd<'a, T> {
 
 impl<'a, T> Copy for NodeTyCmd<'a, T> {}
 
+impl Default for GantzState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 fn graph_scene<Env, N>(
     env: &Env,
     graph: &mut gantz_core::node::GraphNode<N>,

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -8,9 +8,11 @@ use std::collections::HashMap;
 use steel::steel_vm::engine::Engine;
 
 /// A registry of available nodes.
+///
+/// This should be implemented for the `Node`'s input `Env` type.
 pub trait NodeTypeRegistry {
     /// The gantz node type that can be produced by the registry.
-    type Node: Node;
+    type Node;
 
     /// The unique name of each node available.
     fn node_types(&self) -> impl Iterator<Item = &str>;
@@ -34,12 +36,12 @@ pub trait NodeTypeRegistry {
 }
 
 /// The top-level gantz widget.
-pub struct Gantz<'a, T>
+pub struct Gantz<'a, Env>
 where
-    T: NodeTypeRegistry,
+    Env: NodeTypeRegistry,
 {
-    node_ty_reg: &'a T,
-    root: &'a mut gantz_core::node::GraphNode<T::Node>,
+    env: &'a Env,
+    root: &'a mut gantz_core::node::GraphNode<Env::Node>,
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]
@@ -71,19 +73,19 @@ pub struct ViewToggles {
     pub graph_config: bool,
 }
 
-struct NodeTyCmd<'a, T> {
-    reg: &'a T,
+struct NodeTyCmd<'a, Env> {
+    env: &'a Env,
     name: &'a str,
 }
 
-impl<'a, T> Gantz<'a, T>
+impl<'a, Env> Gantz<'a, Env>
 where
-    T: NodeTypeRegistry,
-    T::Node: NodeUi + graph_scene::ToGraphMut<Node = T::Node>,
+    Env: NodeTypeRegistry,
+    Env::Node: gantz_core::Node<Env> + NodeUi<Env> + graph_scene::ToGraphMut<Node = Env::Node>,
 {
     /// Instantiate the full top-level gantz widget.
-    pub fn new(node_ty_reg: &'a T, root: &'a mut gantz_core::node::GraphNode<T::Node>) -> Self {
-        Self { node_ty_reg, root }
+    pub fn new(env: &'a Env, root: &'a mut gantz_core::node::GraphNode<Env::Node>) -> Self {
+        Self { env, root }
     }
 
     /// Present the gantz UI.
@@ -95,8 +97,8 @@ where
         vm: &mut Engine,
         ui: &mut egui::Ui,
     ) {
-        graph_scene(self.root, state, vm, ui);
-        command_palette(self.node_ty_reg, self.root, state, vm, ui);
+        graph_scene(self.env, self.root, state, vm, ui);
+        command_palette(self.env, self.root, state, vm, ui);
         if state.view_toggles.graph_config {
             graph_config(self.root, state, ui);
         }
@@ -104,7 +106,7 @@ where
             log_view(logger, ui);
         }
         if state.view_toggles.node_inspector {
-            node_inspector(self.root, vm, state, ui);
+            node_inspector(self.env, self.root, vm, state, ui);
         }
         if state.view_toggles.steel {
             steel_view(compiled_steel, ui);
@@ -135,36 +137,40 @@ impl GantzState {
     }
 }
 
-impl<'a, T: NodeTypeRegistry> widget::command_palette::Command for NodeTyCmd<'a, T> {
+impl<'a, Env> widget::command_palette::Command for NodeTyCmd<'a, Env>
+where
+    Env: NodeTypeRegistry,
+{
     fn text(&self) -> &str {
         self.name
     }
 
     fn tooltip(&self) -> &str {
-        self.reg.command_tooltip(self.name)
+        self.env.command_tooltip(self.name)
     }
 
     fn formatted_kb_shortcut(&self, ctx: &egui::Context) -> Option<String> {
-        self.reg.command_formatted_kb_shortcut(ctx, self.name)
+        self.env.command_formatted_kb_shortcut(ctx, self.name)
     }
 }
 
 impl<'a, T> Clone for NodeTyCmd<'a, T> {
     fn clone(&self) -> Self {
-        let Self { reg, name } = self;
-        Self { reg, name }
+        let Self { env, name } = self;
+        Self { env, name }
     }
 }
 
 impl<'a, T> Copy for NodeTyCmd<'a, T> {}
 
-fn graph_scene<N>(
+fn graph_scene<Env, N>(
+    env: &Env,
     graph: &mut gantz_core::node::GraphNode<N>,
     state: &mut GantzState,
     vm: &mut Engine,
     ui: &mut egui::Ui,
 ) where
-    N: Node + NodeUi + graph_scene::ToGraphMut<Node = N>,
+    N: Node<Env> + NodeUi<Env> + graph_scene::ToGraphMut<Node = N>,
 {
     // Show the `GraphScene` for the graph at the current path.
     match graph_scene::index_path_graph_mut(graph, &state.path) {
@@ -177,7 +183,7 @@ fn graph_scene<N>(
                 GraphState { view }
             });
 
-            GraphScene::new(graph, &state.path)
+            GraphScene::new(env, graph, &state.path)
                 .with_id(egui::Id::new(&state.path))
                 .auto_layout(state.auto_layout)
                 .layout_flow(state.layout_flow)
@@ -271,15 +277,15 @@ fn graph_scene<N>(
         });
 }
 
-fn command_palette<T>(
-    node_ty_reg: &T,
-    root: &mut gantz_core::node::GraphNode<T::Node>,
+fn command_palette<Env>(
+    env: &Env,
+    root: &mut gantz_core::node::GraphNode<Env::Node>,
     state: &mut GantzState,
     vm: &mut Engine,
     ui: &mut egui::Ui,
 ) where
-    T: NodeTypeRegistry,
-    T::Node: ToGraphMut<Node = T::Node>,
+    Env: NodeTypeRegistry,
+    Env::Node: gantz_core::Node<Env> + ToGraphMut<Node = Env::Node>,
 {
     // If space is pressed, toggle command palette visibility.
     if !ui.ctx().wants_keyboard_input() {
@@ -289,8 +295,8 @@ fn command_palette<T>(
     }
 
     // Map the node types to commands for the command palette.
-    let cmds = node_ty_reg.node_types().map(|k| NodeTyCmd {
-        reg: node_ty_reg,
+    let cmds = env.node_types().map(|k| NodeTyCmd {
+        env,
         name: &k[..],
     });
 
@@ -300,7 +306,7 @@ fn command_palette<T>(
     // If a command was emitted, add the node.
     if let Some(cmd) = state.command_palette.show(ui.ctx(), cmds) {
         // Add a node of the selected type.
-        let Some(node) = node_ty_reg.new_node(cmd.name) else {
+        let Some(node) = env.new_node(cmd.name) else {
             return;
         };
         let id = graph.add_node(node);
@@ -357,13 +363,14 @@ fn log_view(logger: &widget::log_view::Logger, ui: &mut egui::Ui) {
     });
 }
 
-fn node_inspector<N>(
+fn node_inspector<Env, N>(
+    env: &Env,
     root: &mut gantz_core::node::GraphNode<N>,
     vm: &mut Engine,
     state: &mut GantzState,
     ui: &mut egui::Ui,
 ) where
-    N: Node + NodeUi + ToGraphMut<Node = N>,
+    N: Node<Env> + NodeUi<Env> + ToGraphMut<Node = N>,
 {
     // In your egui update loop:
     egui::Window::new("Node Inspector").show(ui.ctx(), |ui| {
@@ -384,7 +391,7 @@ fn node_inspector<N>(
                 };
                 let ix = id.index();
                 let path: Vec<_> = state.path.iter().copied().chain(Some(ix)).collect();
-                let ctx = NodeCtx::new(&path[..], vm, &mut state.graph_scene.cmds);
+                let ctx = NodeCtx::new(env, &path[..], vm, &mut state.graph_scene.cmds);
                 widget::NodeInspector::new(node, ctx).show(ui);
             });
         }

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -301,10 +301,7 @@ fn command_palette<Env>(
     }
 
     // Map the node types to commands for the command palette.
-    let cmds = env.node_types().map(|k| NodeTyCmd {
-        env,
-        name: &k[..],
-    });
+    let cmds = env.node_types().map(|k| NodeTyCmd { env, name: &k[..] });
 
     // We'll only want to apply commands to the currently selected graph.
     let graph = graph_scene::index_path_graph_mut(root, &state.path).unwrap();

--- a/crates/gantz_std/src/bang.rs
+++ b/crates/gantz_std/src/bang.rs
@@ -5,16 +5,16 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct Bang;
 
-impl gantz_core::Node for Bang {
-    fn n_outputs(&self) -> usize {
+impl<Env> gantz_core::Node<Env> for Bang {
+    fn n_outputs(&self, _: &Env) -> usize {
         1
     }
 
-    fn expr(&self, _ctx: gantz_core::node::ExprCtx) -> ExprKind {
+    fn expr(&self, _ctx: gantz_core::node::ExprCtx<Env>) -> ExprKind {
         Engine::emit_ast("'()").unwrap().into_iter().next().unwrap()
     }
 
-    fn push_eval(&self) -> Vec<gantz_core::node::EvalConf> {
+    fn push_eval(&self, _: &Env) -> Vec<gantz_core::node::EvalConf> {
         vec![gantz_core::node::EvalConf::All]
     }
 }

--- a/crates/gantz_std/src/log.rs
+++ b/crates/gantz_std/src/log.rs
@@ -19,12 +19,12 @@ impl Default for Log {
     }
 }
 
-impl gantz_core::Node for Log {
-    fn n_inputs(&self) -> usize {
+impl<Env> gantz_core::Node<Env> for Log {
+    fn n_inputs(&self, _: &Env) -> usize {
         1
     }
 
-    fn expr(&self, ctx: gantz_core::node::ExprCtx) -> ExprKind {
+    fn expr(&self, ctx: gantz_core::node::ExprCtx<Env>) -> ExprKind {
         let Some(Some(input)) = ctx.inputs().get(0) else {
             return ExprKind::empty();
         };

--- a/crates/gantz_std/src/number.rs
+++ b/crates/gantz_std/src/number.rs
@@ -5,20 +5,20 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct Number;
 
-impl gantz_core::Node for Number {
-    fn n_inputs(&self) -> usize {
+impl<Env> gantz_core::Node<Env> for Number {
+    fn n_inputs(&self, _: &Env) -> usize {
         1
     }
 
-    fn n_outputs(&self) -> usize {
+    fn n_outputs(&self, _: &Env) -> usize {
         1
     }
 
-    fn push_eval(&self) -> Vec<gantz_core::node::EvalConf> {
+    fn push_eval(&self, _: &Env) -> Vec<gantz_core::node::EvalConf> {
         vec![gantz_core::node::EvalConf::All]
     }
 
-    fn expr(&self, ctx: gantz_core::node::ExprCtx) -> ExprKind {
+    fn expr(&self, ctx: gantz_core::node::ExprCtx<Env>) -> ExprKind {
         let expr = match ctx.inputs().get(0) {
             // If an input value was provided, use it to update state and
             // forward that value.

--- a/crates/gantz_std/src/ops.rs
+++ b/crates/gantz_std/src/ops.rs
@@ -5,16 +5,16 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct Add;
 
-impl gantz_core::Node for Add {
-    fn n_inputs(&self) -> usize {
+impl<Env> gantz_core::Node<Env> for Add {
+    fn n_inputs(&self, _: &Env) -> usize {
         2
     }
 
-    fn n_outputs(&self) -> usize {
+    fn n_outputs(&self, _: &Env) -> usize {
         1
     }
 
-    fn expr(&self, ctx: gantz_core::node::ExprCtx) -> ExprKind {
+    fn expr(&self, ctx: gantz_core::node::ExprCtx<Env>) -> ExprKind {
         let inputs = ctx.inputs();
         let (l, r) = match (inputs.get(0), inputs.get(1)) {
             (Some(Some(l)), Some(Some(r))) => (&l[..], &r[..]),


### PR DESCRIPTION
Adds a new `Env` type parameter to the `Node` trait, and provides access to this environment via argument on most `Node` methods. This allows for providing arbitrary immutable data to all nodes during the code generation context.

We use this to share a node type registry between nodes so that the new `NamedGraph` nodes can lookup and share graphs via content address, rather than requiring an `Arc` or similar that are less friendly to serialization.

Closes #73.

## Follow-up

- Expose some widgets for saving new node types, i.e. allow for naming graphs.