### PR TITLE
feat: add `Branch` node for conditional output activation

### DIFF
--- a/crates/gantz/src/builtin.rs
+++ b/crates/gantz/src/builtin.rs
@@ -91,6 +91,9 @@ fn primitives() -> Primitives {
     register_primitive(&mut p, "bang", || {
         Box::new(gantz_std::Bang::default()) as Box<_>
     });
+    register_primitive(&mut p, "branch", || {
+        Box::new(gantz_core::node::Branch::default()) as Box<_>
+    });
     register_primitive(&mut p, "comment", || {
         Box::new(gantz_egui::node::Comment::default()) as Box<_>
     });

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -15,6 +15,8 @@ dyn_hash::hash_trait_object!(Node);
 #[typetag::serde]
 impl Node for gantz_core::node::Apply {}
 #[typetag::serde]
+impl Node for gantz_core::node::Branch {}
+#[typetag::serde]
 impl Node for gantz_core::node::Expr {}
 #[typetag::serde]
 impl Node for gantz_core::node::GraphNode<Box<dyn Node>> {}

--- a/crates/gantz_core/src/node.rs
+++ b/crates/gantz_core/src/node.rs
@@ -3,6 +3,7 @@
 #[doc(inline)]
 pub use crate::visit::{self, Visitor};
 pub use apply::Apply;
+pub use branch::{Branch, BranchNewError};
 #[doc(inline)]
 pub use conns::Conns;
 pub use expr::{Expr, ExprNewError};
@@ -18,6 +19,7 @@ pub use state::{NodeState, State, WithStateType};
 use steel::{parser::ast::ExprKind, steel_vm::engine::Engine};
 
 pub mod apply;
+pub mod branch;
 mod conns;
 pub mod expr;
 pub mod fn_;
@@ -455,6 +457,13 @@ impl ExprError {
 /// Shorthand for `node::Expr::new`.
 pub fn expr(expr: impl Into<String>) -> Result<Expr, ExprNewError> {
     Expr::new(expr)
+}
+
+/// Create a branching node from the given expression and branch masks.
+///
+/// Shorthand for `node::Branch::new`.
+pub fn branch(src: impl Into<String>, branches: Vec<Conns>) -> Result<Branch, BranchNewError> {
+    Branch::new(src, branches)
 }
 
 /// Parse a Steel expression string, returning an [`ExprResult`].

--- a/crates/gantz_core/src/node/branch.rs
+++ b/crates/gantz_core/src/node/branch.rs
@@ -1,0 +1,440 @@
+use crate::node::{self, Conns, Node};
+use gantz_ca::CaHash;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use steel::parser::lexer::TokenStream;
+use thiserror::Error;
+
+/// A node that conditionally activates different subsets of its outputs.
+///
+/// Like [`super::Expr`], the expression uses `$var` placeholders for inputs.
+/// Unlike `Expr`, the expression **must** return `(list branch-index value(s))`
+/// where `branch-index` selects which branch's outputs are activated.
+///
+/// Each branch is a [`Conns`] bitmask specifying which outputs are active when
+/// that branch is selected. The number of outputs is inferred from the `Conns`
+/// length (all branches must have the same length).
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, CaHash)]
+#[cahash("gantz.branch")]
+pub struct Branch {
+    src: String,
+    branches: Vec<Conns>,
+    /// Unique `$` variable names in order of first appearance (cached).
+    /// Skipped during serialization and recomputed on deserialization.
+    #[serde(skip)]
+    #[cahash(skip)]
+    vars: Vec<String>,
+}
+
+impl<'de> Deserialize<'de> for Branch {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct BranchData {
+            src: String,
+            branches: Vec<Conns>,
+        }
+        let data = BranchData::deserialize(deserializer)?;
+        if data.branches.is_empty() {
+            return Err(serde::de::Error::custom(
+                "branches must have at least 1 entry",
+            ));
+        }
+        let out_len = data.branches[0].len();
+        if out_len < 1 || out_len > 16 {
+            return Err(serde::de::Error::custom(format!(
+                "output count must be in 1..=16, got {out_len}",
+            )));
+        }
+        for (i, conns) in data.branches.iter().enumerate().skip(1) {
+            if conns.len() != out_len {
+                return Err(serde::de::Error::custom(format!(
+                    "branch {i} has {} outputs but branch 0 has {out_len}",
+                    conns.len(),
+                )));
+            }
+        }
+        let vars = super::expr::vars_from_src(&data.src);
+        Ok(Branch {
+            src: data.src,
+            branches: data.branches,
+            vars,
+        })
+    }
+}
+
+/// An error occurred while constructing the `Branch` node.
+#[derive(Debug, Error)]
+pub enum BranchNewError {
+    /// Failed to parse a valid expression.
+    #[error("failed to parse a valid expr: {err}")]
+    InvalidExpr {
+        #[from]
+        err: steel::rerrs::SteelErr,
+    },
+    /// The parsed result contained no expression.
+    #[error("parsed result contains no expression")]
+    Empty,
+    /// No branches provided.
+    #[error("branches must have at least 1 entry, got 0")]
+    NoBranches,
+    /// Output count (Conns length) is out of range.
+    #[error("output count must be in 1..=16, got {0}")]
+    InvalidOutputs(usize),
+    /// Branches have inconsistent Conns lengths.
+    #[error("branch {ix} has {actual} outputs but branch 0 has {expected}")]
+    ConnsLenMismatch {
+        ix: usize,
+        expected: usize,
+        actual: usize,
+    },
+}
+
+impl Branch {
+    /// Construct a `Branch` node.
+    ///
+    /// - `src` is a Steel expression that must return `(list branch-index value(s))`.
+    /// - `branches` defines the output activation mask for each branch. All
+    ///   entries must have the same `Conns` length (1-16), which determines the
+    ///   number of outputs.
+    ///
+    /// Returns an `Err` if validation fails or the expression cannot be parsed.
+    pub fn new(src: impl Into<String>, branches: Vec<Conns>) -> Result<Self, BranchNewError> {
+        let src: String = src.into();
+        if branches.is_empty() {
+            return Err(BranchNewError::NoBranches);
+        }
+        let out_len = branches[0].len();
+        if out_len < 1 || out_len > 16 {
+            return Err(BranchNewError::InvalidOutputs(out_len));
+        }
+        for (ix, conns) in branches.iter().enumerate().skip(1) {
+            if conns.len() != out_len {
+                return Err(BranchNewError::ConnsLenMismatch {
+                    ix,
+                    expected: out_len,
+                    actual: conns.len(),
+                });
+            }
+        }
+        let vars = super::expr::vars_from_src(&src);
+        // Validate that the source parses successfully.
+        let exprs = steel::steel_vm::engine::Engine::emit_ast(&src)?;
+        if exprs.is_empty() {
+            return Err(BranchNewError::Empty);
+        }
+        Ok(Branch {
+            src,
+            branches,
+            vars,
+        })
+    }
+
+    /// The source string that was used to create this node.
+    pub fn src(&self) -> &str {
+        &self.src
+    }
+
+    /// The number of outputs, inferred from the `Conns` length.
+    pub fn outputs(&self) -> u8 {
+        self.branches[0].len() as u8
+    }
+
+    /// The branch output activation masks.
+    pub fn branch_conns(&self) -> &[Conns] {
+        &self.branches
+    }
+
+    /// The number of branches.
+    pub fn n_branches(&self) -> usize {
+        self.branches.len()
+    }
+
+    /// Set the number of outputs, resizing all branch `Conns` accordingly.
+    ///
+    /// Existing bits are preserved up to `min(old, new)` length. New bits
+    /// default to `false`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is 0 or greater than 16.
+    pub fn set_outputs(&mut self, n: u8) {
+        assert!(n >= 1 && n <= 16, "outputs must be in 1..=16, got {n}");
+        let new_len = n as usize;
+        for conns in &mut self.branches {
+            *conns = resize_conns(*conns, new_len);
+        }
+    }
+
+    /// Replace the branch definitions.
+    ///
+    /// All `Conns` must have the same length, matching the current output count.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `branches` is empty or any `Conns` length mismatches.
+    pub fn set_branch_conns(&mut self, branches: Vec<Conns>) {
+        assert!(!branches.is_empty(), "need at least 1 branch");
+        let out_len = self.outputs() as usize;
+        for (i, c) in branches.iter().enumerate() {
+            assert_eq!(
+                c.len(),
+                out_len,
+                "branch {i} has {} outputs but expected {out_len}",
+                c.len(),
+            );
+        }
+        self.branches = branches;
+    }
+}
+
+/// Resize a `Conns` to a new length, preserving existing bits.
+fn resize_conns(old: Conns, new_len: usize) -> Conns {
+    let mut new = Conns::unconnected(new_len).expect("new_len out of range");
+    let copy_len = old.len().min(new_len);
+    for i in 0..copy_len {
+        if let Some(true) = old.get(i) {
+            new.set(i, true).unwrap();
+        }
+    }
+    new
+}
+
+impl Default for Branch {
+    /// A default 2-output if/else branch.
+    fn default() -> Self {
+        Branch::new(
+            "(if (= 0 $x) (list 0 '()) (list 1 '()))",
+            vec![
+                Conns::try_from([true, false]).unwrap(),
+                Conns::try_from([false, true]).unwrap(),
+            ],
+        )
+        .unwrap()
+    }
+}
+
+impl Node for Branch {
+    fn n_inputs(&self, _ctx: node::MetaCtx) -> usize {
+        self.vars.len()
+    }
+
+    fn n_outputs(&self, _ctx: node::MetaCtx) -> usize {
+        self.outputs() as usize
+    }
+
+    fn branches(&self, _ctx: node::MetaCtx) -> Vec<node::EvalConf> {
+        self.branches
+            .iter()
+            .map(|conns| node::EvalConf::Set(*conns))
+            .collect()
+    }
+
+    fn expr(&self, ctx: node::ExprCtx<'_, '_>) -> node::ExprResult {
+        let tts = TokenStream::new(&self.src, true, None);
+        let new_src = super::expr::interpolate_tokens(tts, &self.vars, ctx.inputs());
+        let exprs = steel::steel_vm::engine::Engine::emit_ast(&new_src)
+            .map_err(|e| node::ExprError::custom(e))?;
+        if exprs.len() == 1 {
+            Ok(exprs.into_iter().next().unwrap())
+        } else {
+            let exprs = exprs
+                .iter()
+                .map(|expr| format!("{expr}"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            let out_src = format!("(begin {})", exprs);
+            node::parse_expr(&out_src)
+        }
+    }
+
+    /// Only generate the state binding if the expr references `state`.
+    fn stateful(&self, _ctx: node::MetaCtx) -> bool {
+        self.src().contains("state")
+    }
+
+    /// Registers a state slot just in case `state` is referenced by the expr.
+    fn register(&self, ctx: node::RegCtx<'_, '_>) {
+        let (_, path, vm) = ctx.into_parts();
+        node::state::init_value_if_absent(vm, path, || steel::SteelVal::Void).unwrap();
+    }
+}
+
+impl fmt::Display for Branch {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.src)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn two_branch_conns() -> Vec<Conns> {
+        vec![
+            Conns::try_from([true, false]).unwrap(),
+            Conns::try_from([false, true]).unwrap(),
+        ]
+    }
+
+    #[test]
+    fn test_new_valid() {
+        let b = Branch::new(
+            "(if (equal? 0 $x) (list 0 '()) (list 1 '()))",
+            two_branch_conns(),
+        )
+        .unwrap();
+        assert_eq!(b.outputs(), 2);
+        assert_eq!(b.n_branches(), 2);
+        assert_eq!(b.src(), "(if (equal? 0 $x) (list 0 '()) (list 1 '()))");
+    }
+
+    #[test]
+    fn test_new_single_branch() {
+        let b = Branch::new("(list 0 $x)", vec![Conns::try_from([true]).unwrap()]).unwrap();
+        assert_eq!(b.outputs(), 1);
+        assert_eq!(b.n_branches(), 1);
+    }
+
+    #[test]
+    fn test_new_extracts_vars() {
+        let b = Branch::new(
+            "(if (equal? 0 $a) (list 0 $b) (list 1 $c))",
+            two_branch_conns(),
+        )
+        .unwrap();
+        let ctx = node::MetaCtx::new(&|_| None);
+        assert_eq!(b.n_inputs(ctx), 3);
+    }
+
+    #[test]
+    fn test_new_no_branches() {
+        let err = Branch::new("(list 0 '())", vec![]).unwrap_err();
+        assert!(matches!(err, BranchNewError::NoBranches));
+    }
+
+    #[test]
+    fn test_new_invalid_outputs_zero() {
+        let err = Branch::new("(list 0 '())", vec![Conns::unconnected(0).unwrap()]).unwrap_err();
+        assert!(matches!(err, BranchNewError::InvalidOutputs(0)));
+    }
+
+    #[test]
+    fn test_new_invalid_outputs_too_high() {
+        let err = Branch::new("(list 0 '())", vec![Conns::unconnected(17).unwrap()]).unwrap_err();
+        assert!(matches!(err, BranchNewError::InvalidOutputs(17)));
+    }
+
+    #[test]
+    fn test_new_conns_len_mismatch() {
+        let bad = vec![
+            Conns::try_from([true, false, false]).unwrap(),
+            Conns::try_from([false, true]).unwrap(),
+        ];
+        let err = Branch::new("(list 0 '())", bad).unwrap_err();
+        assert!(matches!(
+            err,
+            BranchNewError::ConnsLenMismatch {
+                ix: 1,
+                expected: 3,
+                actual: 2,
+            }
+        ));
+    }
+
+    #[test]
+    fn test_new_invalid_expr() {
+        let err = Branch::new("(((", two_branch_conns()).unwrap_err();
+        assert!(matches!(err, BranchNewError::InvalidExpr { .. }));
+    }
+
+    #[test]
+    fn test_node_trait_branches() {
+        let b = Branch::new(
+            "(if (equal? 0 $x) (list 0 '()) (list 1 '()))",
+            two_branch_conns(),
+        )
+        .unwrap();
+        let ctx = node::MetaCtx::new(&|_| None);
+        let branches = b.branches(ctx);
+        assert_eq!(branches.len(), 2);
+        assert_eq!(
+            branches[0],
+            node::EvalConf::Set(Conns::try_from([true, false]).unwrap())
+        );
+        assert_eq!(
+            branches[1],
+            node::EvalConf::Set(Conns::try_from([false, true]).unwrap())
+        );
+    }
+
+    #[test]
+    fn test_set_outputs_resize() {
+        let mut b = Branch::new(
+            "(if (equal? 0 $x) (list 0 '()) (list 1 '()))",
+            two_branch_conns(),
+        )
+        .unwrap();
+        // Grow from 2 to 3 outputs.
+        b.set_outputs(3);
+        assert_eq!(b.outputs(), 3);
+        for conns in b.branch_conns() {
+            assert_eq!(conns.len(), 3);
+        }
+        // First branch: [true, false] -> [true, false, false]
+        assert_eq!(b.branch_conns()[0].get(0), Some(true));
+        assert_eq!(b.branch_conns()[0].get(1), Some(false));
+        assert_eq!(b.branch_conns()[0].get(2), Some(false));
+        // Shrink to 1.
+        b.set_outputs(1);
+        assert_eq!(b.outputs(), 1);
+        assert_eq!(b.branch_conns()[0].get(0), Some(true));
+        assert_eq!(b.branch_conns()[0].len(), 1);
+    }
+
+    #[test]
+    fn test_stateful() {
+        let b = Branch::new("(begin (set! state $x) (list 0 state))", two_branch_conns()).unwrap();
+        let ctx = node::MetaCtx::new(&|_| None);
+        assert!(b.stateful(ctx));
+
+        let b2 = Branch::new(
+            "(if (equal? 0 $x) (list 0 '()) (list 1 '()))",
+            two_branch_conns(),
+        )
+        .unwrap();
+        assert!(!b2.stateful(ctx));
+    }
+
+    #[test]
+    fn test_display() {
+        let b = Branch::new("(list 0 '())", two_branch_conns()).unwrap();
+        assert_eq!(format!("{b}"), "(list 0 '())");
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let original = Branch::new(
+            "(if (equal? 0 $x) (list 0 '()) (list 1 '()))",
+            two_branch_conns(),
+        )
+        .unwrap();
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: Branch = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn test_deser_no_branches() {
+        let json = r#"{"src":"(list 0 '())","branches":[]}"#;
+        assert!(serde_json::from_str::<Branch>(json).is_err());
+    }
+
+    #[test]
+    fn test_deser_conns_len_mismatch() {
+        let json = r#"{"src":"(list 0 '())","branches":["100","01"]}"#;
+        assert!(serde_json::from_str::<Branch>(json).is_err());
+    }
+}

--- a/crates/gantz_core/src/node/expr.rs
+++ b/crates/gantz_core/src/node/expr.rs
@@ -136,7 +136,7 @@ fn default_outputs() -> u8 {
 }
 
 /// Collect unique `$var` names in order of first appearance.
-fn collect_unique_vars(tts: TokenStream) -> Vec<String> {
+pub(crate) fn collect_unique_vars(tts: TokenStream) -> Vec<String> {
     let mut seen = HashSet::new();
     let mut vars = Vec::new();
     for token in tts {
@@ -152,12 +152,16 @@ fn collect_unique_vars(tts: TokenStream) -> Vec<String> {
 }
 
 /// Extract unique vars from a source string.
-fn vars_from_src(src: &str) -> Vec<String> {
+pub(crate) fn vars_from_src(src: &str) -> Vec<String> {
     collect_unique_vars(TokenStream::new(src, true, None))
 }
 
 /// Replace each `$var` with the corresponding input expression based on variable name.
-fn interpolate_tokens(tts: TokenStream, vars: &[String], inputs: &[Option<String>]) -> String {
+pub(crate) fn interpolate_tokens(
+    tts: TokenStream,
+    vars: &[String],
+    inputs: &[Option<String>],
+) -> String {
     // Build a map from var name to input index.
     let var_to_index: std::collections::HashMap<&str, usize> = vars
         .iter()

--- a/crates/gantz_core/tests/graph.rs
+++ b/crates/gantz_core/tests/graph.rs
@@ -1088,3 +1088,71 @@ fn test_graph_zero_output_leaf_nodes() {
     vm.call_function_by_name_with_args(&entry_fn_name(&ep.id()), vec![])
         .unwrap();
 }
+
+/// Test using the `Branch` node type in a graph with push evaluation.
+///
+/// Graph layout:
+///
+///   push_0 (emits 0) ---\
+///                         branch --- out0 -> six -> number
+///   push_1 (emits 1) ---/       \-- out1 -> seven -> number
+///
+/// When push_0 fires (input=0), branch selects index 0 -> six -> number stores 6.
+/// When push_1 fires (input=1), branch selects index 1 -> seven -> number stores 7.
+#[test]
+fn test_graph_branch_node() {
+    let branch = node::Branch::new(
+        "(if (equal? 0 $x) (list 0 '()) (list 1 '()))",
+        vec![
+            node::Conns::try_from([true, false]).unwrap(),
+            node::Conns::try_from([false, true]).unwrap(),
+        ],
+    )
+    .unwrap();
+
+    let mut g = petgraph::graph::DiGraph::new();
+
+    let push_0 = g.add_node(Box::new(node_int(0).with_push_eval()) as Box<dyn DebugNode>);
+    let push_1 = g.add_node(Box::new(node_int(1).with_push_eval()) as Box<_>);
+    let branch_ix = g.add_node(Box::new(branch) as Box<_>);
+    let six = g.add_node(Box::new(node_int(6)) as Box<_>);
+    let seven = g.add_node(Box::new(node_int(7)) as Box<_>);
+    let number = g.add_node(Box::new(node_number()) as Box<_>);
+
+    g.add_edge(push_0, branch_ix, Edge::from((0, 0)));
+    g.add_edge(push_1, branch_ix, Edge::from((0, 0)));
+    g.add_edge(branch_ix, six, Edge::from((0, 0)));
+    g.add_edge(branch_ix, seven, Edge::from((1, 0)));
+    g.add_edge(six, number, Edge::from((0, 0)));
+    g.add_edge(seven, number, Edge::from((0, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let eps = default_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+
+    for f in module {
+        vm.run(format!("{f}")).unwrap();
+    }
+
+    // Push 0 -> branch takes index 0 -> six -> number stores 6.
+    let ep_0 = entrypoint::push(vec![push_0.index()], g[push_0].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_0.id()), vec![])
+        .unwrap();
+    let val = node::state::extract::<u32>(&vm, &[number.index()])
+        .expect("failed to extract")
+        .expect("was None");
+    assert_eq!(val, 6);
+
+    // Push 1 -> branch takes index 1 -> seven -> number stores 7.
+    let ep_1 = entrypoint::push(vec![push_1.index()], g[push_1].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_1.id()), vec![])
+        .unwrap();
+    let val = node::state::extract::<u32>(&vm, &[number.index()])
+        .expect("failed to extract")
+        .expect("was None");
+    assert_eq!(val, 7);
+}

--- a/crates/gantz_core/tests/serde.rs
+++ b/crates/gantz_core/tests/serde.rs
@@ -1,7 +1,9 @@
 //! Ensure that its possible to serialize/deserialize core nodes as trait
 //! objects using typetag.
 
-use gantz_core::node::{self, Expr, MetaCtx, Node, Pull, Push, WithPullEval, WithPushEval};
+use gantz_core::node::{
+    self, Branch, Conns, Expr, MetaCtx, Node, Pull, Push, WithPullEval, WithPushEval,
+};
 use serde_json;
 
 /// A wrapper around the **Node** trait that allows for serializing and
@@ -9,6 +11,8 @@ use serde_json;
 #[typetag::serde(tag = "type")]
 trait SerdeNode: Node {}
 
+#[typetag::serde]
+impl SerdeNode for node::Branch {}
 #[typetag::serde]
 impl SerdeNode for node::Expr {}
 #[typetag::serde]
@@ -122,4 +126,37 @@ fn test_serde_node_vector() {
     // Third node should be pull node
     assert!(deserialized[2].push_eval(ctx).is_empty());
     assert!(!deserialized[2].pull_eval(ctx).is_empty());
+}
+
+// Test serializing and deserializing a Branch node via trait object.
+#[test]
+fn test_serde_branch_roundtrip() {
+    let branch = Branch::new(
+        "(if (equal? 0 $x) (list 0 $x) (list 1 $x))",
+        vec![
+            Conns::try_from([true, false]).unwrap(),
+            Conns::try_from([false, true]).unwrap(),
+        ],
+    )
+    .unwrap();
+
+    let boxed: Box<dyn SerdeNode> = Box::new(branch);
+    let serialized = serde_json::to_string(&boxed).expect("Failed to serialize");
+    let deserialized: Box<dyn SerdeNode> =
+        serde_json::from_str(&serialized).expect("Failed to deserialize");
+
+    let ctx = MetaCtx::new(&no_lookup);
+    assert_eq!(deserialized.n_inputs(ctx), 1);
+    assert_eq!(deserialized.n_outputs(ctx), 2);
+
+    let branches = deserialized.branches(ctx);
+    assert_eq!(branches.len(), 2);
+    assert_eq!(
+        branches[0],
+        node::EvalConf::Set(Conns::try_from([true, false]).unwrap()),
+    );
+    assert_eq!(
+        branches[1],
+        node::EvalConf::Set(Conns::try_from([false, true]).unwrap()),
+    );
 }

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -156,6 +156,9 @@ fn primitives() -> Primitives {
     register_primitive(&mut p, "bang", || {
         Box::new(gantz_std::Bang::default()) as Box<_>
     });
+    register_primitive(&mut p, "branch", || {
+        Box::new(gantz_core::node::Branch::default()) as Box<_>
+    });
     register_primitive(&mut p, "expr", || {
         Box::new(gantz_core::node::Expr::new("()").unwrap()) as Box<_>
     });
@@ -196,6 +199,8 @@ trait Node: Any + DynClone + gantz_ca::CaHash + gantz_core::Node + gantz_egui::N
 
 dyn_clone::clone_trait_object!(Node);
 
+#[typetag::serde]
+impl Node for gantz_core::node::Branch {}
 #[typetag::serde]
 impl Node for gantz_core::node::Expr {}
 #[typetag::serde]

--- a/crates/gantz_egui/src/impls.rs
+++ b/crates/gantz_egui/src/impls.rs
@@ -2,6 +2,7 @@
 
 mod apply;
 mod bang;
+mod branch;
 mod expr;
 mod graph;
 mod identity;

--- a/crates/gantz_egui/src/impls/branch.rs
+++ b/crates/gantz_egui/src/impls/branch.rs
@@ -1,0 +1,220 @@
+use crate::{NodeCtx, NodeUi};
+
+/// A widget used to allow for editing and parsing a branch expression.
+pub struct BranchEdit<'a> {
+    branch: &'a mut gantz_core::node::Branch,
+    pub id: egui::Id,
+}
+
+#[derive(Clone, Default)]
+struct BranchEditState {
+    branch_hash: u64,
+    code: String,
+}
+
+impl<'a> egui::Widget for BranchEdit<'a> {
+    fn ui(self, ui: &mut egui::Ui) -> egui::Response {
+        let Self { branch, id } = self;
+        let code_id = id.with("code");
+
+        // Retrieve the working state.
+        let mut state: BranchEditState = ui
+            .memory_mut(|m| m.data.remove_temp(code_id))
+            .unwrap_or_default();
+
+        // If the input hash has changed, reset the working code string.
+        let hash = branch_hash(branch);
+        if hash != state.branch_hash {
+            state.branch_hash = hash;
+            state.code = branch.src().to_string();
+        }
+
+        let language = "scm";
+        let theme = egui_extras::syntax_highlighting::CodeTheme::from_memory(ui.ctx(), ui.style());
+
+        let mut layouter = |ui: &egui::Ui, buf: &dyn egui::TextBuffer, wrap_width: f32| {
+            let mut layout_job = egui_extras::syntax_highlighting::highlight(
+                ui.ctx(),
+                ui.style(),
+                &theme,
+                buf.as_str(),
+                language,
+            );
+            layout_job.wrap.max_width = wrap_width;
+            ui.fonts_mut(|fonts| fonts.layout_job(layout_job))
+        };
+
+        // Find the longest line width.
+        let mut max_line_width: f32 = 0.0;
+        let font_sel = egui::FontSelection::from(egui::TextStyle::Monospace);
+        let font_id = font_sel.resolve(ui.style());
+        ui.fonts_mut(|fonts| {
+            for line in state.code.split('\n').clone() {
+                let galley = fonts.layout_no_wrap(
+                    line.to_string(),
+                    font_id.clone(),
+                    egui::Color32::PLACEHOLDER,
+                );
+                max_line_width = max_line_width.max(galley.rect.width());
+            }
+        });
+        max_line_width += 7.0;
+
+        let response = ui.add(
+            egui::TextEdit::multiline(&mut state.code)
+                .id(id)
+                .code_editor()
+                .font(font_id)
+                .desired_rows(1)
+                .desired_width(max_line_width)
+                .hint_text("(if (= 0 $x) (list 0 '()) (list 1 '()))")
+                .layouter(&mut layouter),
+        );
+        if response.changed() {
+            if let Ok(new_branch) =
+                gantz_core::node::Branch::new(&state.code, branch.branch_conns().to_vec())
+            {
+                *branch = new_branch;
+            }
+        }
+
+        // Persist the WIP editing code.
+        ui.memory_mut(|m| m.data.insert_temp(code_id, state));
+
+        response
+    }
+}
+
+impl NodeUi for gantz_core::node::Branch {
+    fn name(&self, _: &dyn crate::Registry) -> &str {
+        "branch"
+    }
+
+    fn ui(
+        &mut self,
+        ctx: NodeCtx,
+        uictx: egui_graph::NodeCtx,
+    ) -> egui_graph::FramedResponse<egui::Response> {
+        uictx.framed(|ui, _sockets| {
+            let id = egui::Id::new("BranchEdit").with(ctx.path());
+            ui.add(BranchEdit::new(self, id))
+        })
+    }
+
+    fn inspector_rows(&mut self, _ctx: &mut NodeCtx, body: &mut egui_extras::TableBody) {
+        let row_h = crate::widget::node_inspector::table_row_h(body.ui_mut());
+
+        // Outputs count.
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.add(egui::Label::new("outputs").selectable(false))
+                    .on_hover_text("the number of outputs");
+            });
+            row.col(|ui| {
+                let mut n = self.outputs() as i32;
+                if ui
+                    .add(egui::DragValue::new(&mut n).range(1..=16).speed(0.1))
+                    .on_hover_text("the number of outputs")
+                    .changed()
+                {
+                    self.set_outputs(n.clamp(1, 16) as u8);
+                    // Ensure all branches still have at least 2 entries.
+                    ensure_min_branches(self);
+                }
+            });
+        });
+
+        // Branch count.
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.add(egui::Label::new("branches").selectable(false))
+                    .on_hover_text("the number of possible branches");
+            });
+            row.col(|ui| {
+                let mut n = self.n_branches() as i32;
+                if ui
+                    .add(egui::DragValue::new(&mut n).range(1..=16).speed(0.1))
+                    .on_hover_text("the number of possible branches")
+                    .changed()
+                {
+                    resize_branches(self, n.clamp(1, 16) as usize);
+                }
+            });
+        });
+
+        // Checkbox grid: rows = branches, columns = outputs.
+        let outputs = self.outputs() as usize;
+        let n_branches = self.n_branches();
+        let mut branches = self.branch_conns().to_vec();
+        let mut changed = false;
+
+        for branch_ix in 0..n_branches {
+            body.row(row_h, |mut row| {
+                row.col(|ui| {
+                    ui.add(egui::Label::new(format!("branch {branch_ix}")).selectable(false))
+                        .on_hover_ui(|ui| {
+                            ui.label(format!(
+                                "the active outputs for the branch at index {branch_ix}"
+                            ));
+                        });
+                });
+                row.col(|ui| {
+                    ui.horizontal(|ui| {
+                        ui.style_mut().spacing.item_spacing.x *= 0.25;
+                        for out_ix in 0..outputs {
+                            let mut active = branches[branch_ix].get(out_ix).unwrap_or(false);
+                            if ui
+                                .checkbox(&mut active, "")
+                                .on_hover_ui(|ui| {
+                                    ui.label(format!("output {out_ix}"));
+                                })
+                                .changed()
+                            {
+                                branches[branch_ix].set(out_ix, active).ok();
+                                changed = true;
+                            }
+                        }
+                    });
+                });
+            });
+        }
+
+        if changed {
+            self.set_branch_conns(branches);
+        }
+    }
+}
+
+/// Ensure at least 1 branch exists after an output resize.
+fn ensure_min_branches(branch: &mut gantz_core::node::Branch) {
+    if branch.n_branches() < 1 {
+        let out_len = branch.outputs() as usize;
+        let branches =
+            vec![gantz_core::node::Conns::unconnected(out_len).expect("out_len in range")];
+        branch.set_branch_conns(branches);
+    }
+}
+
+/// Resize the branch count, adding unconnected entries or truncating.
+fn resize_branches(branch: &mut gantz_core::node::Branch, new_count: usize) {
+    let out_len = branch.outputs() as usize;
+    let mut branches = branch.branch_conns().to_vec();
+    branches.truncate(new_count);
+    while branches.len() < new_count {
+        branches.push(gantz_core::node::Conns::unconnected(out_len).expect("out_len in range"));
+    }
+    branch.set_branch_conns(branches);
+}
+
+impl<'a> BranchEdit<'a> {
+    pub fn new(branch: &'a mut gantz_core::node::Branch, id: egui::Id) -> Self {
+        Self { branch, id }
+    }
+}
+
+fn branch_hash(branch: &gantz_core::node::Branch) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::default();
+    branch.hash(&mut hasher);
+    hasher.finish()
+}


### PR DESCRIPTION
Add a new Branch node type that extends the Expr pattern with branching support. The expression must return `(list <branch-index> <value(s)>)`, and each branch defines a `Conns` bitmask specifying which outputs are active when selected.

This should serve as a low-level primitive for building nodes with conditional behaviour.