### PR TITLE
feat: Update `egui_graph` to 0.9 with customisable node frames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "egui_graph"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a90111217c68511fc4dc31039989f8f27ac6ca89ce12cfa43ed68117ee8eb9"
+checksum = "3cb2e987c87e825547ec2bd867a1acfd200399d1efd7c127621322792d354c31"
 dependencies = [
  "egui",
  "layout-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ eframe = { version = "0.33", default-features = false, features = [
 ] }
 egui = { version = "0.33", default-features = false }
 egui_extras = { version = "0.33", default-features = false, features = ["syntect"] }
-egui_graph = "0.8"
+egui_graph = "0.9"
 egui_tiles = "0.14"
 env_logger = { version = "0.11", default-features = false }
 gantz_ca = { version = "0.1.0", path = "crates/gantz_ca" }

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -239,13 +239,20 @@ where
             .inputs(inputs)
             .outputs(outputs)
             .flow(node.flow(env))
-            .show(nctx, ui, |ui| {
+            .show(nctx, ui, |nui_ctx| {
                 path.push(n_ix);
-                // Instantiate the node's UI.
+
+                // Create the gantz node context.
                 let node_ctx =
                     crate::NodeCtx::new(env, &path, &inlets, &outlets, vm, &mut state.cmds);
-                node.ui(node_ctx, ui);
+
+                // Instantiate the node UI, return its response.
+                let response = nui_ctx.framed(|ui| {
+                    node.ui(node_ctx, ui);
+                });
+
                 path.pop();
+                response
             });
 
         if response.changed() {


### PR DESCRIPTION
This is in anticipation of adding a basic comment node, but will also be useful for more customisable node styling generally.