### PR TITLE
feat(ci): Add PR preview deployments to gh-pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,23 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: nix ${{ matrix.command }}
 
+  upload-pr-preview-artifact:
+    needs: nix
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - run: nix build --print-build-logs .#gantz-website
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr-preview-${{ github.event.pull_request.number }}
+          path: result/
+
   cargo-publish:
     needs: nix
     permissions:
@@ -66,21 +83,17 @@ jobs:
     needs: nix
     if: github.ref == 'refs/heads/master'
     permissions:
-      pages: write
       id-token: write
-      contents: read
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@v13
       - run: nix build --print-build-logs .#gantz-website
-      - uses: actions/configure-pages@v4
-      - uses: actions/upload-pages-artifact@v3
+      - uses: peaceiris/actions-gh-pages@v4
         with:
-          path: 'result'
-      - id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./result
+          keep_files: true
+          exclude_assets: '.git*,pr-preview'

--- a/.github/workflows/cleanup-pr-preview.yml
+++ b/.github/workflows/cleanup-pr-preview.yml
@@ -1,0 +1,36 @@
+name: Cleanup PR Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      deployments: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: gh-pages
+
+      - name: Remove preview directory
+        run: |
+          if [ -d "pr-preview/pr-${{ github.event.pull_request.number }}" ]; then
+            rm -rf pr-preview/pr-${{ github.event.pull_request.number }}
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "chore: remove PR preview for #${{ github.event.pull_request.number }}" || echo "Nothing to commit"
+            git push
+          else
+            echo "Preview directory does not exist, skipping cleanup"
+          fi
+
+      - name: Deactivate deployment
+        uses: bobheadxi/deployments@v1
+        with:
+          step: deactivate-env
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,67 @@
+name: Deploy PR Preview
+
+on:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
+
+jobs:
+  deploy-preview:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      deployments: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Get PR info
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.workflow_run.pull_requests[0];
+            if (!pr) {
+              core.setFailed('No PR associated with this workflow run');
+              return;
+            }
+            core.setOutput('number', pr.number);
+            core.setOutput('head_sha', pr.head.sha);
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-preview-${{ steps.pr.outputs.number }}
+          path: ./preview-build
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Start deployment
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: pr-${{ steps.pr.outputs.number }}
+          ref: ${{ steps.pr.outputs.head_sha }}
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./preview-build
+          destination_dir: pr-preview/pr-${{ steps.pr.outputs.number }}
+          keep_files: true
+
+      - name: Finish deployment
+        uses: bobheadxi/deployments@v1
+        with:
+          step: finish
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: pr-${{ steps.pr.outputs.number }}
+          status: success
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env_url: https://nannou-org.github.io/gantz/pr-preview/pr-${{ steps.pr.outputs.number }}/


### PR DESCRIPTION
- Add upload-pr-preview-artifact job to upload website builds for PRs
- Add deploy-pr-preview.yml workflow triggered by workflow_run to deploy previews to gh-pages branch subdirectories (pr-preview/pr-{N}/)
- Add cleanup-pr-preview.yml workflow to remove previews on PR close
- Switch production deploy to peaceiris/actions-gh-pages with keep_files to preserve PR preview directories
- Use bobheadxi/deployments for "View deployment" button in PR UI
- Use workflow_run pattern for fork PR safety

Requires changing GitHub Pages source from "GitHub Actions" to "Deploy from branch" (gh-pages) in repository settings.