### PR TITLE
feat: buffer comment text edits and flush on timeout or mouse activity

### DIFF
--- a/crates/gantz_egui/src/node/comment.rs
+++ b/crates/gantz_egui/src/node/comment.rs
@@ -6,6 +6,25 @@ use gantz_ca::CaHash;
 use gantz_core::node::{self, ExprCtx, ExprResult, MetaCtx};
 use serde::{Deserialize, Serialize};
 
+/// Temporary editing state stored in egui memory to buffer text edits.
+///
+/// This prevents every keystroke from mutating the node's text (and thus
+/// triggering a new content-addressed commit). The buffer is flushed to
+/// the node on focus loss.
+#[derive(Clone, Default)]
+struct CommentEditState {
+    text_hash: u64,
+    text: String,
+    last_edit_time: f64,
+}
+
+fn text_hash(text: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::default();
+    Hash::hash(&text, &mut hasher);
+    hasher.finish()
+}
+
 /// A transparent comment node for documenting graphs.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize, CaHash)]
 #[cahash("gantz.comment")]
@@ -104,13 +123,70 @@ impl NodeUi for Comment {
                         .scroll_bar_visibility(egui::scroll_area::ScrollBarVisibility::AlwaysHidden)
                         .auto_shrink(false)
                         .show(ui, |ui| {
-                            ui.add(
-                                egui::TextEdit::multiline(&mut self.text)
+                            let text_id = node_egui_id.with("comment_text");
+
+                            // Load or initialize the editing state.
+                            let mut state: CommentEditState = ui
+                                .memory_mut(|m| m.data.remove_temp(text_id))
+                                .unwrap_or_default();
+
+                            // Sync from node if the node's text changed externally (undo, etc.).
+                            let current_hash = text_hash(&self.text);
+                            if current_hash != state.text_hash {
+                                state.text_hash = current_hash;
+                                state.text = self.text.clone();
+                            }
+
+                            // Render the TextEdit against the buffered string.
+                            let response = ui.add(
+                                egui::TextEdit::multiline(&mut state.text)
                                     .desired_rows(1)
                                     .hint_text("Add comment...")
                                     .frame(false)
                                     .desired_width(f32::INFINITY),
-                            )
+                            );
+
+                            // Track when the buffer was last edited.
+                            let time = ui.input(|i| i.time);
+                            if response.changed() {
+                                state.last_edit_time = time;
+                            }
+
+                            // Determine whether the buffer has uncommitted changes.
+                            let buffer_dirty = text_hash(&state.text) != state.text_hash;
+
+                            // Flush conditions:
+                            // 1. Focus lost (existing)
+                            // 2. 5+ seconds since last edit with dirty buffer
+                            // 3. Any mouse activity with dirty buffer
+                            let timed_out = buffer_dirty && (time - state.last_edit_time >= 5.0);
+                            let mouse_active = buffer_dirty
+                                && ui.input(|i| {
+                                    i.pointer.is_moving()
+                                        || i.pointer.any_pressed()
+                                        || i.pointer.any_released()
+                                });
+                            let should_flush = response.lost_focus() || timed_out || mouse_active;
+
+                            if should_flush {
+                                self.text = state.text.clone();
+                                state.text_hash = text_hash(&self.text);
+                            }
+
+                            // Schedule a repaint at the timeout for reactive mode.
+                            if buffer_dirty && !should_flush {
+                                let remaining = 10.0 - (time - state.last_edit_time);
+                                if remaining > 0.0 {
+                                    ui.ctx().request_repaint_after(
+                                        std::time::Duration::from_secs_f64(remaining),
+                                    );
+                                }
+                            }
+
+                            // Persist the editing state.
+                            ui.memory_mut(|m| m.data.insert_temp(text_id, state));
+
+                            response
                         })
                         .inner
                 })


### PR DESCRIPTION
Buffer comment `TextEdit` keystrokes in egui temp memory to avoid a content-addressed commit per keystroke. Sync the buffer from the node on external changes (e.g. undo). Flush the buffer to the node on focus loss, 5+ seconds of inactivity after an edit, or any mouse activity. Schedule a repaint at the timeout deadline for reactive mode.