### PR TITLE
feat: Update to `egui_graph` 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "egui_graph"
-version = "0.12.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c226583053b7b0a972bd1b4db4386f9a76244db91bc8ccb06efe21e0aca40ca"
+checksum = "c4f90d93440b5d34528e2190e3fbbf29c31f21e46259ef6f4f78500a54a0b507"
 dependencies = [
  "egui",
  "layout-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ eframe = { version = "0.33", default-features = false, features = [
 ] }
 egui = { version = "0.33", default-features = false, features = ["serde", "persistence"] }
 egui_extras = { version = "0.33", default-features = false, features = ["syntect"] }
-egui_graph = "0.12.1"
+egui_graph = "0.14"
 egui_plot = "0.34"
 egui_tiles = "0.14"
 env_logger = { version = "0.11", default-features = false }

--- a/crates/gantz_egui/src/impls/apply.rs
+++ b/crates/gantz_egui/src/impls/apply.rs
@@ -9,7 +9,7 @@ impl NodeUi for gantz_core::node::Apply {
         &mut self,
         _ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
-    ) -> egui::InnerResponse<egui::Response> {
-        uictx.framed(|ui| ui.add(egui::Label::new("apply").selectable(false)))
+    ) -> egui_graph::FramedResponse<egui::Response> {
+        uictx.framed(|ui, _sockets| ui.add(egui::Label::new("apply").selectable(false)))
     }
 }

--- a/crates/gantz_egui/src/impls/bang.rs
+++ b/crates/gantz_egui/src/impls/bang.rs
@@ -9,8 +9,8 @@ impl NodeUi for gantz_std::Bang {
         &mut self,
         mut ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
-    ) -> egui::InnerResponse<egui::Response> {
-        uictx.framed(|ui| {
+    ) -> egui_graph::FramedResponse<egui::Response> {
+        uictx.framed(|ui, _sockets| {
             let res = ui.add(egui::Button::new(" ! "));
             if res.clicked() {
                 ctx.push_eval();

--- a/crates/gantz_egui/src/impls/expr.rs
+++ b/crates/gantz_egui/src/impls/expr.rs
@@ -93,8 +93,8 @@ impl NodeUi for gantz_core::node::Expr {
         &mut self,
         ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
-    ) -> egui::InnerResponse<egui::Response> {
-        uictx.framed(|ui| {
+    ) -> egui_graph::FramedResponse<egui::Response> {
+        uictx.framed(|ui, _sockets| {
             let id = egui::Id::new("ExprEdit").with(ctx.path());
             ui.add(ExprEdit::new(self, id))
         })

--- a/crates/gantz_egui/src/impls/graph.rs
+++ b/crates/gantz_egui/src/impls/graph.rs
@@ -12,8 +12,8 @@ where
         &mut self,
         ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
-    ) -> egui::InnerResponse<egui::Response> {
-        uictx.framed(|ui| {
+    ) -> egui_graph::FramedResponse<egui::Response> {
+        uictx.framed(|ui, _sockets| {
             let res = ui.add(egui::Label::new("graph").selectable(false));
             if ui.response().double_clicked() {
                 ctx.cmds.push(Cmd::OpenGraph(ctx.path().to_vec()));

--- a/crates/gantz_egui/src/impls/identity.rs
+++ b/crates/gantz_egui/src/impls/identity.rs
@@ -9,8 +9,8 @@ impl NodeUi for gantz_core::node::Identity {
         &mut self,
         _ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
-    ) -> egui::InnerResponse<egui::Response> {
-        uictx.framed(|ui| {
+    ) -> egui_graph::FramedResponse<egui::Response> {
+        uictx.framed(|ui, _sockets| {
             ui.add(egui::Label::new(gantz_core::node::IDENTITY_NAME).selectable(false))
         })
     }

--- a/crates/gantz_egui/src/impls/inlet.rs
+++ b/crates/gantz_egui/src/impls/inlet.rs
@@ -10,8 +10,8 @@ impl NodeUi for gantz_core::node::graph::Inlet {
         &mut self,
         ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
-    ) -> egui::InnerResponse<egui::Response> {
-        uictx.framed(|ui| {
+    ) -> egui_graph::FramedResponse<egui::Response> {
+        uictx.framed(|ui, _sockets| {
             let name = self.name(ctx.registry());
             let ix = inlet_ix(ctx.path(), ctx.inlets());
             let text = format!("{}[{}]", name, ix);

--- a/crates/gantz_egui/src/impls/log.rs
+++ b/crates/gantz_egui/src/impls/log.rs
@@ -15,8 +15,8 @@ impl NodeUi for gantz_std::log::Log {
         &mut self,
         _ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
-    ) -> egui::InnerResponse<egui::Response> {
-        uictx.framed(|ui| {
+    ) -> egui_graph::FramedResponse<egui::Response> {
+        uictx.framed(|ui, _sockets| {
             let level = format!("{:?}", self.level).to_lowercase();
             ui.add(egui::Label::new(&level).selectable(false))
         })

--- a/crates/gantz_egui/src/impls/number.rs
+++ b/crates/gantz_egui/src/impls/number.rs
@@ -10,8 +10,8 @@ impl NodeUi for gantz_std::number::Number {
         &mut self,
         mut ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
-    ) -> egui::InnerResponse<egui::Response> {
-        uictx.framed(|ui| {
+    ) -> egui_graph::FramedResponse<egui::Response> {
+        uictx.framed(|ui, _sockets| {
             let mut val = ctx.extract_value().unwrap().unwrap();
             let res = match val {
                 SteelVal::NumV(ref mut f) => ui.add(egui::DragValue::new(f)),

--- a/crates/gantz_egui/src/impls/ops.rs
+++ b/crates/gantz_egui/src/impls/ops.rs
@@ -9,7 +9,7 @@ impl NodeUi for gantz_std::ops::Add {
         &mut self,
         _ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
-    ) -> egui::InnerResponse<egui::Response> {
-        uictx.framed(|ui| ui.add(egui::Label::new("+").selectable(false)))
+    ) -> egui_graph::FramedResponse<egui::Response> {
+        uictx.framed(|ui, _sockets| ui.add(egui::Label::new("+").selectable(false)))
     }
 }

--- a/crates/gantz_egui/src/impls/outlet.rs
+++ b/crates/gantz_egui/src/impls/outlet.rs
@@ -10,8 +10,8 @@ impl NodeUi for gantz_core::node::graph::Outlet {
         &mut self,
         ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
-    ) -> egui::InnerResponse<egui::Response> {
-        uictx.framed(|ui| {
+    ) -> egui_graph::FramedResponse<egui::Response> {
+        uictx.framed(|ui, _sockets| {
             let name = self.name(ctx.registry());
             let ix = outlet_ix(ctx.path(), ctx.outlets());
             let text = format!("{}[{}]", name, ix);

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -101,7 +101,7 @@ pub trait NodeUi {
         &mut self,
         ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
-    ) -> egui::InnerResponse<egui::Response>;
+    ) -> egui_graph::FramedResponse<egui::Response>;
 
     /// Optionally add additional rows to the node's inspector UI.
     ///
@@ -207,7 +207,7 @@ where
         &mut self,
         ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
-    ) -> egui::InnerResponse<egui::Response> {
+    ) -> egui_graph::FramedResponse<egui::Response> {
         (**self).ui(ctx, uictx)
     }
 
@@ -234,7 +234,7 @@ macro_rules! impl_node_ui_for_ptr {
                 (**self).name(registry)
             }
 
-            fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> egui::InnerResponse<egui::Response> {
+            fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> egui_graph::FramedResponse<egui::Response> {
                 (**self).ui(ctx, uictx)
             }
 

--- a/crates/gantz_egui/src/node/comment.rs
+++ b/crates/gantz_egui/src/node/comment.rs
@@ -58,7 +58,7 @@ impl NodeUi for Comment {
         &mut self,
         _ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
-    ) -> egui::InnerResponse<egui::Response> {
+    ) -> egui_graph::FramedResponse<egui::Response> {
         // Get interaction state
         let interaction = uictx.interaction();
         let style = uictx.style();
@@ -85,7 +85,7 @@ impl NodeUi for Comment {
         let resize_id = node_egui_id.with("resize");
         let min_resize = egui::Vec2::splat(style.interaction.interact_radius);
         let default_size = egui::vec2(self.size[0] as f32, self.size[1] as f32);
-        let response = uictx.framed_with(frame, |ui| {
+        let response = uictx.framed_with(frame, |ui, _sockets| {
             egui::containers::Resize::default()
                 .id(resize_id)
                 .resizable(interaction.selected)

--- a/crates/gantz_egui/src/node/fn_named_ref.rs
+++ b/crates/gantz_egui/src/node/fn_named_ref.rs
@@ -22,7 +22,7 @@ impl NodeUi for FnNamedRef {
         &mut self,
         ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
-    ) -> egui::InnerResponse<egui::Response> {
+    ) -> egui_graph::FramedResponse<egui::Response> {
         let registry = ctx.registry();
         let ref_ca = self.0.content_addr();
 
@@ -49,7 +49,7 @@ impl NodeUi for FnNamedRef {
                 .map(|ca| ca != ref_ca)
                 .unwrap_or(false);
 
-        uictx.framed(|ui| {
+        uictx.framed(|ui, _sockets| {
             ui.horizontal(|ui| {
                 let fn_res = ui.add(egui::Label::new("λ").selectable(false));
                 let name_text = if is_missing {

--- a/crates/gantz_egui/src/node/inspect.rs
+++ b/crates/gantz_egui/src/node/inspect.rs
@@ -46,10 +46,10 @@ impl NodeUi for Inspect {
         &mut self,
         ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
-    ) -> egui::InnerResponse<egui::Response> {
+    ) -> egui_graph::FramedResponse<egui::Response> {
         let mut frame = egui_graph::node::default_frame(uictx.style(), uictx.interaction());
         frame.fill = uictx.style().visuals.extreme_bg_color;
-        uictx.framed_with(frame, |ui| {
+        uictx.framed_with(frame, |ui, _sockets| {
             let text = match ctx.extract_value() {
                 Ok(Some(val)) => format!("{:?}", val),
                 Ok(None) => "∅".to_string(),

--- a/crates/gantz_egui/src/node/named_ref.rs
+++ b/crates/gantz_egui/src/node/named_ref.rs
@@ -131,7 +131,7 @@ impl NodeUi for NamedRef {
         &mut self,
         ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
-    ) -> egui::InnerResponse<egui::Response> {
+    ) -> egui_graph::FramedResponse<egui::Response> {
         let registry = ctx.registry();
         let ref_ca = self.ref_.content_addr();
 
@@ -159,7 +159,7 @@ impl NodeUi for NamedRef {
                 .unwrap_or(false);
 
         // Regular frame, error color if missing, warning color if outdated.
-        let response = uictx.framed(|ui| {
+        let response = uictx.framed(|ui, _sockets| {
             let name_text = if is_missing {
                 egui::RichText::new(&self.name).color(missing_color())
             } else if is_outdated {
@@ -171,7 +171,7 @@ impl NodeUi for NamedRef {
         });
 
         // Open the node on double-click (handler decides if the node is openable).
-        if response.response.double_clicked() {
+        if response.inner.response.double_clicked() {
             ctx.cmds.push(Cmd::OpenNamedNode(
                 self.name.clone(),
                 self.ref_.content_addr(),

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -1,8 +1,5 @@
 use crate::{Cmd, NodeUi, Registry};
-use egui_graph::{
-    self,
-    node::{EdgeEvent, SocketKind},
-};
+use egui_graph::{self, SocketKind, node::EdgeEvent};
 use gantz_core::{
     Edge, Node,
     node::{self, graph::Graph},


### PR DESCRIPTION
- Import `SocketKind` from `egui_graph::SocketKind` (no longer re-exported from `egui_graph::node`).
- Add `_sockets: &mut SocketLayout` parameter to all `framed`/ `framed_with` closures (14 call sites across impls and node modules).
- Update `NodeUi::ui` return type from `egui::InnerResponse<Response>` to `egui_graph::FramedResponse<Response>` in the trait definition, blanket impls, and all implementations.
- Access double-click via `response.inner.response` in `named_ref.rs` to account for `FramedResponse` wrapping `InnerResponse`.