### PR TITLE
feat: Allow for opening named graphs by double clicking on named graph nodes

### DIFF
--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -64,6 +64,7 @@ pub enum Cmd {
     PushEval(Vec<node::Id>),
     PullEval(Vec<node::Id>),
     OpenGraph(Vec<node::Id>),
+    OpenNamedGraph(String, ContentAddr),
 }
 
 /// Used to represent the content address

--- a/crates/gantz_egui/src/node/graph.rs
+++ b/crates/gantz_egui/src/node/graph.rs
@@ -47,7 +47,8 @@ where
         let env = ctx.env();
         env.graph(self.ca)
             .map(|g| gantz_core::node::graph::nested_expr(env, g, ctx.path(), ctx.inputs()))
-            .unwrap_or_else(ExprKind::empty)
+            // FIXME: Check if graph
+            .expect("failed to find graph for CA")
     }
 
     fn n_inputs(&self, env: &Env) -> usize {
@@ -90,11 +91,12 @@ impl<Env> NodeUi<Env> for NamedGraph {
     }
 
     fn ui(&mut self, ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
-        // FIXME: Check if the graph actually exists, give feedback if it
-        // doesn't.
+        // FIXME: Check if the graph actually exists for the internal CA, give
+        // feedback if it doesn't.
         let res = ui.add(egui::Label::new(&self.name).selectable(false));
         if ui.response().double_clicked() {
-            ctx.cmds.push(Cmd::OpenGraph(ctx.path().to_vec()));
+            ctx.cmds
+                .push(Cmd::OpenNamedGraph(self.name.clone(), self.ca));
         }
         res
     }


### PR DESCRIPTION
Also fixes the `panic!` that would occur previously when double-clicking named graph nodes caused by attempting to navigating to a subgraph.