### PR TITLE
feat: Support for demo graphs (inspired by pd help patches)

### DIFF
--- a/crates/bevy_gantz_egui/src/base.rs
+++ b/crates/bevy_gantz_egui/src/base.rs
@@ -26,6 +26,7 @@ pub fn load<N>(
     mut registry: ResMut<Registry<N>>,
     mut base_names: ResMut<BaseNames>,
     mut views: ResMut<crate::Views>,
+    mut demos: ResMut<crate::Demos>,
 ) where
     N: serde::de::DeserializeOwned + Send + Sync + 'static,
 {
@@ -46,6 +47,7 @@ pub fn load<N>(
     base_names.0 = export.registry.names().clone();
     registry.merge(export.registry);
     views.0.extend(export.views);
+    demos.0.extend(export.demos);
 }
 
 /// Path to write the base `.gantz` export to.
@@ -65,10 +67,11 @@ pub fn export_to_file<N>(
     registry: Res<Registry<N>>,
     builtins: Res<bevy_gantz::BuiltinNodes<N>>,
     views: Res<crate::Views>,
+    demos: Res<crate::Demos>,
 ) where
     N: gantz_core::Node + Clone + serde::Serialize + Send + Sync + 'static,
 {
-    let Some(ron_str) = export_all_named_ron(&registry, &builtins, &views) else {
+    let Some(ron_str) = export_all_named_ron(&registry, &builtins, &views, &demos) else {
         log::error!("export_to_file: failed to serialize");
         return;
     };
@@ -85,11 +88,12 @@ pub fn export_all_named_ron<N>(
     registry: &Registry<N>,
     builtins: &bevy_gantz::BuiltinNodes<N>,
     views: &crate::Views,
+    demos: &crate::Demos,
 ) -> Option<String>
 where
     N: gantz_core::Node + Clone + serde::Serialize + Send + Sync + 'static,
 {
-    let node_reg = crate::registry_ref(registry, builtins);
+    let node_reg = crate::registry_ref(registry, builtins, demos);
     let get_node = |ca: &gantz_ca::ContentAddr| node_reg.node(ca);
 
     let named_heads: Vec<gantz_ca::Head> = registry
@@ -99,7 +103,7 @@ where
         .collect();
 
     let export_registry = gantz_core::reg::export_heads(&get_node, registry, named_heads.iter());
-    let export = gantz_egui::export::export_with_views(export_registry, views);
+    let export = gantz_egui::export::export_with(export_registry, views, &demos.0);
 
     ron::ser::to_string_pretty(&export, ron::ser::PrettyConfig::default()).ok()
 }

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -93,6 +93,7 @@ where
             .init_resource::<PerfVm>()
             .init_resource::<PerfGui>()
             .init_resource::<Views>()
+            .init_resource::<Demos>()
             // GUI state observers
             .add_observer(on_head_opened::<N>)
             .add_observer(on_head_changed::<N>)
@@ -110,6 +111,7 @@ where
             .add_observer(on_export_head::<N>)
             .add_observer(on_export_all_named::<N>)
             .add_observer(on_import_file::<N>)
+            .add_observer(on_reset_base_graph::<N>)
             // Systems
             .add_systems(
                 Update,
@@ -157,6 +159,10 @@ pub struct GuiState(pub gantz_egui::widget::GantzState);
 /// Views (layout + camera) for all known commits.
 #[derive(Resource, Default)]
 pub struct Views(pub HashMap<ca::CommitAddr, gantz_egui::GraphViews>);
+
+/// Demo graph associations: maps a commit to its associated `demo-*` graph name.
+#[derive(Resource, Default)]
+pub struct Demos(pub HashMap<ca::CommitAddr, String>);
 
 /// Names of base nodes baked into the binary.
 ///
@@ -260,6 +266,10 @@ pub struct PasteEvent {
     /// How to position the pasted nodes.
     pub pos: gantz_egui::PastePos,
 }
+
+/// Event emitted when a base graph should be reset to its original state.
+#[derive(Event)]
+pub struct ResetBaseGraphEvent(pub String);
 
 // ----------------------------------------------------------------------------
 // QueryData
@@ -397,6 +407,19 @@ impl DerefMut for Views {
     }
 }
 
+impl Deref for Demos {
+    type Target = HashMap<ca::CommitAddr, String>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Demos {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 impl Deref for GraphViews {
     type Target = gantz_egui::GraphViews;
     fn deref(&self) -> &Self::Target {
@@ -417,8 +440,9 @@ impl DerefMut for GraphViews {
 pub fn registry_ref<'a, N: 'static + Send + Sync>(
     registry: &'a Registry<N>,
     builtins: &'a BuiltinNodes<N>,
+    demos: &'a Demos,
 ) -> RegistryRef<'a, N> {
-    RegistryRef::new(&**registry, &*builtins.0)
+    RegistryRef::new(&**registry, &*builtins.0, &demos.0)
 }
 
 // ----------------------------------------------------------------------------
@@ -526,6 +550,7 @@ pub fn on_create_node<N>(
     trigger: On<CreateNodeEvent>,
     registry: Res<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
+    demos: Res<Demos>,
     mut vms: NonSendMut<head::HeadVms>,
     mut heads: Query<head::OpenHeadData<N>, With<head::OpenHead>>,
 ) where
@@ -557,7 +582,7 @@ pub fn on_create_node<N>(
         return;
     };
 
-    let node_reg = registry_ref(&registry, &builtins);
+    let node_reg = registry_ref(&registry, &builtins, &demos);
     let Some(node) = node_reg.create_node(&event.cmd.node_type) else {
         log::error!("CreateNode: unknown node type {:?}", event.cmd.node_type);
         return;
@@ -630,6 +655,7 @@ pub fn on_inspect_edge<N>(
     trigger: On<InspectEdgeEvent>,
     registry: Res<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
+    demos: Res<Demos>,
     mut vms: NonSendMut<head::HeadVms>,
     mut heads: Query<head::OpenHeadData<N>, With<head::OpenHead>>,
     mut views_query: Query<&mut GraphViews, With<head::OpenHead>>,
@@ -655,7 +681,7 @@ pub fn on_inspect_edge<N>(
         return;
     };
 
-    let node_reg = registry_ref(&registry, &builtins);
+    let node_reg = registry_ref(&registry, &builtins, &demos);
     inspect_edge(
         &node_reg,
         &mut data.working_graph,
@@ -735,6 +761,7 @@ pub fn on_paste<N>(
     builtins: Res<BuiltinNodes<N>>,
     gui_state: ResMut<GuiState>,
     mut views: ResMut<Views>,
+    mut demos: ResMut<Demos>,
     mut vms: NonSendMut<head::HeadVms>,
     mut heads: Query<
         (&head::HeadRef, &mut head::WorkingGraph<N>, &mut GraphViews),
@@ -780,6 +807,7 @@ pub fn on_paste<N>(
         gantz_egui::export::paste(
             &mut registry,
             &mut views,
+            &mut demos,
             g,
             &mut view.layout,
             &copied,
@@ -791,7 +819,7 @@ pub fn on_paste<N>(
     // initialized with the correct nested hashmap structure. Idempotent
     // for existing nodes.
     if let Some(vm) = vms.get_mut(&event.head) {
-        let node_reg = registry_ref(&registry, &builtins);
+        let node_reg = registry_ref(&registry, &builtins, &demos);
         let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
         gantz_core::graph::register(&get_node, &**wg, &[], vm);
     }
@@ -816,6 +844,7 @@ pub fn on_export_head<N>(
     registry: Res<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
     views: Res<Views>,
+    demos: Res<Demos>,
     heads: Query<&head::HeadRef, With<head::OpenHead>>,
 ) where
     N: 'static + Node + Clone + serde::Serialize + Send + Sync,
@@ -827,11 +856,11 @@ pub fn on_export_head<N>(
     };
     let head: &ca::Head = &**head_ref;
 
-    let node_reg = registry_ref(&registry, &builtins);
+    let node_reg = registry_ref(&registry, &builtins, &demos);
     let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
 
     let export_registry = gantz_core::reg::export_heads(&get_node, &registry, [head]);
-    let export = gantz_egui::export::export_with_views(export_registry, &views);
+    let export = gantz_egui::export::export_with(export_registry, &views, &demos);
 
     let ron_str = match ron::ser::to_string_pretty(&export, ron::ser::PrettyConfig::default()) {
         Ok(s) => s,
@@ -870,10 +899,11 @@ pub fn on_export_all_named<N>(
     registry: Res<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
     views: Res<Views>,
+    demos: Res<Demos>,
 ) where
     N: 'static + Node + Clone + serde::Serialize + Send + Sync,
 {
-    let node_reg = registry_ref(&registry, &builtins);
+    let node_reg = registry_ref(&registry, &builtins, &demos);
     let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
 
     let named_heads: Vec<ca::Head> = registry
@@ -888,7 +918,7 @@ pub fn on_export_all_named<N>(
     }
 
     let export_registry = gantz_core::reg::export_heads(&get_node, &registry, named_heads.iter());
-    let export = gantz_egui::export::export_with_views(export_registry, &views);
+    let export = gantz_egui::export::export_with(export_registry, &views, &demos);
 
     let ron_str = match ron::ser::to_string_pretty(&export, ron::ser::PrettyConfig::default()) {
         Ok(s) => s,
@@ -924,6 +954,7 @@ pub fn on_import_file<N>(
     mut registry: ResMut<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
     mut views: ResMut<Views>,
+    mut demos: ResMut<Demos>,
     mut cmds: Commands,
 ) where
     N: 'static + Node + Clone + serde::de::DeserializeOwned + Send + Sync,
@@ -946,7 +977,7 @@ pub fn on_import_file<N>(
 
     // Compute root names before merge if we might open a head.
     let root_name = if event.open_head {
-        let node_reg = registry_ref(&registry, &builtins);
+        let node_reg = registry_ref(&registry, &builtins, &demos);
         let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
         let roots = gantz_core::reg::root_names(&get_node, &export.registry);
         if roots.len() == 1 {
@@ -958,7 +989,7 @@ pub fn on_import_file<N>(
         None
     };
 
-    let result = gantz_egui::export::merge_with_views(&mut registry, &mut views, export);
+    let result = gantz_egui::export::merge_with(&mut registry, &mut views, &mut demos, export);
     log::info!(
         "Imported: {} names added, {} replaced",
         result.names_added.len(),
@@ -967,6 +998,46 @@ pub fn on_import_file<N>(
 
     if let Some(name) = root_name {
         cmds.trigger(head::OpenEvent(ca::Head::Branch(name)));
+    }
+}
+
+/// Reset a base graph to its original state by re-merging from the base export.
+pub fn on_reset_base_graph<N>(trigger: On<ResetBaseGraphEvent>, mut registry: ResMut<Registry<N>>)
+where
+    N: 'static + Clone + serde::de::DeserializeOwned + Send + Sync,
+{
+    let name = &trigger.event().0;
+    let text = match std::str::from_utf8(gantz_base::BYTES) {
+        Ok(s) => s,
+        Err(e) => {
+            log::error!("ResetBaseGraph: invalid UTF-8: {e}");
+            return;
+        }
+    };
+    let export: gantz_egui::export::Export<Graph<N>> = match ron::from_str(text) {
+        Ok(e) => e,
+        Err(e) => {
+            log::error!("ResetBaseGraph: failed to deserialize base: {e}");
+            return;
+        }
+    };
+    // Extract just the commits reachable from the target name.
+    if let Some(&base_commit_ca) = export.registry.names().get(name) {
+        let mut required = std::collections::HashSet::new();
+        let mut ca = base_commit_ca;
+        loop {
+            required.insert(ca);
+            match export.registry.commits().get(&ca).and_then(|c| c.parent) {
+                Some(parent) => ca = parent,
+                None => break,
+            }
+        }
+        let mut subset = export.registry.export(&required);
+        subset.insert_name(name.clone(), base_commit_ca);
+        registry.merge(subset);
+        log::info!("Reset base graph '{name}' to original version");
+    } else {
+        log::warn!("ResetBaseGraph: name '{name}' not found in base export");
     }
 }
 
@@ -1014,10 +1085,11 @@ fn poll_import_task(task: Option<ResMut<ImportTask>>, mut cmds: Commands) {
 pub fn prune_views<N: 'static + Node + Send + Sync>(
     registry: Res<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
+    demos: Res<Demos>,
     mut views: ResMut<Views>,
     heads: Query<&head::HeadRef, With<head::OpenHead>>,
 ) {
-    let node_reg = registry_ref(&registry, &builtins);
+    let node_reg = registry_ref(&registry, &builtins, &demos);
     let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
     let head_iter = heads.iter().map(|h| &**h);
     let required = gantz_core::reg::required_commits(&get_node, &registry, head_iter);
@@ -1032,7 +1104,7 @@ pub fn prune_views<N: 'static + Node + Send + Sync>(
 /// are available as system parameters. Event-dispatched commands (node
 /// creation, edge inspection, clipboard) need mutable access to per-head
 /// components (`WorkingGraph`, `GraphViews`, `HeadVms`) that would conflict
-/// with the iteration query — observers handle these with separate queries.
+/// with the iteration query - observers handle these with separate queries.
 ///
 /// All [`gantz_egui::Cmd`] variants must be handled here *and* in the demo's
 /// `process_cmds` (see `gantz_egui/examples/demo.rs`).
@@ -1068,19 +1140,12 @@ pub fn process_cmds<N: 'static + Send + Sync>(
                         kind: EvalKind::Pull,
                     });
                 }
-                gantz_egui::Cmd::OpenGraph(path) => {
+                gantz_egui::Cmd::OpenPath(path) => {
                     let head_state = gui_state.open_heads.get_mut(&head).unwrap();
                     head_state.path = path;
                 }
-                gantz_egui::Cmd::OpenNamedNode(name, content_ca) => {
-                    let commit_ca = ca::CommitAddr::from(content_ca);
-                    if registry.names().get(&name) == Some(&commit_ca) {
-                        cmds.trigger(head::OpenEvent(ca::Head::Branch(name.to_string())));
-                    } else {
-                        log::debug!(
-                            "Attempted to open named node, but the content address has changed"
-                        );
-                    }
+                gantz_egui::Cmd::OpenHead(target) => {
+                    cmds.trigger(head::OpenEvent(target));
                 }
                 gantz_egui::Cmd::BranchNode { new_name, ca, path } => {
                     cmds.trigger(BranchNodeEvent {
@@ -1168,8 +1233,8 @@ pub fn update<N>(
     mut focused: ResMut<head::FocusedHead>,
     mut heads_query: Query<OpenHeadViews<N>, With<head::OpenHead>>,
     import_task: Option<Res<ImportTask>>,
-    base_names: Res<BaseNames>,
-    base_immutable: Res<BaseImmutable>,
+    (base_names, base_immutable): (Res<BaseNames>, Res<BaseImmutable>),
+    mut demos: ResMut<Demos>,
     mut cmds: Commands,
 ) -> Result
 where
@@ -1194,8 +1259,8 @@ where
     // Create the head access adapter.
     let mut access = HeadAccess::new(&tab_order, &mut heads_query, &mut vms);
 
-    // Construct node registry on-demand for the widget.
-    let node_reg = registry_ref(&registry, &builtins);
+    // Construct node registry on-demand for the widget (with demo lookup).
+    let node_reg = registry_ref(&registry, &builtins, &demos);
 
     let level = bevy_log::tracing_subscriber::filter::LevelFilter::current();
 
@@ -1205,6 +1270,7 @@ where
         .show(ctx, |ui| {
             gantz_egui::widget::Gantz::new(&node_reg, &base_names.0)
                 .base_immutable(base_immutable.0)
+                .demos(&demos.0)
                 .trace_capture(trace_capture.0.clone(), level)
                 .perf_captures(&mut perf_vm.0, &mut perf_gui.0)
                 .show(&mut *gui_state, focused_ix, &mut access, ui)
@@ -1273,6 +1339,27 @@ where
             bytes: drop.bytes.clone(),
             open_head,
         });
+    }
+
+    // Handle demo graph association change.
+    if let Some((head, demo_val)) = &response.demo_changed {
+        if let Some(commit_ca) = registry.head_commit_ca(head).copied() {
+            match demo_val {
+                Some(name) => {
+                    demos.insert(commit_ca, name.clone());
+                }
+                None => {
+                    demos.remove(&commit_ca);
+                }
+            }
+        }
+    }
+
+    // Handle demo reset - re-merge the base version of the demo graph.
+    if let Some(head) = &response.reset_base_graph {
+        if let ca::Head::Branch(name) = head {
+            cmds.trigger(ResetBaseGraphEvent(name.clone()));
+        }
     }
 
     // Handle import button - open a file dialog (only if none already in flight).

--- a/crates/gantz/src/builtin.rs
+++ b/crates/gantz/src/builtin.rs
@@ -14,6 +14,9 @@ type PrimitiveInstances = HashMap<ca::ContentAddr, Box<dyn Node>>;
 /// Mapping from builtin content addresses to their names.
 type PrimitiveNames = HashMap<ca::ContentAddr, String>;
 
+/// Mapping from builtin node names to their associated demo graph names.
+type DemoGraphs = BTreeMap<String, String>;
+
 /// The set of all known node types accessible to gantz.
 pub struct Builtins {
     /// Constructors for all builtin nodes.
@@ -22,16 +25,20 @@ pub struct Builtins {
     instances: PrimitiveInstances,
     /// Mapping from content addresses to names.
     names: PrimitiveNames,
+    /// Mapping from builtin names to their associated demo graph names.
+    demo_graphs: DemoGraphs,
 }
 
 impl Builtins {
     pub fn new() -> Self {
         let constructors = primitives();
         let (instances, names) = primitive_instances_and_names(&constructors);
+        let demo_graphs = DemoGraphs::default();
         Self {
             constructors,
             instances,
             names,
+            demo_graphs,
         }
     }
 }
@@ -66,6 +73,10 @@ impl gantz_core::Builtins for Builtins {
             .iter()
             .find(|(_, n)| *n == name)
             .map(|(ca, _)| *ca)
+    }
+
+    fn demo_graph(&self, name: &str) -> Option<&str> {
+        self.demo_graphs.get(name).map(|s| s.as_str())
     }
 }
 

--- a/crates/gantz_core/src/builtin.rs
+++ b/crates/gantz_core/src/builtin.rs
@@ -26,4 +26,10 @@ pub trait Builtins: Send + Sync {
 
     /// Get content address by name.
     fn content_addr(&self, name: &str) -> Option<ContentAddr>;
+
+    /// Get the name of the demo graph associated with a builtin, if any.
+    fn demo_graph(&self, name: &str) -> Option<&str> {
+        let _ = name;
+        None
+    }
 }

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -842,21 +842,13 @@ fn process_cmds(ctx: &egui::Context, state: &mut State) {
                         log::error!("{e}");
                     }
                 }
-                gantz_egui::Cmd::OpenGraph(path) => {
+                gantz_egui::Cmd::OpenPath(path) => {
                     // Re-borrow head_state to modify path.
                     let head_state = state.gantz.open_heads.get_mut(&head).unwrap();
                     head_state.path = path;
                 }
-                gantz_egui::Cmd::OpenNamedNode(name, content_ca) => {
-                    // The content_ca represents a CommitAddr for graph nodes.
-                    let commit_ca = gantz_ca::CommitAddr::from(content_ca);
-                    if state.env.registry.names().get(&name) == Some(&commit_ca) {
-                        open_head(state, gantz_ca::Head::Branch(name.to_string()));
-                    } else {
-                        log::debug!(
-                            "Attempted to open named node, but the content address has changed"
-                        );
-                    }
+                gantz_egui::Cmd::OpenHead(target) => {
+                    open_head(state, target);
                 }
                 gantz_egui::Cmd::BranchNode { new_name, ca, path } => {
                     let commit_ca = gantz_ca::CommitAddr::from(ca);
@@ -925,9 +917,11 @@ fn process_cmds(ctx: &egui::Context, state: &mut State) {
                         };
                         let view = gv.entry(path).or_default();
                         let mut all_views = std::collections::HashMap::new();
+                        let mut all_demos = std::collections::HashMap::new();
                         gantz_egui::export::paste(
                             &mut state.env.registry,
                             &mut all_views,
+                            &mut all_demos,
                             g,
                             &mut view.layout,
                             &copied,
@@ -978,7 +972,11 @@ fn process_cmds(ctx: &egui::Context, state: &mut State) {
                     let export_registry =
                         gantz_core::reg::export_heads(&get_node, &state.env.registry, [&head]);
                     let all_views = HashMap::new();
-                    let export = gantz_egui::export::export_with_views(export_registry, &all_views);
+                    let export = gantz_egui::export::export_with(
+                        export_registry,
+                        &all_views,
+                        &HashMap::new(),
+                    );
                     let ron_str = match ron::ser::to_string_pretty(
                         &export,
                         ron::ser::PrettyConfig::default(),
@@ -1022,7 +1020,11 @@ fn process_cmds(ctx: &egui::Context, state: &mut State) {
                         named_heads.iter(),
                     );
                     let all_views = HashMap::new();
-                    let export = gantz_egui::export::export_with_views(export_registry, &all_views);
+                    let export = gantz_egui::export::export_with(
+                        export_registry,
+                        &all_views,
+                        &HashMap::new(),
+                    );
                     let ron_str = match ron::ser::to_string_pretty(
                         &export,
                         ron::ser::PrettyConfig::default(),
@@ -1294,8 +1296,13 @@ fn import_bytes(state: &mut State, bytes: Vec<u8>, open_head: bool) {
     };
 
     let mut all_views = HashMap::new();
-    let result =
-        gantz_egui::export::merge_with_views(&mut state.env.registry, &mut all_views, export);
+    let mut all_demos = HashMap::new();
+    let result = gantz_egui::export::merge_with(
+        &mut state.env.registry,
+        &mut all_views,
+        &mut all_demos,
+        export,
+    );
     log::info!(
         "Imported: {} names added, {} replaced",
         result.names_added.len(),

--- a/crates/gantz_egui/src/export.rs
+++ b/crates/gantz_egui/src/export.rs
@@ -22,36 +22,55 @@ pub struct Export<G> {
         serialize_with = "gantz_ca::serde_sorted::serialize_map_of_maps"
     )]
     pub views: HashMap<CommitAddr, GraphViews>,
+    /// Maps commits to their associated demo graph name (a `demo-*` name).
+    #[serde(default)]
+    pub demos: HashMap<CommitAddr, String>,
 }
 
-/// Produce an [`Export`] by filtering views to commits present in the registry.
-pub fn export_with_views<G>(
+/// Produce an [`Export`] by filtering views and demos to commits present in the registry.
+pub fn export_with<G>(
     registry: gantz_ca::Registry<G>,
     all_views: &HashMap<CommitAddr, GraphViews>,
+    all_demos: &HashMap<CommitAddr, String>,
 ) -> Export<G>
 where
     G: Clone,
 {
+    let commits = registry.commits();
+    let filter = |ca: &&CommitAddr| commits.contains_key(ca);
     let views = all_views
         .iter()
-        .filter(|(ca, _)| registry.commits().contains_key(ca))
+        .filter(|(ca, _)| filter(ca))
         .map(|(&ca, v)| (ca, v.clone()))
         .collect();
-    Export { registry, views }
+    let demos = all_demos
+        .iter()
+        .filter(|(ca, _)| filter(ca))
+        .map(|(&ca, v)| (ca, v.clone()))
+        .collect();
+    Export {
+        registry,
+        views,
+        demos,
+    }
 }
 
-/// Merge an [`Export`] into an existing registry and views map.
+/// Merge an [`Export`] into an existing registry, views and demos maps.
 ///
-/// Incoming views for new commits are inserted; existing views for known
-/// commits are kept.
-pub fn merge_with_views<G>(
+/// Incoming views and demos for new commits are inserted; existing
+/// entries for known commits are kept.
+pub fn merge_with<G>(
     registry: &mut gantz_ca::Registry<G>,
     views: &mut HashMap<CommitAddr, GraphViews>,
+    demos: &mut HashMap<CommitAddr, String>,
     export: Export<G>,
 ) -> MergeResult {
     let result = registry.merge(export.registry);
     for (ca, v) in export.views {
         views.entry(ca).or_insert(v);
+    }
+    for (ca, d) in export.demos {
+        demos.entry(ca).or_insert(d);
     }
     result
 }
@@ -141,7 +160,7 @@ where
         }
     }
     let export_registry = registry.export(&required_commits);
-    let export = export_with_views(export_registry, all_views);
+    let export = export_with(export_registry, all_views, &HashMap::new());
 
     Copied {
         export,
@@ -158,6 +177,7 @@ where
 pub fn paste<N>(
     registry: &mut gantz_ca::Registry<Graph<N>>,
     views: &mut HashMap<CommitAddr, GraphViews>,
+    demos: &mut HashMap<CommitAddr, String>,
     target_graph: &mut Graph<N>,
     target_layout: &mut egui_graph::Layout,
     copied: &Copied<N>,
@@ -166,7 +186,7 @@ pub fn paste<N>(
 where
     N: Clone,
 {
-    merge_with_views(registry, views, copied.export.clone());
+    merge_with(registry, views, demos, copied.export.clone());
     let new_indices = gantz_core::graph::add_subgraph(target_graph, &copied.graph);
 
     // Map positions from subgraph indices to target indices with offset.
@@ -207,6 +227,7 @@ mod tests {
         Export {
             registry,
             views: HashMap::new(),
+            demos: HashMap::new(),
         }
     }
 
@@ -240,7 +261,8 @@ mod tests {
         let recovered: Export<String> = ron::from_str(&s).expect("deserialize");
         let mut target = gantz_ca::Registry::<String>::default();
         let mut views = HashMap::new();
-        let result = merge_with_views(&mut target, &mut views, recovered);
+        let mut demos = HashMap::new();
+        let result = merge_with(&mut target, &mut views, &mut demos, recovered);
         assert_eq!(result.names_added, vec!["alpha".to_string()]);
         assert!(result.names_replaced.is_empty());
         let ca = commit_addr_raw(10);
@@ -249,7 +271,7 @@ mod tests {
     }
 
     #[test]
-    fn export_with_views_filters_views() {
+    fn export_with_filters_views() {
         let ga = graph_addr(1);
         let ca = commit_addr_raw(10);
         let cb = commit_addr_raw(20);
@@ -262,7 +284,7 @@ mod tests {
         let mut all_views = HashMap::new();
         all_views.insert(ca, GraphViews::new());
         all_views.insert(cb, GraphViews::new()); // cb not in registry
-        let export = export_with_views(registry, &all_views);
+        let export = export_with(registry, &all_views, &HashMap::new());
         assert!(export.views.contains_key(&ca));
         assert!(!export.views.contains_key(&cb));
     }
@@ -303,7 +325,7 @@ mod tests {
     }
 
     #[test]
-    fn merge_with_views_keeps_existing_views() {
+    fn merge_with_keeps_existing_views() {
         let ga = graph_addr(1);
         let ca = commit_addr_raw(10);
         let commit = Commit::new(Duration::from_secs(1), None, ga);
@@ -315,6 +337,7 @@ mod tests {
         let mut existing_view = GraphViews::new();
         existing_view.insert(vec![0], egui_graph::View::default());
         let mut views = HashMap::from([(ca, existing_view)]);
+        let mut demos = HashMap::new();
         let export = Export {
             registry: gantz_ca::Registry::new(
                 HashMap::from([(ga, "g".to_string())]),
@@ -322,8 +345,9 @@ mod tests {
                 BTreeMap::new(),
             ),
             views: HashMap::from([(ca, GraphViews::new())]),
+            demos: HashMap::new(),
         };
-        merge_with_views(&mut registry, &mut views, export);
+        merge_with(&mut registry, &mut views, &mut demos, export);
         // Existing view (with 1 entry) should be preserved, not replaced by empty.
         assert_eq!(views[&ca].len(), 1);
     }

--- a/crates/gantz_egui/src/impls/graph.rs
+++ b/crates/gantz_egui/src/impls/graph.rs
@@ -16,7 +16,7 @@ where
         uictx.framed(|ui, _sockets| {
             let res = ui.add(egui::Label::new("graph").selectable(false));
             if ui.response().double_clicked() {
-                ctx.cmds.push(Cmd::OpenGraph(ctx.path().to_vec()));
+                ctx.cmds.push(Cmd::OpenPath(ctx.path().to_vec()));
             }
             res
         })

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -50,6 +50,12 @@ pub use widget::graph_select::GraphRegistry;
 pub trait Registry: NameRegistry + FnNodeNames + NodeTypeRegistry + GraphRegistry {
     /// Look up a node by content address.
     fn node(&self, ca: &gantz_ca::ContentAddr) -> Option<&dyn gantz_core::Node>;
+
+    /// Get the demo graph name for a node at the given content address.
+    fn demo_graph(&self, ca: &gantz_ca::ContentAddr) -> Option<&str> {
+        let _ = ca;
+        None
+    }
 }
 
 /// Provides access to open head data for the Gantz widget.
@@ -123,6 +129,11 @@ pub trait NodeUi {
     fn flow(&self, _registry: &dyn Registry) -> egui::Direction {
         egui::Direction::TopDown
     }
+
+    /// Look up the demo graph name associated with this node, if any.
+    fn demo_graph<'a>(&self, _registry: &'a dyn Registry) -> Option<&'a str> {
+        None
+    }
 }
 
 /// A wrapper around a node's path and the VM providing easy access to the
@@ -174,8 +185,10 @@ pub fn resolve_paste_offset(pos: &PastePos, copied_positions: &egui_graph::Layou
 pub enum Cmd {
     PushEval(Vec<node::Id>),
     PullEval(Vec<node::Id>),
-    OpenGraph(Vec<node::Id>),
-    OpenNamedNode(String, gantz_ca::ContentAddr),
+    /// Navigate the path within the current head's graph hierarchy.
+    OpenPath(Vec<node::Id>),
+    /// Open a head (named or commit) as a new tab.
+    OpenHead(gantz_ca::Head),
     /// Branch a named node: create a new name with its own commit for the
     /// given content address, and replace the node with a reference to it.
     BranchNode {
@@ -255,6 +268,10 @@ where
     fn flow(&self, registry: &dyn Registry) -> egui::Direction {
         (**self).flow(registry)
     }
+
+    fn demo_graph<'b>(&self, registry: &'b dyn Registry) -> Option<&'b str> {
+        (**self).demo_graph(registry)
+    }
 }
 
 macro_rules! impl_node_ui_for_ptr {
@@ -281,6 +298,10 @@ macro_rules! impl_node_ui_for_ptr {
 
             fn flow(&self, registry: &dyn Registry) -> egui::Direction {
                 (**self).flow(registry)
+            }
+
+            fn demo_graph<'a>(&self, registry: &'a dyn Registry) -> Option<&'a str> {
+                (**self).demo_graph(registry)
             }
         }
     };

--- a/crates/gantz_egui/src/node/named_ref.rs
+++ b/crates/gantz_egui/src/node/named_ref.rs
@@ -127,6 +127,10 @@ impl NodeUi for NamedRef {
         &self.name
     }
 
+    fn demo_graph<'a>(&self, registry: &'a dyn crate::Registry) -> Option<&'a str> {
+        registry.demo_graph(&self.ref_.content_addr())
+    }
+
     fn ui(
         &mut self,
         ctx: NodeCtx,
@@ -172,10 +176,8 @@ impl NodeUi for NamedRef {
 
         // Open the node on double-click (handler decides if the node is openable).
         if response.inner.response.double_clicked() {
-            ctx.cmds.push(Cmd::OpenNamedNode(
-                self.name.clone(),
-                self.ref_.content_addr(),
-            ));
+            ctx.cmds
+                .push(Cmd::OpenHead(gantz_ca::Head::Branch(self.name.clone())));
         }
 
         response

--- a/crates/gantz_egui/src/reg.rs
+++ b/crates/gantz_egui/src/reg.rs
@@ -11,7 +11,7 @@ use crate::widget::graph_select::GraphRegistry;
 use gantz_ca as ca;
 use gantz_core::node::{self, graph::Graph};
 use gantz_core::{Builtins, Node};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// Registry reference providing unified node access.
 ///
@@ -21,17 +21,20 @@ use std::collections::BTreeMap;
 pub struct RegistryRef<'a, N: 'static + Send + Sync> {
     ca_registry: &'a ca::Registry<Graph<N>>,
     builtins: &'a dyn Builtins<Node = N>,
+    demos: &'a HashMap<ca::CommitAddr, String>,
 }
 
 impl<'a, N: 'static + Send + Sync> RegistryRef<'a, N> {
-    /// Construct from a CA registry and builtins provider.
+    /// Construct from a CA registry, builtins provider and demo associations.
     pub fn new(
         ca_registry: &'a ca::Registry<Graph<N>>,
         builtins: &'a dyn Builtins<Node = N>,
+        demos: &'a HashMap<ca::CommitAddr, String>,
     ) -> Self {
         Self {
             ca_registry,
             builtins,
+            demos,
         }
     }
 
@@ -150,5 +153,18 @@ impl<N: 'static + Node + Send + Sync> FnNodeNames for RegistryRef<'_, N> {
 impl<N: 'static + Node + Send + Sync> Registry for RegistryRef<'_, N> {
     fn node(&self, ca: &ca::ContentAddr) -> Option<&dyn Node> {
         RegistryRef::node(self, ca)
+    }
+
+    fn demo_graph(&self, ca: &ca::ContentAddr) -> Option<&str> {
+        // Check demos map (commit-level associations from Export).
+        let commit_ca = ca::CommitAddr::from(*ca);
+        if let Some(name) = self.demos.get(&commit_ca) {
+            return Some(name.as_str());
+        }
+        // Check builtins.
+        if let Some(builtin_name) = self.builtins.name(ca) {
+            return self.builtins.demo_graph(builtin_name);
+        }
+        None
     }
 }

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -53,6 +53,7 @@ pub trait NodeTypeRegistry {
 pub struct Gantz<'a> {
     env: &'a dyn Registry,
     base_names: &'a gantz_ca::registry::Names,
+    demos: Option<&'a HashMap<gantz_ca::CommitAddr, String>>,
     log_source: Option<LogSource>,
     perf_vm: Option<&'a mut widget::PerfCapture>,
     perf_gui: Option<&'a mut widget::PerfCapture>,
@@ -196,6 +197,10 @@ pub struct GantzResponse {
     pub new_branch: Option<(gantz_ca::Head, String)>,
     /// Files dropped onto gantz panes.
     pub file_drops: Vec<FileDrop>,
+    /// Demo graph association changed: (head, Some(demo_name) | None).
+    pub demo_changed: Option<(gantz_ca::Head, Option<String>)>,
+    /// A base graph should be reset to its original state.
+    pub reset_base_graph: Option<gantz_ca::Head>,
 }
 
 /// State for editing a tab name via double-click.
@@ -285,11 +290,18 @@ impl<'a> Gantz<'a> {
         Self {
             env,
             base_names,
+            demos: None,
             log_source: None,
             perf_vm: None,
             perf_gui: None,
             base_immutable: true,
         }
+    }
+
+    /// Provide demo graph associations for the config dropdown.
+    pub fn demos(mut self, demos: &'a HashMap<gantz_ca::CommitAddr, String>) -> Self {
+        self.demos = Some(demos);
+        self
     }
 
     /// Enable the logging window with a basic env logger.
@@ -377,6 +389,8 @@ impl<'a> Gantz<'a> {
             closed_heads: Vec::new(),
             new_branch: None,
             file_drops: Vec::new(),
+            demo_changed: None,
+            reset_base_graph: None,
         };
 
         // The context for traversing the tree of tiles.
@@ -527,15 +541,42 @@ where
                         gantz_ca::Head::Branch(name) => base_names.contains_key(name),
                         _ => false,
                     };
-                    let immutable = is_base && gantz.base_immutable;
+                    let is_demo =
+                        matches!(&head, gantz_ca::Head::Branch(name) if name.starts_with("demo-"));
+                    let immutable = is_base && gantz.base_immutable && !is_demo;
+
+                    // Collect demo-* names for the dropdown.
+                    let demo_names_vec: Vec<&str> = names
+                        .keys()
+                        .filter(|n| n.starts_with("demo-"))
+                        .map(|n| n.as_str())
+                        .collect();
+
+                    // Look up the current demo association for this head.
+                    let current_demo = match &head {
+                        gantz_ca::Head::Branch(name) => names
+                            .get(name)
+                            .and_then(|ca| gantz.demos.and_then(|d| d.get(ca)))
+                            .map(|s| s.as_str()),
+                        _ => None,
+                    };
+
                     let res = pane_ui(ui, |ui| {
                         widget::GraphConfig::new(&head, head_state, names)
                             .is_base(is_base)
                             .immutable(immutable)
+                            .demo_names(&demo_names_vec)
+                            .current_demo(current_demo)
                             .show(ui)
                     });
                     if res.inner.new_branch.is_some() {
                         gantz_response.new_branch = res.inner.new_branch;
+                    }
+                    if let Some(demo_val) = res.inner.demo_changed {
+                        gantz_response.demo_changed = Some((head.clone(), demo_val));
+                    }
+                    if res.inner.reset_base_graph {
+                        gantz_response.reset_base_graph = Some(head.clone());
                     }
                     if res.inner.export {
                         let head_state = state.open_heads.entry(head).or_default();
@@ -944,8 +985,12 @@ where
             .expect("pane head not found in heads");
 
         // Compute whether this head should be immutable.
+        // Demo base graphs are mutable so users can experiment.
+        let is_demo =
+            matches!(pane_head, gantz_ca::Head::Branch(name) if name.starts_with("demo-"));
         let immutable = self.base_immutable
-            && matches!(pane_head, gantz_ca::Head::Branch(name) if self.base_names.contains_key(name));
+            && matches!(pane_head, gantz_ca::Head::Branch(name) if self.base_names.contains_key(name))
+            && !is_demo;
 
         let head_state = self.state.open_heads.entry(pane_head.clone()).or_default();
         let auto_layout = head_state.auto_layout;
@@ -1379,7 +1424,7 @@ where
                 .show(ui, |ui| {
                     ui.vertical_centered_justified(|ui| {
                         if ui.add(button("R")).on_hover_text("root graph").clicked() {
-                            head_state.scene.cmds.push(Cmd::OpenGraph(vec![]));
+                            head_state.scene.cmds.push(Cmd::OpenPath(vec![]));
                             head_state.scene.interaction.selection.clear();
                         }
                     });
@@ -1395,7 +1440,7 @@ where
                                 .clicked()
                             {
                                 if !current_path {
-                                    head_state.scene.cmds.push(Cmd::OpenGraph(path.to_vec()));
+                                    head_state.scene.cmds.push(Cmd::OpenPath(path.to_vec()));
                                     head_state.scene.interaction.selection.clear();
                                 }
                             }

--- a/crates/gantz_egui/src/widget/graph_config.rs
+++ b/crates/gantz_egui/src/widget/graph_config.rs
@@ -121,7 +121,11 @@ impl<'a> GraphConfig<'a> {
         // Reset button for demo base graphs.
         let mut reset_base_graph = false;
         if self.is_base && is_demo {
-            if ui.button("Reset Demo").clicked() {
+            if ui
+                .button("Reset")
+                .on_hover_text("reset demo to initial state")
+                .clicked()
+            {
                 reset_base_graph = true;
             }
         }

--- a/crates/gantz_egui/src/widget/graph_config.rs
+++ b/crates/gantz_egui/src/widget/graph_config.rs
@@ -13,6 +13,8 @@ pub struct GraphConfig<'a> {
     names: &'a gantz_ca::registry::Names,
     is_base: bool,
     immutable: bool,
+    demo_names: &'a [&'a str],
+    current_demo: Option<&'a str>,
 }
 
 /// Response from the [`GraphConfig`] widget.
@@ -21,6 +23,10 @@ pub struct GraphConfigResponse {
     pub new_branch: Option<(gantz_ca::Head, String)>,
     /// The "Export" button was clicked.
     pub export: bool,
+    /// Demo graph association changed: `Some(Some(name))` = set, `Some(None)` = clear.
+    pub demo_changed: Option<Option<String>>,
+    /// The "Reset" button was clicked for a base graph.
+    pub reset_base_graph: bool,
 }
 
 impl<'a> GraphConfig<'a> {
@@ -35,6 +41,8 @@ impl<'a> GraphConfig<'a> {
             names,
             is_base: false,
             immutable: false,
+            demo_names: &[],
+            current_demo: None,
         }
     }
 
@@ -53,6 +61,18 @@ impl<'a> GraphConfig<'a> {
         self
     }
 
+    /// Available demo graph names for the dropdown.
+    pub fn demo_names(mut self, demo_names: &'a [&'a str]) -> Self {
+        self.demo_names = demo_names;
+        self
+    }
+
+    /// The current demo graph association for this graph, if any.
+    pub fn current_demo(mut self, current_demo: Option<&'a str>) -> Self {
+        self.current_demo = current_demo;
+        self
+    }
+
     pub fn show(self, ui: &mut egui::Ui) -> GraphConfigResponse {
         // Name editing TextEdit with per-head temp state.
         let edit_id = egui::Id::new("graph_config_name_edit").with(self.head);
@@ -62,6 +82,49 @@ impl<'a> GraphConfig<'a> {
         let name_res = head_name_edit(self.head, &mut name, self.names, ui);
         ui.memory_mut(|m| m.data.insert_temp(edit_id, name));
         let new_branch = name_res.new_branch;
+
+        // Demo graph selector (only for named, non-demo graphs).
+        let is_named = matches!(self.head, gantz_ca::Head::Branch(_));
+        let is_demo =
+            matches!(&self.head, gantz_ca::Head::Branch(name) if name.starts_with("demo-"));
+        let mut demo_changed = None;
+        if is_named && !is_demo && !self.demo_names.is_empty() {
+            ui.add_enabled_ui(!self.immutable, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label("Demo:");
+                    let selected_text = self.current_demo.unwrap_or("none");
+                    egui::ComboBox::from_id_salt("demo_graph_select")
+                        .selected_text(selected_text)
+                        .show_ui(ui, |ui| {
+                            if ui
+                                .selectable_label(self.current_demo.is_none(), "none")
+                                .clicked()
+                            {
+                                demo_changed = Some(None);
+                            }
+                            for &demo_name in self.demo_names {
+                                if ui
+                                    .selectable_label(
+                                        self.current_demo == Some(demo_name),
+                                        demo_name,
+                                    )
+                                    .clicked()
+                                {
+                                    demo_changed = Some(Some(demo_name.to_string()));
+                                }
+                            }
+                        });
+                });
+            });
+        }
+
+        // Reset button for demo base graphs.
+        let mut reset_base_graph = false;
+        if self.is_base && is_demo {
+            if ui.button("Reset Demo").clicked() {
+                reset_base_graph = true;
+            }
+        }
 
         if self.is_base {
             ui.label(
@@ -93,6 +156,11 @@ impl<'a> GraphConfig<'a> {
         });
 
         let export = ui.button("Export").clicked();
-        GraphConfigResponse { new_branch, export }
+        GraphConfigResponse {
+            new_branch,
+            export,
+            demo_changed,
+            reset_base_graph,
+        }
     }
 }

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -376,6 +376,19 @@ where
                 state.cmds.push(Cmd::CopyNodes(target.clone()));
                 ui.close();
             }
+            // Demo graph, if the node has one.
+            let demo_name = graph[n_id].demo_graph(registry);
+            let demo_btn = ui.add_enabled(demo_name.is_some(), egui::Button::new("demo"));
+            if let Some(name) = demo_name {
+                if demo_btn.on_hover_text(format!("opens {name}")).clicked() {
+                    state
+                        .cmds
+                        .push(Cmd::OpenHead(gantz_ca::Head::Branch(name.to_string())));
+                    ui.close();
+                }
+            } else {
+                demo_btn.on_disabled_hover_text("no associated demo");
+            }
             if !immutable {
                 if ui.button("delete").clicked() {
                     nodes_to_delete.extend(target);

--- a/crates/gantz_egui/src/widget/graph_select.rs
+++ b/crates/gantz_egui/src/widget/graph_select.rs
@@ -123,80 +123,105 @@ impl<'a> GraphSelect<'a> {
                 ui.available_height() - ui.spacing().interact_size.y - ui.spacing().item_spacing.y,
             )
             .show(ui, |ui| {
-                // Partition names into user names and base names.
+                // Partition names into groups:
+                // 1. User-named, non-demo
+                // 2. Base-named, non-demo
+                // 3. All demos (alphabetical, regardless of user/base)
                 let is_base = |name: &str| self.base_names.contains_key(name);
-
-                // Show user-named graphs first.
-                let mut visited = HashSet::new();
-                for (name, ca) in names.iter().filter(|(n, _)| !is_base(n)) {
-                    if !state.name_filter.is_empty()
-                        && !state
+                let is_demo = |name: &str| name.starts_with("demo-");
+                let matches_filter = |name: &str| {
+                    state.name_filter.is_empty()
+                        || state
                             .name_filter
                             .split_whitespace()
                             .all(|s| name.contains(s))
-                    {
+                };
+
+                let mut visited = HashSet::new();
+
+                // Helper: show a named graph row and handle clicks.
+                let show_named =
+                    |ui: &mut egui::Ui,
+                     name: &str,
+                     ca: &gantz_ca::CommitAddr,
+                     row_type: HeadRowType<'_>,
+                     heads: &[gantz_ca::Head],
+                     focused_head: Option<usize>,
+                     response: &mut GraphSelectResponse| {
+                        let head = gantz_ca::Head::Branch(name.to_string());
+                        let res = head_row(heads, &head, row_type, ca, focused_head, ui);
+                        if res.row.clicked() {
+                            let ctrl = ui.input(|i| i.modifiers.ctrl);
+                            if ctrl {
+                                if heads.contains(&head) {
+                                    response.closed = Some(head);
+                                } else {
+                                    response.opened = Some(head);
+                                }
+                            } else {
+                                response.replaced = Some(head);
+                            }
+                        } else if let Some(delete) = res.delete {
+                            if delete.clicked() {
+                                response.name_removed = Some(name.to_string());
+                            }
+                        }
+                    };
+
+                // 1. User-named, non-demo.
+                for (name, ca) in names.iter().filter(|(n, _)| !is_base(n) && !is_demo(n)) {
+                    if !matches_filter(name) {
                         continue;
                     }
-                    visited.insert(ca);
-                    let head = gantz_ca::Head::Branch(name.to_string());
-                    let res = head_row(
-                        self.heads,
-                        &head,
-                        HeadRowType::Named(name),
-                        ca,
-                        self.focused_head,
+                    visited.insert(*ca);
+                    show_named(
                         ui,
+                        name,
+                        ca,
+                        HeadRowType::Named(name),
+                        self.heads,
+                        self.focused_head,
+                        &mut response,
                     );
-                    if res.row.clicked() {
-                        let ctrl = ui.input(|i| i.modifiers.ctrl);
-                        if ctrl {
-                            if self.heads.contains(&head) {
-                                response.closed = Some(head);
-                            } else {
-                                response.opened = Some(head);
-                            }
-                        } else {
-                            response.replaced = Some(head);
-                        }
-                    } else if let Some(delete) = res.delete {
-                        if delete.clicked() {
-                            response.name_removed = Some(name.to_string());
-                        }
-                    }
                 }
 
-                // Show base-named graphs after user graphs.
-                for (name, ca) in names.iter().filter(|(n, _)| is_base(n)) {
-                    if !state.name_filter.is_empty()
-                        && !state
-                            .name_filter
-                            .split_whitespace()
-                            .all(|s| name.contains(s))
-                    {
+                // 2. Base-named, non-demo.
+                for (name, ca) in names.iter().filter(|(n, _)| is_base(n) && !is_demo(n)) {
+                    if !matches_filter(name) {
                         continue;
                     }
-                    visited.insert(ca);
-                    let head = gantz_ca::Head::Branch(name.to_string());
-                    let res = head_row(
-                        self.heads,
-                        &head,
-                        HeadRowType::Base(name),
-                        ca,
-                        self.focused_head,
+                    visited.insert(*ca);
+                    show_named(
                         ui,
+                        name,
+                        ca,
+                        HeadRowType::Base(name),
+                        self.heads,
+                        self.focused_head,
+                        &mut response,
                     );
-                    if res.row.clicked() {
-                        let ctrl = ui.input(|i| i.modifiers.ctrl);
-                        if ctrl {
-                            if self.heads.contains(&head) {
-                                response.closed = Some(head);
-                            } else {
-                                response.opened = Some(head);
-                            }
-                        } else {
-                            response.replaced = Some(head);
-                        }
+                }
+
+                // 3. All demos, alphabetical, regardless of user/base.
+                for (name, ca) in names.iter().filter(|(n, _)| is_demo(n)) {
+                    if !matches_filter(name) {
+                        continue;
                     }
+                    visited.insert(*ca);
+                    let row_type = if is_base(name) {
+                        HeadRowType::Base(name)
+                    } else {
+                        HeadRowType::Named(name)
+                    };
+                    show_named(
+                        ui,
+                        name,
+                        ca,
+                        row_type,
+                        self.heads,
+                        self.focused_head,
+                        &mut response,
+                    );
                 }
 
                 // Collect commit addresses for open heads (excluding named ones already shown).


### PR DESCRIPTION
Add a `demos` map (`CommitAddr -> String`) to associate named graphs with `demo-*` graphs. Thread demo associations through the export/import pipeline, `RegistryRef`, and the `Builtins` trait.

Add a demo dropdown to GraphConfig allowing users to assign a demo graph to any named graph. Disable the dropdown for immutable base graphs. Add a "Reset" button for base demo graphs that re-merges the original base export.

Simplify `Cmd` variants: rename `OpenGraph` to `OpenPath` and replace `OpenNamedNode` with a generic `OpenHead`. Make demo base graphs mutable so users can experiment with them.

Polish the Graphs list: list all demo graphs in a single alphabetical section regardless of user/base origin. Always show the "demo" button in node context menus - disable it with hover text when no demo is associated.