### PR TITLE
feat: emit list bindings for unconditional multi-edge inputs

### DIFF
--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -36,27 +36,6 @@ const STATE: &str = "state";
 /// Binding used for the current branch index.
 const BRANCH_IX: &str = "branch-ix";
 
-/// Whether or not the given node input requires a dedicated binding name.
-///
-/// This is required in the case that the node is within or following a "join"
-/// control flow node, and the input has more than one incoming edge.
-///
-/// Disambiguation only requires generating one extra binding, so we just check
-/// if there's more than one edge and don't worry about checking the flow graph.
-fn node_input_needs_binding(mg: &MetaGraph, n: node::Id, input: usize) -> bool {
-    let mut count = 0;
-    for e_ref in mg.edges_directed(n, petgraph::Incoming) {
-        for (edge, _kind) in e_ref.weight() {
-            let ix = edge.input.0 as usize;
-            count += (ix == input).then_some(1).unwrap_or(0);
-            if count > 1 {
-                return true;
-            }
-        }
-    }
-    false
-}
-
 /// The expression for a call to a node function.
 fn node_fn_call(
     node_path: &[node::Id],
@@ -340,23 +319,6 @@ pub fn entry_fn_name(id: &super::EntrypointId) -> String {
     format!("entry-fn-{}", id.0.display_short())
 }
 
-/// The set of outputs on the given node that require dedicated bindings due to
-/// being connected to an input on a node that has multiple incoming edges.
-fn node_outputs_that_need_bindings(
-    mg: &MetaGraph,
-    n: node::Id,
-) -> BTreeSet<(node::Output, (node::Id, node::Input))> {
-    let mut need_bindings = BTreeSet::default();
-    for e_ref in mg.edges_directed(n, petgraph::Outgoing) {
-        for (edge, _kind) in e_ref.weight() {
-            if node_input_needs_binding(mg, e_ref.target(), edge.input.0 as usize) {
-                need_bindings.insert((edge.output, (e_ref.target(), edge.input)));
-            }
-        }
-    }
-    need_bindings
-}
-
 /// Generate a statement that creates a node input binding for `dst` to the
 /// given `src` node's output.
 fn define_node_input_binding(
@@ -375,113 +337,75 @@ fn define_node_input_binding(
         .unwrap()
 }
 
-/// For the given node's outputs that connect to node inputs that have more than
-/// one incoming edge, create dedicated bindings for those inputs.
+/// For the given target node, create dedicated input bindings for all inputs
+/// that have multiple incoming MetaGraph edges (i.e. `DedicatedBinding` args).
 ///
-/// Excludes any `(target_node, input_index)` pairs in `exclude` - these are
-/// handled elsewhere (e.g. by list bindings for unconditional multi-edge
-/// inputs).
-fn define_necessary_node_input_bindings(
-    g: &MetaGraph,
-    n: node::Id,
-    exclude: &HashSet<(node::Id, usize)>,
-) -> impl Iterator<Item = ExprKind> {
-    node_outputs_that_need_bindings(g, n)
-        .into_iter()
-        .filter(move |(_, (dst_id, dst_input))| !exclude.contains(&(*dst_id, dst_input.0 as usize)))
-        .map(move |(output, dst)| define_node_input_binding((n, output), dst))
-}
-
-/// For each node in the block, collect inputs that have more than one
-/// unconditional incoming edge from other nodes within the same block.
+/// Skips inputs in `active_phi` - those are handled by phi variables at join
+/// points.
 ///
-/// Returns `target_node -> input_ix -> [(source_node, source_output)]`,
-/// ordered by source position in the block (topological order).
-fn collect_block_multi_edge_inputs(
+/// For single-source inputs, emits `(define node-X-iY node-SRC-oZ)`.
+/// For multi-source inputs, emits `(define node-X-iY (list ...))`.
+fn define_target_input_bindings(
     mg: &MetaGraph,
-    block: &Block,
     reachable: &HashSet<node::Id>,
-) -> BTreeMap<node::Id, BTreeMap<usize, Vec<(node::Id, node::Output)>>> {
-    // Build a set of node IDs present in this block for fast lookup,
-    // and a position map for deterministic ordering.
-    let block_ids: HashSet<node::Id> = block.iter().map(|conf| conf.id).collect();
-    let block_pos: HashMap<node::Id, usize> = block
-        .iter()
-        .enumerate()
-        .map(|(i, conf)| (conf.id, i))
-        .collect();
-
-    let mut result: BTreeMap<node::Id, BTreeMap<usize, Vec<(node::Id, node::Output)>>> =
-        BTreeMap::new();
-
-    for conf in block.iter() {
-        let n = conf.id;
-        // For each input index, collect all in-block, reachable sources.
-        let mut input_sources: BTreeMap<usize, Vec<(node::Id, node::Output)>> = BTreeMap::new();
+    in_scope: &HashSet<node::Id>,
+    n: node::Id,
+    conns: &NodeConns,
+    active_phi: &HashSet<(node::Id, usize)>,
+) -> Result<Vec<ExprKind>, CodegenError> {
+    let args = node_fn_call_args(mg, reachable, n, &conns.inputs)?;
+    let mut stmts = Vec::new();
+    for (ix, arg) in args.iter().enumerate() {
+        if !matches!(arg, Some(NodeFnCallArg::DedicatedBinding)) {
+            continue;
+        }
+        if active_phi.contains(&(n, ix)) {
+            continue;
+        }
+        // Collect sources whose outputs are currently in scope.
+        let mut sources: Vec<(node::Id, node::Output)> = Vec::new();
         for e_ref in mg.edges_directed(n, petgraph::Incoming) {
-            let src = e_ref.source();
-            if !block_ids.contains(&src) || !reachable.contains(&src) {
+            if !in_scope.contains(&e_ref.source()) {
                 continue;
             }
             for (edge, _kind) in e_ref.weight() {
-                let input_ix = edge.input.0 as usize;
-                input_sources
-                    .entry(input_ix)
-                    .or_default()
-                    .push((src, edge.output));
+                if edge.input.0 as usize == ix {
+                    sources.push((e_ref.source(), edge.output));
+                }
             }
         }
-        // Keep only inputs with >1 source (true multi-edge).
-        input_sources.retain(|_, sources| sources.len() > 1);
-        // Sort sources by their block position for deterministic ordering.
-        for sources in input_sources.values_mut() {
-            sources.sort_by_key(|(src, _)| block_pos[src]);
-        }
-        if !input_sources.is_empty() {
-            result.insert(n, input_sources);
+        // Sort by node ID for deterministic ordering.
+        sources.sort_by_key(|(src, _)| *src);
+        match sources.len() {
+            0 => {}
+            1 => {
+                let (src, src_out) = sources[0];
+                stmts.push(define_node_input_binding(
+                    (src, src_out),
+                    (n, node::Input(ix as u16)),
+                ));
+            }
+            _ => {
+                let elements: Vec<String> = sources
+                    .iter()
+                    .map(|(src, out)| node_output_var(*src, out.0 as usize))
+                    .collect();
+                let s = format!(
+                    "(define {} (list {}))",
+                    node_input_var(n, ix),
+                    elements.join(" "),
+                );
+                stmts.push(
+                    Engine::emit_ast(&s)
+                        .expect("failed to emit AST")
+                        .into_iter()
+                        .next()
+                        .unwrap(),
+                );
+            }
         }
     }
-    result
-}
-
-/// Generate a `(define node-X-iY (list node-A-oZ node-B-oW ...))` statement
-/// for a multi-edge input.
-fn define_list_input_binding(
-    dst: node::Id,
-    dst_in_ix: usize,
-    sources: &[(node::Id, node::Output)],
-) -> ExprKind {
-    let elements: Vec<String> = sources
-        .iter()
-        .map(|(src, out)| node_output_var(*src, out.0 as usize))
-        .collect();
-    let s = format!(
-        "(define {} (list {}))",
-        node_input_var(dst, dst_in_ix),
-        elements.join(" "),
-    );
-    Engine::emit_ast(&s)
-        .expect("failed to emit AST")
-        .into_iter()
-        .next()
-        .unwrap()
-}
-
-/// Like `define_necessary_node_input_bindings`, but filtered to only the
-/// outputs active in a given branch, excluding any destinations that are
-/// active phi vars (to avoid shadowing outer phi declarations).
-fn define_branch_node_input_bindings(
-    mg: &MetaGraph,
-    n: node::Id,
-    active_outputs: &node::Conns,
-    exclude: &HashSet<(node::Id, usize)>,
-) -> Vec<ExprKind> {
-    node_outputs_that_need_bindings(mg, n)
-        .into_iter()
-        .filter(|(output, _)| active_outputs.get(output.0 as usize).unwrap_or(false))
-        .filter(|(_, (dst_id, dst_input))| !exclude.contains(&(*dst_id, dst_input.0 as usize)))
-        .map(|(output, dst)| define_node_input_binding((n, output), dst))
-        .collect()
+    Ok(stmts)
 }
 
 /// For a join block's first node, find which inputs are `DedicatedBinding`
@@ -566,28 +490,22 @@ pub(crate) fn eval_fn_block_stmts(
     outlets: &BTreeSet<node::Id>,
     reachable: &HashSet<node::Id>,
     block: &Block,
+    in_scope: &mut HashSet<node::Id>,
+    active_phi: &HashSet<(node::Id, usize)>,
 ) -> Result<Vec<ExprKind>, CodegenError> {
-    // Pre-compute unconditional multi-edge inputs within this block.
-    let multi_edge = collect_block_multi_edge_inputs(mg, block, reachable);
-
-    // Build the set of (target, input_ix) pairs handled by list bindings,
-    // so that `define_necessary_node_input_bindings` can skip them.
-    let handled: HashSet<(node::Id, usize)> = multi_edge
-        .iter()
-        .flat_map(|(&dst, inputs)| inputs.keys().map(move |&ix| (dst, ix)))
-        .collect();
-
     let mut stmts = Vec::new();
     let mut iter = block.0.iter().peekable();
     while let Some(conf) = iter.next() {
-        // Before evaluating this node, emit list bindings for any of its
-        // unconditional multi-edge inputs. All sources appear earlier in
-        // the block (topological order), so their output vars are available.
-        if let Some(inputs) = multi_edge.get(&conf.id) {
-            for (&input_ix, sources) in inputs {
-                stmts.push(define_list_input_binding(conf.id, input_ix, sources));
-            }
-        }
+        // Before evaluating this node, create dedicated input bindings for
+        // any inputs with multiple incoming edges (scalar or list).
+        stmts.extend(define_target_input_bindings(
+            mg,
+            reachable,
+            in_scope,
+            conf.id,
+            &conf.conns,
+            active_phi,
+        )?);
 
         let node_path: Vec<_> = path.iter().copied().chain(Some(conf.id)).collect();
         let stateful = stateful.contains(&conf.id);
@@ -606,12 +524,9 @@ pub(crate) fn eval_fn_block_stmts(
             continue;
         }
 
-        // Destructure the node's outputs.
+        // Destructure the node's outputs and mark them as in-scope.
         stmts.extend(destructure_node_outputs_stmt(conf.id, conf.conns.outputs));
-        // For outputs connected to node inputs that have more than one incoming
-        // edge, we create dedicated bindings for those inputs. Skip any that
-        // are already handled by list bindings above.
-        stmts.extend(define_necessary_node_input_bindings(mg, conf.id, &handled));
+        in_scope.insert(conf.id);
     }
     Ok(stmts)
 }
@@ -719,12 +634,15 @@ fn flow_node_stmts(
     fg: &FlowGraph,
     post_dom: &HashMap<NodeIndex, NodeIndex>,
     phi_params: &BTreeMap<NodeIndex, Vec<(usize, String)>>,
+    in_scope: &mut HashSet<node::Id>,
     active_phi: &HashSet<(node::Id, usize)>,
     stop_at: Option<NodeIndex>,
 ) -> Result<Vec<ExprKind>, CodegenError> {
     // Add the block.
     let block = &fg[flow_ix];
-    let mut stmts = eval_fn_block_stmts(path, mg, stateful, inlets, outlets, &reachable, block)?;
+    let mut stmts = eval_fn_block_stmts(
+        path, mg, stateful, inlets, outlets, reachable, block, in_scope, active_phi,
+    )?;
 
     // Collect the output branching edges.
     let mut edges: Vec<_> = fg
@@ -742,6 +660,7 @@ fn flow_node_stmts(
         let (_branch, dst) = edges.pop().unwrap();
         let conf = *block.last().unwrap();
         stmts.extend(destructure_node_outputs_stmt(conf.id, conf.conns.outputs));
+        in_scope.insert(conf.id);
 
         // If the successor is the reconvergence point we're stopping at,
         // emit phi set statements and return.
@@ -753,15 +672,11 @@ fn flow_node_stmts(
             return Ok(stmts);
         }
 
-        // Otherwise continue normally.
-        stmts.extend(define_necessary_node_input_bindings(
-            mg,
-            conf.id,
-            &HashSet::new(),
-        ));
+        // Otherwise continue normally. The next block's
+        // `eval_fn_block_stmts` handles input bindings via before-target.
         stmts.extend(flow_node_stmts(
             path, dst, mg, stateful, inlets, outlets, reachable, fg, post_dom, phi_params,
-            active_phi, stop_at,
+            in_scope, active_phi, stop_at,
         )?);
         return Ok(stmts);
     }
@@ -801,12 +716,6 @@ fn flow_node_stmts(
                 destructure_node_outputs_stmt(conf.id, branch.conns)
                     .into_iter()
                     .collect();
-            branch_stmts.extend(define_branch_node_input_bindings(
-                mg,
-                conf.id,
-                &branch.conns,
-                &inner_phi,
-            ));
 
             if dst == join_ix {
                 // Branch target IS the join - just emit phi sets.
@@ -819,6 +728,11 @@ fn flow_node_stmts(
                 }
             } else {
                 // Recurse with stop_at = join_ix so it stops at the join.
+                // Clone in_scope so this arm doesn't leak its nodes to
+                // sibling arms. Add the branch node since its outputs were
+                // destructured above.
+                let mut arm_scope = in_scope.clone();
+                arm_scope.insert(conf.id);
                 branch_stmts.extend(flow_node_stmts(
                     path,
                     dst,
@@ -830,6 +744,7 @@ fn flow_node_stmts(
                     fg,
                     post_dom,
                     phi_params,
+                    &mut arm_scope,
                     &inner_phi,
                     Some(join_ix),
                 )?);
@@ -856,7 +771,7 @@ fn flow_node_stmts(
         // After the if: generate the join block and everything after it.
         stmts.extend(flow_node_stmts(
             path, join_ix, mg, stateful, inlets, outlets, reachable, fg, post_dom, phi_params,
-            active_phi, stop_at,
+            in_scope, &inner_phi, stop_at,
         )?);
 
         return Ok(stmts);
@@ -865,16 +780,25 @@ fn flow_node_stmts(
     // No reconvergence found - fall back to code duplication.
     let mut expr = "'()".to_string();
     while let Some((branch, dst)) = edges.pop() {
+        // Clone in_scope so each arm is independent. Add the branch node
+        // since its outputs are destructured in each arm below.
+        let mut arm_scope = in_scope.clone();
+        arm_scope.insert(conf.id);
         let dst_stmts = flow_node_stmts(
-            path, dst, mg, stateful, inlets, outlets, reachable, fg, post_dom, phi_params,
-            active_phi, stop_at,
+            path,
+            dst,
+            mg,
+            stateful,
+            inlets,
+            outlets,
+            reachable,
+            fg,
+            post_dom,
+            phi_params,
+            &mut arm_scope,
+            active_phi,
+            stop_at,
         )?;
-        let bindings = define_branch_node_input_bindings(mg, conf.id, &branch.conns, active_phi);
-        let bindings_str = bindings
-            .iter()
-            .map(|e| format!("{e}"))
-            .collect::<Vec<_>>()
-            .join(" ");
         let dst_stmts_str = dst_stmts
             .into_iter()
             .map(|expr| format!("{expr}"))
@@ -883,10 +807,7 @@ fn flow_node_stmts(
         let destructure_str = destructure_node_outputs_stmt(conf.id, branch.conns)
             .map(|e| format!("{e}"))
             .unwrap_or_default();
-        let dst_expr = format!(
-            "(begin {} {} {} '())",
-            destructure_str, bindings_str, dst_stmts_str,
-        );
+        let dst_expr = format!("(begin {} {} '())", destructure_str, dst_stmts_str,);
         expr = format!("(if (= {} {BRANCH_IX}) {dst_expr} {expr})", branch.ix);
     }
 
@@ -931,6 +852,7 @@ pub fn entry_fn_body(
         fg,
         &post_dom,
         &phi_params_map,
+        &mut HashSet::new(),
         &HashSet::new(),
         None,
     )

--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -377,13 +377,94 @@ fn define_node_input_binding(
 
 /// For the given node's outputs that connect to node inputs that have more than
 /// one incoming edge, create dedicated bindings for those inputs.
+///
+/// Excludes any `(target_node, input_index)` pairs in `exclude` - these are
+/// handled elsewhere (e.g. by list bindings for unconditional multi-edge
+/// inputs).
 fn define_necessary_node_input_bindings(
     g: &MetaGraph,
     n: node::Id,
+    exclude: &HashSet<(node::Id, usize)>,
 ) -> impl Iterator<Item = ExprKind> {
     node_outputs_that_need_bindings(g, n)
         .into_iter()
+        .filter(move |(_, (dst_id, dst_input))| !exclude.contains(&(*dst_id, dst_input.0 as usize)))
         .map(move |(output, dst)| define_node_input_binding((n, output), dst))
+}
+
+/// For each node in the block, collect inputs that have more than one
+/// unconditional incoming edge from other nodes within the same block.
+///
+/// Returns `target_node -> input_ix -> [(source_node, source_output)]`,
+/// ordered by source position in the block (topological order).
+fn collect_block_multi_edge_inputs(
+    mg: &MetaGraph,
+    block: &Block,
+    reachable: &HashSet<node::Id>,
+) -> BTreeMap<node::Id, BTreeMap<usize, Vec<(node::Id, node::Output)>>> {
+    // Build a set of node IDs present in this block for fast lookup,
+    // and a position map for deterministic ordering.
+    let block_ids: HashSet<node::Id> = block.iter().map(|conf| conf.id).collect();
+    let block_pos: HashMap<node::Id, usize> = block
+        .iter()
+        .enumerate()
+        .map(|(i, conf)| (conf.id, i))
+        .collect();
+
+    let mut result: BTreeMap<node::Id, BTreeMap<usize, Vec<(node::Id, node::Output)>>> =
+        BTreeMap::new();
+
+    for conf in block.iter() {
+        let n = conf.id;
+        // For each input index, collect all in-block, reachable sources.
+        let mut input_sources: BTreeMap<usize, Vec<(node::Id, node::Output)>> = BTreeMap::new();
+        for e_ref in mg.edges_directed(n, petgraph::Incoming) {
+            let src = e_ref.source();
+            if !block_ids.contains(&src) || !reachable.contains(&src) {
+                continue;
+            }
+            for (edge, _kind) in e_ref.weight() {
+                let input_ix = edge.input.0 as usize;
+                input_sources
+                    .entry(input_ix)
+                    .or_default()
+                    .push((src, edge.output));
+            }
+        }
+        // Keep only inputs with >1 source (true multi-edge).
+        input_sources.retain(|_, sources| sources.len() > 1);
+        // Sort sources by their block position for deterministic ordering.
+        for sources in input_sources.values_mut() {
+            sources.sort_by_key(|(src, _)| block_pos[src]);
+        }
+        if !input_sources.is_empty() {
+            result.insert(n, input_sources);
+        }
+    }
+    result
+}
+
+/// Generate a `(define node-X-iY (list node-A-oZ node-B-oW ...))` statement
+/// for a multi-edge input.
+fn define_list_input_binding(
+    dst: node::Id,
+    dst_in_ix: usize,
+    sources: &[(node::Id, node::Output)],
+) -> ExprKind {
+    let elements: Vec<String> = sources
+        .iter()
+        .map(|(src, out)| node_output_var(*src, out.0 as usize))
+        .collect();
+    let s = format!(
+        "(define {} (list {}))",
+        node_input_var(dst, dst_in_ix),
+        elements.join(" "),
+    );
+    Engine::emit_ast(&s)
+        .expect("failed to emit AST")
+        .into_iter()
+        .next()
+        .unwrap()
 }
 
 /// Like `define_necessary_node_input_bindings`, but filtered to only the
@@ -486,9 +567,28 @@ pub(crate) fn eval_fn_block_stmts(
     reachable: &HashSet<node::Id>,
     block: &Block,
 ) -> Result<Vec<ExprKind>, CodegenError> {
+    // Pre-compute unconditional multi-edge inputs within this block.
+    let multi_edge = collect_block_multi_edge_inputs(mg, block, reachable);
+
+    // Build the set of (target, input_ix) pairs handled by list bindings,
+    // so that `define_necessary_node_input_bindings` can skip them.
+    let handled: HashSet<(node::Id, usize)> = multi_edge
+        .iter()
+        .flat_map(|(&dst, inputs)| inputs.keys().map(move |&ix| (dst, ix)))
+        .collect();
+
     let mut stmts = Vec::new();
     let mut iter = block.0.iter().peekable();
     while let Some(conf) = iter.next() {
+        // Before evaluating this node, emit list bindings for any of its
+        // unconditional multi-edge inputs. All sources appear earlier in
+        // the block (topological order), so their output vars are available.
+        if let Some(inputs) = multi_edge.get(&conf.id) {
+            for (&input_ix, sources) in inputs {
+                stmts.push(define_list_input_binding(conf.id, input_ix, sources));
+            }
+        }
+
         let node_path: Vec<_> = path.iter().copied().chain(Some(conf.id)).collect();
         let stateful = stateful.contains(&conf.id);
         let NodeConns { inputs, outputs } = conf.conns;
@@ -509,8 +609,9 @@ pub(crate) fn eval_fn_block_stmts(
         // Destructure the node's outputs.
         stmts.extend(destructure_node_outputs_stmt(conf.id, conf.conns.outputs));
         // For outputs connected to node inputs that have more than one incoming
-        // edge, we create dedicated bindings for those inputs.
-        stmts.extend(define_necessary_node_input_bindings(mg, conf.id));
+        // edge, we create dedicated bindings for those inputs. Skip any that
+        // are already handled by list bindings above.
+        stmts.extend(define_necessary_node_input_bindings(mg, conf.id, &handled));
     }
     Ok(stmts)
 }
@@ -653,7 +754,11 @@ fn flow_node_stmts(
         }
 
         // Otherwise continue normally.
-        stmts.extend(define_necessary_node_input_bindings(mg, conf.id));
+        stmts.extend(define_necessary_node_input_bindings(
+            mg,
+            conf.id,
+            &HashSet::new(),
+        ));
         stmts.extend(flow_node_stmts(
             path, dst, mg, stateful, inlets, outlets, reachable, fg, post_dom, phi_params,
             active_phi, stop_at,

--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -446,17 +446,29 @@ fn declare_phi_vars(phi_params: &[(usize, String)]) -> Vec<ExprKind> {
 
 /// Generate `(set! name value)` statements to assign phi variables from a
 /// predecessor node's outputs.
+///
+/// When `active_outputs` is `Some`, only edges whose output index is active
+/// in the given conns are considered. This is needed when the predecessor is
+/// a branch node with multiple outputs feeding the same target input - each
+/// arm must reference only its own active output.
 fn phi_set_stmts(
     mg: &MetaGraph,
     pred_last_node: node::Id,
     join_node_id: node::Id,
     phi_params: &[(usize, String)],
+    active_outputs: Option<node::Conns>,
 ) -> Vec<ExprKind> {
-    // Collect all edges from the predecessor to the join node.
+    // Collect edges from the predecessor to the join node, optionally
+    // filtered to the branch arm's active outputs.
     let edges: Vec<_> = mg
         .edges_directed(join_node_id, petgraph::Incoming)
         .filter(|e| e.source() == pred_last_node)
         .flat_map(|e| e.weight().clone())
+        .filter(|(edge, _kind)| {
+            active_outputs.map_or(true, |conns| {
+                conns.get(edge.output.0 as usize).unwrap_or(false)
+            })
+        })
         .collect();
     phi_params
         .iter()
@@ -667,7 +679,7 @@ fn flow_node_stmts(
         if stop_at == Some(dst) {
             let join_first_id = fg[dst].first().expect("join block must not be empty").id;
             if let Some(params) = phi_params.get(&dst) {
-                stmts.extend(phi_set_stmts(mg, conf.id, join_first_id, params));
+                stmts.extend(phi_set_stmts(mg, conf.id, join_first_id, params, None));
             }
             return Ok(stmts);
         }
@@ -724,7 +736,13 @@ fn flow_node_stmts(
                     .expect("join block must not be empty")
                     .id;
                 if let Some(params) = phi_params.get(&join_ix) {
-                    branch_stmts.extend(phi_set_stmts(mg, conf.id, join_first_id, params));
+                    branch_stmts.extend(phi_set_stmts(
+                        mg,
+                        conf.id,
+                        join_first_id,
+                        params,
+                        Some(branch.conns),
+                    ));
                 }
             } else {
                 // Recurse with stop_at = join_ix so it stops at the join.

--- a/crates/gantz_core/src/compile/flow.rs
+++ b/crates/gantz_core/src/compile/flow.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::node;
 use petgraph::visit::{EdgeRef, IntoEdgeReferences};
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fmt, ops,
 };
 
@@ -67,14 +67,52 @@ pub struct Branch {
     pub conns: node::Conns,
 }
 
-/// A control flow graph describing indifidual node function call dependency.
+/// A control flow graph describing individual node function call dependency.
 ///
 /// Each `NodeConf` node represents a node function call statement that should
 /// be made.
 ///
 /// This is derived from the `Meta` graph and is used to construct the
 /// `FlowGraph` via edge contraction.
-pub type NodeConfGraph = petgraph::graphmap::DiGraphMap<NodeConf, Branch>;
+///
+/// Uses a simple edge list rather than `DiGraphMap` because `DiGraphMap` only
+/// supports one edge per (source, target) pair. When multiple branch outputs
+/// feed the same target `NodeConf`, all branch edges must be preserved.
+struct NodeConfGraph {
+    nodes: BTreeSet<NodeConf>,
+    edges: BTreeSet<(NodeConf, NodeConf, Branch)>,
+}
+
+impl NodeConfGraph {
+    fn new() -> Self {
+        Self {
+            nodes: BTreeSet::new(),
+            edges: BTreeSet::new(),
+        }
+    }
+
+    fn add_node(&mut self, conf: NodeConf) {
+        self.nodes.insert(conf);
+    }
+
+    fn add_edge(&mut self, a: NodeConf, b: NodeConf, branch: Branch) {
+        self.nodes.insert(a);
+        self.nodes.insert(b);
+        self.edges.insert((a, b, branch));
+    }
+
+    fn all_edges(&self) -> impl Iterator<Item = (NodeConf, NodeConf, &Branch)> {
+        self.edges.iter().map(|(a, b, w)| (*a, *b, w))
+    }
+
+    fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    fn edge_count(&self) -> usize {
+        self.edges.len()
+    }
+}
 
 /// A node within the control flow graph.
 ///
@@ -228,7 +266,9 @@ fn flow_graph_edge_contraction(g: &mut FlowGraph) {
     // Maintain a stack of all edges that require reducing.
     let mut edges: Vec<_> = g.edge_references().map(|e_ref| e_ref.id()).collect();
     while let Some(e) = edges.pop() {
-        let (src, dst) = g.edge_endpoints(e).unwrap();
+        let Some((src, dst)) = g.edge_endpoints(e) else {
+            continue; // Edge was removed when its node was merged.
+        };
 
         // Check whether or not this is the only edge between src and dst.
         let mergeable = g.edges_directed(src, petgraph::Outgoing).take(2).count() == 1
@@ -363,7 +403,9 @@ fn node_conf_graph(
                 // block with all connected outputs in the config, then the
                 // *edges* should have the branch subsets.
                 let sub_ncg = node_conf_graph(meta, &sub_mg, Some((conns, branch)))?;
-                g.extend(sub_ncg.all_edges().map(|(a, b, &w)| (a, b, w)));
+                for (a, b, &w) in sub_ncg.all_edges() {
+                    g.add_edge(a, b, w);
+                }
             }
 
             // We've handled the branches in the recursive cases - we're done.

--- a/crates/gantz_core/src/node.rs
+++ b/crates/gantz_core/src/node.rs
@@ -78,6 +78,11 @@ pub trait Node: std::any::Any {
     /// [`Node::n_inputs`] immediately prior. Inputs are `Some` in the case that
     /// they are connected, and `None` otherwise.
     ///
+    /// At runtime, each connected input binding holds a single value when
+    /// exactly one edge targets that input index. When multiple unconditional
+    /// edges target the same input index, the binding holds a `(list ...)` of
+    /// all incoming values in topological source order.
+    ///
     /// If [`Node::n_outputs`] is 1, the expr should result in a single value.
     ///
     /// If [`Node::n_outputs`] is > 1, the expr should result in a list of values.
@@ -228,7 +233,9 @@ pub struct ExprCtx<'env, 'data> {
     /// An element for each input to the node.
     ///
     /// If the input is connected, it is `Some(name)` where `name` is a binding
-    /// to the incoming value.
+    /// to the incoming value. When multiple unconditional edges target the same
+    /// input index, the binding holds a `(list ...)` of all incoming values
+    /// rather than a single value.
     inputs: &'data [Option<String>],
     /// An element for each output from the node.
     ///
@@ -340,7 +347,9 @@ impl<'env, 'data> ExprCtx<'env, 'data> {
     /// An element for each input to the node.
     ///
     /// If the input is connected, it is `Some(name)` where `name` is a binding
-    /// to the incoming value.
+    /// to the incoming value. When multiple unconditional edges target the same
+    /// input index, the binding holds a `(list ...)` of all incoming values
+    /// rather than a single value.
     pub fn inputs(&self) -> &'data [Option<String>] {
         self.inputs
     }

--- a/crates/gantz_core/tests/graph.rs
+++ b/crates/gantz_core/tests/graph.rs
@@ -1156,3 +1156,80 @@ fn test_graph_branch_node() {
         .expect("was None");
     assert_eq!(val, 7);
 }
+
+// Test that multiple unconditional edges to the same input produce a list.
+//
+//    --------
+//    | push |
+//    -+------
+//     |
+//     |----------
+//     |         |
+//    -+------- -+------
+//    | three | | four |
+//    -+------- -+------
+//     |         |
+//     |---------- (both connect to sum.i0)
+//     |
+//    -+-------
+//    |  sum  |  expr: (apply + $x) - sums all list elements
+//    -+-------
+//     |
+//    -+-------
+//    | store |
+//    ---------
+//
+// Both `three` and `four` connect unconditionally to `sum`'s single input.
+// With multi-edge list bindings, `sum` receives `(list 3 4)` and
+// `(apply + (list 3 4))` = 7.
+#[test]
+fn test_graph_multi_edge_input_list() {
+    let mut g = petgraph::graph::DiGraph::new();
+
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let three = g.add_node(Box::new(node_int(3)) as Box<_>);
+    let four = g.add_node(Box::new(node_int(4)) as Box<_>);
+    // Sum all elements in the input list.
+    let sum = g.add_node(Box::new(node::expr("(apply + $x)").unwrap()) as Box<_>);
+    let store = g.add_node(Box::new(node_number()) as Box<_>);
+
+    g.add_edge(push, three, Edge::from((0, 0)));
+    g.add_edge(push, four, Edge::from((0, 0)));
+    // Both connect to sum's input 0.
+    g.add_edge(three, sum, Edge::from((0, 0)));
+    g.add_edge(four, sum, Edge::from((0, 0)));
+    g.add_edge(sum, store, Edge::from((0, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let eps = default_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+
+    // Verify the generated code contains a list binding.
+    let module_str = module
+        .iter()
+        .map(|e| format!("{e}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        module_str.contains("(list"),
+        "expected a (list ...) binding for multi-edge input\n{module_str}",
+    );
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+
+    for f in &module {
+        vm.run(format!("{f}")).unwrap();
+    }
+
+    let ep = entrypoint::push(vec![push.index()], g[push].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep.id()), vec![])
+        .unwrap();
+
+    let val = node::state::extract::<u32>(&vm, &[store.index()])
+        .expect("failed to extract")
+        .expect("was None");
+    // 3 + 4 = 7 (not just 4 from last-write-wins).
+    assert_eq!(val, 7);
+}

--- a/crates/gantz_core/tests/graph.rs
+++ b/crates/gantz_core/tests/graph.rs
@@ -1233,3 +1233,271 @@ fn test_graph_multi_edge_input_list() {
     // 3 + 4 = 7 (not just 4 from last-write-wins).
     assert_eq!(val, 7);
 }
+
+/// Test branching to independent terminal nodes (no reconvergence).
+///
+/// Exercises the code-duplication fallback in `flow_node_stmts` directly,
+/// with `in_scope` cloned per arm and no join or phi variables.
+///
+///   push_0 (emits 0) ---\              /--- store_a (stateful leaf)
+///                         select -----<
+///   push_1 (emits 1) ---/              \--- store_b (stateful leaf)
+#[test]
+fn test_graph_branch_divergent_terminal() {
+    #[derive(Debug)]
+    struct Select;
+
+    impl Node for Select {
+        fn n_inputs(&self, _ctx: node::MetaCtx) -> usize {
+            1
+        }
+        fn n_outputs(&self, _ctx: node::MetaCtx) -> usize {
+            2
+        }
+        fn branches(&self, _ctx: node::MetaCtx) -> Vec<node::EvalConf> {
+            vec![
+                node::EvalConf::Set([true, false].try_into().unwrap()),
+                node::EvalConf::Set([false, true].try_into().unwrap()),
+            ]
+        }
+        fn expr(&self, ctx: node::ExprCtx<'_, '_>) -> node::ExprResult {
+            let x = ctx.inputs()[0].as_deref().expect("must have one input");
+            node::parse_expr(&format!(
+                "(if (equal? 0 {x}) (list 0 42) (list 1 99))"
+            ))
+        }
+    }
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let push_0 = g.add_node(Box::new(node_int(0).with_push_eval()) as Box<dyn DebugNode>);
+    let push_1 = g.add_node(Box::new(node_int(1).with_push_eval()) as Box<_>);
+    let select = g.add_node(Box::new(Select) as Box<_>);
+    let store_a = g.add_node(Box::new(node_number()) as Box<_>);
+    let store_b = g.add_node(Box::new(node_number()) as Box<_>);
+
+    g.add_edge(push_0, select, Edge::from((0, 0)));
+    g.add_edge(push_1, select, Edge::from((0, 0)));
+    g.add_edge(select, store_a, Edge::from((0, 0)));
+    g.add_edge(select, store_b, Edge::from((1, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let eps = default_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    for f in &module {
+        vm.run(format!("{f}")).unwrap();
+    }
+
+    // Push 0 -> arm 0 -> store_a receives 42.
+    let ep_0 = entrypoint::push(vec![push_0.index()], g[push_0].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_0.id()), vec![])
+        .unwrap();
+    let val_a = node::state::extract::<u32>(&vm, &[store_a.index()])
+        .expect("failed to extract")
+        .expect("store_a was None");
+    assert_eq!(val_a, 42);
+    // store_b should be untouched (still void/initial).
+    let val_b = node::state::extract::<u32>(&vm, &[store_b.index()]).ok().flatten();
+    assert!(val_b.is_none(), "store_b should not have been evaluated");
+
+    // Push 1 -> arm 1 -> store_b receives 99, store_a unchanged.
+    let ep_1 = entrypoint::push(vec![push_1.index()], g[push_1].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_1.id()), vec![])
+        .unwrap();
+    let val_a = node::state::extract::<u32>(&vm, &[store_a.index()])
+        .expect("failed to extract")
+        .expect("store_a was None");
+    assert_eq!(val_a, 42, "store_a should be unchanged");
+    let val_b = node::state::extract::<u32>(&vm, &[store_b.index()])
+        .expect("failed to extract")
+        .expect("store_b was None");
+    assert_eq!(val_b, 99);
+}
+
+/// Test multi-edge list binding within a branch arm.
+///
+/// Inside arm 0, two nodes (`three` and `four`) both feed `sum`'s single
+/// input, which should produce a `(list ...)` binding using only in-scope
+/// sources. Arm 1 takes a separate path through `eight`.
+///
+///   push_0 ---\              /--arm0--> three \
+///               select -----<            four  +--> sum --\
+///   push_1 ---/              \--arm1--> eight ------------ number
+#[test]
+fn test_graph_multi_edge_in_branch_arm() {
+    #[derive(Debug)]
+    struct Select;
+
+    impl Node for Select {
+        fn n_inputs(&self, _ctx: node::MetaCtx) -> usize {
+            1
+        }
+        fn n_outputs(&self, _ctx: node::MetaCtx) -> usize {
+            2
+        }
+        fn branches(&self, _ctx: node::MetaCtx) -> Vec<node::EvalConf> {
+            vec![
+                node::EvalConf::Set([true, false].try_into().unwrap()),
+                node::EvalConf::Set([false, true].try_into().unwrap()),
+            ]
+        }
+        fn expr(&self, ctx: node::ExprCtx<'_, '_>) -> node::ExprResult {
+            let x = ctx.inputs()[0].as_deref().expect("must have one input");
+            node::parse_expr(&format!(
+                "(if (equal? 0 {x}) (list 0 '() '()) (list 1 '() '()))"
+            ))
+        }
+    }
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let push_0 = g.add_node(Box::new(node_int(0).with_push_eval()) as Box<dyn DebugNode>);
+    let push_1 = g.add_node(Box::new(node_int(1).with_push_eval()) as Box<_>);
+    let select = g.add_node(Box::new(Select) as Box<_>);
+    let three = g.add_node(Box::new(node_int(3)) as Box<_>);
+    let four = g.add_node(Box::new(node_int(4)) as Box<_>);
+    let sum = g.add_node(Box::new(node::expr("(apply + $x)").unwrap()) as Box<_>);
+    let eight = g.add_node(Box::new(node_int(8)) as Box<_>);
+    let number = g.add_node(Box::new(node_number()) as Box<_>);
+
+    g.add_edge(push_0, select, Edge::from((0, 0)));
+    g.add_edge(push_1, select, Edge::from((0, 0)));
+    // Arm 0: select output 0 fans out to three and four.
+    g.add_edge(select, three, Edge::from((0, 0)));
+    g.add_edge(select, four, Edge::from((0, 0)));
+    // Both feed sum's input 0 (multi-edge list within the arm).
+    g.add_edge(three, sum, Edge::from((0, 0)));
+    g.add_edge(four, sum, Edge::from((0, 0)));
+    // Arm 1: select output 1 to eight.
+    g.add_edge(select, eight, Edge::from((1, 0)));
+    // Both arms converge at number.
+    g.add_edge(sum, number, Edge::from((0, 0)));
+    g.add_edge(eight, number, Edge::from((0, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let eps = default_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    for f in &module {
+        vm.run(format!("{f}")).unwrap();
+    }
+
+    // Push 0 -> arm 0 -> sum receives (list 3 4) -> (apply + ...) = 7 -> number stores 7.
+    let ep_0 = entrypoint::push(vec![push_0.index()], g[push_0].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_0.id()), vec![])
+        .unwrap();
+    let val = node::state::extract::<u32>(&vm, &[number.index()])
+        .expect("failed to extract")
+        .expect("was None");
+    assert_eq!(val, 7);
+
+    // Push 1 -> arm 1 -> eight = 8 -> number stores 8.
+    let ep_1 = entrypoint::push(vec![push_1.index()], g[push_1].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_1.id()), vec![])
+        .unwrap();
+    let val = node::state::extract::<u32>(&vm, &[number.index()])
+        .expect("failed to extract")
+        .expect("was None");
+    assert_eq!(val, 8);
+}
+
+/// Test a three-way branch with reconvergence.
+///
+/// All existing branch tests use binary (2-arm) branches. This exercises
+/// the generality of the branch loop and phi handling with 3 arms.
+///
+///   push_0 ---\                 /--arm0--> six   \
+///   push_1 ----+-- select3 ---<---arm1--> seven  +--> number
+///   push_2 ---/                 \--arm2--> eight /
+#[test]
+fn test_graph_three_way_branch() {
+    #[derive(Debug)]
+    struct Select3;
+
+    impl Node for Select3 {
+        fn n_inputs(&self, _ctx: node::MetaCtx) -> usize {
+            1
+        }
+        fn n_outputs(&self, _ctx: node::MetaCtx) -> usize {
+            3
+        }
+        fn branches(&self, _ctx: node::MetaCtx) -> Vec<node::EvalConf> {
+            vec![
+                node::EvalConf::Set([true, false, false].try_into().unwrap()),
+                node::EvalConf::Set([false, true, false].try_into().unwrap()),
+                node::EvalConf::Set([false, false, true].try_into().unwrap()),
+            ]
+        }
+        fn expr(&self, ctx: node::ExprCtx<'_, '_>) -> node::ExprResult {
+            let x = ctx.inputs()[0].as_deref().expect("must have one input");
+            node::parse_expr(&format!(
+                "(if (equal? 0 {x}) (list 0 '() '() '()) \
+                   (if (equal? 1 {x}) (list 1 '() '() '()) \
+                     (list 2 '() '() '())))"
+            ))
+        }
+    }
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let push_0 = g.add_node(Box::new(node_int(0).with_push_eval()) as Box<dyn DebugNode>);
+    let push_1 = g.add_node(Box::new(node_int(1).with_push_eval()) as Box<_>);
+    let push_2 = g.add_node(Box::new(node_int(2).with_push_eval()) as Box<_>);
+    let select = g.add_node(Box::new(Select3) as Box<_>);
+    let six = g.add_node(Box::new(node_int(6)) as Box<_>);
+    let seven = g.add_node(Box::new(node_int(7)) as Box<_>);
+    let eight = g.add_node(Box::new(node_int(8)) as Box<_>);
+    let number = g.add_node(Box::new(node_number()) as Box<_>);
+
+    g.add_edge(push_0, select, Edge::from((0, 0)));
+    g.add_edge(push_1, select, Edge::from((0, 0)));
+    g.add_edge(push_2, select, Edge::from((0, 0)));
+    g.add_edge(select, six, Edge::from((0, 0)));
+    g.add_edge(select, seven, Edge::from((1, 0)));
+    g.add_edge(select, eight, Edge::from((2, 0)));
+    g.add_edge(six, number, Edge::from((0, 0)));
+    g.add_edge(seven, number, Edge::from((0, 0)));
+    g.add_edge(eight, number, Edge::from((0, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let eps = default_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    for f in &module {
+        vm.run(format!("{f}")).unwrap();
+    }
+
+    // Push 0 -> arm 0 -> six -> number stores 6.
+    let ep_0 = entrypoint::push(vec![push_0.index()], g[push_0].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_0.id()), vec![])
+        .unwrap();
+    let val = node::state::extract::<u32>(&vm, &[number.index()])
+        .expect("failed to extract")
+        .expect("was None");
+    assert_eq!(val, 6);
+
+    // Push 1 -> arm 1 -> seven -> number stores 7.
+    let ep_1 = entrypoint::push(vec![push_1.index()], g[push_1].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_1.id()), vec![])
+        .unwrap();
+    let val = node::state::extract::<u32>(&vm, &[number.index()])
+        .expect("failed to extract")
+        .expect("was None");
+    assert_eq!(val, 7);
+
+    // Push 2 -> arm 2 -> eight -> number stores 8.
+    let ep_2 = entrypoint::push(vec![push_2.index()], g[push_2].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_2.id()), vec![])
+        .unwrap();
+    let val = node::state::extract::<u32>(&vm, &[number.index()])
+        .expect("failed to extract")
+        .expect("was None");
+    assert_eq!(val, 8);
+}

--- a/crates/gantz_core/tests/graph.rs
+++ b/crates/gantz_core/tests/graph.rs
@@ -468,6 +468,78 @@ fn test_graph_branch_target_is_join() {
     );
 }
 
+/// Both branch outputs feed the same target input - phi_set_stmts must
+/// reference the correct output variable for each arm.
+///
+///   push_0 --\          /-- output 0 --\
+///              select --<               number
+///   push_1 --/          \-- output 1 --/
+#[test]
+fn test_graph_branch_both_outputs_same_target() {
+    #[derive(Debug)]
+    struct Select;
+
+    impl Node for Select {
+        fn n_inputs(&self, _ctx: node::MetaCtx) -> usize {
+            1
+        }
+        fn n_outputs(&self, _ctx: node::MetaCtx) -> usize {
+            2
+        }
+        fn branches(&self, _ctx: node::MetaCtx) -> Vec<node::EvalConf> {
+            vec![
+                node::EvalConf::Set([true, false].try_into().unwrap()),
+                node::EvalConf::Set([false, true].try_into().unwrap()),
+            ]
+        }
+        fn expr(&self, ctx: node::ExprCtx<'_, '_>) -> node::ExprResult {
+            let x = ctx.inputs()[0].as_deref().expect("must have one input");
+            node::parse_expr(&format!("(if (equal? 0 {x}) (list 0 42) (list 1 99))"))
+        }
+    }
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let push_0 = g.add_node(Box::new(node_int(0).with_push_eval()) as Box<dyn DebugNode>);
+    let push_1 = g.add_node(Box::new(node_int(1).with_push_eval()) as Box<_>);
+    let select = g.add_node(Box::new(Select) as Box<_>);
+    let number = g.add_node(Box::new(node_number()) as Box<_>);
+
+    g.add_edge(push_0, select, Edge::from((0, 0)));
+    g.add_edge(push_1, select, Edge::from((0, 0)));
+    // Both branch outputs go to number's single input.
+    g.add_edge(select, number, Edge::from((0, 0)));
+    g.add_edge(select, number, Edge::from((1, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let eps = default_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    for f in &module {
+        vm.run(format!("{f}")).unwrap();
+    }
+
+    // Push 0 -> arm 0 -> number receives 42.
+    let ep_0 = entrypoint::push(vec![push_0.index()], g[push_0].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_0.id()), vec![])
+        .unwrap();
+    let val = node::state::extract::<u32>(&vm, &[number.index()])
+        .expect("failed to extract")
+        .expect("number was None");
+    assert_eq!(val, 42);
+
+    // Push 1 -> arm 1 -> number receives 99.
+    let ep_1 = entrypoint::push(vec![push_1.index()], g[push_1].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_1.id()), vec![])
+        .unwrap();
+    let val = node::state::extract::<u32>(&vm, &[number.index()])
+        .expect("failed to extract")
+        .expect("number was None");
+    assert_eq!(val, 99);
+}
+
 // Nested diamond: outer branch contains an inner branch, both with
 // distinct reconvergence points.
 //
@@ -1262,9 +1334,7 @@ fn test_graph_branch_divergent_terminal() {
         }
         fn expr(&self, ctx: node::ExprCtx<'_, '_>) -> node::ExprResult {
             let x = ctx.inputs()[0].as_deref().expect("must have one input");
-            node::parse_expr(&format!(
-                "(if (equal? 0 {x}) (list 0 42) (list 1 99))"
-            ))
+            node::parse_expr(&format!("(if (equal? 0 {x}) (list 0 42) (list 1 99))"))
         }
     }
 
@@ -1300,7 +1370,9 @@ fn test_graph_branch_divergent_terminal() {
         .expect("store_a was None");
     assert_eq!(val_a, 42);
     // store_b should be untouched (still void/initial).
-    let val_b = node::state::extract::<u32>(&vm, &[store_b.index()]).ok().flatten();
+    let val_b = node::state::extract::<u32>(&vm, &[store_b.index()])
+        .ok()
+        .flatten();
     assert!(val_b.is_none(), "store_b should not have been evaluated");
 
     // Push 1 -> arm 1 -> store_b receives 99, store_a unchanged.


### PR DESCRIPTION
## Summary

In the case that multiple active edges are connected to a single input, all values will now be provided to the node's input in the form of a list value.

The list order is undefined, so users should construct a list manually if they want to specify a particular order in which each of the edge values appear in the list.

- Unify the five separate input-binding codegen paths into a single `define_target_input_bindings` function that classifies each input as `DirectRef` (single source, no binding needed) or `DedicatedBinding` (let-bound, supports multi-edge list aggregation and phi variables).
- Track `in_scope: HashSet<node::Id>` through codegen so branch arms only reference outputs produced within their own arm, preventing cross-arm variable leaks in lattice/diamond graphs.
- Emit `(list ...)` bindings for unconditional multi-edge inputs, aggregating all static edges into a single list value at the target.
- Add three edge-case tests: divergent terminal branches (no join), multi-edge list binding within a branch arm, and three-way branches.