### PR TITLE
Add configurable apply arg inputs

### DIFF
--- a/crates/gantz_core/src/node/apply.rs
+++ b/crates/gantz_core/src/node/apply.rs
@@ -3,24 +3,185 @@
 use crate::node;
 use gantz_ca::CaHash;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// A fixed apply argument count outside the supported range was requested.
+#[derive(Clone, Copy, Debug, Error, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[error(
+    "fixed apply arg count must be between {min} and {max}, got {0}",
+    min = FixedArgCount::MIN,
+    max = FixedArgCount::MAX
+)]
+pub struct InvalidFixedArgCount(pub usize);
+
+/// A validated fixed argument count for [`Apply`] separate-arg mode.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, CaHash)]
+#[cahash("gantz.apply.fixed-arg-count")]
+pub struct FixedArgCount(u8);
+
+impl FixedArgCount {
+    /// The minimum supported fixed argument count.
+    pub const MIN: usize = 1;
+    /// The maximum supported fixed argument count.
+    pub const MAX: usize = 10;
+
+    /// Get the count as a `usize`.
+    pub fn get(self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl TryFrom<usize> for FixedArgCount {
+    type Error = InvalidFixedArgCount;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        if !(Self::MIN..=Self::MAX).contains(&value) {
+            return Err(InvalidFixedArgCount(value));
+        }
+        Ok(Self(value as u8))
+    }
+}
+
+impl<'de> Deserialize<'de> for FixedArgCount {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let count = u8::deserialize(deserializer)?;
+        Self::try_from(count as usize).map_err(serde::de::Error::custom)
+    }
+}
+
+/// The mode by which an [`Apply`] node receives function arguments.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, Deserialize, Serialize, CaHash)]
+#[cahash("gantz.apply.mode")]
+pub enum ArgMode {
+    /// A single input receives a list of arguments.
+    #[default]
+    List,
+    /// A dedicated input is exposed for each argument.
+    Fixed(FixedArgCount),
+}
+
+impl ArgMode {
+    fn from_fixed_arg_count(fixed_arg_count: Option<usize>) -> Result<Self, InvalidFixedArgCount> {
+        fixed_arg_count
+            .map(FixedArgCount::try_from)
+            .transpose()
+            .map(|fixed_arg_count| fixed_arg_count.map_or(Self::List, Self::Fixed))
+    }
+
+    fn fixed_arg_count(self) -> Option<usize> {
+        match self {
+            Self::List => None,
+            Self::Fixed(arg_count) => Some(arg_count.get()),
+        }
+    }
+
+    fn node_input_count(self) -> usize {
+        1 + self.arg_input_count()
+    }
+
+    fn arg_input_count(self) -> usize {
+        self.fixed_arg_count().unwrap_or(1)
+    }
+
+    fn arg_input_indices(self) -> Vec<usize> {
+        (1..=self.arg_input_count()).collect()
+    }
+
+    fn cleared_inputs_for_transition(self, next: Self) -> Vec<usize> {
+        match (self, next) {
+            (Self::List, Self::List) => Vec::new(),
+            (Self::Fixed(current), Self::Fixed(next)) if next >= current => Vec::new(),
+            (Self::Fixed(current), Self::Fixed(next)) => {
+                ((next.get() + 1)..=current.get()).collect()
+            }
+            (Self::List, Self::Fixed(_)) | (Self::Fixed(_), Self::List) => self.arg_input_indices(),
+        }
+    }
+}
 
 /// A node that applies a function to arguments.
 ///
 /// In other words, this node "calls" the function received on the first input
-/// with the arguments received on the second input.
+/// with the arguments received on the second input, or on a configurable set
+/// of separate argument inputs.
 ///
 /// The node is stateless and evaluates immediately when a function is received.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Deserialize, Serialize, CaHash)]
 #[cahash("gantz.apply")]
-pub struct Apply;
+pub struct Apply {
+    arg_mode: ArgMode,
+}
+
+impl Apply {
+    /// The maximum number of separate argument inputs.
+    pub const MAX_FIXED_ARGS: usize = FixedArgCount::MAX;
+
+    /// Construct an [`Apply`] node using a single list input for arguments.
+    pub fn list() -> Self {
+        Self::default()
+    }
+
+    /// Construct an [`Apply`] node with one input per argument.
+    pub fn fixed(arg_count: usize) -> Result<Self, InvalidFixedArgCount> {
+        Ok(Self {
+            arg_mode: ArgMode::Fixed(FixedArgCount::try_from(arg_count)?),
+        })
+    }
+
+    /// The current argument mode.
+    pub fn arg_mode(&self) -> ArgMode {
+        self.arg_mode
+    }
+
+    /// The current fixed argument count, if separate-arg mode is enabled.
+    pub fn fixed_arg_count(&self) -> Option<usize> {
+        self.arg_mode.fixed_arg_count()
+    }
+
+    /// Return a reconfigured apply node and the arg-side inputs that should be
+    /// cleared when transitioning to the given mode.
+    pub fn reconfigured(
+        &self,
+        fixed_arg_count: Option<usize>,
+    ) -> Result<(Self, Vec<usize>), InvalidFixedArgCount> {
+        let arg_mode = ArgMode::from_fixed_arg_count(fixed_arg_count)?;
+        let next = Self { arg_mode };
+        let cleared_inputs = self.arg_mode.cleared_inputs_for_transition(arg_mode);
+        Ok((next, cleared_inputs))
+    }
+
+    fn input_expr(inputs: &[Option<String>], index: usize) -> String {
+        inputs
+            .get(index)
+            .and_then(|input| input.as_ref())
+            .cloned()
+            .unwrap_or_else(|| "'()".to_string())
+    }
+
+    fn arg_expr(&self, inputs: &[Option<String>]) -> String {
+        match self.arg_mode {
+            ArgMode::List => Self::input_expr(inputs, 1),
+            ArgMode::Fixed(arg_count) => {
+                let args = (1..=arg_count.get())
+                    .map(|index| Self::input_expr(inputs, index))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                format!("(list {args})")
+            }
+        }
+    }
+}
 
 impl node::Node for Apply {
-    /// Two inputs:
+    /// Inputs:
     ///
     /// 1. A function value. Receiving this triggers evaluation.
-    /// 2. A list of arguments. Assumed `'()` if unconnected.
+    /// 2. Either a list of arguments, or one separate input per argument.
     fn n_inputs(&self, _ctx: node::MetaCtx) -> usize {
-        2
+        self.arg_mode.node_input_count()
     }
 
     /// The result of function application.
@@ -31,13 +192,54 @@ impl node::Node for Apply {
     fn expr(&self, ctx: node::ExprCtx<'_, '_>) -> node::ExprResult {
         let inputs = ctx.inputs();
 
-        // Get function and arguments from inputs
         let function = inputs.get(0).and_then(|opt| opt.as_ref());
-        let arguments = inputs.get(1).and_then(|opt| opt.as_ref());
-        let args = arguments.map_or("'()", |s| &s[..]);
+        let args = self.arg_expr(inputs);
         let expr = function
             .map(|f| format!("(apply {f} {args})"))
             .unwrap_or_else(|| "'()".to_string());
         node::parse_expr(&expr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reconfigured_returns_cleared_inputs_for_list_and_fixed_modes() {
+        let apply = Apply::default();
+        assert_eq!(apply.reconfigured(None).unwrap().1, Vec::<usize>::new());
+        assert_eq!(apply.reconfigured(Some(2)).unwrap().1, vec![1]);
+
+        let apply = Apply::fixed(4).unwrap();
+        assert_eq!(apply.reconfigured(Some(4)).unwrap().1, Vec::<usize>::new());
+        assert_eq!(apply.reconfigured(Some(2)).unwrap().1, vec![3, 4]);
+        assert_eq!(apply.reconfigured(Some(6)).unwrap().1, Vec::<usize>::new());
+        assert_eq!(apply.reconfigured(None).unwrap().1, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn fixed_arg_count_validation() {
+        assert!(Apply::fixed(0).is_err());
+        assert!(Apply::fixed(Apply::MAX_FIXED_ARGS + 1).is_err());
+        assert_eq!(
+            Apply::fixed(3)
+                .ok()
+                .and_then(|apply| apply.fixed_arg_count()),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn content_addr_changes_with_arg_mode() {
+        let list = gantz_ca::content_addr(&Apply::default());
+        let fixed = gantz_ca::content_addr(&Apply::fixed(2).unwrap());
+        assert_ne!(list, fixed);
+    }
+
+    #[test]
+    fn invalid_fixed_arg_count_deserialization_fails() {
+        let json = r#"{"arg_mode":{"Fixed":0}}"#;
+        assert!(serde_json::from_str::<Apply>(json).is_err());
     }
 }

--- a/crates/gantz_core/tests/fn_apply.rs
+++ b/crates/gantz_core/tests/fn_apply.rs
@@ -16,12 +16,20 @@ fn node_int(i: i32) -> node::expr::Expr {
     node::expr(format!("{}", i)).unwrap()
 }
 
+fn node_nil() -> node::expr::Expr {
+    node::expr("'()").unwrap()
+}
+
 fn node_list_single() -> node::expr::Expr {
     node::expr("(list $x)").unwrap()
 }
 
 fn node_assert_eq() -> node::expr::Expr {
     node::expr("(assert! (equal? $l $r))").unwrap()
+}
+
+fn node_add() -> node::expr::Expr {
+    node::expr("(+ $l $r)").unwrap()
 }
 
 // Helper trait for debugging
@@ -70,7 +78,7 @@ fn test_fn_apply_identity() {
     // Create nodes
     let bang = node_bang();
     let fn_node = Fn::new(Ref::new(id_ca));
-    let apply_node = Apply;
+    let apply_node = Apply::default();
     let value = node_int(42);
     let list = node_list_single(); // Wrap value in list for apply
     let expected = node_int(42);
@@ -177,7 +185,7 @@ fn test_fn_apply_graph() {
 
     let bang = node_bang();
     let fn_node = Fn::new(Ref::new(double_ca));
-    let apply_node = Apply;
+    let apply_node = Apply::default();
     let value = node_int(21);
     let list = node_list_single();
     let expected = node_int(42);
@@ -218,6 +226,100 @@ fn test_fn_apply_graph() {
     }
 
     // Execute pull evaluation from assert_eq.
+    vm.call_function_by_name_with_args(&pull_eval_fn_name(&[assert_eq.index()]), vec![])
+        .unwrap();
+}
+
+#[test]
+fn test_fn_apply_fixed_args() {
+    let mut g = petgraph::graph::DiGraph::new();
+
+    let mut nodes: HashMap<gantz_ca::ContentAddr, Box<dyn DebugNode>> = HashMap::new();
+    let add = node_add();
+    let add_ca = gantz_ca::content_addr(&add);
+    nodes.insert(add_ca, Box::new(add) as Box<dyn DebugNode>);
+
+    let get_node = |ca: &gantz_ca::ContentAddr| -> Option<&dyn Node> {
+        nodes.get(ca).map(|b| &**b as &dyn Node)
+    };
+
+    let bang = node_bang();
+    let fn_node = Fn::new(Ref::new(add_ca));
+    let apply_node = Apply::fixed(2).unwrap();
+    let lhs = node_int(20);
+    let rhs = node_int(22);
+    let expected = node_int(42);
+    let assert_eq = node_assert_eq().with_pull_eval();
+
+    let bang = g.add_node(Box::new(bang) as Box<dyn DebugNode>);
+    let fn_node = g.add_node(Box::new(fn_node) as Box<_>);
+    let apply_node = g.add_node(Box::new(apply_node) as Box<_>);
+    let lhs = g.add_node(Box::new(lhs) as Box<_>);
+    let rhs = g.add_node(Box::new(rhs) as Box<_>);
+    let expected = g.add_node(Box::new(expected) as Box<_>);
+    let assert_eq = g.add_node(Box::new(assert_eq) as Box<_>);
+
+    g.add_edge(bang, fn_node, Edge::from((0, 0)));
+    g.add_edge(fn_node, apply_node, Edge::from((0, 0)));
+    g.add_edge(lhs, apply_node, Edge::from((0, 1)));
+    g.add_edge(rhs, apply_node, Edge::from((0, 2)));
+    g.add_edge(apply_node, assert_eq, Edge::from((0, 0)));
+    g.add_edge(expected, assert_eq, Edge::from((0, 1)));
+
+    let module = gantz_core::compile::module(&get_node, &g).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&get_node, &g, &[], &mut vm);
+
+    for expr in module {
+        vm.run(expr.to_pretty(80)).unwrap();
+    }
+
+    vm.call_function_by_name_with_args(&pull_eval_fn_name(&[assert_eq.index()]), vec![])
+        .unwrap();
+}
+
+#[test]
+fn test_fn_apply_fixed_missing_arg_defaults_to_nil() {
+    let mut g = petgraph::graph::DiGraph::new();
+
+    let mut nodes: HashMap<gantz_ca::ContentAddr, Box<dyn DebugNode>> = HashMap::new();
+    let id = gantz_core::node::Identity;
+    let id_ca = gantz_ca::content_addr(&id);
+    nodes.insert(id_ca, Box::new(id) as Box<dyn DebugNode>);
+
+    let get_node = |ca: &gantz_ca::ContentAddr| -> Option<&dyn Node> {
+        nodes.get(ca).map(|b| &**b as &dyn Node)
+    };
+
+    let bang = node_bang();
+    let fn_node = Fn::new(Ref::new(id_ca));
+    let apply_node = Apply::fixed(1).unwrap();
+    let expected = node_nil();
+    let assert_eq = node_assert_eq().with_pull_eval();
+
+    let bang = g.add_node(Box::new(bang) as Box<dyn DebugNode>);
+    let fn_node = g.add_node(Box::new(fn_node) as Box<_>);
+    let apply_node = g.add_node(Box::new(apply_node) as Box<_>);
+    let expected = g.add_node(Box::new(expected) as Box<_>);
+    let assert_eq = g.add_node(Box::new(assert_eq) as Box<_>);
+
+    g.add_edge(bang, fn_node, Edge::from((0, 0)));
+    g.add_edge(fn_node, apply_node, Edge::from((0, 0)));
+    g.add_edge(apply_node, assert_eq, Edge::from((0, 0)));
+    g.add_edge(expected, assert_eq, Edge::from((0, 1)));
+
+    let module = gantz_core::compile::module(&get_node, &g).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&get_node, &g, &[], &mut vm);
+
+    for expr in module {
+        vm.run(expr.to_pretty(80)).unwrap();
+    }
+
     vm.call_function_by_name_with_args(&pull_eval_fn_name(&[assert_eq.index()]), vec![])
         .unwrap();
 }

--- a/crates/gantz_core/tests/fn_apply.rs
+++ b/crates/gantz_core/tests/fn_apply.rs
@@ -16,12 +16,20 @@ fn node_int(i: i32) -> node::expr::Expr {
     node::expr(format!("{}", i)).unwrap()
 }
 
+fn node_nil() -> node::expr::Expr {
+    node::expr("'()").unwrap()
+}
+
 fn node_list_single() -> node::expr::Expr {
     node::expr("(list $x)").unwrap()
 }
 
 fn node_assert_eq() -> node::expr::Expr {
     node::expr("(assert! (equal? $l $r))").unwrap()
+}
+
+fn node_add() -> node::expr::Expr {
+    node::expr("(+ $l $r)").unwrap()
 }
 
 // Helper trait for debugging
@@ -70,7 +78,7 @@ fn test_fn_apply_identity() {
     // Create nodes
     let bang = node_bang();
     let fn_node = Fn::new(Ref::new(id_ca));
-    let apply_node = Apply;
+    let apply_node = Apply::default();
     let value = node_int(42);
     let list = node_list_single(); // Wrap value in list for apply
     let expected = node_int(42);
@@ -180,7 +188,7 @@ fn test_fn_apply_graph() {
 
     let bang = node_bang();
     let fn_node = Fn::new(Ref::new(double_ca));
-    let apply_node = Apply;
+    let apply_node = Apply::default();
     let value = node_int(21);
     let list = node_list_single();
     let expected = node_int(42);
@@ -225,5 +233,99 @@ fn test_fn_apply_graph() {
     // Execute pull evaluation from assert_eq.
     let ep = entrypoint::pull(vec![assert_eq.index()], g[assert_eq].n_inputs(ctx) as u8);
     vm.call_function_by_name_with_args(&entry_fn_name(&ep.id()), vec![])
+        .unwrap();
+}
+
+#[test]
+fn test_fn_apply_fixed_args() {
+    let mut g = petgraph::graph::DiGraph::new();
+
+    let mut nodes: HashMap<gantz_ca::ContentAddr, Box<dyn DebugNode>> = HashMap::new();
+    let add = node_add();
+    let add_ca = gantz_ca::content_addr(&add);
+    nodes.insert(add_ca, Box::new(add) as Box<dyn DebugNode>);
+
+    let get_node = |ca: &gantz_ca::ContentAddr| -> Option<&dyn Node> {
+        nodes.get(ca).map(|b| &**b as &dyn Node)
+    };
+
+    let bang = node_bang();
+    let fn_node = Fn::new(Ref::new(add_ca));
+    let apply_node = Apply::fixed(2).unwrap();
+    let lhs = node_int(20);
+    let rhs = node_int(22);
+    let expected = node_int(42);
+    let assert_eq = node_assert_eq().with_pull_eval();
+
+    let bang = g.add_node(Box::new(bang) as Box<dyn DebugNode>);
+    let fn_node = g.add_node(Box::new(fn_node) as Box<_>);
+    let apply_node = g.add_node(Box::new(apply_node) as Box<_>);
+    let lhs = g.add_node(Box::new(lhs) as Box<_>);
+    let rhs = g.add_node(Box::new(rhs) as Box<_>);
+    let expected = g.add_node(Box::new(expected) as Box<_>);
+    let assert_eq = g.add_node(Box::new(assert_eq) as Box<_>);
+
+    g.add_edge(bang, fn_node, Edge::from((0, 0)));
+    g.add_edge(fn_node, apply_node, Edge::from((0, 0)));
+    g.add_edge(lhs, apply_node, Edge::from((0, 1)));
+    g.add_edge(rhs, apply_node, Edge::from((0, 2)));
+    g.add_edge(apply_node, assert_eq, Edge::from((0, 0)));
+    g.add_edge(expected, assert_eq, Edge::from((0, 1)));
+
+    let module = gantz_core::compile::module(&get_node, &g).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&get_node, &g, &[], &mut vm);
+
+    for expr in module {
+        vm.run(expr.to_pretty(80)).unwrap();
+    }
+
+    vm.call_function_by_name_with_args(&pull_eval_fn_name(&[assert_eq.index()]), vec![])
+        .unwrap();
+}
+
+#[test]
+fn test_fn_apply_fixed_missing_arg_defaults_to_nil() {
+    let mut g = petgraph::graph::DiGraph::new();
+
+    let mut nodes: HashMap<gantz_ca::ContentAddr, Box<dyn DebugNode>> = HashMap::new();
+    let id = gantz_core::node::Identity;
+    let id_ca = gantz_ca::content_addr(&id);
+    nodes.insert(id_ca, Box::new(id) as Box<dyn DebugNode>);
+
+    let get_node = |ca: &gantz_ca::ContentAddr| -> Option<&dyn Node> {
+        nodes.get(ca).map(|b| &**b as &dyn Node)
+    };
+
+    let bang = node_bang();
+    let fn_node = Fn::new(Ref::new(id_ca));
+    let apply_node = Apply::fixed(1).unwrap();
+    let expected = node_nil();
+    let assert_eq = node_assert_eq().with_pull_eval();
+
+    let bang = g.add_node(Box::new(bang) as Box<dyn DebugNode>);
+    let fn_node = g.add_node(Box::new(fn_node) as Box<_>);
+    let apply_node = g.add_node(Box::new(apply_node) as Box<_>);
+    let expected = g.add_node(Box::new(expected) as Box<_>);
+    let assert_eq = g.add_node(Box::new(assert_eq) as Box<_>);
+
+    g.add_edge(bang, fn_node, Edge::from((0, 0)));
+    g.add_edge(fn_node, apply_node, Edge::from((0, 0)));
+    g.add_edge(apply_node, assert_eq, Edge::from((0, 0)));
+    g.add_edge(expected, assert_eq, Edge::from((0, 1)));
+
+    let module = gantz_core::compile::module(&get_node, &g).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&get_node, &g, &[], &mut vm);
+
+    for expr in module {
+        vm.run(expr.to_pretty(80)).unwrap();
+    }
+
+    vm.call_function_by_name_with_args(&pull_eval_fn_name(&[assert_eq.index()]), vec![])
         .unwrap();
 }

--- a/crates/gantz_core/tests/serde.rs
+++ b/crates/gantz_core/tests/serde.rs
@@ -12,6 +12,8 @@ trait SerdeNode: Node {}
 #[typetag::serde]
 impl SerdeNode for node::Expr {}
 #[typetag::serde]
+impl SerdeNode for node::Apply {}
+#[typetag::serde]
 impl SerdeNode for node::Push<node::Expr> {}
 #[typetag::serde]
 impl SerdeNode for node::Pull<node::Expr> {}
@@ -29,6 +31,10 @@ fn push_expr() -> Push<Expr> {
 // Helper function to create a pullable expression node
 fn pull_expr() -> Pull<Expr> {
     node::expr("(+ $a $b)").unwrap().with_pull_eval()
+}
+
+fn fixed_apply() -> node::Apply {
+    node::Apply::fixed(3).unwrap()
 }
 
 // A no-op node lookup function for tests that don't need it.
@@ -86,6 +92,21 @@ fn test_serde_push_node() {
     assert_eq!(n.n_outputs(ctx), 1);
     assert!(!n.push_eval(ctx).is_empty());
     assert!(n.pull_eval(ctx).is_empty());
+}
+
+#[test]
+fn test_serde_fixed_apply_node() {
+    let node = fixed_apply();
+
+    let boxed: Box<dyn SerdeNode> = Box::new(node);
+    let serialized = serde_json::to_string(&boxed).expect("Failed to serialize");
+    let deserialized: Box<dyn SerdeNode> =
+        serde_json::from_str(&serialized).expect("Failed to deserialize");
+
+    let ctx = MetaCtx::new(&no_lookup);
+    let n = deserialized;
+    assert_eq!(n.n_inputs(ctx), 4);
+    assert_eq!(n.n_outputs(ctx), 1);
 }
 
 // Test serializing and deserializing a vector of various node types

--- a/crates/gantz_core/tests/serde.rs
+++ b/crates/gantz_core/tests/serde.rs
@@ -16,6 +16,8 @@ impl SerdeNode for node::Branch {}
 #[typetag::serde]
 impl SerdeNode for node::Expr {}
 #[typetag::serde]
+impl SerdeNode for node::Apply {}
+#[typetag::serde]
 impl SerdeNode for node::Push<node::Expr> {}
 #[typetag::serde]
 impl SerdeNode for node::Pull<node::Expr> {}
@@ -33,6 +35,10 @@ fn push_expr() -> Push<Expr> {
 // Helper function to create a pullable expression node
 fn pull_expr() -> Pull<Expr> {
     node::expr("(+ $a $b)").unwrap().with_pull_eval()
+}
+
+fn fixed_apply() -> node::Apply {
+    node::Apply::fixed(3).unwrap()
 }
 
 // A no-op node lookup function for tests that don't need it.
@@ -90,6 +96,21 @@ fn test_serde_push_node() {
     assert_eq!(n.n_outputs(ctx), 1);
     assert!(!n.push_eval(ctx).is_empty());
     assert!(n.pull_eval(ctx).is_empty());
+}
+
+#[test]
+fn test_serde_fixed_apply_node() {
+    let node = fixed_apply();
+
+    let boxed: Box<dyn SerdeNode> = Box::new(node);
+    let serialized = serde_json::to_string(&boxed).expect("Failed to serialize");
+    let deserialized: Box<dyn SerdeNode> =
+        serde_json::from_str(&serialized).expect("Failed to deserialize");
+
+    let ctx = MetaCtx::new(&no_lookup);
+    let n = deserialized;
+    assert_eq!(n.n_inputs(ctx), 4);
+    assert_eq!(n.n_outputs(ctx), 1);
 }
 
 // Test serializing and deserializing a vector of various node types

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -441,8 +441,9 @@ impl App {
 }
 
 impl eframe::App for App {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        gui(ctx, &mut self.state);
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        let ctx = ui.ctx().clone();
+        gui(&ctx, ui, &mut self.state);
 
         // Check for changes to each open graph and commit/recompile them.
         // FIXME: Rather than checking changed CA to monitor changes, ideally
@@ -471,7 +472,7 @@ impl eframe::App for App {
                     new_commit_ca.display_short()
                 );
                 // Update the graph pane if the head's commit CA changed.
-                gantz_egui::widget::update_graph_pane_head(ctx, &old_head, head);
+                gantz_egui::widget::update_graph_pane_head(&ctx, &old_head, head);
                 self.state.gantz.migrate_head(&old_head, head, true);
 
                 // Recompile this head's graph into its VM.
@@ -487,7 +488,7 @@ impl eframe::App for App {
         }
 
         // Process any pending commands generated from the UI.
-        process_cmds(ctx, &mut self.state);
+        process_cmds(&ctx, &mut self.state);
     }
 
     fn save(&mut self, storage: &mut dyn eframe::Storage) {
@@ -1181,10 +1182,10 @@ fn create_node(
     view.layout.entry(egui_id).or_insert(egui::Pos2::ZERO);
 }
 
-fn gui(ctx: &egui::Context, state: &mut State) {
+fn gui(ctx: &egui::Context, ui: &mut egui::Ui, state: &mut State) {
     let response = egui::containers::CentralPanel::default()
         .frame(egui::Frame::default())
-        .show(ctx, |ui| {
+        .show_inside(ui, |ui| {
             // Create the head access adapter.
             let mut access =
                 DemoHeadAccess::new(&mut state.heads, &state.compiled_modules, &mut state.vms);

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -447,8 +447,9 @@ impl App {
 }
 
 impl eframe::App for App {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        gui(ctx, &mut self.state);
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        let ctx = ui.ctx().clone();
+        gui(&ctx, ui, &mut self.state);
 
         // Check for changes to each open graph and commit/recompile them.
         // FIXME: Rather than checking changed CA to monitor changes, ideally
@@ -477,7 +478,7 @@ impl eframe::App for App {
                     new_commit_ca.display_short()
                 );
                 // Update the graph pane if the head's commit CA changed.
-                gantz_egui::widget::update_graph_pane_head(ctx, &old_head, head);
+                gantz_egui::widget::update_graph_pane_head(&ctx, &old_head, head);
                 self.state.gantz.migrate_head(&old_head, head, true);
 
                 // Recompile this head's graph into its VM.
@@ -494,7 +495,7 @@ impl eframe::App for App {
         }
 
         // Process any pending commands generated from the UI.
-        process_cmds(ctx, &mut self.state);
+        process_cmds(&ctx, &mut self.state);
     }
 
     fn save(&mut self, storage: &mut dyn eframe::Storage) {
@@ -1181,10 +1182,10 @@ fn create_node(
     view.layout.entry(egui_id).or_insert(egui::Pos2::ZERO);
 }
 
-fn gui(ctx: &egui::Context, state: &mut State) {
+fn gui(ctx: &egui::Context, ui: &mut egui::Ui, state: &mut State) {
     let response = egui::containers::CentralPanel::default()
         .frame(egui::Frame::default())
-        .show(ctx, |ui| {
+        .show_inside(ui, |ui| {
             // Create the head access adapter.
             let mut access =
                 DemoHeadAccess::new(&mut state.heads, &state.compiled_modules, &mut state.vms);

--- a/crates/gantz_egui/src/impls/apply.rs
+++ b/crates/gantz_egui/src/impls/apply.rs
@@ -1,4 +1,4 @@
-use crate::{NodeCtx, NodeUi, Registry};
+use crate::{NodeCtx, NodeUi, Registry, widget::node_inspector};
 
 impl NodeUi for gantz_core::node::Apply {
     fn name(&self, _: &dyn Registry) -> &str {
@@ -11,5 +11,42 @@ impl NodeUi for gantz_core::node::Apply {
         uictx: egui_graph::NodeCtx,
     ) -> egui_graph::FramedResponse<egui::Response> {
         uictx.framed(|ui, _sockets| ui.add(egui::Label::new("apply").selectable(false)))
+    }
+
+    fn inspector_rows(&mut self, ctx: &mut NodeCtx, body: &mut egui_extras::TableBody) {
+        let row_h = node_inspector::table_row_h(body.ui_mut());
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("arg inputs");
+            });
+            row.col(|ui| {
+                let current = self.fixed_arg_count();
+                let selected_text = current
+                    .map(|arg_count| arg_count.to_string())
+                    .unwrap_or_else(|| "list".to_string());
+                let salt = format!("apply-arg-inputs-{:?}", ctx.path());
+                egui::ComboBox::from_id_salt(salt)
+                    .selected_text(selected_text)
+                    .show_ui(ui, |ui| {
+                        if ui.selectable_label(current.is_none(), "list").clicked() {
+                            if current.is_some() {
+                                *self = gantz_core::node::Apply::list();
+                            }
+                        }
+
+                        for arg_count in 1..=gantz_core::node::Apply::MAX_FIXED_ARGS {
+                            if ui
+                                .selectable_label(current == Some(arg_count), arg_count.to_string())
+                                .clicked()
+                            {
+                                if current != Some(arg_count) {
+                                    *self = gantz_core::node::Apply::fixed(arg_count)
+                                        .expect("apply inspector only exposes valid arg counts");
+                                }
+                            }
+                        }
+                    });
+            });
+        });
     }
 }


### PR DESCRIPTION
Extend the apply node so it can operate in two explicit modes: the existing list-input mode and a fixed separate-argument mode with 1..=10 argument sockets. The core node now stores its arg mode directly, validates fixed counts through a dedicated FixedArgCount type, rejects invalid serialized counts, and builds apply expressions by assembling either the provided argument list or a generated (list ...) form from separate inputs.

Add core coverage for fixed-arg application, missing fixed inputs defaulting to '(), serde round-tripping of configured apply nodes, and content-address changes across modes. Update the egui apply inspector to expose an 'arg inputs' selector that mutates the node in place without dispatching extra graph events, leaving dangling edges untouched when the input count changes.

Also update the demo app to the current eframe App::ui API and route its central panel through show_inside so workspace builds continue to pass under the newer eframe interface.