### PR TITLE
feat(gantz_egui): replace floating char-menu with popup pane menu

### DIFF
--- a/crates/gantz_egui/src/widget.rs
+++ b/crates/gantz_egui/src/widget.rs
@@ -9,6 +9,7 @@ pub use label_button::LabelButton;
 pub use label_toggle::LabelToggle;
 pub use log_view::LogView;
 pub use node_inspector::NodeInspector;
+pub use pane_menu::PaneMenu;
 
 pub mod command_palette;
 pub mod gantz;
@@ -19,6 +20,7 @@ pub mod label_button;
 pub mod label_toggle;
 pub mod log_view;
 pub mod node_inspector;
+pub mod pane_menu;
 #[cfg(feature = "tracing")]
 pub mod trace_view;
 

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -464,50 +464,10 @@ where
                     }
                 }
 
-                // Floating toggles over the bottom right corner of the graph scene pane.
+                // Floating pane menu over the bottom right corner of the graph scene pane.
                 let space = ui.style().interaction.interact_radius * 3.0;
-                egui::Window::new("view_toggle_window")
-                    .pivot(egui::Align2::RIGHT_BOTTOM)
-                    .fixed_pos(rect.right_bottom() + egui::vec2(-space, -space))
-                    .title_bar(false)
-                    .resizable(false)
-                    .collapsible(false)
-                    .frame(egui::Frame::NONE)
-                    .show(ui.ctx(), |ui| {
-                        fn toggle<'a>(s: &str, b: &'a mut bool) -> widget::LabelToggle<'a> {
-                            let text = egui::RichText::new(s).size(24.0);
-                            widget::LabelToggle::new(text, b)
-                        }
-                        let grid_w = 150.0;
-                        let n_cols = 5;
-                        let gap_space = ui.spacing().item_spacing.x * (n_cols as f32 - 1.0);
-                        let col_w = (grid_w - gap_space) / n_cols as f32;
-                        egui::Grid::new("view_toggles")
-                            .min_col_width(col_w)
-                            .max_col_width(col_w)
-                            .show(ui, |ui| {
-                                ui.vertical_centered_justified(|ui| {
-                                    ui.add(toggle("C", &mut state.view_toggles.graph_config))
-                                        .on_hover_text("Graph Configuration");
-                                });
-                                ui.vertical_centered_justified(|ui| {
-                                    ui.add(toggle("G", &mut state.view_toggles.graph_select))
-                                        .on_hover_text("Graph Select");
-                                });
-                                ui.vertical_centered_justified(|ui| {
-                                    ui.add(toggle("N", &mut state.view_toggles.node_inspector))
-                                        .on_hover_text("Node Inspector");
-                                });
-                                ui.vertical_centered_justified(|ui| {
-                                    ui.add(toggle("L", &mut state.view_toggles.logs))
-                                        .on_hover_text("Log View");
-                                });
-                                ui.vertical_centered_justified(|ui| {
-                                    ui.add(toggle("λ", &mut state.view_toggles.steel))
-                                        .on_hover_text("Steel View");
-                                });
-                            });
-                    });
+                let anchor = rect.right_bottom() + egui::vec2(-space, -space);
+                widget::PaneMenu::new(&mut state.view_toggles).show(ui.ctx(), anchor);
             }
             Pane::GraphSelect => {
                 let heads: Vec<_> = gantz.heads.iter().map(|(h, _, _)| h.clone()).collect();

--- a/crates/gantz_egui/src/widget/pane_menu.rs
+++ b/crates/gantz_egui/src/widget/pane_menu.rs
@@ -1,0 +1,117 @@
+use super::{LabelToggle, gantz::ViewToggles};
+
+/// A menu widget for toggling pane visibility.
+///
+/// Displays as a subtle icon in the bottom-right corner. When clicked, a
+/// separate menu window appears above with toggle options for each pane.
+pub struct PaneMenu<'a> {
+    view_toggles: &'a mut ViewToggles,
+}
+
+/// Persistent state for the pane menu.
+#[derive(Clone, Default)]
+struct PaneMenuState {
+    open: bool,
+}
+
+impl<'a> PaneMenu<'a> {
+    pub fn new(view_toggles: &'a mut ViewToggles) -> Self {
+        Self { view_toggles }
+    }
+
+    /// Show the pane menu anchored to the given position (bottom-right corner).
+    pub fn show(self, ctx: &egui::Context, anchor_pos: egui::Pos2) {
+        let id = egui::Id::new("pane_menu");
+        let state_id = id.with("state");
+
+        // Load state from memory.
+        let mut state: PaneMenuState = ctx
+            .memory(|m| m.data.get_temp(state_id))
+            .unwrap_or_default();
+
+        // Animate the open/close transition.
+        let animation_time = 0.15;
+        let openness = ctx.animate_bool_with_time(id.with("openness"), state.open, animation_time);
+
+        // The menu button window (fixed at bottom-right, transparent).
+        let button_response = egui::Area::new(id.with("button"))
+            .pivot(egui::Align2::RIGHT_BOTTOM)
+            .fixed_pos(anchor_pos)
+            .order(egui::Order::Foreground)
+            .show(ctx, |ui| {
+                egui::Frame::NONE.show(ui, |ui| {
+                    let icon_text = egui::RichText::new("👁").size(24.0);
+                    let response = ui.add(LabelToggle::new(icon_text, &mut state.open));
+
+                    if !state.open {
+                        response.on_hover_text("Toggle pane visibility")
+                    } else {
+                        response
+                    }
+                })
+            });
+
+        // The menu items window (separate, transparent, positioned above button).
+        let menu_items_response = if openness > 0.0 {
+            // Position the menu window above the button.
+            let spacing = ctx.style().spacing.item_spacing.y;
+            let menu_anchor = anchor_pos
+                - egui::vec2(0.0, button_response.inner.response.rect.height() + spacing);
+
+            let mut items_response: Option<egui::Response> = None;
+
+            egui::Area::new(id.with("menu"))
+                .pivot(egui::Align2::RIGHT_BOTTOM)
+                .fixed_pos(menu_anchor)
+                .order(egui::Order::Foreground)
+                .show(ctx, |ui| {
+                    egui::Frame::NONE.show(ui, |ui| {
+                        ui.with_layout(egui::Layout::bottom_up(egui::Align::RIGHT), |ui| {
+                            // Menu items in reverse order (bottom-up layout).
+                            items_response = [
+                                menu_item(ui, "Steel", &mut self.view_toggles.steel),
+                                menu_item(ui, "Logs", &mut self.view_toggles.logs),
+                                menu_item(
+                                    ui,
+                                    "Node Inspector",
+                                    &mut self.view_toggles.node_inspector,
+                                ),
+                                menu_item(ui, "Graph Select", &mut self.view_toggles.graph_select),
+                                menu_item(ui, "Graph Config", &mut self.view_toggles.graph_config),
+                            ]
+                            .into_iter()
+                            .reduce(|acc, r| acc.union(r));
+                        });
+                    });
+                });
+
+            items_response
+        } else {
+            None
+        };
+
+        // Close menu if clicked outside both button and menu areas.
+        if state.open {
+            let button_interacted = button_response.inner.inner.hovered()
+                || button_response.inner.inner.is_pointer_button_down_on();
+            let menu_interacted = menu_items_response
+                .as_ref()
+                .is_some_and(|r| r.hovered() || r.is_pointer_button_down_on());
+
+            let clicked_outside =
+                ctx.input(|i| i.pointer.any_pressed()) && !button_interacted && !menu_interacted;
+
+            if clicked_outside {
+                state.open = false;
+            }
+        }
+
+        // Store state back to memory.
+        ctx.memory_mut(|m| m.data.insert_temp(state_id, state));
+    }
+}
+
+/// Render a single menu item as a toggle.
+fn menu_item(ui: &mut egui::Ui, label: &str, selected: &mut bool) -> egui::Response {
+    ui.add(LabelToggle::new(label, selected))
+}


### PR DESCRIPTION
Replace the horizontal character toggles (C, G, N, L, λ) in the bottom-right of the graph scene with a popup menu that expands upward when clicked.

- Add `PaneMenu` widget with eye icon button fixed at bottom-right
- Menu items appear in separate transparent window above button
- Use `LabelToggle` for both button and items for consistent styling
- Click outside menu to close
- Smooth open/close animation

Closes #148