### PR TITLE
feat(perf): add graph execution and GUI frame time profiling panes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2269,6 +2269,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_plot"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33233ffc010fd450381805bbbebecbbb82f077de7712ddc439f0b20effd42db7"
+dependencies = [
+ "ahash",
+ "egui",
+ "emath",
+]
+
+[[package]]
 name = "egui_tiles"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2780,6 +2791,7 @@ dependencies = [
  "egui",
  "egui_extras",
  "egui_graph",
+ "egui_plot",
  "egui_tiles",
  "gantz_ca",
  "gantz_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ eframe = { version = "0.33", default-features = false, features = [
 egui = { version = "0.33", default-features = false, features = ["serde", "persistence"] }
 egui_extras = { version = "0.33", default-features = false, features = ["syntect"] }
 egui_graph = "0.11"
+egui_plot = "0.34"
 egui_tiles = "0.14"
 env_logger = { version = "0.11", default-features = false }
 gantz_ca = { version = "0.1.0", path = "crates/gantz_ca" }

--- a/crates/gantz_egui/Cargo.toml
+++ b/crates/gantz_egui/Cargo.toml
@@ -17,6 +17,7 @@ blake3.workspace = true
 egui.workspace = true
 egui_extras.workspace = true
 egui_graph.workspace = true
+egui_plot.workspace = true
 egui_tiles.workspace = true
 gantz_ca.workspace = true
 gantz_core.workspace = true

--- a/crates/gantz_egui/src/widget.rs
+++ b/crates/gantz_egui/src/widget.rs
@@ -12,6 +12,7 @@ pub use label_toggle::LabelToggle;
 pub use log_view::LogView;
 pub use node_inspector::NodeInspector;
 pub use pane_menu::PaneMenu;
+pub use perf_view::{PerfCapture, PerfView};
 
 pub mod command_palette;
 pub mod gantz;
@@ -25,6 +26,7 @@ pub mod label_toggle;
 pub mod log_view;
 pub mod node_inspector;
 pub mod pane_menu;
+pub mod perf_view;
 #[cfg(feature = "tracing")]
 pub mod trace_view;
 

--- a/crates/gantz_egui/src/widget/pane_menu.rs
+++ b/crates/gantz_egui/src/widget/pane_menu.rs
@@ -71,6 +71,8 @@ impl<'a> PaneMenu<'a> {
                             items_response = [
                                 menu_item(ui, "Steel", &mut self.view_toggles.steel),
                                 menu_item(ui, "Logs", &mut self.view_toggles.logs),
+                                menu_item(ui, "GUI Perf", &mut self.view_toggles.perf_gui),
+                                menu_item(ui, "VM Perf", &mut self.view_toggles.perf_vm),
                                 menu_item(
                                     ui,
                                     "Node Inspector",

--- a/crates/gantz_egui/src/widget/perf_view.rs
+++ b/crates/gantz_egui/src/widget/perf_view.rs
@@ -1,0 +1,147 @@
+//! Simple performance monitoring widgets for VM execution and GUI frame times.
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+const DEFAULT_MAX_SAMPLES: usize = 500;
+
+/// Format a millisecond value as a Duration debug string (e.g. "231µs", "1.2ms").
+fn format_ms(ms: f64) -> String {
+    let duration = Duration::from_secs_f64(ms.max(0.0) / 1000.0);
+    format!("{duration:?}")
+}
+
+/// Capture of timing samples. All on main thread, no sync needed.
+pub struct PerfCapture {
+    samples: VecDeque<Duration>,
+    max_samples: usize,
+}
+
+impl Default for PerfCapture {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_SAMPLES)
+    }
+}
+
+impl PerfCapture {
+    /// Create a new capture with the given max sample count.
+    pub fn new(max_samples: usize) -> Self {
+        Self {
+            samples: VecDeque::with_capacity(max_samples),
+            max_samples,
+        }
+    }
+
+    /// Record a new timing sample.
+    pub fn record(&mut self, duration: Duration) {
+        if self.samples.len() >= self.max_samples {
+            self.samples.pop_front();
+        }
+        self.samples.push_back(duration);
+    }
+
+    /// Get the samples.
+    pub fn samples(&self) -> &VecDeque<Duration> {
+        &self.samples
+    }
+
+    /// Get the max samples setting.
+    pub fn max_samples(&self) -> usize {
+        self.max_samples
+    }
+
+    /// Set the max samples. Truncates if necessary.
+    pub fn set_max_samples(&mut self, max: usize) {
+        self.max_samples = max;
+        while self.samples.len() > max {
+            self.samples.pop_front();
+        }
+    }
+}
+
+/// Minimal widget for displaying performance data as a plot.
+pub struct PerfView<'a> {
+    id: egui::Id,
+    title: &'a str,
+    capture: &'a mut PerfCapture,
+}
+
+impl<'a> PerfView<'a> {
+    pub fn new(title: &'a str, capture: &'a mut PerfCapture) -> Self {
+        let id = egui::Id::new(title);
+        Self { id, title, capture }
+    }
+
+    pub fn with_id(mut self, id: egui::Id) -> Self {
+        self.id = id;
+        self
+    }
+
+    pub fn show(&mut self, ui: &mut egui::Ui) {
+        // Load state for context menu.
+        let state_id = self.id.with("state");
+        let mut max_samples = ui
+            .memory(|m| m.data.get_temp::<usize>(state_id))
+            .unwrap_or(self.capture.max_samples());
+
+        // Get text color for the line.
+        let text_color = ui.visuals().text_color();
+
+        // Convert samples to plot points (index, duration_ms).
+        let points: egui_plot::PlotPoints = self
+            .capture
+            .samples()
+            .iter()
+            .enumerate()
+            .map(|(i, d)| [i as f64, d.as_secs_f64() * 1000.0])
+            .collect();
+
+        let line = egui_plot::Line::new(self.title, points)
+            .color(text_color)
+            .fill(0.0)
+            .fill_alpha(0.3);
+
+        let plot = egui_plot::Plot::new(self.id)
+            .height(ui.available_height())
+            .width(ui.available_width())
+            .allow_boxed_zoom(false)
+            .allow_drag(false)
+            .allow_scroll(false)
+            .show_axes(false)
+            .show_grid(false)
+            .set_margin_fraction(egui::Vec2::ZERO)
+            .include_y(0.0)
+            .label_formatter(|_, point| format_ms(point.y));
+
+        ui.scope(|ui| {
+            // Remove the 1px border around the plot background.
+            ui.style_mut().visuals.widgets.noninteractive.bg_stroke = egui::Stroke::NONE;
+            // Make the plot background blend-in with the pane background.
+            ui.style_mut().visuals.extreme_bg_color = ui.style().visuals.window_fill;
+
+            let plot_response = plot.show(ui, |plot_ui| {
+                plot_ui.line(line);
+            });
+
+            // Context menu for configuration.
+            plot_response.response.context_menu(|ui| {
+                ui.label("Max Samples");
+                ui.horizontal(|ui| {
+                    for &n in &[100, 250, 500, 1000, 2000] {
+                        if ui
+                            .selectable_label(max_samples == n, format!("{n}"))
+                            .clicked()
+                        {
+                            max_samples = n;
+                            self.capture.set_max_samples(n);
+                            ui.close();
+                        }
+                    }
+                });
+            });
+        });
+
+        // Store state.
+        ui.memory_mut(|m| m.data.insert_temp(state_id, max_samples));
+    }
+}


### PR DESCRIPTION
Add simple performance monitoring to track timing data with `egui_plot`:

- Add `PerfCapture` struct for storing Duration samples in a FIFO queue
- Add `PerfView` widget displaying timing as a filled line plot
- Instrument VM execution (push/pull eval) and GUI frame timing
- Add VM Perf and GUI Perf panes to the left column layout
- Add pane visibility toggles to the pane menu

Plot features:
- Filled area under line with 30% alpha
- Hover shows Duration in debug format (e.g. "231µs", "1.2ms")
- Coordinates display in bottom-left corner
- Right-click context menu to configure max samples (100-2000)
- No axes, no grid, no margin for minimal appearance

Closes #150 

### Example

See the perf panes on the side-panel below for an example of how they're looking:

<img width="893" height="720" alt="Screenshot From 2026-01-27 16-51-59" src="https://github.com/user-attachments/assets/c9447d96-c2ec-40c7-8aa1-c1272353a223" />

