### PR TITLE
feat: add configurable output count to expr node

### DIFF
--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -257,23 +257,30 @@ fn eval_stmt(
 }
 
 /// Create a statement that binds a var for each value in the node's outputs.
-fn destructure_node_outputs_stmt(n: node::Id, outputs: node::Conns) -> ExprKind {
+///
+/// Returns `None` when the node has no connected outputs.
+fn destructure_node_outputs_stmt(n: node::Id, outputs: node::Conns) -> Option<ExprKind> {
     // Collect the names of the outputs.
     let vars: Vec<_> = outputs
         .iter()
         .enumerate()
         .filter_map(|(ix, b)| b.then(|| node_output_var(n, ix)))
         .collect();
+    if vars.is_empty() {
+        return None;
+    }
     let outputs_var = node_outputs_var(n);
     let stmt = match vars.len() {
         1 => format!("(define {} {outputs_var})", vars.join(" ")),
         _ => format!("(define-values ({}) {outputs_var})", vars.join(" ")),
     };
-    Engine::emit_ast(&stmt)
-        .expect("failed to emit AST")
-        .into_iter()
-        .next()
-        .unwrap()
+    Some(
+        Engine::emit_ast(&stmt)
+            .expect("failed to emit AST")
+            .into_iter()
+            .next()
+            .unwrap(),
+    )
 }
 
 /// Create a statement that destructures the node
@@ -500,7 +507,7 @@ pub(crate) fn eval_fn_block_stmts(
         }
 
         // Destructure the node's outputs.
-        stmts.push(destructure_node_outputs_stmt(conf.id, conf.conns.outputs));
+        stmts.extend(destructure_node_outputs_stmt(conf.id, conf.conns.outputs));
         // For outputs connected to node inputs that have more than one incoming
         // edge, we create dedicated bindings for those inputs.
         stmts.extend(define_necessary_node_input_bindings(mg, conf.id));
@@ -633,7 +640,7 @@ fn flow_node_stmts(
     } else if edges.len() == 1 {
         let (_branch, dst) = edges.pop().unwrap();
         let conf = *block.last().unwrap();
-        stmts.push(destructure_node_outputs_stmt(conf.id, conf.conns.outputs));
+        stmts.extend(destructure_node_outputs_stmt(conf.id, conf.conns.outputs));
 
         // If the successor is the reconvergence point we're stopping at,
         // emit phi set statements and return.
@@ -685,7 +692,10 @@ fn flow_node_stmts(
         let mut expr = "'()".to_string();
         let mut sorted_edges = edges;
         while let Some((branch, dst)) = sorted_edges.pop() {
-            let mut branch_stmts = vec![destructure_node_outputs_stmt(conf.id, branch.conns)];
+            let mut branch_stmts: Vec<ExprKind> =
+                destructure_node_outputs_stmt(conf.id, branch.conns)
+                    .into_iter()
+                    .collect();
             branch_stmts.extend(define_branch_node_input_bindings(
                 mg,
                 conf.id,
@@ -765,11 +775,12 @@ fn flow_node_stmts(
             .map(|expr| format!("{expr}"))
             .collect::<Vec<_>>()
             .join(" ");
+        let destructure_str = destructure_node_outputs_stmt(conf.id, branch.conns)
+            .map(|e| format!("{e}"))
+            .unwrap_or_default();
         let dst_expr = format!(
             "(begin {} {} {} '())",
-            destructure_node_outputs_stmt(conf.id, branch.conns),
-            bindings_str,
-            dst_stmts_str,
+            destructure_str, bindings_str, dst_stmts_str,
         );
         expr = format!("(if (= {} {BRANCH_IX}) {dst_expr} {expr})", branch.ix);
     }

--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -485,11 +485,13 @@ pub(crate) fn eval_fn_block_stmts(
         let node_path: Vec<_> = path.iter().copied().chain(Some(conf.id)).collect();
         let stateful = stateful.contains(&conf.id);
         let NodeConns { inputs, outputs } = conf.conns;
-        if let Some(stmt) = eval_stmt(
+        let Some(stmt) = eval_stmt(
             mg, reachable, inlets, outlets, &node_path, &inputs, &outputs, stateful,
-        )? {
-            stmts.push(stmt);
-        }
+        )?
+        else {
+            continue;
+        };
+        stmts.push(stmt);
 
         // If this is the last node fn call in the block, it must be either
         // branching or terminal, so there's no need to destructure here.

--- a/crates/gantz_core/src/node/expr.rs
+++ b/crates/gantz_core/src/node/expr.rs
@@ -22,6 +22,7 @@ use thiserror::Error;
 #[cahash("gantz.expr")]
 pub struct Expr {
     src: String,
+    outputs: u8,
     /// Unique `$` variable names in order of first appearance (cached).
     /// Skipped during serialization and recomputed on deserialization.
     #[serde(skip)]
@@ -37,11 +38,20 @@ impl<'de> Deserialize<'de> for Expr {
         #[derive(Deserialize)]
         struct ExprData {
             src: String,
+            #[serde(default = "default_outputs")]
+            outputs: u8,
         }
         let data = ExprData::deserialize(deserializer)?;
+        if data.outputs < 1 || data.outputs > 16 {
+            return Err(serde::de::Error::custom(format!(
+                "outputs must be in 1..=16, got {}",
+                data.outputs,
+            )));
+        }
         let vars = vars_from_src(&data.src);
         Ok(Expr {
             src: data.src,
+            outputs: data.outputs,
             vars,
         })
     }
@@ -80,13 +90,49 @@ impl Expr {
         if exprs.is_empty() {
             return Err(ExprNewError::Empty);
         }
-        Ok(Expr { src, vars })
+        Ok(Expr {
+            src,
+            outputs: 1,
+            vars,
+        })
+    }
+
+    /// Set the number of outputs for this expression node.
+    ///
+    /// When `n > 1`, the expression should evaluate to `(list v1 v2 ...)`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is 0 or greater than 16.
+    pub fn with_outputs(mut self, n: u8) -> Self {
+        assert!(n >= 1 && n <= 16, "outputs must be in 1..=16, got {n}");
+        self.outputs = n;
+        self
+    }
+
+    /// The number of outputs for this expression node.
+    pub fn outputs(&self) -> u8 {
+        self.outputs
+    }
+
+    /// Set the number of outputs in place.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is 0 or greater than 16.
+    pub fn set_outputs(&mut self, n: u8) {
+        assert!(n >= 1 && n <= 16, "outputs must be in 1..=16, got {n}");
+        self.outputs = n;
     }
 
     /// The source string that was used to create this node.
     pub fn src(&self) -> &str {
         &self.src
     }
+}
+
+fn default_outputs() -> u8 {
+    1
 }
 
 /// Collect unique `$var` names in order of first appearance.
@@ -140,7 +186,7 @@ impl Node for Expr {
     }
 
     fn n_outputs(&self, _ctx: node::MetaCtx) -> usize {
-        1
+        self.outputs as usize
     }
 
     fn expr(&self, ctx: node::ExprCtx<'_, '_>) -> node::ExprResult {
@@ -219,4 +265,35 @@ fn test_collect_unique_vars() {
     // Multiple unique vars.
     let vars = vars_from_src("($a $b $c $d $e)");
     assert_eq!(vars, vec!["$a", "$b", "$c", "$d", "$e"]);
+}
+
+#[test]
+fn test_outputs_default() {
+    let e = Expr::new("(+ $a $b)").unwrap();
+    assert_eq!(e.outputs(), 1);
+}
+
+#[test]
+fn test_with_outputs() {
+    let e = Expr::new("(values $a $b)").unwrap().with_outputs(2);
+    assert_eq!(e.outputs(), 2);
+}
+
+#[test]
+fn test_set_outputs() {
+    let mut e = Expr::new("(values $a $b $c)").unwrap();
+    e.set_outputs(3);
+    assert_eq!(e.outputs(), 3);
+}
+
+#[test]
+#[should_panic]
+fn test_outputs_zero_panics() {
+    Expr::new("$a").unwrap().with_outputs(0);
+}
+
+#[test]
+#[should_panic]
+fn test_outputs_exceeds_max_panics() {
+    Expr::new("$a").unwrap().with_outputs(17);
 }

--- a/crates/gantz_core/src/node/graph.rs
+++ b/crates/gantz_core/src/node/graph.rs
@@ -407,7 +407,7 @@ where
     // Construct the final expression based on number of outputs
     let outlet_values_expr = if outlet_values.len() > 1 {
         let ret_values = outlet_values.join(" ");
-        format!("(values {})", ret_values)
+        format!("(list {})", ret_values)
     } else if outlet_values.len() == 1 {
         outlet_values[0].clone()
     } else {

--- a/crates/gantz_core/tests/graph.rs
+++ b/crates/gantz_core/tests/graph.rs
@@ -969,3 +969,63 @@ fn test_entrypoint_naming_consistency() {
     assert_eq!(default_ep.id(), manual.id());
     assert_eq!(entry_fn_name(&default_ep.id()), entry_fn_name(&manual.id()));
 }
+
+// A 2-output expr node returns `(values 6 7)`. Each output is wired to a
+// separate stateful store node. After push evaluation, each store should hold
+// the corresponding value.
+//
+//    --------
+//    | push |
+//    --------
+//       |
+//    ----------
+//    | pair   |  outputs=2, expr: (begin $push (values 6 7))
+//    ----------
+//     |      |
+//     o0     o1
+//     |      |
+// ---------  ---------
+// | num_a |  | num_b |
+// ---------  ---------
+#[test]
+fn test_graph_multi_output_expr() {
+    let mut g = petgraph::graph::DiGraph::new();
+
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let pair = node::expr("(begin $push (list 6 7))")
+        .unwrap()
+        .with_outputs(2);
+    let pair = g.add_node(Box::new(pair) as Box<_>);
+    let num_a = g.add_node(Box::new(node_number()) as Box<_>);
+    let num_b = g.add_node(Box::new(node_number()) as Box<_>);
+
+    g.add_edge(push, pair, Edge::from((0, 0)));
+    g.add_edge(pair, num_a, Edge::from((0, 0))); // output 0 -> num_a
+    g.add_edge(pair, num_b, Edge::from((1, 0))); // output 1 -> num_b
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+
+    let eps = default_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+
+    for f in &module {
+        vm.run(format!("{f}")).unwrap();
+    }
+
+    let ep = entrypoint::push(vec![push.index()], g[push].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep.id()), vec![])
+        .unwrap();
+
+    let a = node::state::extract::<u32>(&vm, &[num_a.index()])
+        .expect("failed to extract num_a state")
+        .expect("num_a state was None");
+    let b = node::state::extract::<u32>(&vm, &[num_b.index()])
+        .expect("failed to extract num_b state")
+        .expect("num_b state was None");
+    assert_eq!(a, 6);
+    assert_eq!(b, 7);
+}

--- a/crates/gantz_core/tests/graph.rs
+++ b/crates/gantz_core/tests/graph.rs
@@ -1029,3 +1029,62 @@ fn test_graph_multi_output_expr() {
     assert_eq!(a, 6);
     assert_eq!(b, 7);
 }
+
+// Test that nodes with 0 outputs (side-effect-only nodes like Log) work
+// correctly even when multiple appear in the same evaluation path.
+//
+// The graph:
+//
+//    ----------
+//    | push   |  (push_eval, 1 output)
+//    -+--------
+//     |\
+//     | \
+//    -+------  -+------
+//    |effect1|  |effect2|  (each: 1 input, 0 outputs)
+//    --------  ---------
+//
+// Both effect nodes end up in the same basic block. The first one
+// is NOT last in the block, so destructure_node_outputs_stmt is
+// called on it. With 0 outputs this must be a no-op, not an
+// invalid (define-values () node-X) referencing an undefined binding.
+#[test]
+fn test_graph_zero_output_leaf_nodes() {
+    /// A node with 1 input and 0 outputs (pure side-effect).
+    #[derive(Debug)]
+    struct Effect;
+
+    impl Node for Effect {
+        fn n_inputs(&self, _ctx: node::MetaCtx) -> usize {
+            1
+        }
+        fn expr(&self, ctx: node::ExprCtx<'_, '_>) -> node::ExprResult {
+            let input = ctx.inputs()[0].as_deref().unwrap_or("'()");
+            node::parse_expr(&format!("(begin {input} '())"))
+        }
+    }
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let effect1 = g.add_node(Box::new(Effect) as Box<dyn DebugNode>);
+    let effect2 = g.add_node(Box::new(Effect) as Box<dyn DebugNode>);
+    g.add_edge(push, effect1, Edge::from((0, 0)));
+    g.add_edge(push, effect2, Edge::from((0, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let eps = default_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+
+    for f in &module {
+        vm.run(f.to_pretty(100)).unwrap();
+    }
+
+    // Execute the push entrypoint - should not crash.
+    let ep = entrypoint::push(vec![push.index()], g[push].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep.id()), vec![])
+        .unwrap();
+}

--- a/crates/gantz_core/tests/nested.rs
+++ b/crates/gantz_core/tests/nested.rs
@@ -536,3 +536,91 @@ fn test_graph_nested_push_through_outlet() {
         .expect("number state was None");
     assert_eq!(number_state, 42);
 }
+
+// Test that a nested graph with multiple outlets correctly returns a list
+// that is destructured via `define-values` in the outer graph.
+//
+// INNER GRAPH:
+//
+//    --------- ---------
+//    | Inlet | | Inlet |
+//    -+------- -+-------
+//     |         |
+//    -+-------  |
+//    | Outlet | |
+//    ---------- |
+//              -+-------
+//              | Outlet |
+//              ----------
+//
+// OUTER GRAPH:
+//
+//    --------
+//    | push |
+//    -+------
+//     |
+//     |------
+//     |     |
+//    -+--- -+---
+//    | 6 | | 7 |
+//    -+--- -+---
+//     |     |
+//    -+-----+----
+//    | INNER    |
+//    -+------+---
+//     |      |
+//     o0     o1
+//     |      |
+//   num_a  num_b
+#[test]
+fn test_graph_nested_multi_outlet() {
+    // Inner graph: 2 inlets pass through to 2 outlets.
+    let mut inner = GraphNode::default();
+    let inlet_a = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+    let inlet_b = inner.add_node(Box::new(node::graph::Inlet) as Box<_>);
+    let outlet_a = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    let outlet_b = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    inner.add_edge(inlet_a, outlet_a, Edge::from((0, 0)));
+    inner.add_edge(inlet_b, outlet_b, Edge::from((0, 0)));
+
+    // Outer graph.
+    let mut outer = petgraph::graph::DiGraph::new();
+    let push = outer.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let six = outer.add_node(Box::new(node_int(6)) as Box<_>);
+    let seven = outer.add_node(Box::new(node_int(7)) as Box<_>);
+    let graph = outer.add_node(Box::new(inner) as Box<_>);
+    let num_a = outer.add_node(Box::new(node_number()) as Box<_>);
+    let num_b = outer.add_node(Box::new(node_number()) as Box<_>);
+
+    outer.add_edge(push, six, Edge::from((0, 0)));
+    outer.add_edge(push, seven, Edge::from((0, 0)));
+    outer.add_edge(six, graph, Edge::from((0, 0)));
+    outer.add_edge(seven, graph, Edge::from((0, 1)));
+    outer.add_edge(graph, num_a, Edge::from((0, 0))); // outlet 0
+    outer.add_edge(graph, num_b, Edge::from((1, 0))); // outlet 1
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let eps = default_entrypoints(&no_lookup, &outer);
+    let module = gantz_core::compile::module(&no_lookup, &outer, &eps).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &outer, &[], &mut vm);
+
+    for f in &module {
+        vm.run(f.to_pretty(100)).unwrap();
+    }
+
+    let ep = entrypoint::push(vec![push.index()], outer[push].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep.id()), vec![])
+        .unwrap();
+
+    let a = node::state::extract::<u32>(&vm, &[num_a.index()])
+        .expect("failed to extract num_a state")
+        .expect("num_a state was None");
+    let b = node::state::extract::<u32>(&vm, &[num_b.index()])
+        .expect("failed to extract num_b state")
+        .expect("num_b state was None");
+    assert_eq!(a, 6);
+    assert_eq!(b, 7);
+}

--- a/crates/gantz_egui/src/impls/expr.rs
+++ b/crates/gantz_egui/src/impls/expr.rs
@@ -99,6 +99,24 @@ impl NodeUi for gantz_core::node::Expr {
             ui.add(ExprEdit::new(self, id))
         })
     }
+
+    fn inspector_rows(&mut self, _ctx: &mut NodeCtx, body: &mut egui_extras::TableBody) {
+        let row_h = crate::widget::node_inspector::table_row_h(body.ui_mut());
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("outputs");
+            });
+            row.col(|ui| {
+                let mut n = self.outputs() as i32;
+                if ui
+                    .add(egui::DragValue::new(&mut n).range(1..=16).speed(0.1))
+                    .changed()
+                {
+                    self.set_outputs(n.clamp(1, 16) as u8);
+                }
+            });
+        });
+    }
 }
 
 impl<'a> ExprEdit<'a> {

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -541,9 +541,7 @@ where
                         gantz_ca::Head::Branch(name) => base_names.contains_key(name),
                         _ => false,
                     };
-                    let is_demo =
-                        matches!(&head, gantz_ca::Head::Branch(name) if name.starts_with("demo-"));
-                    let immutable = is_base && gantz.base_immutable && !is_demo;
+                    let immutable = head_immutable(&head, gantz.base_immutable, base_names);
 
                     // Collect demo-* names for the dropdown.
                     let demo_names_vec: Vec<&str> = names
@@ -637,8 +635,7 @@ where
 
                 // Show the command palette once (not per-pane), operating on the focused head.
                 if let Some(fh) = access.heads().get(*focused_head).cloned() {
-                    let focused_immutable = gantz.base_immutable
-                        && matches!(&fh, gantz_ca::Head::Branch(name) if base_names.contains_key(name));
+                    let focused_immutable = head_immutable(&fh, gantz.base_immutable, base_names);
 
                     let head_state = state.open_heads.entry(fh.clone()).or_default();
 
@@ -754,16 +751,7 @@ where
             Pane::NodeInspector => {
                 // Use the focused head for the node inspector.
                 if let Some(fh) = access.heads().get(*focused_head).cloned() {
-                    let is_demo = matches!(
-                        &fh,
-                        gantz_ca::Head::Branch(name) if name.starts_with("demo-")
-                    );
-                    let immutable = gantz.base_immutable
-                        && matches!(
-                            &fh,
-                            gantz_ca::Head::Branch(name) if base_names.contains_key(name)
-                        )
-                        && !is_demo;
+                    let immutable = head_immutable(&fh, gantz.base_immutable, base_names);
                     let head_state = state.open_heads.entry(fh.clone()).or_default();
                     access.with_head_mut(&fh, |data| {
                         node_inspector(gantz.env, data.graph, data.vm, head_state, immutable, ui);
@@ -994,13 +982,7 @@ where
             .position(|h| h == pane_head)
             .expect("pane head not found in heads");
 
-        // Compute whether this head should be immutable.
-        // Demo base graphs are mutable so users can experiment.
-        let is_demo =
-            matches!(pane_head, gantz_ca::Head::Branch(name) if name.starts_with("demo-"));
-        let immutable = self.base_immutable
-            && matches!(pane_head, gantz_ca::Head::Branch(name) if self.base_names.contains_key(name))
-            && !is_demo;
+        let immutable = head_immutable(pane_head, self.base_immutable, self.base_names);
 
         let head_state = self.state.open_heads.entry(pane_head.clone()).or_default();
         let auto_layout = head_state.auto_layout;
@@ -1506,6 +1488,21 @@ fn trace_view(
         widget::trace_view::TraceView::new("trace-view".into(), trace_capture.clone(), level)
             .show(ui);
     })
+}
+
+/// Whether the given head should be treated as immutable.
+///
+/// A head is immutable when `base_immutable` is enabled and the head is a base
+/// graph that is not a demo (demo base graphs are always mutable so users can
+/// experiment).
+fn head_immutable(
+    head: &gantz_ca::Head,
+    base_immutable: bool,
+    base_names: &gantz_ca::registry::Names,
+) -> bool {
+    let is_base = matches!(head, gantz_ca::Head::Branch(name) if base_names.contains_key(name));
+    let is_demo = matches!(head, gantz_ca::Head::Branch(name) if name.starts_with("demo-"));
+    base_immutable && is_base && !is_demo
 }
 
 fn node_inspector<N>(

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -754,9 +754,19 @@ where
             Pane::NodeInspector => {
                 // Use the focused head for the node inspector.
                 if let Some(fh) = access.heads().get(*focused_head).cloned() {
+                    let is_demo = matches!(
+                        &fh,
+                        gantz_ca::Head::Branch(name) if name.starts_with("demo-")
+                    );
+                    let immutable = gantz.base_immutable
+                        && matches!(
+                            &fh,
+                            gantz_ca::Head::Branch(name) if base_names.contains_key(name)
+                        )
+                        && !is_demo;
                     let head_state = state.open_heads.entry(fh.clone()).or_default();
                     access.with_head_mut(&fh, |data| {
-                        node_inspector(gantz.env, data.graph, data.vm, head_state, ui);
+                        node_inspector(gantz.env, data.graph, data.vm, head_state, immutable, ui);
                     });
                 }
             }
@@ -1503,6 +1513,7 @@ fn node_inspector<N>(
     root: &mut gantz_core::node::graph::Graph<N>,
     vm: &mut Engine,
     head_state: &mut OpenHeadState,
+    immutable: bool,
     ui: &mut egui::Ui,
 ) -> egui::InnerResponse<()>
 where
@@ -1536,7 +1547,7 @@ where
                             vm,
                             &mut head_state.scene.cmds,
                         );
-                        let resp = widget::NodeInspector::new(node, ctx).show(ui);
+                        let resp = widget::NodeInspector::new(node, ctx, immutable).show(ui);
                         if resp.label_response.clicked() {
                             let sel = &mut head_state.scene.interaction.selection.nodes;
                             if ui.input(|i| i.modifiers.command) {

--- a/crates/gantz_egui/src/widget/node_inspector.rs
+++ b/crates/gantz_egui/src/widget/node_inspector.rs
@@ -7,6 +7,7 @@ use gantz_core::node::{self, MetaCtx, Node};
 pub struct NodeInspector<'a, N> {
     node: &'a mut N,
     ctx: NodeCtx<'a>,
+    immutable: bool,
 }
 
 /// The response returned from [`NodeInspector::show`].
@@ -20,13 +21,24 @@ impl<'a, N> NodeInspector<'a, N>
 where
     N: Node + NodeUi,
 {
-    pub fn new(node: &'a mut N, ctx: NodeCtx<'a>) -> Self {
-        Self { node, ctx }
+    pub fn new(node: &'a mut N, ctx: NodeCtx<'a>, immutable: bool) -> Self {
+        Self {
+            node,
+            ctx,
+            immutable,
+        }
     }
 
     pub fn show(self, ui: &mut egui::Ui) -> NodeInspectorResponse {
-        let Self { node, mut ctx } = self;
-        let (scroll_area_output, label_response) = table(node, &mut ctx, ui);
+        let Self {
+            node,
+            mut ctx,
+            immutable,
+        } = self;
+        let (scroll_area_output, label_response) = table(node, &mut ctx, immutable, ui);
+        if immutable {
+            ui.disable();
+        }
         let node_response = node.inspector_ui(ctx, ui);
         NodeInspectorResponse {
             scroll_area_output,
@@ -43,6 +55,7 @@ pub fn table_row_h(ui: &egui::Ui) -> f32 {
 pub fn table(
     node: &mut (impl Node + NodeUi),
     ctx: &mut NodeCtx,
+    immutable: bool,
     ui: &mut egui::Ui,
 ) -> (ScrollAreaOutput<()>, egui::Response) {
     // Extract info we need upfront before the closure borrows ctx.
@@ -131,6 +144,9 @@ pub fn table(
                 });
             }
 
+            if immutable {
+                body.ui_mut().disable();
+            }
             node.inspector_rows(ctx, &mut body);
         });
     (scroll_area_output, label_response)


### PR DESCRIPTION
Support multiple outputs on `Expr` nodes (1-16).

When outputs > 1, the expression should evaluate to `(list v1 v2 ...)` which the existing codegen destructures via `define-values`.

Add inspector UI with DragValue, serde backwards compat with range validation, and an integration test exercising the full compile+execute pipeline.

Also fixes a couple issues discovered while testing this - see commit msgs for details.