### PR TITLE
feat: Add `$?var` syntax for optional inputs in `Expr` and `Branch` nodes. Fix terminating branch behaviour.

### DIFF
--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -640,6 +640,7 @@ fn flow_node_stmts(
     flow_ix: NodeIndex,
     mg: &MetaGraph,
     stateful: &BTreeSet<node::Id>,
+    branching: &BTreeMap<node::Id, usize>,
     inlets: &BTreeSet<node::Id>,
     outlets: &BTreeSet<node::Id>,
     reachable: &HashSet<node::Id>,
@@ -668,7 +669,7 @@ fn flow_node_stmts(
         return Ok(stmts);
 
     // Single successor: either a linear continuation or leads to a join.
-    } else if edges.len() == 1 {
+    } else if edges.len() == 1 && !branching.contains_key(&block.last().unwrap().id) {
         let (_branch, dst) = edges.pop().unwrap();
         let conf = *block.last().unwrap();
         stmts.extend(destructure_node_outputs_stmt(conf.id, conf.conns.outputs));
@@ -687,8 +688,8 @@ fn flow_node_stmts(
         // Otherwise continue normally. The next block's
         // `eval_fn_block_stmts` handles input bindings via before-target.
         stmts.extend(flow_node_stmts(
-            path, dst, mg, stateful, inlets, outlets, reachable, fg, post_dom, phi_params,
-            in_scope, active_phi, stop_at,
+            path, dst, mg, stateful, branching, inlets, outlets, reachable, fg, post_dom,
+            phi_params, in_scope, active_phi, stop_at,
         )?);
         return Ok(stmts);
     }
@@ -699,10 +700,18 @@ fn flow_node_stmts(
 
     // Post-dominator gives the reconvergence point directly.
     // Skip if it equals stop_at (handled by outer level).
+    // Also skip if this branching node has dead branches (fewer edges than
+    // branches) - the join block must not run unconditionally when some
+    // branches terminate evaluation.
     let reconvergence = post_dom
         .get(&flow_ix)
         .copied()
-        .filter(|&r| stop_at != Some(r));
+        .filter(|&r| stop_at != Some(r))
+        .filter(|_| {
+            branching
+                .get(&conf.id)
+                .map_or(true, |&n_branches| edges.len() >= n_branches)
+        });
 
     if let Some(join_ix) = reconvergence {
         // Declare phi variable placeholders for the join's inputs.
@@ -756,6 +765,7 @@ fn flow_node_stmts(
                     dst,
                     mg,
                     stateful,
+                    branching,
                     inlets,
                     outlets,
                     reachable,
@@ -788,8 +798,8 @@ fn flow_node_stmts(
 
         // After the if: generate the join block and everything after it.
         stmts.extend(flow_node_stmts(
-            path, join_ix, mg, stateful, inlets, outlets, reachable, fg, post_dom, phi_params,
-            in_scope, &inner_phi, stop_at,
+            path, join_ix, mg, stateful, branching, inlets, outlets, reachable, fg, post_dom,
+            phi_params, in_scope, &inner_phi, stop_at,
         )?);
 
         return Ok(stmts);
@@ -807,6 +817,7 @@ fn flow_node_stmts(
             dst,
             mg,
             stateful,
+            branching,
             inlets,
             outlets,
             reachable,
@@ -845,6 +856,7 @@ pub fn entry_fn_body(
     path: &[node::Id],
     mg: &MetaGraph,
     stateful: &BTreeSet<node::Id>,
+    branching: &BTreeMap<node::Id, usize>,
     inlets: &BTreeSet<node::Id>,
     outlets: &BTreeSet<node::Id>,
     fg: &FlowGraph,
@@ -864,6 +876,7 @@ pub fn entry_fn_body(
         entry.id(),
         mg,
         stateful,
+        branching,
         inlets,
         outlets,
         &reachable,
@@ -885,6 +898,7 @@ pub(crate) fn eval_stmts_from_flow(
     path: &[node::Id],
     mg: &MetaGraph,
     stateful: &BTreeSet<node::Id>,
+    branching: &BTreeMap<node::Id, usize>,
     inlets: &BTreeSet<node::Id>,
     outlets: &BTreeSet<node::Id>,
     flow: &Flow,
@@ -892,7 +906,7 @@ pub(crate) fn eval_stmts_from_flow(
     flow.entrypoints
         .iter()
         .map(|(id, fg)| {
-            let stmts = entry_fn_body(path, mg, stateful, inlets, outlets, fg)?;
+            let stmts = entry_fn_body(path, mg, stateful, branching, inlets, outlets, fg)?;
             Ok((id.clone(), stmts))
         })
         .collect()
@@ -951,10 +965,13 @@ pub(crate) fn entry_fns(
     // Post-order: children before parent, so nested eval runs first.
     let mut all_stmts: BTreeMap<super::EntrypointId, Vec<ExprKind>> = BTreeMap::new();
     flow_tree.try_visit_post(&[], &mut |path, (meta, flow)| -> Result<(), CodegenError> {
+        let branching: BTreeMap<node::Id, usize> =
+            meta.branches.iter().map(|(&id, v)| (id, v.len())).collect();
         let level_stmts = eval_stmts_from_flow(
             path,
             &meta.graph,
             &meta.stateful,
+            &branching,
             &meta.inlets,
             &meta.outlets,
             flow,

--- a/crates/gantz_core/src/compile/flow.rs
+++ b/crates/gantz_core/src/compile/flow.rs
@@ -225,8 +225,9 @@ pub fn flow_graph(
     let order: Vec<_> = super::eval_order(&meta.graph, push, pull).collect();
     let included: HashSet<_> = order.iter().copied().collect();
     let mg = reachable_subgraph(&meta.graph, &included);
+    let branching: BTreeSet<node::Id> = meta.branches.keys().copied().collect();
     let conf_graph = node_conf_graph(meta, &mg, None)?;
-    Ok(flow_graph_from_conf_graph(&conf_graph))
+    Ok(flow_graph_from_conf_graph(&conf_graph, &branching))
 }
 
 /// Filter unreachable nodes from the given metagraph.
@@ -239,7 +240,7 @@ fn reachable_subgraph(g: &MetaGraph, reachable: &HashSet<node::Id>) -> MetaGraph
 
 /// Given a node configuration flow graph, return the reduced control flow graph
 /// of basic blocks.
-fn flow_graph_from_conf_graph(cg: &NodeConfGraph) -> FlowGraph {
+fn flow_graph_from_conf_graph(cg: &NodeConfGraph, branching: &BTreeSet<node::Id>) -> FlowGraph {
     // Initialise the flow graph with the same nodes and edges.
     let mut g = FlowGraph::with_capacity(cg.node_count(), cg.edge_count());
     let mut visited = HashMap::with_capacity(cg.node_count());
@@ -252,7 +253,7 @@ fn flow_graph_from_conf_graph(cg: &NodeConfGraph) -> FlowGraph {
             .or_insert_with(|| g.add_node(Block(vec![b])));
         g.add_edge(na, nb, branch);
     }
-    flow_graph_edge_contraction(&mut g);
+    flow_graph_edge_contraction(&mut g, branching);
     g
 }
 
@@ -262,13 +263,21 @@ fn flow_graph_from_conf_graph(cg: &NodeConfGraph) -> FlowGraph {
 /// Ie for each edge, if that edge is the only output for the source node, and
 /// the only input for the destination node, remove the edge and merge the src
 /// and dst nodes.
-fn flow_graph_edge_contraction(g: &mut FlowGraph) {
+fn flow_graph_edge_contraction(g: &mut FlowGraph, branching: &BTreeSet<node::Id>) {
     // Maintain a stack of all edges that require reducing.
     let mut edges: Vec<_> = g.edge_references().map(|e_ref| e_ref.id()).collect();
     while let Some(e) = edges.pop() {
         let Some((src, dst)) = g.edge_endpoints(e) else {
             continue; // Edge was removed when its node was merged.
         };
+
+        // Never contract edges from branching nodes - even with a single
+        // active branch edge, the codegen must handle branch destructuring.
+        if let Some(last) = g[src].last() {
+            if branching.contains(&last.id) {
+                continue;
+            }
+        }
 
         // Check whether or not this is the only edge between src and dst.
         let mergeable = g.edges_directed(src, petgraph::Outgoing).take(2).count() == 1

--- a/crates/gantz_core/src/compile/meta.rs
+++ b/crates/gantz_core/src/compile/meta.rs
@@ -98,15 +98,15 @@ impl Meta {
 
         // Add edges for inputs.
         for (n, edge) in inputs {
-            loop {
-                if let Some(edges) = self.graph.edge_weight_mut(n, id) {
-                    let n_branches = self.branches.get(&n).map(|bs| &bs[..]);
-                    if let Some(kind) = edge_kind(n_branches, edge.output.0 as usize)? {
-                        edges.push((edge, kind));
-                        break;
-                    }
-                }
-                self.graph.add_edge(n, id, vec![]);
+            let n_branches = self.branches.get(&n).map(|bs| &bs[..]);
+            // Skip edges from outputs that are unreachable through all branches.
+            let Some(kind) = edge_kind(n_branches, edge.output.0 as usize)? else {
+                continue;
+            };
+            if let Some(edges) = self.graph.edge_weight_mut(n, id) {
+                edges.push((edge, kind));
+            } else {
+                self.graph.add_edge(n, id, vec![(edge, kind)]);
             }
         }
 

--- a/crates/gantz_core/src/node/branch.rs
+++ b/crates/gantz_core/src/node/branch.rs
@@ -437,4 +437,22 @@ mod tests {
         let json = r#"{"src":"(list 0 '())","branches":["100","01"]}"#;
         assert!(serde_json::from_str::<Branch>(json).is_err());
     }
+
+    #[test]
+    fn test_optional_input() {
+        let b = Branch::new(
+            "(if (Some? $?x) (list 0 (Some->value $?x)) (list 1 '()))",
+            two_branch_conns(),
+        )
+        .unwrap();
+        let ctx = node::MetaCtx::new(&|_| None);
+        assert_eq!(b.n_inputs(ctx), 1);
+
+        // Verify expr with unconnected optional input produces (None).
+        let outputs = Conns::try_from([true, false]).unwrap();
+        let expr_ctx = node::ExprCtx::new(&|_| None, &[0], &[None], &outputs);
+        let expr = b.expr(expr_ctx).unwrap();
+        let s = format!("{expr}");
+        assert!(s.contains("(None)"), "expected (None) in expr: {s}");
+    }
 }

--- a/crates/gantz_core/src/node/expr.rs
+++ b/crates/gantz_core/src/node/expr.rs
@@ -18,6 +18,17 @@ use thiserror::Error;
 ///
 /// Variables are identified by unique names - if the same `$var` appears
 /// multiple times in the expression, it refers to the same inlet.
+///
+/// ## Optional inputs
+///
+/// Variables prefixed with `$?` are treated as optional inputs. When
+/// connected, the value is wrapped as `(Some value)`. When unconnected,
+/// `(None)` is substituted. This uses Steel's built-in Option type, so
+/// `Some?`, `None?`, and `Some->value` are available.
+///
+/// ```ignore
+/// (+ $a (if (Some? $?b) (Some->value $?b) 0))
+/// ```
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, CaHash)]
 #[cahash("gantz.expr")]
 pub struct Expr {
@@ -157,6 +168,14 @@ pub(crate) fn vars_from_src(src: &str) -> Vec<String> {
 }
 
 /// Replace each `$var` with the corresponding input expression based on variable name.
+///
+/// Variables with a `$?` prefix are treated as optional inputs:
+/// - Connected: substituted with `(Some <binding>)`.
+/// - Unconnected: substituted with `(None)`.
+///
+/// Regular `$var` variables use the existing behaviour:
+/// - Connected: substituted with the binding name.
+/// - Unconnected: substituted with `'()`.
 pub(crate) fn interpolate_tokens(
     tts: TokenStream,
     vars: &[String],
@@ -171,7 +190,13 @@ pub(crate) fn interpolate_tokens(
 
     let tokens = tts.map(|token| {
         let src = token.source();
-        if src.starts_with("$") {
+        if src.starts_with("$?") {
+            let index = var_to_index.get(src).unwrap();
+            match inputs.get(*index).and_then(|o| o.as_ref()) {
+                None => "(None)".to_string(),
+                Some(in_expr) => format!("(Some {in_expr})"),
+            }
+        } else if src.starts_with("$") {
             let index = var_to_index.get(src).unwrap();
             match inputs.get(*index).and_then(|o| o.as_ref()) {
                 None => "'()".to_string(),
@@ -269,6 +294,18 @@ fn test_collect_unique_vars() {
     // Multiple unique vars.
     let vars = vars_from_src("($a $b $c $d $e)");
     assert_eq!(vars, vec!["$a", "$b", "$c", "$d", "$e"]);
+
+    // Optional vars are captured with $? prefix.
+    let vars = vars_from_src("(+ $?a $b)");
+    assert_eq!(vars, vec!["$?a", "$b"]);
+
+    // Duplicate optional vars deduplicate.
+    let vars = vars_from_src("(if $?x $?x 0)");
+    assert_eq!(vars, vec!["$?x"]);
+
+    // Mixed required and optional.
+    let vars = vars_from_src("(+ $a $?b $?c)");
+    assert_eq!(vars, vec!["$a", "$?b", "$?c"]);
 }
 
 #[test]
@@ -300,4 +337,55 @@ fn test_outputs_zero_panics() {
 #[should_panic]
 fn test_outputs_exceeds_max_panics() {
     Expr::new("$a").unwrap().with_outputs(17);
+}
+
+#[test]
+fn test_interpolate_optional_unconnected() {
+    let src = "(if $?a $?a 0)";
+    let vars = vars_from_src(src);
+    let tts = TokenStream::new(src, true, None);
+    let result = interpolate_tokens(tts, &vars, &[None]);
+    assert!(result.contains("(None)"), "expected (None) in: {result}");
+}
+
+#[test]
+fn test_interpolate_optional_connected() {
+    let src = "(if $?a $?a 0)";
+    let vars = vars_from_src(src);
+    let tts = TokenStream::new(src, true, None);
+    let result = interpolate_tokens(tts, &vars, &[Some("input0".into())]);
+    assert!(
+        result.contains("(Some input0)"),
+        "expected (Some input0) in: {result}",
+    );
+}
+
+#[test]
+fn test_interpolate_mixed_required_optional() {
+    let src = "(+ $a (unwrap-or $?b 0))";
+    let vars = vars_from_src(src);
+    let tts = TokenStream::new(src, true, None);
+    // $a connected, $?b unconnected.
+    let result = interpolate_tokens(tts, &vars, &[Some("input0".into()), None]);
+    assert!(result.contains("input0"), "expected input0 in: {result}");
+    assert!(result.contains("(None)"), "expected (None) in: {result}");
+}
+
+#[test]
+fn test_interpolate_required_unconnected_unchanged() {
+    let src = "(+ $a $b)";
+    let vars = vars_from_src(src);
+    let tts = TokenStream::new(src, true, None);
+    let result = interpolate_tokens(tts, &vars, &[Some("input0".into()), None]);
+    assert!(result.contains("input0"), "expected input0 in: {result}");
+    assert!(result.contains("'()"), "expected '() in: {result}");
+    // Ensure no Option wrapping for required vars.
+    assert!(
+        !result.contains("(None)"),
+        "should not contain (None): {result}"
+    );
+    assert!(
+        !result.contains("(Some"),
+        "should not contain (Some: {result}"
+    );
 }

--- a/crates/gantz_core/src/node/graph.rs
+++ b/crates/gantz_core/src/node/graph.rs
@@ -370,10 +370,13 @@ where
             .map(|&n| (g.to_index(n), node::Conns::connected(1).unwrap())),
     )
     .map_err(|e| node::ExprError::custom(e))?;
+    let branching: std::collections::BTreeMap<node::Id, usize> =
+        meta.branches.iter().map(|(&id, v)| (id, v.len())).collect();
     let stmts = compile::entry_fn_body(
         path,
         &meta.graph,
         &meta.stateful,
+        &branching,
         &meta.inlets,
         &meta.outlets,
         &flow_graph,

--- a/crates/gantz_core/tests/graph.rs
+++ b/crates/gantz_core/tests/graph.rs
@@ -1664,3 +1664,277 @@ fn test_graph_three_way_branch() {
         .expect("was None");
     assert_eq!(val, 8);
 }
+
+/// Branch with 1 output, 2 branches: branch 0 active, branch 1 dead.
+///
+/// When branch 1 is taken at runtime, evaluation should terminate at the
+/// branch node - downstream `number` should not execute.
+///
+///   push_0 (emits 0) ---\
+///                         branch ---(out 0, branch 0)--> number
+///   push_1 (emits 1) ---/
+///
+/// Branch 0: [true]  -> output 0 active, downstream runs.
+/// Branch 1: [false] -> output 0 dead, downstream does NOT run.
+#[test]
+fn test_graph_branch_single_output_dead_branch() {
+    let branch = node::Branch::new(
+        "(if (equal? 0 $x) (list 0 42) (list 1 99))",
+        vec![
+            node::Conns::try_from([true]).unwrap(),
+            node::Conns::try_from([false]).unwrap(),
+        ],
+    )
+    .unwrap();
+
+    let mut g = petgraph::graph::DiGraph::new();
+
+    let push_0 = g.add_node(Box::new(node_int(0).with_push_eval()) as Box<dyn DebugNode>);
+    let push_1 = g.add_node(Box::new(node_int(1).with_push_eval()) as Box<_>);
+    let branch_ix = g.add_node(Box::new(branch) as Box<_>);
+    let number = g.add_node(Box::new(node_number()) as Box<_>);
+
+    g.add_edge(push_0, branch_ix, Edge::from((0, 0)));
+    g.add_edge(push_1, branch_ix, Edge::from((0, 0)));
+    g.add_edge(branch_ix, number, Edge::from((0, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let eps = default_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    for f in &module {
+        vm.run(format!("{f}")).unwrap();
+    }
+
+    // Push 0 -> branch index 0 (active) -> number stores 42.
+    let ep_0 = entrypoint::push(vec![push_0.index()], g[push_0].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_0.id()), vec![])
+        .unwrap();
+    let val = node::state::extract::<u32>(&vm, &[number.index()])
+        .expect("failed to extract")
+        .expect("was None");
+    assert_eq!(val, 42);
+
+    // Push 1 -> branch index 1 (dead) -> number should NOT be updated.
+    let ep_1 = entrypoint::push(vec![push_1.index()], g[push_1].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_1.id()), vec![])
+        .unwrap();
+    let val = node::state::extract::<u32>(&vm, &[number.index()])
+        .expect("failed to extract")
+        .expect("was None");
+    assert_eq!(
+        val, 42,
+        "number should still be 42 - dead branch must not propagate"
+    );
+}
+
+/// Branch with 2 outputs, 2 branches: branch 0 fully active, branch 1 fully dead.
+///
+///   push_0 (emits 0) ---\                /---(out 0)--> store_a
+///                         branch --------<
+///   push_1 (emits 1) ---/                \---(out 1)--> store_b
+///
+/// Branch 0: [true, true]   -> both outputs active.
+/// Branch 1: [false, false] -> both outputs dead - evaluation terminates.
+#[test]
+fn test_graph_branch_two_outputs_one_dead() {
+    let branch = node::Branch::new(
+        "(if (equal? 0 $x) (list 0 (list 42 43)) (list 1 (list 99 100)))",
+        vec![
+            node::Conns::try_from([true, true]).unwrap(),
+            node::Conns::try_from([false, false]).unwrap(),
+        ],
+    )
+    .unwrap();
+
+    let mut g = petgraph::graph::DiGraph::new();
+
+    let push_0 = g.add_node(Box::new(node_int(0).with_push_eval()) as Box<dyn DebugNode>);
+    let push_1 = g.add_node(Box::new(node_int(1).with_push_eval()) as Box<_>);
+    let branch_ix = g.add_node(Box::new(branch) as Box<_>);
+    let store_a = g.add_node(Box::new(node_number()) as Box<_>);
+    let store_b = g.add_node(Box::new(node_number()) as Box<_>);
+
+    g.add_edge(push_0, branch_ix, Edge::from((0, 0)));
+    g.add_edge(push_1, branch_ix, Edge::from((0, 0)));
+    g.add_edge(branch_ix, store_a, Edge::from((0, 0)));
+    g.add_edge(branch_ix, store_b, Edge::from((1, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let eps = default_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    for f in &module {
+        vm.run(format!("{f}")).unwrap();
+    }
+
+    // Push 0 -> branch 0 (active) -> store_a=42, store_b=43.
+    let ep_0 = entrypoint::push(vec![push_0.index()], g[push_0].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_0.id()), vec![])
+        .unwrap();
+    let val_a = node::state::extract::<u32>(&vm, &[store_a.index()])
+        .expect("failed to extract")
+        .expect("was None");
+    assert_eq!(val_a, 42);
+    let val_b = node::state::extract::<u32>(&vm, &[store_b.index()])
+        .expect("failed to extract")
+        .expect("was None");
+    assert_eq!(val_b, 43);
+
+    // Push 1 -> branch 1 (dead) -> stores should remain unchanged.
+    let ep_1 = entrypoint::push(vec![push_1.index()], g[push_1].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_1.id()), vec![])
+        .unwrap();
+    let val_a = node::state::extract::<u32>(&vm, &[store_a.index()])
+        .expect("failed to extract")
+        .expect("was None");
+    assert_eq!(val_a, 42, "store_a should be unchanged after dead branch");
+    let val_b = node::state::extract::<u32>(&vm, &[store_b.index()])
+        .expect("failed to extract")
+        .expect("was None");
+    assert_eq!(val_b, 43, "store_b should be unchanged after dead branch");
+}
+
+/// Branch where ALL branches have zero active outputs.
+///
+/// The branch node's expression still evaluates (side effects like state
+/// updates run), but nothing propagates downstream.
+///
+///   push ----> branch ---x---> number (should never run)
+///
+/// Branch 0: [false], Branch 1: [false] -> both dead.
+#[test]
+fn test_graph_branch_all_dead() {
+    // Stateful branch: stores the value in state, then returns branch info.
+    let branch = node::Branch::new(
+        "(begin (set! state $x) (if (equal? 0 $x) (list 0 '()) (list 1 '())))",
+        vec![
+            node::Conns::try_from([false]).unwrap(),
+            node::Conns::try_from([false]).unwrap(),
+        ],
+    )
+    .unwrap();
+
+    let mut g = petgraph::graph::DiGraph::new();
+
+    let push = g.add_node(Box::new(node_int(42).with_push_eval()) as Box<dyn DebugNode>);
+    let branch_ix = g.add_node(Box::new(branch) as Box<_>);
+    let number = g.add_node(Box::new(node_number()) as Box<_>);
+
+    g.add_edge(push, branch_ix, Edge::from((0, 0)));
+    g.add_edge(branch_ix, number, Edge::from((0, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let eps = default_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    for f in &module {
+        vm.run(format!("{f}")).unwrap();
+    }
+
+    // Push -> branch evaluates (stores 42 in state), but number is unreachable.
+    let ep = entrypoint::push(vec![push.index()], g[push].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep.id()), vec![])
+        .unwrap();
+
+    // Branch's own state should have been updated.
+    let branch_state = node::state::extract::<u32>(&vm, &[branch_ix.index()])
+        .expect("failed to extract")
+        .expect("branch state was None");
+    assert_eq!(branch_state, 42);
+
+    // number should never have been evaluated.
+    let number_state = node::state::extract::<u32>(&vm, &[number.index()])
+        .ok()
+        .flatten();
+    assert!(
+        number_state.is_none(),
+        "number should not have been evaluated"
+    );
+}
+
+/// Pd-style `+` node: hot left inlet triggers output, cold right inlet only
+/// updates state. Uses `$?var` optional input + Branch to achieve this.
+///
+///   push_hot (5) ----> [hot_inlet] +_node [cold_inlet] <---- push_cold (3)
+///                                    |
+///                                  number (stores result)
+///
+/// The `+` node uses a Branch: when the hot inlet fires, it adds state
+/// (cold value) and emits; when the cold inlet fires, it stores the new
+/// value in state but does NOT emit.
+#[test]
+fn test_graph_branch_optional_input_pd_add() {
+    // Pd-style +: hot inlet ($a) is required, cold inlet ($?b) is optional.
+    // When hot fires ($a is a number), update state from $?b if present, then
+    // emit $a + state on branch 0.
+    // When cold fires ($a is unconnected = '()), update state from $?b, then
+    // take branch 1 (dead - no output).
+    let pd_add = node::Branch::new(
+        "(begin \
+           (if (Some? $?b) (set! state (Some->value $?b)) '()) \
+           (if (number? $a) \
+               (list 0 (+ $a (if (number? state) state 0))) \
+               (list 1 '())))",
+        vec![
+            node::Conns::try_from([true]).unwrap(),  // branch 0: emit
+            node::Conns::try_from([false]).unwrap(), // branch 1: dead (cold only)
+        ],
+    )
+    .unwrap();
+
+    let mut g = petgraph::graph::DiGraph::new();
+
+    let push_hot = g.add_node(Box::new(node_int(5).with_push_eval()) as Box<dyn DebugNode>);
+    let push_cold = g.add_node(Box::new(node_int(3).with_push_eval()) as Box<_>);
+    let pd_add_ix = g.add_node(Box::new(pd_add) as Box<_>);
+    let number = g.add_node(Box::new(node_number()) as Box<_>);
+
+    // Cold inlet -> input 0 ($?b appears first in expression).
+    g.add_edge(push_cold, pd_add_ix, Edge::from((0, 0)));
+    // Hot inlet -> input 1 ($a appears second in expression).
+    g.add_edge(push_hot, pd_add_ix, Edge::from((0, 1)));
+    // Output 0 -> number.
+    g.add_edge(pd_add_ix, number, Edge::from((0, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let eps = default_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    for f in &module {
+        vm.run(format!("{f}")).unwrap();
+    }
+
+    // First: push cold (3) to set state. Number should NOT be updated.
+    let ep_cold = entrypoint::push(vec![push_cold.index()], g[push_cold].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_cold.id()), vec![])
+        .unwrap();
+    let number_state = node::state::extract::<u32>(&vm, &[number.index()])
+        .ok()
+        .flatten();
+    assert!(
+        number_state.is_none(),
+        "number should not run on cold inlet push"
+    );
+
+    // Then: push hot (5). pd_add should compute 5 + 3 = 8 and emit.
+    let ep_hot = entrypoint::push(vec![push_hot.index()], g[push_hot].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep_hot.id()), vec![])
+        .unwrap();
+    let val = node::state::extract::<u32>(&vm, &[number.index()])
+        .expect("failed to extract")
+        .expect("was None");
+    assert_eq!(val, 8, "hot inlet should emit 5 + 3 = 8");
+}

--- a/crates/gantz_core/tests/graph.rs
+++ b/crates/gantz_core/tests/graph.rs
@@ -1478,6 +1478,97 @@ fn test_graph_multi_edge_in_branch_arm() {
     assert_eq!(val, 8);
 }
 
+/// Test an Expr node with an optional input ($?var).
+///
+///   push ----> add_opt ----> store
+///
+/// `add_opt` uses `(if (Some? $?b) (Some->value $?b) 0)` to default to 0
+/// when `$?b` is unconnected.
+///
+/// When `$?b` is unconnected, `(None)` is substituted, `(Some? (None))`
+/// is false, so the result is `5 + 0 = 5`.
+#[test]
+fn test_graph_optional_input_unconnected() {
+    let mut g = petgraph::graph::DiGraph::new();
+
+    let push = g.add_node(Box::new(node_int(5).with_push_eval()) as Box<dyn DebugNode>);
+    let add_opt = g.add_node(Box::new(
+        node::expr("(+ $a (if (Some? $?b) (Some->value $?b) 0))").unwrap(),
+    ) as Box<_>);
+    let store = g.add_node(Box::new(node_number()) as Box<_>);
+
+    // Only connect $a (input 0). $?b (input 1) is left unconnected.
+    g.add_edge(push, add_opt, Edge::from((0, 0)));
+    g.add_edge(add_opt, store, Edge::from((0, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let eps = default_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    for f in &module {
+        vm.run(format!("{f}")).unwrap();
+    }
+
+    let ep = entrypoint::push(vec![push.index()], g[push].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep.id()), vec![])
+        .unwrap();
+
+    // 5 + 0 = 5.
+    let val = node::state::extract::<u32>(&vm, &[store.index()])
+        .expect("failed to extract")
+        .expect("was None");
+    assert_eq!(val, 5);
+}
+
+/// Test an Expr node with an optional input ($?var) that IS connected.
+///
+///   push ----> three ----> add_opt ----> store
+///                    \--/
+///
+/// When `$?b` is connected, `(Some 3)` is substituted, `(Some? (Some 3))`
+/// is true, so the result is `5 + 3 = 8`.
+#[test]
+fn test_graph_optional_input_connected() {
+    let mut g = petgraph::graph::DiGraph::new();
+
+    let push = g.add_node(Box::new(node_int(5).with_push_eval()) as Box<dyn DebugNode>);
+    let three = g.add_node(Box::new(node_int(3)) as Box<_>);
+    let add_opt = g.add_node(Box::new(
+        node::expr("(+ $a (if (Some? $?b) (Some->value $?b) 0))").unwrap(),
+    ) as Box<_>);
+    let store = g.add_node(Box::new(node_number()) as Box<_>);
+
+    // Connect both $a and $?b.
+    g.add_edge(push, add_opt, Edge::from((0, 0)));
+    g.add_edge(push, three, Edge::from((0, 0)));
+    g.add_edge(three, add_opt, Edge::from((0, 1)));
+    g.add_edge(add_opt, store, Edge::from((0, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let eps = default_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    for f in &module {
+        vm.run(format!("{f}")).unwrap();
+    }
+
+    let ep = entrypoint::push(vec![push.index()], g[push].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep.id()), vec![])
+        .unwrap();
+
+    // 5 + 3 = 8.
+    let val = node::state::extract::<u32>(&vm, &[store.index()])
+        .expect("failed to extract")
+        .expect("was None");
+    assert_eq!(val, 8);
+}
+
 /// Test a three-way branch with reconvergence.
 ///
 /// All existing branch tests use binary (2-arm) branches. This exercises


### PR DESCRIPTION
## Optional Inputs

Extends the `$var` placeholder convention with a `$?` prefix for optional inputs. When connected, the value is wrapped as `(Some value)`. When unconnected, `(None)` is substituted. This uses Steel's built-in `Option` type.

Example: `(+ $a (if (Some? $?b) (Some->value $?b) 0))` - adds `$b` if connected, defaults to `0` otherwise.

## Fix Terminating Branches

When a `Branch` node has some branches with zero active outputs (all `Conns` bits false), codegen now correctly terminates evaluation for those branches instead of treating the node as linear.

Three fixes applied:

- `flow.rs`: prevent edge contraction from merging branching nodes with their downstream, even when only one branch edge survives.
- `codegen.rs`: thread `branching: BTreeMap<node::Id, usize>` through the pipeline; single-edge nodes that are branching fall through to the multi-edge codepath which handles conditional evaluation correctly.
- `codegen.rs`: skip post-dominator reconvergence when a branching node has fewer active edges than total branches (dead branches should terminate, not rejoin).

Also fix a pre-existing bug in meta.rs where `edge_kind` returning `None` (output unreachable through all branches) caused edges to still be added to the `MetaGraph`.

Add four new tests: single-output dead branch, two-outputs one dead, all-dead branches, and a Pd-style optional-input + branch integration test.