### PR TITLE
feat: add typed visitor support for downcasting during node traversal

### DIFF
--- a/crates/gantz_core/src/graph.rs
+++ b/crates/gantz_core/src/graph.rs
@@ -66,6 +66,21 @@ pub fn visit<'a, G>(
     }
 }
 
+/// Visit all nodes in the graph with a [`visit::TypedVisitor`].
+pub fn visit_typed<'a, G, V>(get_node: node::GetNode<'a>, g: G, path: &[node::Id], visitor: &mut V)
+where
+    G: Data<EdgeWeight = Edge> + IntoEdgesDirected + IntoNodeReferences + NodeIndexable + Visitable,
+    G::NodeWeight: Node,
+    V: visit::TypedVisitor<G::NodeWeight>,
+{
+    visit(
+        get_node,
+        g,
+        path,
+        &mut visit::Typed::<&mut V, G::NodeWeight>::new(visitor),
+    );
+}
+
 /// Register the given graph of nodes, including any nested nodes.
 pub fn register<'a, G>(get_node: node::GetNode<'a>, g: G, path: &[node::Id], vm: &mut Engine)
 where

--- a/crates/gantz_core/src/node.rs
+++ b/crates/gantz_core/src/node.rs
@@ -30,7 +30,10 @@ pub mod rust;
 pub mod state;
 
 /// The definitive abstraction of a gantz graph, the gantz `Node` trait.
-pub trait Node {
+///
+/// The [`std::any::Any`] supertrait enables [`Visitor`] implementations to
+/// downcast `&dyn Node` to concrete types via [`visit::TypedVisitor`].
+pub trait Node: std::any::Any {
     /// The number of inputs to the node.
     ///
     /// The maximum number is [`Conns::MAX`].
@@ -354,59 +357,6 @@ impl<'env, 'data> ExprCtx<'env, 'data> {
     }
 }
 
-impl<N> Node for &N
-where
-    N: ?Sized + Node,
-{
-    fn n_inputs(&self, ctx: MetaCtx) -> usize {
-        (**self).n_inputs(ctx)
-    }
-
-    fn n_outputs(&self, ctx: MetaCtx) -> usize {
-        (**self).n_outputs(ctx)
-    }
-
-    fn branches(&self, ctx: MetaCtx) -> Vec<EvalConf> {
-        (**self).branches(ctx)
-    }
-
-    fn expr(&self, ctx: ExprCtx<'_, '_>) -> ExprResult {
-        (**self).expr(ctx)
-    }
-
-    fn push_eval(&self, ctx: MetaCtx) -> Vec<EvalConf> {
-        (**self).push_eval(ctx)
-    }
-
-    fn pull_eval(&self, ctx: MetaCtx) -> Vec<EvalConf> {
-        (**self).pull_eval(ctx)
-    }
-
-    fn inlet(&self, ctx: MetaCtx) -> bool {
-        (**self).inlet(ctx)
-    }
-
-    fn outlet(&self, ctx: MetaCtx) -> bool {
-        (**self).outlet(ctx)
-    }
-
-    fn stateful(&self, ctx: MetaCtx) -> bool {
-        (**self).stateful(ctx)
-    }
-
-    fn register(&self, ctx: RegCtx<'_, '_>) {
-        (**self).register(ctx)
-    }
-
-    fn required_addrs(&self) -> Vec<gantz_ca::ContentAddr> {
-        (**self).required_addrs()
-    }
-
-    fn visit(&self, ctx: visit::Ctx<'_, '_>, visitor: &mut dyn Visitor) {
-        (**self).visit(ctx, visitor)
-    }
-}
-
 macro_rules! impl_node_for_ptr {
     ($($Ty:ident)::*) => {
         impl<T> Node for $($Ty)::*<T>
@@ -519,6 +469,18 @@ pub fn visit(ctx: visit::Ctx<'_, '_>, node: &dyn Node, visitor: &mut dyn Visitor
     visitor.visit_pre(ctx, node);
     node.visit(ctx, visitor);
     visitor.visit_post(ctx, node);
+}
+
+/// Visit this node and all nested nodes with a [`visit::TypedVisitor`].
+///
+/// The root node is passed directly as `&N`. Nested nodes that are not `N`
+/// are silently skipped.
+pub fn visit_typed<V: visit::TypedVisitor<N>, N: Node>(
+    ctx: visit::Ctx<'_, '_>,
+    node: &N,
+    visitor: &mut V,
+) {
+    visit(ctx, node, &mut visit::Typed::<&mut V, N>::new(visitor));
 }
 
 /// Register the given node and all nested nodes.

--- a/crates/gantz_core/src/node/state.rs
+++ b/crates/gantz_core/src/node/state.rs
@@ -79,7 +79,7 @@ impl<N: Node> WithStateType for N {
 impl<N, S> Node for State<N, S>
 where
     N: Node,
-    S: NodeState,
+    S: NodeState + 'static,
 {
     fn n_inputs(&self, ctx: node::MetaCtx) -> usize {
         self.node.n_inputs(ctx)

--- a/crates/gantz_core/src/visit.rs
+++ b/crates/gantz_core/src/visit.rs
@@ -6,6 +6,9 @@ use crate::{
 };
 use std::collections::HashSet;
 use steel::steel_vm::engine::Engine;
+pub use typed::{Typed, TypedVisitor};
+
+mod typed;
 
 /// For types used to traverse nested graphs of [`Node`]s.
 ///

--- a/crates/gantz_core/src/visit/typed.rs
+++ b/crates/gantz_core/src/visit/typed.rs
@@ -1,0 +1,139 @@
+//! Typed visitor support for downcasting `&dyn Node` to concrete types.
+//!
+//! [`TypedVisitor<N>`] mirrors [`Visitor`] but receives `&N` instead of
+//! `&dyn Node`. The [`Typed`] adapter wraps a `TypedVisitor<N>` into a
+//! `Visitor` by downcasting each visited node via [`Any`].
+
+use super::{Ctx, Visitor};
+use crate::node::Node;
+use std::any::Any;
+use std::marker::PhantomData;
+
+/// A visitor that receives concrete `&N` instead of `&dyn Node`.
+///
+/// Implement this trait to handle only nodes of a specific concrete type
+/// during traversal. Nodes that don't match `N` are silently skipped.
+pub trait TypedVisitor<N> {
+    /// Called prior to traversing nested nodes.
+    fn visit_pre(&mut self, _ctx: Ctx<'_, '_>, _node: &N) {}
+    /// Called following traversal of nested nodes.
+    fn visit_post(&mut self, _ctx: Ctx<'_, '_>, _node: &N) {}
+}
+
+/// Adapts a [`TypedVisitor<N>`] into a [`Visitor`] via [`Any`] downcasting.
+///
+/// Nodes whose concrete type is not `N` are silently skipped.
+pub struct Typed<V, N> {
+    /// The inner typed visitor.
+    pub visitor: V,
+    _marker: PhantomData<fn() -> N>,
+}
+
+impl<V: ?Sized + TypedVisitor<N>, N> TypedVisitor<N> for &mut V {
+    fn visit_pre(&mut self, ctx: Ctx<'_, '_>, node: &N) {
+        (**self).visit_pre(ctx, node);
+    }
+    fn visit_post(&mut self, ctx: Ctx<'_, '_>, node: &N) {
+        (**self).visit_post(ctx, node);
+    }
+}
+
+impl<V, N> Typed<V, N> {
+    /// Wrap a [`TypedVisitor<N>`] as a [`Visitor`].
+    pub fn new(visitor: V) -> Self {
+        Self {
+            visitor,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Unwrap, returning the inner visitor.
+    pub fn into_inner(self) -> V {
+        self.visitor
+    }
+}
+
+impl<V: TypedVisitor<N>, N: 'static> Visitor for Typed<V, N> {
+    fn visit_pre(&mut self, ctx: Ctx<'_, '_>, node: &dyn Node) {
+        let any: &dyn Any = node;
+        if let Some(n) = any.downcast_ref::<N>() {
+            self.visitor.visit_pre(ctx, n);
+        }
+    }
+    fn visit_post(&mut self, ctx: Ctx<'_, '_>, node: &dyn Node) {
+        let any: &dyn Any = node;
+        if let Some(n) = any.downcast_ref::<N>() {
+            self.visitor.visit_post(ctx, n);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::{self, ExprCtx, ExprResult, MetaCtx, Node};
+    use crate::visit;
+
+    /// A concrete node type for testing typed visitors.
+    #[derive(Debug)]
+    struct TestNode {
+        label: String,
+    }
+
+    impl Node for TestNode {
+        fn n_inputs(&self, _ctx: MetaCtx) -> usize {
+            0
+        }
+        fn n_outputs(&self, _ctx: MetaCtx) -> usize {
+            1
+        }
+        fn expr(&self, _ctx: ExprCtx<'_, '_>) -> ExprResult {
+            node::parse_expr("42")
+        }
+    }
+
+    fn no_lookup(_: &gantz_ca::ContentAddr) -> Option<&'static dyn Node> {
+        None
+    }
+
+    struct LabelCollector {
+        labels: Vec<String>,
+    }
+
+    impl TypedVisitor<TestNode> for LabelCollector {
+        fn visit_pre(&mut self, _ctx: Ctx<'_, '_>, node: &TestNode) {
+            self.labels.push(node.label.clone());
+        }
+    }
+
+    #[test]
+    fn typed_visitor_downcasts_matching_nodes() {
+        let mut collector = LabelCollector { labels: vec![] };
+        let ctx = visit::Ctx::new(&no_lookup, &[0], &[]);
+        let test_node = TestNode {
+            label: "hello".into(),
+        };
+
+        node::visit_typed::<_, TestNode>(ctx, &test_node, &mut collector);
+        assert_eq!(collector.labels, vec!["hello"]);
+    }
+
+    #[test]
+    fn graph_visit_typed_collects_matching_nodes() {
+        use crate::Edge;
+        use crate::graph;
+        use crate::node::graph::Graph;
+
+        // Use a concrete node type directly so that downcast succeeds.
+        let mut g: Graph<TestNode> = Graph::default();
+        let a = g.add_node(TestNode { label: "A".into() });
+        let b = g.add_node(TestNode { label: "B".into() });
+        let c = g.add_node(TestNode { label: "C".into() });
+        g.add_edge(a, b, Edge::new(0.into(), 0.into()));
+        g.add_edge(b, c, Edge::new(0.into(), 0.into()));
+
+        let mut collector = LabelCollector { labels: vec![] };
+        graph::visit_typed(&no_lookup, &g, &[], &mut collector);
+        assert_eq!(collector.labels, vec!["A", "B", "C"]);
+    }
+}


### PR DESCRIPTION
Add `Any` as a supertrait to `Node`, enabling visitor implementations to downcast `&dyn Node` to concrete types via trait upcasting.

- Add `visit::TypedVisitor<N>` trait mirroring `Visitor` but with `&N`
- Add `visit::Typed<V, N>` adapter that downcasts via `Any`
- Add `node::visit_typed` and `graph::visit_typed` convenience fns
- Remove unused `impl Node for &N` (incompatible with `Any`)
- Add `S: 'static` bound to `impl Node for State<N, S>`

Closes #198 