### PR TITLE
fix: handle branch-join reconvergence via phi variables in codegen

### DIFF
--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -5,16 +5,15 @@ use crate::{
     compile::{
         Block, Flow, FlowGraph, Meta, MetaGraph, NodeConns, RoseTree,
         error::{CodegenError, InvalidInputIndex, TooManyConns},
-        flow::Branch,
     },
     node,
 };
 pub(crate) use node_fn::{node_fns, unique_node_confs};
 use petgraph::{
     graph::NodeIndex,
-    visit::{EdgeRef, IntoNodeReferences, NodeRef},
+    visit::{EdgeRef, IntoEdgeReferences, IntoNodeReferences, NodeRef},
 };
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use steel::{parser::ast::ExprKind, steel_vm::engine::Engine};
 
 mod node_fn;
@@ -369,8 +368,8 @@ fn define_node_input_binding(
         .unwrap()
 }
 
-// For the given node's outputs that connect to node inputs that have more than
-// one incoming edge, create dedicated bindings for those inputs.
+/// For the given node's outputs that connect to node inputs that have more than
+/// one incoming edge, create dedicated bindings for those inputs.
 fn define_necessary_node_input_bindings(
     g: &MetaGraph,
     n: node::Id,
@@ -378,6 +377,23 @@ fn define_necessary_node_input_bindings(
     node_outputs_that_need_bindings(g, n)
         .into_iter()
         .map(move |(output, dst)| define_node_input_binding((n, output), dst))
+}
+
+/// Like `define_necessary_node_input_bindings`, but filtered to only the
+/// outputs active in a given branch, excluding any destinations that are
+/// active phi vars (to avoid shadowing outer phi declarations).
+fn define_branch_node_input_bindings(
+    mg: &MetaGraph,
+    n: node::Id,
+    active_outputs: &node::Conns,
+    exclude: &HashSet<(node::Id, usize)>,
+) -> Vec<ExprKind> {
+    node_outputs_that_need_bindings(mg, n)
+        .into_iter()
+        .filter(|(output, _)| active_outputs.get(output.0 as usize).unwrap_or(false))
+        .filter(|(_, (dst_id, dst_input))| !exclude.contains(&(*dst_id, dst_input.0 as usize)))
+        .map(|(output, dst)| define_node_input_binding((n, output), dst))
+        .collect()
 }
 
 /// For a join block's first node, find which inputs are `DedicatedBinding`
@@ -526,82 +542,55 @@ fn find_join_points(fg: &FlowGraph) -> HashSet<NodeIndex> {
         .collect()
 }
 
-/// Check if `to` is reachable from `from` in the flow graph via DFS.
-fn is_reachable_in(fg: &FlowGraph, from: NodeIndex, to: NodeIndex) -> bool {
-    let mut stack = vec![from];
-    let mut visited = HashSet::new();
-    while let Some(n) = stack.pop() {
-        if n == to {
-            return true;
-        }
-        if !visited.insert(n) {
-            continue;
-        }
-        for e in fg.edges_directed(n, petgraph::Outgoing) {
-            stack.push(e.target());
-        }
-    }
-    false
-}
-
-/// Given a branching block's outgoing edges, find the reconvergence point
-/// where all branches meet (if one exists).
+/// Compute immediate post-dominators for all flow graph nodes.
 ///
-/// Returns `None` if branches don't all converge on the same join point,
-/// in which case the caller falls back to code duplication.
-fn find_reconvergence(
-    fg: &FlowGraph,
-    branch_targets: &[(Branch, NodeIndex)],
-    join_points: &HashSet<NodeIndex>,
-) -> Option<NodeIndex> {
-    if branch_targets.is_empty() {
-        return None;
+/// The immediate post-dominator of a node is the first node that ALL
+/// paths from it must pass through. For a branching block, this is the
+/// reconvergence point.
+///
+/// Built by reversing the flow graph, adding a virtual exit, and
+/// computing the dominator tree on the reversed graph.
+fn compute_post_dominators(fg: &FlowGraph) -> HashMap<NodeIndex, NodeIndex> {
+    use petgraph::algo::dominators;
+
+    let nodes: Vec<_> = fg.node_indices().collect();
+    if nodes.is_empty() {
+        return HashMap::new();
     }
-    // For each branch target, DFS to collect all reachable join points.
-    let mut common: Option<HashSet<NodeIndex>> = None;
-    for &(_, target) in branch_targets {
-        let mut reachable_joins = HashSet::new();
-        let mut stack = vec![target];
-        let mut visited = HashSet::new();
-        while let Some(n) = stack.pop() {
-            if !visited.insert(n) {
-                continue;
-            }
-            if join_points.contains(&n) {
-                reachable_joins.insert(n);
-            }
-            for e in fg.edges_directed(n, petgraph::Outgoing) {
-                stack.push(e.target());
+
+    // Build reversed graph (plain DiGraph for trait compat with simple_fast).
+    let mut reversed = petgraph::graph::DiGraph::<(), ()>::new();
+    let mut fg_to_rev = HashMap::new();
+    for &n in &nodes {
+        fg_to_rev.insert(n, reversed.add_node(()));
+    }
+    for e_ref in fg.edge_references() {
+        reversed.add_edge(fg_to_rev[&e_ref.target()], fg_to_rev[&e_ref.source()], ());
+    }
+
+    // Virtual exit: root of reversed graph.
+    // Terminal nodes (no outgoing edges in original) connect from this root.
+    let virtual_exit = reversed.add_node(());
+    for &n in &nodes {
+        if fg.edges_directed(n, petgraph::Outgoing).count() == 0 {
+            reversed.add_edge(virtual_exit, fg_to_rev[&n], ());
+        }
+    }
+
+    let doms = dominators::simple_fast(&reversed, virtual_exit);
+
+    // Map back: immediate dominator in reversed = post-dominator in original.
+    let rev_to_fg: HashMap<_, _> = fg_to_rev.iter().map(|(&f, &r)| (r, f)).collect();
+    let mut post_dom = HashMap::new();
+    for &fg_n in &nodes {
+        if let Some(idom) = doms.immediate_dominator(fg_to_rev[&fg_n]) {
+            // Filter out virtual exit (not in rev_to_fg).
+            if let Some(&orig) = rev_to_fg.get(&idom) {
+                post_dom.insert(fg_n, orig);
             }
         }
-        common = Some(match common {
-            None => reachable_joins,
-            Some(prev) => prev.intersection(&reachable_joins).copied().collect(),
-        });
     }
-    let common = common?;
-    if common.is_empty() {
-        return None;
-    }
-    if common.len() == 1 {
-        return common.into_iter().next();
-    }
-    // Multiple common joins: find the earliest (closest to branch targets).
-    // This is the one that no other common join is an ancestor of.
-    let minimal: Vec<_> = common
-        .iter()
-        .copied()
-        .filter(|&j| {
-            !common
-                .iter()
-                .any(|&other| other != j && is_reachable_in(fg, other, j))
-        })
-        .collect();
-    if minimal.len() == 1 {
-        Some(minimal[0])
-    } else {
-        None
-    }
+    post_dom
 }
 
 /// The eval fn statements for the control flow block at the given `flow_ix`.
@@ -618,8 +607,9 @@ fn flow_node_stmts(
     outlets: &BTreeSet<node::Id>,
     reachable: &HashSet<node::Id>,
     fg: &FlowGraph,
-    join_points: &HashSet<NodeIndex>,
+    post_dom: &HashMap<NodeIndex, NodeIndex>,
     phi_params: &BTreeMap<NodeIndex, Vec<(usize, String)>>,
+    active_phi: &HashSet<(node::Id, usize)>,
     stop_at: Option<NodeIndex>,
 ) -> Result<Vec<ExprKind>, CodegenError> {
     // Add the block.
@@ -656,17 +646,8 @@ fn flow_node_stmts(
         // Otherwise continue normally.
         stmts.extend(define_necessary_node_input_bindings(mg, conf.id));
         stmts.extend(flow_node_stmts(
-            path,
-            dst,
-            mg,
-            stateful,
-            inlets,
-            outlets,
-            reachable,
-            fg,
-            join_points,
-            phi_params,
-            stop_at,
+            path, dst, mg, stateful, inlets, outlets, reachable, fg, post_dom, phi_params,
+            active_phi, stop_at,
         )?);
         return Ok(stmts);
     }
@@ -675,11 +656,27 @@ fn flow_node_stmts(
     let conf = *block.last().unwrap();
     stmts.push(destructure_node_branch_stmt(conf.id));
 
-    // Try to find a reconvergence point for the phi-variable approach.
-    if let Some(join_ix) = find_reconvergence(fg, &edges, join_points) {
+    // Post-dominator gives the reconvergence point directly.
+    // Skip if it equals stop_at (handled by outer level).
+    let reconvergence = post_dom
+        .get(&flow_ix)
+        .copied()
+        .filter(|&r| stop_at != Some(r));
+
+    if let Some(join_ix) = reconvergence {
         // Declare phi variable placeholders for the join's inputs.
         if let Some(params) = phi_params.get(&join_ix) {
             stmts.extend(declare_phi_vars(params));
+        }
+
+        // Extend active phi vars with this join's phi params so that
+        // branch bodies and deeper recursions won't shadow them.
+        let mut inner_phi = active_phi.clone();
+        if let Some(params) = phi_params.get(&join_ix) {
+            let join_first_id = fg[join_ix].first().expect("block must not be empty").id;
+            for (ix, _) in params {
+                inner_phi.insert((join_first_id, *ix));
+            }
         }
 
         // Build nested if-else with each branch body.
@@ -687,6 +684,12 @@ fn flow_node_stmts(
         let mut sorted_edges = edges;
         while let Some((branch, dst)) = sorted_edges.pop() {
             let mut branch_stmts = vec![destructure_node_outputs_stmt(conf.id, branch.conns)];
+            branch_stmts.extend(define_branch_node_input_bindings(
+                mg,
+                conf.id,
+                &branch.conns,
+                &inner_phi,
+            ));
 
             if dst == join_ix {
                 // Branch target IS the join - just emit phi sets.
@@ -708,8 +711,9 @@ fn flow_node_stmts(
                     outlets,
                     reachable,
                     fg,
-                    join_points,
+                    post_dom,
                     phi_params,
+                    &inner_phi,
                     Some(join_ix),
                 )?);
             }
@@ -734,47 +738,36 @@ fn flow_node_stmts(
 
         // After the if: generate the join block and everything after it.
         stmts.extend(flow_node_stmts(
-            path,
-            join_ix,
-            mg,
-            stateful,
-            inlets,
-            outlets,
-            reachable,
-            fg,
-            join_points,
-            phi_params,
-            stop_at,
+            path, join_ix, mg, stateful, inlets, outlets, reachable, fg, post_dom, phi_params,
+            active_phi, stop_at,
         )?);
 
         return Ok(stmts);
     }
 
     // No reconvergence found - fall back to code duplication.
-    stmts.extend(define_necessary_node_input_bindings(mg, conf.id));
     let mut expr = "'()".to_string();
     while let Some((branch, dst)) = edges.pop() {
         let dst_stmts = flow_node_stmts(
-            path,
-            dst,
-            mg,
-            stateful,
-            inlets,
-            outlets,
-            reachable,
-            fg,
-            join_points,
-            phi_params,
-            stop_at,
+            path, dst, mg, stateful, inlets, outlets, reachable, fg, post_dom, phi_params,
+            active_phi, stop_at,
         )?;
+        let bindings = define_branch_node_input_bindings(mg, conf.id, &branch.conns, active_phi);
+        let bindings_str = bindings
+            .iter()
+            .map(|e| format!("{e}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let dst_stmts_str = dst_stmts
+            .into_iter()
+            .map(|expr| format!("{expr}"))
+            .collect::<Vec<_>>()
+            .join(" ");
         let dst_expr = format!(
-            "(begin {} {} '())",
+            "(begin {} {} {} '())",
             destructure_node_outputs_stmt(conf.id, branch.conns),
-            dst_stmts
-                .into_iter()
-                .map(|expr| format!("{expr}"))
-                .collect::<Vec<_>>()
-                .join(" ")
+            bindings_str,
+            dst_stmts_str,
         );
         expr = format!("(if (= {} {BRANCH_IX}) {dst_expr} {expr})", branch.ix);
     }
@@ -804,6 +797,7 @@ pub fn entry_fn_body(
     };
     let reachable = flow_graph_nodes(fg);
     let join_points = find_join_points(fg);
+    let post_dom = compute_post_dominators(fg);
     let mut phi_params_map = BTreeMap::new();
     for &j in &join_points {
         phi_params_map.insert(j, join_phi_params(mg, &reachable, &fg[j])?);
@@ -817,8 +811,9 @@ pub fn entry_fn_body(
         outlets,
         &reachable,
         fg,
-        &join_points,
+        &post_dom,
         &phi_params_map,
+        &HashSet::new(),
         None,
     )
 }

--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -5,6 +5,7 @@ use crate::{
     compile::{
         Block, Flow, FlowGraph, Meta, MetaGraph, NodeConns, RoseTree,
         error::{CodegenError, InvalidInputIndex, TooManyConns},
+        flow::Branch,
     },
     node,
 };
@@ -379,6 +380,78 @@ fn define_necessary_node_input_bindings(
         .map(move |(output, dst)| define_node_input_binding((n, output), dst))
 }
 
+/// For a join block's first node, find which inputs are `DedicatedBinding`
+/// (have multiple incoming MetaGraph edges) and need phi variables.
+///
+/// Returns `(input_ix, phi_var_name)` pairs.
+fn join_phi_params(
+    mg: &MetaGraph,
+    reachable: &HashSet<node::Id>,
+    block: &Block,
+) -> Result<Vec<(usize, String)>, CodegenError> {
+    let first = block.first().expect("block must not be empty");
+    let args = node_fn_call_args(mg, reachable, first.id, &first.conns.inputs)?;
+    Ok(args
+        .into_iter()
+        .enumerate()
+        .filter_map(|(ix, arg)| match arg {
+            Some(NodeFnCallArg::DedicatedBinding) => Some((ix, node_input_var(first.id, ix))),
+            _ => None,
+        })
+        .collect())
+}
+
+/// Generate `(define name '())` placeholder statements for phi variables.
+fn declare_phi_vars(phi_params: &[(usize, String)]) -> Vec<ExprKind> {
+    phi_params
+        .iter()
+        .map(|(_, name)| {
+            let stmt = format!("(define {name} '())");
+            Engine::emit_ast(&stmt)
+                .expect("failed to emit AST")
+                .into_iter()
+                .next()
+                .unwrap()
+        })
+        .collect()
+}
+
+/// Generate `(set! name value)` statements to assign phi variables from a
+/// predecessor node's outputs.
+fn phi_set_stmts(
+    mg: &MetaGraph,
+    pred_last_node: node::Id,
+    join_node_id: node::Id,
+    phi_params: &[(usize, String)],
+) -> Vec<ExprKind> {
+    // Collect all edges from the predecessor to the join node.
+    let edges: Vec<_> = mg
+        .edges_directed(join_node_id, petgraph::Incoming)
+        .filter(|e| e.source() == pred_last_node)
+        .flat_map(|e| e.weight().clone())
+        .collect();
+    phi_params
+        .iter()
+        .filter_map(|(input_ix, name)| {
+            edges.iter().find_map(|(edge, _kind)| {
+                if edge.input.0 as usize == *input_ix {
+                    let value = node_output_var(pred_last_node, edge.output.0 as usize);
+                    let stmt = format!("(set! {name} {value})");
+                    Some(
+                        Engine::emit_ast(&stmt)
+                            .expect("failed to emit AST")
+                            .into_iter()
+                            .next()
+                            .unwrap(),
+                    )
+                } else {
+                    None
+                }
+            })
+        })
+        .collect()
+}
+
 /// Generate a sequence of node fn call statements from the given flow graph
 /// basic block.
 pub(crate) fn eval_fn_block_stmts(
@@ -440,7 +513,102 @@ fn flow_graph_nodes(fg: &FlowGraph) -> HashSet<node::Id> {
     set
 }
 
+/// Find flow graph nodes that are join points (in-degree > 1).
+fn find_join_points(fg: &FlowGraph) -> HashSet<NodeIndex> {
+    fg.node_references()
+        .filter(|n_ref| {
+            fg.edges_directed(n_ref.id(), petgraph::Incoming)
+                .take(2)
+                .count()
+                > 1
+        })
+        .map(|n_ref| n_ref.id())
+        .collect()
+}
+
+/// Check if `to` is reachable from `from` in the flow graph via DFS.
+fn is_reachable_in(fg: &FlowGraph, from: NodeIndex, to: NodeIndex) -> bool {
+    let mut stack = vec![from];
+    let mut visited = HashSet::new();
+    while let Some(n) = stack.pop() {
+        if n == to {
+            return true;
+        }
+        if !visited.insert(n) {
+            continue;
+        }
+        for e in fg.edges_directed(n, petgraph::Outgoing) {
+            stack.push(e.target());
+        }
+    }
+    false
+}
+
+/// Given a branching block's outgoing edges, find the reconvergence point
+/// where all branches meet (if one exists).
+///
+/// Returns `None` if branches don't all converge on the same join point,
+/// in which case the caller falls back to code duplication.
+fn find_reconvergence(
+    fg: &FlowGraph,
+    branch_targets: &[(Branch, NodeIndex)],
+    join_points: &HashSet<NodeIndex>,
+) -> Option<NodeIndex> {
+    if branch_targets.is_empty() {
+        return None;
+    }
+    // For each branch target, DFS to collect all reachable join points.
+    let mut common: Option<HashSet<NodeIndex>> = None;
+    for &(_, target) in branch_targets {
+        let mut reachable_joins = HashSet::new();
+        let mut stack = vec![target];
+        let mut visited = HashSet::new();
+        while let Some(n) = stack.pop() {
+            if !visited.insert(n) {
+                continue;
+            }
+            if join_points.contains(&n) {
+                reachable_joins.insert(n);
+            }
+            for e in fg.edges_directed(n, petgraph::Outgoing) {
+                stack.push(e.target());
+            }
+        }
+        common = Some(match common {
+            None => reachable_joins,
+            Some(prev) => prev.intersection(&reachable_joins).copied().collect(),
+        });
+    }
+    let common = common?;
+    if common.is_empty() {
+        return None;
+    }
+    if common.len() == 1 {
+        return common.into_iter().next();
+    }
+    // Multiple common joins: find the earliest (closest to branch targets).
+    // This is the one that no other common join is an ancestor of.
+    let minimal: Vec<_> = common
+        .iter()
+        .copied()
+        .filter(|&j| {
+            !common
+                .iter()
+                .any(|&other| other != j && is_reachable_in(fg, other, j))
+        })
+        .collect();
+    if minimal.len() == 1 {
+        Some(minimal[0])
+    } else {
+        None
+    }
+}
+
 /// The eval fn statements for the control flow block at the given `flow_ix`.
+///
+/// When `stop_at` is `Some(join_ix)`, generation stops when reaching that
+/// join - phi set statements are emitted and control returns to the caller
+/// which handles the join block after its branch `if`.
 fn flow_node_stmts(
     path: &[node::Id],
     flow_ix: NodeIndex,
@@ -450,6 +618,9 @@ fn flow_node_stmts(
     outlets: &BTreeSet<node::Id>,
     reachable: &HashSet<node::Id>,
     fg: &FlowGraph,
+    join_points: &HashSet<NodeIndex>,
+    phi_params: &BTreeMap<NodeIndex, Vec<(usize, String)>>,
+    stop_at: Option<NodeIndex>,
 ) -> Result<Vec<ExprKind>, CodegenError> {
     // Add the block.
     let block = &fg[flow_ix];
@@ -466,34 +637,136 @@ fn flow_node_stmts(
     if edges.is_empty() {
         return Ok(stmts);
 
-    // If there is one edge, this must be part of a join.
-    // FIXME: For now, just continue generating stmts. We should handle joins
-    // properly though.
+    // Single successor: either a linear continuation or leads to a join.
     } else if edges.len() == 1 {
         let (_branch, dst) = edges.pop().unwrap();
-
-        // Destructure the last node's output.
         let conf = *block.last().unwrap();
         stmts.push(destructure_node_outputs_stmt(conf.id, conf.conns.outputs));
-        stmts.extend(define_necessary_node_input_bindings(mg, conf.id));
 
-        // Continue generating...
+        // If the successor is the reconvergence point we're stopping at,
+        // emit phi set statements and return.
+        if stop_at == Some(dst) {
+            let join_first_id = fg[dst].first().expect("join block must not be empty").id;
+            if let Some(params) = phi_params.get(&dst) {
+                stmts.extend(phi_set_stmts(mg, conf.id, join_first_id, params));
+            }
+            return Ok(stmts);
+        }
+
+        // Otherwise continue normally.
+        stmts.extend(define_necessary_node_input_bindings(mg, conf.id));
         stmts.extend(flow_node_stmts(
-            path, dst, mg, stateful, inlets, outlets, reachable, fg,
+            path,
+            dst,
+            mg,
+            stateful,
+            inlets,
+            outlets,
+            reachable,
+            fg,
+            join_points,
+            phi_params,
+            stop_at,
         )?);
         return Ok(stmts);
     }
 
-    // Otherwise, add a statement to destructure the branch index.
+    // Multiple edges: this is a branch.
     let conf = *block.last().unwrap();
     stmts.push(destructure_node_branch_stmt(conf.id));
-    stmts.extend(define_necessary_node_input_bindings(mg, conf.id));
 
-    // Add the branches.
-    // FIXME: This doesn't properly handle joins.
+    // Try to find a reconvergence point for the phi-variable approach.
+    if let Some(join_ix) = find_reconvergence(fg, &edges, join_points) {
+        // Declare phi variable placeholders for the join's inputs.
+        if let Some(params) = phi_params.get(&join_ix) {
+            stmts.extend(declare_phi_vars(params));
+        }
+
+        // Build nested if-else with each branch body.
+        let mut expr = "'()".to_string();
+        let mut sorted_edges = edges;
+        while let Some((branch, dst)) = sorted_edges.pop() {
+            let mut branch_stmts = vec![destructure_node_outputs_stmt(conf.id, branch.conns)];
+
+            if dst == join_ix {
+                // Branch target IS the join - just emit phi sets.
+                let join_first_id = fg[join_ix]
+                    .first()
+                    .expect("join block must not be empty")
+                    .id;
+                if let Some(params) = phi_params.get(&join_ix) {
+                    branch_stmts.extend(phi_set_stmts(mg, conf.id, join_first_id, params));
+                }
+            } else {
+                // Recurse with stop_at = join_ix so it stops at the join.
+                branch_stmts.extend(flow_node_stmts(
+                    path,
+                    dst,
+                    mg,
+                    stateful,
+                    inlets,
+                    outlets,
+                    reachable,
+                    fg,
+                    join_points,
+                    phi_params,
+                    Some(join_ix),
+                )?);
+            }
+
+            let branch_str = branch_stmts
+                .iter()
+                .map(|s| format!("{s}"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            expr = format!(
+                "(if (= {} {BRANCH_IX}) (begin {branch_str}) {expr})",
+                branch.ix
+            );
+        }
+
+        let expr = Engine::emit_ast(&expr)
+            .expect("failed to emit AST for branch")
+            .into_iter()
+            .next()
+            .unwrap();
+        stmts.push(expr);
+
+        // After the if: generate the join block and everything after it.
+        stmts.extend(flow_node_stmts(
+            path,
+            join_ix,
+            mg,
+            stateful,
+            inlets,
+            outlets,
+            reachable,
+            fg,
+            join_points,
+            phi_params,
+            stop_at,
+        )?);
+
+        return Ok(stmts);
+    }
+
+    // No reconvergence found - fall back to code duplication.
+    stmts.extend(define_necessary_node_input_bindings(mg, conf.id));
     let mut expr = "'()".to_string();
     while let Some((branch, dst)) = edges.pop() {
-        let dst_stmts = flow_node_stmts(path, dst, mg, stateful, inlets, outlets, reachable, fg)?;
+        let dst_stmts = flow_node_stmts(
+            path,
+            dst,
+            mg,
+            stateful,
+            inlets,
+            outlets,
+            reachable,
+            fg,
+            join_points,
+            phi_params,
+            stop_at,
+        )?;
         let dst_expr = format!(
             "(begin {} {} '())",
             destructure_node_outputs_stmt(conf.id, branch.conns),
@@ -507,7 +780,7 @@ fn flow_node_stmts(
     }
 
     let expr = Engine::emit_ast(&expr)
-        .expect("Failed to emit AST for function")
+        .expect("failed to emit AST for branch")
         .into_iter()
         .next()
         .unwrap();
@@ -526,12 +799,15 @@ pub fn entry_fn_body(
     outlets: &BTreeSet<node::Id>,
     fg: &FlowGraph,
 ) -> Result<Vec<ExprKind>, CodegenError> {
-    // Find the entry node. Collect the set of reachable nodes to filter out
-    // unreachable nodes from the meta graph.
     let Some(entry) = flow_graph_entry(fg) else {
         return Ok(vec![]);
     };
     let reachable = flow_graph_nodes(fg);
+    let join_points = find_join_points(fg);
+    let mut phi_params_map = BTreeMap::new();
+    for &j in &join_points {
+        phi_params_map.insert(j, join_phi_params(mg, &reachable, &fg[j])?);
+    }
     flow_node_stmts(
         path,
         entry.id(),
@@ -541,6 +817,9 @@ pub fn entry_fn_body(
         outlets,
         &reachable,
         fg,
+        &join_points,
+        &phi_params_map,
+        None,
     )
 }
 

--- a/crates/gantz_core/tests/graph.rs
+++ b/crates/gantz_core/tests/graph.rs
@@ -406,9 +406,7 @@ fn test_graph_branch_target_is_join() {
         fn expr(&self, ctx: node::ExprCtx<'_, '_>) -> node::ExprResult {
             let x = ctx.inputs()[0].as_deref().expect("must have one input");
             // Branch 0: pass 6 as the value. Branch 1: pass input through.
-            node::parse_expr(&format!(
-                "(if (equal? 0 {x}) (list 0 6) (list 1 {x}))"
-            ))
+            node::parse_expr(&format!("(if (equal? 0 {x}) (list 0 6) (list 1 {x}))"))
         }
     }
 
@@ -465,7 +463,8 @@ fn test_graph_branch_target_is_join() {
     assert!(
         count <= 3, // 1 fn def + up to 1 call per entry fn
         "number node fn appears {} times - join duplicated!\n{}",
-        count, module_str,
+        count,
+        module_str,
     );
 }
 
@@ -521,9 +520,7 @@ fn test_graph_nested_diamond() {
         }
         fn expr(&self, ctx: node::ExprCtx<'_, '_>) -> node::ExprResult {
             let x = ctx.inputs()[0].as_deref().expect("must have one input");
-            node::parse_expr(&format!(
-                "(if (equal? 0 {x}) (list 0 '()) (list 1 '()))"
-            ))
+            node::parse_expr(&format!("(if (equal? 0 {x}) (list 0 '()) (list 1 '()))"))
         }
     }
 
@@ -597,8 +594,10 @@ fn test_graph_nested_diamond() {
         .map(|e| format!("{e}"))
         .collect::<Vec<_>>()
         .join("\n");
-    for (name, ix) in [("inner_result", inner_result.index()), ("outer_result", outer_result.index())]
-    {
+    for (name, ix) in [
+        ("inner_result", inner_result.index()),
+        ("outer_result", outer_result.index()),
+    ] {
         let prefix = format!("node-fn-{ix}");
         let count = module_str.matches(&prefix).count();
         assert!(
@@ -606,6 +605,134 @@ fn test_graph_nested_diamond() {
             "{name} fn '{prefix}' appears {count} times - join duplicated!\n{module_str}",
         );
     }
+}
+
+// Lattice: both outer branch targets share the same inner branching
+// structure. The post-dominator approach finds number as the reconvergence.
+//
+//      ----------       ----------
+//      | push_0 |       | push_1 |
+//      ----+-----       ----+-----
+//          |                |
+//          |-------  -------|
+//                 |  |
+//            -----+--+-------
+//            | select_outer  |  br0=left, br1=right
+//            ---+--------+----
+//               |        |
+//         ------+--   ---+-------
+//         | sel_L |   |  sel_R  |  both branch to six and seven
+//         --+---+--   ---+---+---
+//           |   |        |   |
+//           |   +-----+--+   |
+//           +-----+   |  +---+
+//                 |   |
+//            -----+---+---
+//            |   six      |
+//            ------+-------
+//                  |
+//            ------+-------
+//            |   seven    |
+//            ------+-------
+//                  |
+//            ------+-------
+//            |   number   |  join - all paths converge here
+//            --------------
+//
+// Push 0 -> outer-left -> sel_L -> right (since '() != 0) -> seven(7) -> number(7).
+// Push 1 -> outer-right -> sel_R -> right (since '() != 0) -> seven(7) -> number(7).
+#[test]
+fn test_graph_lattice_reconvergence() {
+    #[derive(Debug)]
+    struct Select;
+
+    impl Node for Select {
+        fn n_inputs(&self, _ctx: node::MetaCtx) -> usize {
+            1
+        }
+        fn n_outputs(&self, _ctx: node::MetaCtx) -> usize {
+            2
+        }
+        fn branches(&self, _ctx: node::MetaCtx) -> Vec<node::EvalConf> {
+            vec![
+                node::EvalConf::Set([true, false].try_into().unwrap()),
+                node::EvalConf::Set([false, true].try_into().unwrap()),
+            ]
+        }
+        fn expr(&self, ctx: node::ExprCtx<'_, '_>) -> node::ExprResult {
+            let x = ctx.inputs()[0].as_deref().expect("must have one input");
+            node::parse_expr(&format!("(if (equal? 0 {x}) (list 0 '()) (list 1 '()))"))
+        }
+    }
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let push_0 = g.add_node(Box::new(node_int(0).with_push_eval()) as Box<dyn DebugNode>);
+    let push_1 = g.add_node(Box::new(node_int(1).with_push_eval()) as Box<dyn DebugNode>);
+    let select_outer = g.add_node(Box::new(Select) as Box<_>);
+    let sel_l = g.add_node(Box::new(Select) as Box<_>);
+    let sel_r = g.add_node(Box::new(Select) as Box<_>);
+    let six = g.add_node(Box::new(node_int(6)) as Box<_>);
+    let seven = g.add_node(Box::new(node_int(7)) as Box<_>);
+    let number = g.add_node(Box::new(node_number()) as Box<_>);
+
+    // Outer structure.
+    g.add_edge(push_0, select_outer, Edge::from((0, 0)));
+    g.add_edge(push_1, select_outer, Edge::from((0, 0)));
+    g.add_edge(select_outer, sel_l, Edge::from((0, 0)));
+    g.add_edge(select_outer, sel_r, Edge::from((1, 0)));
+
+    // Both inner selects branch to the same six/seven nodes.
+    g.add_edge(sel_l, six, Edge::from((0, 0)));
+    g.add_edge(sel_l, seven, Edge::from((1, 0)));
+    g.add_edge(sel_r, six, Edge::from((0, 0)));
+    g.add_edge(sel_r, seven, Edge::from((1, 0)));
+
+    // Both converge at number.
+    g.add_edge(six, number, Edge::from((0, 0)));
+    g.add_edge(seven, number, Edge::from((0, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+
+    let eps = default_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    for f in &module {
+        vm.run(format!("{f}")).unwrap();
+    }
+
+    // Push 0: outer-left → sel_L → right (default) → seven(7) → number(7).
+    let ep_0 = entrypoint::push(vec![push_0.index()], g[push_0].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_0.id()), vec![])
+        .unwrap();
+    let state = node::state::extract::<u32>(&vm, &[number.index()])
+        .expect("failed to extract")
+        .expect("state was None");
+    assert_eq!(state, 7);
+
+    // Push 1: outer-right → sel_R → right (default) → seven(7) → number(7).
+    let ep_1 = entrypoint::push(vec![push_1.index()], g[push_1].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_1.id()), vec![])
+        .unwrap();
+    let state = node::state::extract::<u32>(&vm, &[number.index()])
+        .expect("failed to extract")
+        .expect("state was None");
+    assert_eq!(state, 7);
+
+    // Verify number's fn call is not duplicated per outer branch.
+    let module_str = module
+        .iter()
+        .map(|e| format!("{e}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let number_fn_prefix = format!("node-fn-{}", number.index());
+    let count = module_str.matches(&number_fn_prefix).count();
+    assert!(
+        count <= 3, // 1 fn def + up to 1 call per entry fn
+        "number fn '{number_fn_prefix}' appears {count} times - join duplicated!\n{module_str}",
+    );
 }
 
 // A simple test graph that is expected to `panic!`.

--- a/crates/gantz_core/tests/graph.rs
+++ b/crates/gantz_core/tests/graph.rs
@@ -294,6 +294,320 @@ fn test_graph_push_cond_eval() {
     assert_eq!(number_state, 7);
 }
 
+// Verify that the conditional eval codegen does not duplicate the join
+// node's function call in the generated Scheme. The "number" node sits
+// after a branch-and-join and should appear exactly once in each entry
+// function body.
+#[test]
+fn test_graph_cond_eval_no_join_duplication() {
+    #[derive(Debug)]
+    struct Select;
+
+    impl Node for Select {
+        fn n_inputs(&self, _ctx: node::MetaCtx) -> usize {
+            1
+        }
+        fn n_outputs(&self, _ctx: node::MetaCtx) -> usize {
+            2
+        }
+        fn branches(&self, _ctx: node::MetaCtx) -> Vec<node::EvalConf> {
+            vec![
+                node::EvalConf::Set([true, false].try_into().unwrap()),
+                node::EvalConf::Set([false, true].try_into().unwrap()),
+            ]
+        }
+        fn expr(&self, ctx: node::ExprCtx<'_, '_>) -> node::ExprResult {
+            let x = ctx.inputs()[0].as_deref().expect("must have one input");
+            node::parse_expr(&format!("(if (equal? 0 {x}) (list 0 '()) (list 1 '()))"))
+        }
+    }
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let push_0 = g.add_node(Box::new(node_int(0).with_push_eval()) as Box<dyn DebugNode>);
+    let _push_1 = g.add_node(Box::new(node_int(1).with_push_eval()) as Box<dyn DebugNode>);
+    let select = g.add_node(Box::new(Select) as Box<_>);
+    let six = g.add_node(Box::new(node_int(6)) as Box<_>);
+    let seven = g.add_node(Box::new(node_int(7)) as Box<_>);
+    let number = g.add_node(Box::new(node_number()) as Box<_>);
+    g.add_edge(push_0, select, Edge::from((0, 0)));
+    g.add_edge(select, six, Edge::from((0, 0)));
+    g.add_edge(select, seven, Edge::from((1, 0)));
+    g.add_edge(six, number, Edge::from((0, 0)));
+    g.add_edge(seven, number, Edge::from((0, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+
+    // Build the entrypoint for push_0 only.
+    let ep =
+        gantz_core::compile::entrypoint::push(vec![push_0.index()], g[push_0].n_outputs(ctx) as u8);
+    let module = gantz_core::compile::module(&no_lookup, &g, &[ep]).unwrap();
+
+    // The number node's function name contains its index (5).
+    // Count how many times it appears across all generated expressions.
+    let module_str = module
+        .iter()
+        .map(|e| format!("{e}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let number_fn_prefix = format!("node-fn-{}", number.index());
+    let count = module_str.matches(&number_fn_prefix).count();
+    // Once in the node function definition, once in the entry fn body call.
+    // If the join is duplicated, the entry fn body would contain 2+ calls.
+    assert!(
+        count <= 2,
+        "number node fn '{}' appears {} times - join is duplicated!\nGenerated module:\n{}",
+        number_fn_prefix,
+        count,
+        module_str,
+    );
+}
+
+// Edge case: one branch goes *directly* to the join node (no intermediate
+// nodes), while the other branch goes through an intermediate node first.
+//
+//    ---------- ----------
+//    | push_0 | | push_1 |
+//    -+-------- -+--------
+//     |          |
+//     |-----------
+//     |
+//    -+--------
+//    | select | // br0 passes 6 directly, br1 passes through
+//    -+-----+-+
+//     |       |
+//     |      -+-------
+//     |      | seven |
+//     |      -+-------
+//     |       |
+//    -+-------+-
+//    | number  |
+//    -----------
+//
+// Branch 0 (left): select's output 0 goes directly to number (the join).
+// Branch 1 (right): select's output 1 goes through seven, then to number.
+#[test]
+fn test_graph_branch_target_is_join() {
+    #[derive(Debug)]
+    struct Select;
+
+    impl Node for Select {
+        fn n_inputs(&self, _ctx: node::MetaCtx) -> usize {
+            1
+        }
+        fn n_outputs(&self, _ctx: node::MetaCtx) -> usize {
+            2
+        }
+        fn branches(&self, _ctx: node::MetaCtx) -> Vec<node::EvalConf> {
+            vec![
+                node::EvalConf::Set([true, false].try_into().unwrap()),
+                node::EvalConf::Set([false, true].try_into().unwrap()),
+            ]
+        }
+        fn expr(&self, ctx: node::ExprCtx<'_, '_>) -> node::ExprResult {
+            let x = ctx.inputs()[0].as_deref().expect("must have one input");
+            // Branch 0: pass 6 as the value. Branch 1: pass input through.
+            node::parse_expr(&format!(
+                "(if (equal? 0 {x}) (list 0 6) (list 1 {x}))"
+            ))
+        }
+    }
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let push_0 = g.add_node(Box::new(node_int(0).with_push_eval()) as Box<dyn DebugNode>);
+    let push_1 = g.add_node(Box::new(node_int(1).with_push_eval()) as Box<dyn DebugNode>);
+    let select = g.add_node(Box::new(Select) as Box<_>);
+    let seven = g.add_node(Box::new(node_int(7)) as Box<_>);
+    let number = g.add_node(Box::new(node_number()) as Box<_>);
+    g.add_edge(push_0, select, Edge::from((0, 0)));
+    g.add_edge(push_1, select, Edge::from((0, 0)));
+    g.add_edge(select, number, Edge::from((0, 0))); // br0: direct to join
+    g.add_edge(select, seven, Edge::from((1, 0))); // br1: through seven
+    g.add_edge(seven, number, Edge::from((0, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+
+    let eps = default_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    for f in &module {
+        vm.run(format!("{f}")).unwrap();
+    }
+
+    // Push 0: select goes left, passes 6 directly to number.
+    let ep_0 = entrypoint::push(vec![push_0.index()], g[push_0].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_0.id()), vec![])
+        .unwrap();
+    let state = node::state::extract::<u32>(&vm, &[number.index()])
+        .expect("failed to extract")
+        .expect("state was None");
+    assert_eq!(state, 6);
+
+    // Push 1: select goes right, through seven (constant 7) to number.
+    let ep_1 = entrypoint::push(vec![push_1.index()], g[push_1].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_1.id()), vec![])
+        .unwrap();
+    let state = node::state::extract::<u32>(&vm, &[number.index()])
+        .expect("failed to extract")
+        .expect("state was None");
+    assert_eq!(state, 7);
+
+    // Verify no join duplication in the generated code.
+    let module_str = module
+        .iter()
+        .map(|e| format!("{e}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let number_fn_prefix = format!("node-fn-{}", number.index());
+    let count = module_str.matches(&number_fn_prefix).count();
+    assert!(
+        count <= 3, // 1 fn def + up to 1 call per entry fn
+        "number node fn appears {} times - join duplicated!\n{}",
+        count, module_str,
+    );
+}
+
+// Nested diamond: outer branch contains an inner branch, both with
+// distinct reconvergence points.
+//
+//    ----------   ----------
+//    | push_0 |   | push_1 |
+//    -+--------   -+--------
+//     |            |
+//     |------ ------
+//     |
+//    -+--------------
+//    | select_outer | // br0=left, br1=right
+//    -+-------+-----+
+//     |              |
+//    -+------------  |
+//    |select_inner|  |
+//    -+-----+-----  |
+//     |     |        |
+//    -+-  --+--     -+-------
+//    |6|  |  7|     | eight |
+//    -+-  ----      -+-------
+//     |     |        |
+//    -+-----+-       |
+//    |inner_res|     |
+//    -+--------      |
+//     |              |
+//    -+--------------+
+//    |  outer_result  |
+//    ------------------
+//
+// Push 0 → outer-left → inner-right (since select_inner gets '()
+// which != 0) → seven(7) → inner_result(7) → outer_result(7).
+// Push 1 → outer-right → eight(8) → outer_result(8).
+#[test]
+fn test_graph_nested_diamond() {
+    #[derive(Debug)]
+    struct Select;
+
+    impl Node for Select {
+        fn n_inputs(&self, _ctx: node::MetaCtx) -> usize {
+            1
+        }
+        fn n_outputs(&self, _ctx: node::MetaCtx) -> usize {
+            2
+        }
+        fn branches(&self, _ctx: node::MetaCtx) -> Vec<node::EvalConf> {
+            vec![
+                node::EvalConf::Set([true, false].try_into().unwrap()),
+                node::EvalConf::Set([false, true].try_into().unwrap()),
+            ]
+        }
+        fn expr(&self, ctx: node::ExprCtx<'_, '_>) -> node::ExprResult {
+            let x = ctx.inputs()[0].as_deref().expect("must have one input");
+            node::parse_expr(&format!(
+                "(if (equal? 0 {x}) (list 0 '()) (list 1 '()))"
+            ))
+        }
+    }
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let push_0 = g.add_node(Box::new(node_int(0).with_push_eval()) as Box<dyn DebugNode>);
+    let push_1 = g.add_node(Box::new(node_int(1).with_push_eval()) as Box<dyn DebugNode>);
+    let select_outer = g.add_node(Box::new(Select) as Box<_>);
+    let select_inner = g.add_node(Box::new(Select) as Box<_>);
+    let six = g.add_node(Box::new(node_int(6)) as Box<_>);
+    let seven = g.add_node(Box::new(node_int(7)) as Box<_>);
+    let inner_result = g.add_node(Box::new(node_number()) as Box<_>);
+    let eight = g.add_node(Box::new(node_int(8)) as Box<_>);
+    let outer_result = g.add_node(Box::new(node_number()) as Box<_>);
+    // Outer structure.
+    g.add_edge(push_0, select_outer, Edge::from((0, 0)));
+    g.add_edge(push_1, select_outer, Edge::from((0, 0)));
+    g.add_edge(select_outer, select_inner, Edge::from((0, 0)));
+    g.add_edge(select_outer, eight, Edge::from((1, 0)));
+    // Inner diamond.
+    g.add_edge(select_inner, six, Edge::from((0, 0)));
+    g.add_edge(select_inner, seven, Edge::from((1, 0)));
+    g.add_edge(six, inner_result, Edge::from((0, 0)));
+    g.add_edge(seven, inner_result, Edge::from((0, 0)));
+    // Outer reconvergence.
+    g.add_edge(inner_result, outer_result, Edge::from((0, 0)));
+    g.add_edge(eight, outer_result, Edge::from((0, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+
+    let eps = default_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    for f in &module {
+        vm.run(format!("{f}")).unwrap();
+    }
+
+    // Push 0: outer-left → inner-right (since '() != 0) → seven(7)
+    // → inner_result stores 7, outer_result stores 7.
+    let ep_0 = entrypoint::push(vec![push_0.index()], g[push_0].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_0.id()), vec![])
+        .unwrap();
+    let inner = node::state::extract::<u32>(&vm, &[inner_result.index()])
+        .expect("failed to extract")
+        .expect("inner_result state was None");
+    assert_eq!(inner, 7);
+    let outer = node::state::extract::<u32>(&vm, &[outer_result.index()])
+        .expect("failed to extract")
+        .expect("outer_result state was None");
+    assert_eq!(outer, 7);
+
+    // Push 1: outer-right → eight(8) → outer_result stores 8.
+    // inner_result is not evaluated, stays at 7.
+    let ep_1 = entrypoint::push(vec![push_1.index()], g[push_1].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_1.id()), vec![])
+        .unwrap();
+    let inner = node::state::extract::<u32>(&vm, &[inner_result.index()])
+        .expect("failed to extract")
+        .expect("inner_result state was None");
+    assert_eq!(inner, 7); // unchanged
+    let outer = node::state::extract::<u32>(&vm, &[outer_result.index()])
+        .expect("failed to extract")
+        .expect("outer_result state was None");
+    assert_eq!(outer, 8);
+
+    // Verify neither join node's function call is duplicated.
+    let module_str = module
+        .iter()
+        .map(|e| format!("{e}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    for (name, ix) in [("inner_result", inner_result.index()), ("outer_result", outer_result.index())]
+    {
+        let prefix = format!("node-fn-{ix}");
+        let count = module_str.matches(&prefix).count();
+        assert!(
+            count <= 3, // 1 fn def + up to 1 call per entry fn
+            "{name} fn '{prefix}' appears {count} times - join duplicated!\n{module_str}",
+        );
+    }
+}
+
 // A simple test graph that is expected to `panic!`.
 //
 //    -+-----


### PR DESCRIPTION
## Summary

Replace the codegen's branch handling with proper reconvergence detection and phi-variable join semantics, eliminating downstream code duplication at branch-join points.

- **Phi-variable joins**: When branches reconverge, declare mutable phi-var placeholders before the `if`, `set!` them inside each branch body, then generate the join block once after the `if`. Avoids duplicating all downstream code per branch.
- **Post-dominator reconvergence**: Replace DFS + set-intersection (`find_reconvergence`) with a post-dominator tree computed via `petgraph::algo::dominators::simple_fast` on a reversed flow graph with virtual exit node. The immediate post-dominator of a branching block is the reconvergence point by definition - handles lattice topologies where parallel inner joins previously masked the true reconvergence.
- **Active phi tracking**: Accumulate active phi-var identities through recursive `flow_node_stmts` calls so that `define` inside branch bodies never shadows an outer phi declaration. Handles arbitrary nesting depth.
- Falls back to code duplication for topologies with no single reconvergence (e.g. one branch terminates).

### Codegen changes (`compile/codegen.rs`)

| New function | Purpose |
|---|---|
| `compute_post_dominators` | Reverse flow graph + virtual exit + dominator tree |
| `find_join_points` | Identify flow graph nodes with in-degree > 1 |
| `join_phi_params` | Determine which join inputs need phi vars (`DedicatedBinding`) |
| `declare_phi_vars` | Generate `(define name '())` placeholders |
| `phi_set_stmts` | Generate `(set! name value)` from predecessor outputs |
| `define_branch_node_input_bindings` | Like `define_necessary_node_input_bindings` but filtered by active branch outputs and excluding phi-var targets |

`flow_node_stmts` gains `post_dom`, `phi_params`, `active_phi`, and `stop_at` parameters to drive the reconvergence/phi logic. `entry_fn_body` signature is unchanged.

## Tests

- [x] `test_graph_cond_eval_no_join_duplication` - join node fn appears at most once per entry fn
- [x] `test_graph_branch_target_is_join` - one branch goes directly to the join, the other through an intermediate node
- [x] `test_graph_nested_diamond` - outer branch contains inner branch, both with distinct reconvergence points
- [x] `test_graph_lattice_reconvergence` - both outer branch targets share the same inner branching structure (the topology that motivated the post-dominator approach)

Closes nannou-org/gantz#89