### PR TITLE
fix: Improve input latency on Wayland by using `PresentMode::AutoNoVsync`

### DIFF
--- a/crates/gantz/src/main.rs
+++ b/crates/gantz/src/main.rs
@@ -87,6 +87,10 @@ fn window_plugin() -> WindowPlugin {
             title: "gantz".into(),
             name: Some("gantz".into()),
             fit_canvas_to_parent: true,
+            // NOTE: This vastly improves input-latency on wayland. If you
+            // notice tearing or simialr issues, open an issue so we can try and
+            // select the right `PresentMode` for each system!
+            present_mode: bevy::window::PresentMode::AutoNoVsync,
             ..default()
         }),
         ..default()


### PR DESCRIPTION
Closes #124 

See #124 for rationale.