### PR TITLE
fix: Update gantz_egui to use egui_graph 0.9.1 and fix node size retrieval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "egui_graph"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb2e987c87e825547ec2bd867a1acfd200399d1efd7c127621322792d354c31"
+checksum = "2df4ac9d159b56a739507bc16591cbc6bdf0bbddfe3ca459ff3083b70c4bb0c9"
 dependencies = [
  "egui",
  "layout-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ eframe = { version = "0.33", default-features = false, features = [
 ] }
 egui = { version = "0.33", default-features = false }
 egui_extras = { version = "0.33", default-features = false, features = ["syntect"] }
-egui_graph = "0.9"
+egui_graph = "0.9.1"
 egui_tiles = "0.14"
 env_logger = { version = "0.11", default-features = false }
 gantz_ca = { version = "0.1.0", path = "crates/gantz_ca" }


### PR DESCRIPTION
- Update egui_graph dependency from 0.9.0 to 0.9.1
- Refactor layout function to use new `with_graph_memory` API for efficient node size access without cloning
- Fix graph ID mismatch by using `Graph::from_id()` instead of `Graph::new()` to ensure layout and graph widget share the same ID

The layout function now correctly retrieves actual node sizes from the graph's temporary memory, enabling proper auto-layout based on real node dimensions rather than falling back to defaults.