### PR TITLE
feat: Add new `GraphSelect` widget

### DIFF
--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -206,5 +206,5 @@ where
 
 /// Format the given content address into a hex string.
 pub fn fmt_content_addr(ca: ContentAddr) -> String {
-    format!("{ca:#016x}")
+    format!("{ca:#018x}")
 }

--- a/crates/gantz_egui/src/widget.rs
+++ b/crates/gantz_egui/src/widget.rs
@@ -3,6 +3,7 @@
 pub use command_palette::CommandPalette;
 pub use gantz::{Gantz, GantzState};
 pub use graph_scene::{GraphScene, GraphSceneState};
+pub use graph_select::GraphSelect;
 pub use label_button::LabelButton;
 pub use label_toggle::LabelToggle;
 pub use log_view::LogView;
@@ -11,6 +12,7 @@ pub use node_inspector::NodeInspector;
 pub mod command_palette;
 pub mod gantz;
 pub mod graph_scene;
+pub mod graph_select;
 pub mod label_button;
 pub mod label_toggle;
 pub mod log_view;

--- a/crates/gantz_egui/src/widget/graph_select.rs
+++ b/crates/gantz_egui/src/widget/graph_select.rs
@@ -1,0 +1,220 @@
+//! A simple widget for selecting between, naming and creating new graphs.
+
+use crate::{ContentAddr, fmt_content_addr};
+use std::collections::{BTreeMap, HashSet};
+
+/// A widget for selecting between, naming, and creating new graphs.
+pub struct GraphSelect<'a> {
+    id: egui::Id,
+    graph_reg: &'a dyn GraphRegistry,
+    head: Head<'a>,
+}
+
+#[derive(Clone, Default)]
+struct GraphSelectState {
+    /// The last head name provided via argument. We track this to know if we
+    /// should reset the working graph name.
+    last_head_name: Option<String>,
+    working_graph_name: String,
+}
+
+/// The currently active graph.
+pub struct Head<'a> {
+    /// The currently selected graph's CA.
+    pub ca: ContentAddr,
+    /// The currently active name.
+    pub name: Option<&'a str>,
+}
+
+/// Methods required on the provided graph registry.
+pub trait GraphRegistry {
+    /// All selectable graph addresses.
+    fn addrs(&self) -> Vec<ContentAddr>;
+    /// An iterator yielding all name -> CA pairs.
+    fn names(&self) -> &GraphNames;
+}
+
+/// The map from names to graph CAs.
+pub type GraphNames = BTreeMap<String, ContentAddr>;
+
+/// Commands emitted from the `GraphSelect` widget.
+#[derive(Debug, Default)]
+pub struct GraphSelectResponse {
+    /// Indicates the new graph button was clicked.
+    pub new_graph: bool,
+    /// If a graph was selected this is its content address and name (if named).
+    pub selected: Option<(Option<String>, ContentAddr)>,
+    /// The name was updated.
+    pub name_updated: Option<Option<String>>,
+}
+
+impl<'a> GraphSelect<'a> {
+    pub fn new(graph_reg: &'a dyn GraphRegistry, head: Head<'a>) -> Self {
+        let id = egui::Id::new("gantz-graph-select");
+        Self {
+            graph_reg,
+            head,
+            id,
+        }
+    }
+
+    pub fn with_id(mut self, id: egui::Id) -> Self {
+        self.id = id;
+        self
+    }
+
+    pub fn show(&mut self, ui: &mut egui::Ui) -> GraphSelectResponse {
+        // Load any state specific to this widget (e.g. working text strings).
+        let state_id = self.id.with("state");
+        let mut state = ui
+            .memory_mut(|mem| mem.data.get_temp::<GraphSelectState>(state_id))
+            .unwrap_or_default();
+
+        // If the given active name has changed, reset the working name to the
+        // new input.
+        if state.last_head_name.as_deref() != self.head.name {
+            state.last_head_name = self.head.name.map(str::to_string);
+            state.working_graph_name = self.head.name.map(str::to_string).unwrap_or_default();
+        }
+
+        // FIXME: Shouldn't need this.
+        ui.set_max_width(260.0);
+
+        let mut response = GraphSelectResponse::default();
+
+        // Allow for editing the name.
+        // Show the currently selected head, allow using a name.
+        let graph_names = self.graph_reg.names();
+        let (_name_res, new_name) = head_name_text_edit(&self.head, graph_names, &mut state, ui);
+        if let Some(name_opt) = new_name.as_ref() {
+            response.selected = Some((name_opt.clone(), self.head.ca));
+        }
+        response.name_updated = new_name.clone();
+
+        ui.separator();
+
+        // List all the graphs, named then unnamed.
+        egui::ScrollArea::vertical().show(ui, |ui| {
+            // Show named graphs first.
+            let mut visited = HashSet::new();
+            for (name, &ca) in graph_names {
+                visited.insert(ca);
+                let res = graph_select_row(&self.head, name, ca, ui);
+                if res.clicked() && ca != self.head.ca {
+                    response.selected = Some((Some(name.to_string()), ca));
+                }
+            }
+
+            // Show remaining unnamed graphs.
+            for ca in self
+                .graph_reg
+                .addrs()
+                .into_iter()
+                .filter(|ca| !visited.contains(ca))
+            {
+                let res = graph_select_row(&self.head, "----------", ca, ui);
+                if res.clicked() && ca != self.head.ca {
+                    response.selected = Some((None, ca));
+                }
+            }
+        });
+
+        ui.vertical_centered_justified(|ui| {
+            response.new_graph |= ui.button("+").clicked();
+        });
+
+        // Store the modified state back in memory
+        ui.memory_mut(|mem| mem.data.insert_temp(state_id, state));
+
+        response
+    }
+}
+
+// Allow for editing the name.
+// Show the currently selected head, allow using a name.
+fn head_name_text_edit(
+    head: &Head,
+    graph_names: &GraphNames,
+    state: &mut GraphSelectState,
+    ui: &mut egui::Ui,
+) -> (egui::Response, Option<Option<String>>) {
+    let ca_string = fmt_content_addr(head.ca);
+
+    // If this name is already assigned, but to a different CA, we'll colour the
+    // name red and require `Ctrl + Enter` to overwrite the CA.
+    let name_is_different = !(head.name.is_none() && state.working_graph_name.is_empty())
+        && head.name != Some(&state.working_graph_name[..]);
+    let name_is_taken = match graph_names.get(&state.working_graph_name) {
+        Some(&ca) => ca != head.ca,
+        None => false,
+    };
+    let hint_text = egui::RichText::new(&ca_string).monospace();
+    let mut text_edit =
+        egui::TextEdit::singleline(&mut state.working_graph_name).hint_text(hint_text);
+
+    // If the name is taken, provide feedback via text color.
+    if name_is_different && name_is_taken {
+        text_edit = text_edit.text_color(egui::Color32::RED);
+    }
+
+    // Only update the name if its different.
+    let name_res = ui.add(text_edit);
+    let mut new_name = None;
+    if name_res.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+        // If the name is taken, only update if ctrl is down.
+        let update = name_is_different && !name_is_taken || ui.input(|i| i.modifiers.ctrl);
+        if update {
+            new_name = if state.working_graph_name.is_empty() {
+                Some(None)
+            } else {
+                Some(Some(state.working_graph_name.clone()))
+            };
+        }
+    }
+    (name_res, new_name)
+}
+
+fn graph_select_row(head: &Head, name: &str, ca: ContentAddr, ui: &mut egui::Ui) -> egui::Response {
+    let w = ui.max_rect().width();
+    let h = ui.style().interaction.interact_radius;
+    let size = egui::Vec2::new(w, h);
+    let (rect, mut response) = ui.allocate_at_least(size, egui::Sense::click());
+
+    let builder = egui::UiBuilder::new()
+        .sense(egui::Sense::click())
+        .max_rect(rect);
+    ui.scope_builder(builder, |ui| {
+        let mut res = ui.response();
+        let hovered = res.hovered();
+
+        // Create a child UI for the labels positioned over the allocated rect
+        ui.horizontal(|ui| {
+            let mut text = egui::RichText::new(name.to_string());
+            text = if ca == head.ca && Some(name) == head.name {
+                text.strong()
+            } else if hovered {
+                text
+            } else {
+                text.weak()
+            };
+            let label = egui::Label::new(text).selectable(false);
+            res |= ui.add(label);
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
+                let mut text = egui::RichText::new(fmt_content_addr(ca)).monospace();
+                text = if ca == head.ca {
+                    text.strong()
+                } else if hovered {
+                    text
+                } else {
+                    text.weak()
+                };
+                let label = egui::Label::new(text).selectable(false);
+                res |= ui.add(label);
+            });
+        });
+
+        response |= res;
+    });
+
+    response
+}

--- a/crates/gantz_egui/src/widget/log_view.rs
+++ b/crates/gantz_egui/src/widget/log_view.rs
@@ -185,42 +185,48 @@ impl LogView {
                 });
             })
             .body(|mut body| {
-                for entry in entries {
+                let row_h = 18.0;
+                let n_rows = entries.len();
+                let text_color = body.ui_mut().style().visuals.text_color();
+                body.rows(row_h, n_rows, |mut row| {
+                    let entry = &entries[row.index()];
                     let freshness = entry.freshness();
-                    let text_color = if freshness > 0.0 {
-                        let col = body.ui_mut().style().visuals.text_color();
+                    let fresh = freshness > 0.0;
+                    let text_color = if fresh {
                         let hl_col = egui::Color32::WHITE;
-                        body.ui_mut().ctx().request_repaint();
-                        col.lerp_to_gamma(hl_col, freshness)
+                        text_color.lerp_to_gamma(hl_col, freshness)
                     } else {
-                        body.ui_mut().style().visuals.text_color()
+                        text_color
                     };
-                    body.row(18.0, |mut row| {
-                        row.col(|ui| {
-                            let text = entry.format_timestamp();
-                            ui.colored_label(text_color, text);
-                        });
 
-                        row.col(|ui| {
-                            let (color, text) = match entry.level {
-                                Level::Error => (egui::Color32::from_rgb(255, 100, 100), "ERROR"),
-                                Level::Warn => (egui::Color32::from_rgb(255, 200, 100), "WARN"),
-                                Level::Info => (egui::Color32::from_rgb(100, 200, 255), "INFO"),
-                                Level::Debug => (egui::Color32::GRAY, "DEBUG"),
-                                Level::Trace => (egui::Color32::DARK_GRAY, "TRACE"),
-                            };
-                            ui.colored_label(color, text);
-                        });
-
-                        row.col(|ui| {
-                            ui.colored_label(text_color, &entry.target);
-                        });
-
-                        row.col(|ui| {
-                            ui.colored_label(text_color, &entry.message);
-                        });
+                    row.col(|ui| {
+                        let text = entry.format_timestamp();
+                        ui.colored_label(text_color, text);
                     });
-                }
+
+                    row.col(|ui| {
+                        let (color, text) = match entry.level {
+                            Level::Error => (egui::Color32::from_rgb(255, 100, 100), "ERROR"),
+                            Level::Warn => (egui::Color32::from_rgb(255, 200, 100), "WARN"),
+                            Level::Info => (egui::Color32::from_rgb(100, 200, 255), "INFO"),
+                            Level::Debug => (egui::Color32::GRAY, "DEBUG"),
+                            Level::Trace => (egui::Color32::DARK_GRAY, "TRACE"),
+                        };
+                        ui.colored_label(color, text);
+                    });
+
+                    row.col(|ui| {
+                        ui.colored_label(text_color, &entry.target);
+                    });
+
+                    row.col(|ui| {
+                        ui.colored_label(text_color, &entry.message);
+                    });
+
+                    if fresh {
+                        row.response().ctx.request_repaint();
+                    }
+                });
             });
 
         if state.auto_scroll {


### PR DESCRIPTION
Allows for selecting between graphs at the top-level, and for adding named graphs as nodes.

Also adds `GantzResponse` from top-level widget to propagate up the `GraphSelect` response.

Still missing features like the ability to delete names, some bugs, etc.

Closes #94.