### PR TITLE
fix: show UI feedback for missing CAs instead of panicking

### DIFF
--- a/crates/gantz/src/main.rs
+++ b/crates/gantz/src/main.rs
@@ -557,7 +557,10 @@ fn open_head(
     }
 
     // Head is not open - add it as a new tab.
-    let graph = env.registry.head_graph(&new_head).unwrap();
+    let Some(graph) = env.registry.head_graph(&new_head) else {
+        bevy::log::error!("cannot open head: graph missing from registry");
+        return;
+    };
     let new_graph = graph::clone(graph);
 
     // Load the views for this head's commit, or create empty.
@@ -602,7 +605,10 @@ fn replace_head(
     let old_head = open.heads[ix].0.clone();
 
     // Load the new graph.
-    let graph = env.registry.head_graph(&new_head).unwrap();
+    let Some(graph) = env.registry.head_graph(&new_head) else {
+        bevy::log::error!("cannot replace head: graph missing from registry");
+        return;
+    };
     let new_graph = graph::clone(graph);
 
     // Load the views for this head's commit, or create empty.

--- a/crates/gantz_egui/src/node.rs
+++ b/crates/gantz_egui/src/node.rs
@@ -9,7 +9,7 @@ pub use fn_named_ref::{FnNamedRef, FnNodeNames};
 #[doc(inline)]
 pub use gantz_core::node::{Id, state};
 pub use inspect::Inspect;
-pub use named_ref::{NameRegistry, NamedRef, outdated_color};
+pub use named_ref::{NameRegistry, NamedRef, missing_color, outdated_color};
 
 pub mod comment;
 pub mod fn_named_ref;


### PR DESCRIPTION
When a NamedRef or Fn<NamedRef> node references a CA that no longer exists in the registry, show red "missing" status in the UI instead of crashing.

- Add `missing_color()` (red) to distinguish from `outdated_color()` (yellow)
- Update NamedRef and FnNamedRef to detect missing CAs via `env.node(&ca).is_none()`
- Show red text on node name and "missing" status in inspector when CA is missing
- Fix panics in `open_head()` and `replace_head()` by handling missing graphs gracefully

Closes #109