### PR TITLE
Improve timestamp formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,6 +2967,7 @@ dependencies = [
  "serde",
  "steel-core",
  "sublime_fuzzy",
+ "time",
  "tracing",
  "tracing-subscriber",
  "typetag",
@@ -3971,6 +3972,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -5462,7 +5472,10 @@ checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ steel-core = "0.7"
 steel-derive = "0.6"
 sublime_fuzzy = "0.7"
 thiserror = "2"
+time = { version = "0.3", features = ["local-offset", "wasm-bindgen"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 typetag = "0.2"

--- a/crates/gantz_egui/Cargo.toml
+++ b/crates/gantz_egui/Cargo.toml
@@ -29,6 +29,7 @@ petgraph.workspace = true
 serde.workspace = true
 steel-core.workspace = true
 sublime_fuzzy.workspace = true
+time.workspace = true
 tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 web-time.workspace = true

--- a/crates/gantz_egui/src/widget.rs
+++ b/crates/gantz_egui/src/widget.rs
@@ -1,4 +1,5 @@
 //! A collection of useful widgets for gantz.
+use time::{OffsetDateTime, UtcOffset, format_description};
 
 pub use command_palette::CommandPalette;
 pub use gantz::{Gantz, GantzState, update_graph_pane_head};
@@ -33,6 +34,24 @@ pub mod pane_menu;
 pub mod perf_view;
 #[cfg(feature = "tracing")]
 pub mod trace_view;
+
+/// Convert a UTC datetime to local timezone, with fallback to UTC if unavailable.
+pub(crate) fn to_local_datetime(datetime: OffsetDateTime) -> OffsetDateTime {
+    UtcOffset::current_local_offset()
+        .map(|offset| datetime.to_offset(offset))
+        .unwrap_or(datetime)
+}
+
+/// Format a SystemTime as a local datetime string.
+pub(crate) fn format_local_datetime(system_time: std::time::SystemTime) -> String {
+    let datetime = OffsetDateTime::from(system_time);
+    let local_datetime = to_local_datetime(datetime);
+    let format = format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second]")
+        .expect("invalid format");
+    local_datetime
+        .format(&format)
+        .unwrap_or_else(|_| "<invalid-timestamp>".to_string())
+}
 
 /// Simple shorthand for viewing steel code.
 pub fn steel_view(ui: &mut egui::Ui, code: &str) {

--- a/crates/gantz_egui/src/widget/head_row.rs
+++ b/crates/gantz_egui/src/widget/head_row.rs
@@ -103,6 +103,6 @@ pub fn head_row(
 pub fn fmt_commit_timestamp(timestamp: gantz_ca::Timestamp) -> String {
     std::time::UNIX_EPOCH
         .checked_add(timestamp)
-        .map(|time| humantime::format_rfc3339_seconds(time).to_string())
+        .map(|system_time| crate::widget::format_local_datetime(system_time))
         .unwrap_or_else(|| "<invalid-timestamp>".to_string())
 }

--- a/crates/gantz_egui/src/widget/log_view.rs
+++ b/crates/gantz_egui/src/widget/log_view.rs
@@ -30,8 +30,8 @@ pub struct LogEntry {
 
 impl LogEntry {
     fn format_timestamp(&self) -> String {
-        let time = crate::system_time_from_web(self.timestamp).expect("failed to convert");
-        humantime::format_rfc3339_seconds(time).to_string()
+        let system_time = crate::system_time_from_web(self.timestamp).expect("failed to convert");
+        crate::widget::format_local_datetime(system_time)
     }
 
     fn freshness(&self) -> f32 {

--- a/crates/gantz_egui/src/widget/trace_view.rs
+++ b/crates/gantz_egui/src/widget/trace_view.rs
@@ -47,8 +47,8 @@ struct MessageVisitor {
 
 impl TraceEntry {
     fn format_timestamp(&self) -> String {
-        let time = crate::system_time_from_web(self.timestamp).expect("failed to convert");
-        humantime::format_rfc3339_seconds(time).to_string()
+        let system_time = crate::system_time_from_web(self.timestamp).expect("failed to convert");
+        crate::widget::format_local_datetime(system_time)
     }
 
     fn freshness(&self) -> f32 {


### PR DESCRIPTION
## Description
Improves timestamp formatting in LogView, TraceView, and GraphSelect widgets to use a more readable format with local timezone offset.

## Changes
- Changed timestamp format from `2025-11-11T22:32:58Z` to `2025-11-29 14:32:58`
- Timestamps now display in local timezone instead of UTC
- Added `time` crate with `wasm-bindgen` feature for cross-platform support
- Created shared `to_local_datetime()` helper function to avoid code duplication

## Testing
- ✅ Tested on native (Windows/macOS/Linux) - timestamps display correctly
- ✅ Verified code compiles for `wasm32-unknown-unknown` target without errors
- ⚠️ Unable to test runtime behavior in browser environment

## Notes
The `time` crate's `wasm-bindgen` feature should handle web platform compatibility automatically, but I wasn't able to verify this in a browser environment. The code compiles for `wasm32-unknown-unknown` target without errors.

Closes #132