### PR TITLE
feat: Add `Comment` node for graph documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "egui_graph"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913a13b90edf71b2a95cde3a11f3da64c3a7d9465a2b292dd148bd9ce4ad87d4"
+checksum = "6d5a64d0755595a551866d67e89a14c17b2b1c2056ff7f4c1278a6a2e727b375"
 dependencies = [
  "egui",
  "layout-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ eframe = { version = "0.33", default-features = false, features = [
 ] }
 egui = { version = "0.33", default-features = false }
 egui_extras = { version = "0.33", default-features = false, features = ["syntect"] }
-egui_graph = "0.10.1"
+egui_graph = "0.10.2"
 egui_tiles = "0.14"
 env_logger = { version = "0.11", default-features = false }
 gantz_ca = { version = "0.1.0", path = "crates/gantz_ca" }

--- a/crates/gantz/src/env.rs
+++ b/crates/gantz/src/env.rs
@@ -105,6 +105,9 @@ pub fn primitives() -> Primitives {
     register_primitive(&mut p, "number", || {
         Box::new(gantz_std::Number::default()) as Box<_>
     });
+    register_primitive(&mut p, "comment", || {
+        Box::new(gantz_egui::node::Comment::default()) as Box<_>
+    });
     p
 }
 

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -42,6 +42,9 @@ impl Node for gantz_std::Number {}
 impl Node for gantz_egui::node::NamedGraph {}
 
 #[typetag::serde]
+impl Node for gantz_egui::node::Comment {}
+
+#[typetag::serde]
 impl Node for Box<dyn Node> {}
 
 // To allow for navigating between nested graphs in a graph scene, we need to be

--- a/crates/gantz_egui/src/impls/bang.rs
+++ b/crates/gantz_egui/src/impls/bang.rs
@@ -5,11 +5,17 @@ impl<Env> NodeUi<Env> for gantz_std::Bang {
         "!"
     }
 
-    fn ui(&mut self, mut ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
-        let res = ui.add(egui::Button::new(" ! "));
-        if res.clicked() {
-            ctx.push_eval();
-        }
-        res
+    fn ui(
+        &mut self,
+        mut ctx: NodeCtx<Env>,
+        uictx: egui_graph::NodeCtx,
+    ) -> egui::InnerResponse<egui::Response> {
+        uictx.framed(|ui| {
+            let res = ui.add(egui::Button::new(" ! "));
+            if res.clicked() {
+                ctx.push_eval();
+            }
+            res
+        })
     }
 }

--- a/crates/gantz_egui/src/impls/expr.rs
+++ b/crates/gantz_egui/src/impls/expr.rs
@@ -89,9 +89,15 @@ impl<Env> NodeUi<Env> for gantz_core::node::Expr {
         "expr"
     }
 
-    fn ui(&mut self, ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
-        let id = egui::Id::new("ExprEdit").with(ctx.path());
-        ui.add(ExprEdit::new(self, id))
+    fn ui(
+        &mut self,
+        ctx: NodeCtx<Env>,
+        uictx: egui_graph::NodeCtx,
+    ) -> egui::InnerResponse<egui::Response> {
+        uictx.framed(|ui| {
+            let id = egui::Id::new("ExprEdit").with(ctx.path());
+            ui.add(ExprEdit::new(self, id))
+        })
     }
 }
 

--- a/crates/gantz_egui/src/impls/graph.rs
+++ b/crates/gantz_egui/src/impls/graph.rs
@@ -8,12 +8,18 @@ where
         "graph"
     }
 
-    fn ui(&mut self, ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
-        let res = ui.add(egui::Label::new("graph").selectable(false));
-        if ui.response().double_clicked() {
-            ctx.cmds.push(Cmd::OpenGraph(ctx.path().to_vec()));
-        }
-        res
+    fn ui(
+        &mut self,
+        ctx: NodeCtx<Env>,
+        uictx: egui_graph::NodeCtx,
+    ) -> egui::InnerResponse<egui::Response> {
+        uictx.framed(|ui| {
+            let res = ui.add(egui::Label::new("graph").selectable(false));
+            if ui.response().double_clicked() {
+                ctx.cmds.push(Cmd::OpenGraph(ctx.path().to_vec()));
+            }
+            res
+        })
     }
 
     fn inspector_rows(&mut self, _ctx: &NodeCtx<Env>, body: &mut egui_extras::TableBody) {

--- a/crates/gantz_egui/src/impls/inlet.rs
+++ b/crates/gantz_egui/src/impls/inlet.rs
@@ -6,11 +6,17 @@ impl<Env> NodeUi<Env> for gantz_core::node::graph::Inlet {
         "in"
     }
 
-    fn ui(&mut self, ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
-        let name = self.name(ctx.env());
-        let ix = inlet_ix(ctx.path(), ctx.inlets());
-        let text = format!("{}[{}]", name, ix);
-        ui.add(egui::Label::new(text).selectable(false))
+    fn ui(
+        &mut self,
+        ctx: NodeCtx<Env>,
+        uictx: egui_graph::NodeCtx,
+    ) -> egui::InnerResponse<egui::Response> {
+        uictx.framed(|ui| {
+            let name = self.name(ctx.env());
+            let ix = inlet_ix(ctx.path(), ctx.inlets());
+            let text = format!("{}[{}]", name, ix);
+            ui.add(egui::Label::new(text).selectable(false))
+        })
     }
 
     fn inspector_rows(&mut self, ctx: &NodeCtx<Env>, body: &mut egui_extras::TableBody) {

--- a/crates/gantz_egui/src/impls/log.rs
+++ b/crates/gantz_egui/src/impls/log.rs
@@ -11,8 +11,14 @@ impl<Env> NodeUi<Env> for gantz_std::log::Log {
         }
     }
 
-    fn ui(&mut self, _ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
-        let level = format!("{:?}", self.level).to_lowercase();
-        ui.add(egui::Label::new(&level).selectable(false))
+    fn ui(
+        &mut self,
+        _ctx: NodeCtx<Env>,
+        uictx: egui_graph::NodeCtx,
+    ) -> egui::InnerResponse<egui::Response> {
+        uictx.framed(|ui| {
+            let level = format!("{:?}", self.level).to_lowercase();
+            ui.add(egui::Label::new(&level).selectable(false))
+        })
     }
 }

--- a/crates/gantz_egui/src/impls/number.rs
+++ b/crates/gantz_egui/src/impls/number.rs
@@ -6,17 +6,23 @@ impl<Env> NodeUi<Env> for gantz_std::number::Number {
         "number"
     }
 
-    fn ui(&mut self, mut ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
-        let mut val = ctx.extract_value().unwrap().unwrap();
-        let res = match val {
-            SteelVal::NumV(ref mut f) => ui.add(egui::DragValue::new(f)),
-            SteelVal::IntV(ref mut i) => ui.add(egui::DragValue::new(i)),
-            _ => ui.add(egui::Label::new("ERR")),
-        };
-        if res.changed() {
-            ctx.update_value(val).unwrap();
-            ctx.push_eval();
-        }
-        res
+    fn ui(
+        &mut self,
+        mut ctx: NodeCtx<Env>,
+        uictx: egui_graph::NodeCtx,
+    ) -> egui::InnerResponse<egui::Response> {
+        uictx.framed(|ui| {
+            let mut val = ctx.extract_value().unwrap().unwrap();
+            let res = match val {
+                SteelVal::NumV(ref mut f) => ui.add(egui::DragValue::new(f)),
+                SteelVal::IntV(ref mut i) => ui.add(egui::DragValue::new(i)),
+                _ => ui.add(egui::Label::new("ERR")),
+            };
+            if res.changed() {
+                ctx.update_value(val).unwrap();
+                ctx.push_eval();
+            }
+            res
+        })
     }
 }

--- a/crates/gantz_egui/src/impls/ops.rs
+++ b/crates/gantz_egui/src/impls/ops.rs
@@ -5,7 +5,11 @@ impl<Env> NodeUi<Env> for gantz_std::ops::Add {
         "+"
     }
 
-    fn ui(&mut self, _ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
-        ui.add(egui::Label::new("+").selectable(false))
+    fn ui(
+        &mut self,
+        _ctx: NodeCtx<Env>,
+        uictx: egui_graph::NodeCtx,
+    ) -> egui::InnerResponse<egui::Response> {
+        uictx.framed(|ui| ui.add(egui::Label::new("+").selectable(false)))
     }
 }

--- a/crates/gantz_egui/src/impls/outlet.rs
+++ b/crates/gantz_egui/src/impls/outlet.rs
@@ -6,11 +6,17 @@ impl<Env> NodeUi<Env> for gantz_core::node::graph::Outlet {
         "out"
     }
 
-    fn ui(&mut self, ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
-        let name = self.name(ctx.env());
-        let ix = outlet_ix(ctx.path(), ctx.outlets());
-        let text = format!("{}[{}]", name, ix);
-        ui.add(egui::Label::new(text).selectable(false))
+    fn ui(
+        &mut self,
+        ctx: NodeCtx<Env>,
+        uictx: egui_graph::NodeCtx,
+    ) -> egui::InnerResponse<egui::Response> {
+        uictx.framed(|ui| {
+            let name = self.name(ctx.env());
+            let ix = outlet_ix(ctx.path(), ctx.outlets());
+            let text = format!("{}[{}]", name, ix);
+            ui.add(egui::Label::new(text).selectable(false))
+        })
     }
 
     fn inspector_rows(&mut self, ctx: &NodeCtx<Env>, body: &mut egui_extras::TableBody) {

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -24,8 +24,13 @@ pub trait NodeUi<Env> {
     /// Instantiate the `Ui` for the given node.
     ///
     /// The node's path into the state tree and the VM are provided to allow for
-    /// access to the node's state.
-    fn ui(&mut self, _ctx: NodeCtx<Env>, _ui: &mut egui::Ui) -> egui::Response;
+    /// access to the node's state. The egui_graph node context is provided to
+    /// allow customizing the frame and other node display properties.
+    fn ui(
+        &mut self,
+        ctx: NodeCtx<Env>,
+        uictx: egui_graph::NodeCtx,
+    ) -> egui::InnerResponse<egui::Response>;
 
     /// Optionally add additional rows to the node's inspector UI.
     ///
@@ -78,8 +83,12 @@ where
         (**self).name(env)
     }
 
-    fn ui(&mut self, ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
-        (**self).ui(ctx, ui)
+    fn ui(
+        &mut self,
+        ctx: NodeCtx<Env>,
+        uictx: egui_graph::NodeCtx,
+    ) -> egui::InnerResponse<egui::Response> {
+        (**self).ui(ctx, uictx)
     }
 
     fn inspector_rows(&mut self, ctx: &NodeCtx<Env>, body: &mut egui_extras::TableBody) {
@@ -105,8 +114,8 @@ macro_rules! impl_node_ui_for_ptr {
                 (**self).name(env)
             }
 
-            fn ui(&mut self, ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
-                (**self).ui(ctx, ui)
+            fn ui(&mut self, ctx: NodeCtx<Env>, uictx: egui_graph::NodeCtx) -> egui::InnerResponse<egui::Response> {
+                (**self).ui(ctx, uictx)
             }
 
             fn inspector_rows(&mut self, ctx: &NodeCtx<Env>, body: &mut egui_extras::TableBody) {

--- a/crates/gantz_egui/src/node.rs
+++ b/crates/gantz_egui/src/node.rs
@@ -4,8 +4,10 @@
 //! Provides new node items, while re-exporting some of the `gantz_core::node`
 //! items for convenience.
 
+pub use comment::Comment;
 #[doc(inline)]
 pub use gantz_core::node::{Id, state};
 pub use graph::NamedGraph;
 
+pub mod comment;
 pub mod graph;

--- a/crates/gantz_egui/src/node/comment.rs
+++ b/crates/gantz_egui/src/node/comment.rs
@@ -1,0 +1,134 @@
+//! A Comment node for documenting patches.
+
+use crate::widget::node_inspector;
+use crate::{NodeCtx, NodeUi};
+use gantz_core::node;
+use serde::{Deserialize, Serialize};
+use steel::parser::ast::ExprKind;
+use steel::steel_vm::engine::Engine;
+
+/// A transparent comment node for documenting graphs.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
+pub struct Comment {
+    text: String,
+    // TODO: Remove this in favour of using a resizable frame. This will involve
+    // tweaks upstream in egui_graph to enable.
+    width: u16,
+    rows: u16,
+}
+
+impl Comment {
+    /// An arbitrary size for the default comment dimensions.
+    pub const DEFAULT_WIDTH: u16 = 150;
+    pub const DEFAULT_ROWS: u16 = 4;
+
+    /// Create a new Comment node with the given text.
+    pub fn new(text: String) -> Self {
+        Self {
+            text,
+            width: Self::DEFAULT_WIDTH,
+            rows: Self::DEFAULT_ROWS,
+        }
+    }
+}
+
+impl Default for Comment {
+    fn default() -> Self {
+        Self::new(String::new())
+    }
+}
+
+impl<Env> gantz_core::Node<Env> for Comment {
+    // Comments have no inputs or outputs - they're purely for documentation
+    fn n_inputs(&self, _: &Env) -> usize {
+        0
+    }
+
+    fn n_outputs(&self, _: &Env) -> usize {
+        0
+    }
+
+    // Comments don't evaluate to anything
+    fn expr(&self, _ctx: node::ExprCtx<Env>) -> ExprKind {
+        // Return void/empty expression since comments don't compute anything
+        Engine::emit_ast("void")
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+    }
+}
+
+impl gantz_ca::CaHash for Comment {
+    fn hash(&self, hasher: &mut gantz_ca::Hasher) {
+        "gantz_egui::Comment".hash(hasher);
+        self.text.hash(hasher);
+    }
+}
+
+impl<Env> NodeUi<Env> for Comment {
+    fn name(&self, _env: &Env) -> &str {
+        "comment"
+    }
+
+    fn ui(
+        &mut self,
+        _ctx: NodeCtx<Env>,
+        uictx: egui_graph::NodeCtx,
+    ) -> egui::InnerResponse<egui::Response> {
+        // Get interaction state
+        let interaction = uictx.interaction();
+        let style = uictx.style();
+        // Use the default margin as the stroke width, as this will be the only
+        // draggable part of the node.
+        let stroke_w = style.spacing.window_margin.top as f32;
+        let stroke = if interaction.selected {
+            egui::Stroke::new(stroke_w, style.visuals.selection.stroke.color)
+        } else if interaction.in_selection_rect || interaction.hovered {
+            egui::Stroke::new(stroke_w, style.visuals.weak_text_color())
+        } else {
+            egui::Stroke::new(stroke_w, egui::Color32::TRANSPARENT)
+        };
+
+        // Use a custom, transparent frame for comment nodes.
+        let frame = egui::Frame::new()
+            .fill(egui::Color32::TRANSPARENT)
+            .corner_radius(style.visuals.window_corner_radius)
+            .stroke(stroke);
+
+        // Use a transparent frame for comment nodes
+        let response = uictx.framed_with(frame, |ui| {
+            ui.add(
+                egui::TextEdit::multiline(&mut self.text)
+                    .desired_width(self.width as f32)
+                    .hint_text("Add comment...")
+                    .frame(false)
+                    .desired_rows(self.rows.into())
+                    .min_size(egui::vec2(self.width as f32, 10.0)),
+            )
+        });
+
+        response
+    }
+
+    fn inspector_rows(&mut self, _ctx: &NodeCtx<Env>, body: &mut egui_extras::TableBody) {
+        dbg!(&self);
+        let row_h = node_inspector::table_row_h(body.ui_mut());
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("width");
+            });
+            row.col(|ui| {
+                ui.add(egui::DragValue::new(&mut self.width).range(10..=3_000));
+            });
+        });
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("rows");
+            });
+            row.col(|ui| {
+                ui.add(egui::DragValue::new(&mut self.rows).range(1..=50));
+            });
+        });
+    }
+}

--- a/crates/gantz_egui/src/node/graph.rs
+++ b/crates/gantz_egui/src/node/graph.rs
@@ -94,15 +94,21 @@ impl<Env> NodeUi<Env> for NamedGraph {
         self.name.as_str()
     }
 
-    fn ui(&mut self, ctx: NodeCtx<Env>, ui: &mut egui::Ui) -> egui::Response {
-        // FIXME: Check if the graph actually exists for the internal CA, give
-        // feedback if it doesn't.
-        let res = ui.add(egui::Label::new(&self.name).selectable(false));
-        if ui.response().double_clicked() {
-            ctx.cmds
-                .push(Cmd::OpenNamedGraph(self.name.clone(), self.graph));
-        }
-        res
+    fn ui(
+        &mut self,
+        ctx: NodeCtx<Env>,
+        uictx: egui_graph::NodeCtx,
+    ) -> egui::InnerResponse<egui::Response> {
+        uictx.framed(|ui| {
+            // FIXME: Check if the graph actually exists for the internal CA, give
+            // feedback if it doesn't.
+            let res = ui.add(egui::Label::new(&self.name).selectable(false));
+            if ui.response().double_clicked() {
+                ctx.cmds
+                    .push(Cmd::OpenNamedGraph(self.name.clone(), self.graph));
+            }
+            res
+        })
     }
 
     fn inspector_rows(&mut self, _ctx: &NodeCtx<Env>, body: &mut egui_extras::TableBody) {

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -1,7 +1,7 @@
 use crate::{Cmd, NodeUi};
 use egui_graph::{
     self,
-    node::{EdgeEvent, NodeResponse, SocketKind},
+    node::{EdgeEvent, SocketKind},
 };
 use gantz_core::{
     Edge, Node,
@@ -21,6 +21,9 @@ pub struct GraphSceneResponse {
     /// Responses from each node, keyed by node index.
     pub nodes: Vec<(NodeIndex, NodeResponse)>,
 }
+
+/// An alias for the node response type returned from gantz nodes.
+pub type NodeResponse = egui_graph::node::NodeResponse<egui::Response>;
 
 impl GraphSceneResponse {
     /// Returns true if any node was clicked.
@@ -250,9 +253,7 @@ where
                     crate::NodeCtx::new(env, &path, &inlets, &outlets, vm, &mut state.cmds);
 
                 // Instantiate the node UI, return its response.
-                let response = nui_ctx.framed(|ui| {
-                    node.ui(node_ctx, ui);
-                });
+                let response = node.ui(node_ctx, nui_ctx);
 
                 path.pop();
                 response


### PR DESCRIPTION
Adds a new `Comment` node type that provides transparent text annotations for documenting graphs.

Changes:
- Add `Comment` node implementation with transparent background and conditional stroke styling (visible on hover/selection).
- Update NodeUi trait to pass `egui_graph::NodeCtx` for frame control, allowing nodes to customize their frame appearance.
- Migrate all node implementations to use explicit framing with the new `NodeCtx`-based UI method signature.
- Add width/rows controls in inspector for resizing comment nodes.
- Register Comment node as a primitive in the environment.

The Comment node features:
- Transparent background for non-intrusive documentation.
- Consistent stroke width with transparency changes to prevent text shifting.
- Selection highlighting using theme colors.
- Hover indication with subtle stroke.
- Adjustable width and row count via inspector. This is temporary until
  we can enable resizable node frames (requires egui_graph tweaks).

Breaking change: `NodeUi::ui()` now takes `egui_graph::NodeCtx` and returns `InnerResponse<Response>` to support custom framing and return values from node UI implementations.