### PR TITLE
fix: Use egui_graph 0.12 GraphResponse for selection sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2280,9 +2280,9 @@ dependencies = [
 
 [[package]]
 name = "egui_graph"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4f51863cb355b20a85c3041d960dec024fdce82d6c4bf001a56ea2ccd8cb63"
+checksum = "e3bca9b3932587a2df841562a9398c75c1d1a02d7e26528eb0be614d9b54fa6b"
 dependencies = [
  "egui",
  "layout-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ eframe = { version = "0.33", default-features = false, features = [
 ] }
 egui = { version = "0.33", default-features = false, features = ["serde", "persistence"] }
 egui_extras = { version = "0.33", default-features = false, features = ["syntect"] }
-egui_graph = "0.11.1"
+egui_graph = "0.12"
 egui_plot = "0.34"
 egui_tiles = "0.14"
 env_logger = { version = "0.11", default-features = false }


### PR DESCRIPTION
Replace the manual `is_node_selected` workaround (nannou-org/egui_graph#47) with the new `GraphResponse::selection_changed` field. This provides a post-frame snapshot of the selected nodes, eliminating the stale-read ordering bug where clicking a higher-indexed node failed to deselect a lower-indexed one.