### PR TITLE
feat: nested-graph branching (`Node::branches` for `GraphNode`)

### DIFF
--- a/crates/gantz_core/src/compile.rs
+++ b/crates/gantz_core/src/compile.rs
@@ -6,7 +6,7 @@ use crate::{
     node::{self, Node},
 };
 #[doc(inline)]
-pub use codegen::{entry_fn_body, entry_fn_name};
+pub use codegen::{OutletActivity, entry_fn_body, entry_fn_name};
 #[doc(inline)]
 pub use entrypoint::{
     Entrypoint, EntrypointId, EvalKind, EvalSource, pull_source, push_pull_entrypoints, push_source,

--- a/crates/gantz_core/src/compile.rs
+++ b/crates/gantz_core/src/compile.rs
@@ -15,6 +15,7 @@ pub use entrypoint::{
 pub use error::ModuleError;
 #[doc(inline)]
 pub use flow::{Block, Flow, FlowGraph, NodeConf, NodeConns, flow_graph};
+pub(crate) use flow::{flow_graph_roots, outlet_patterns};
 use meta::MetaTree;
 #[doc(inline)]
 pub use meta::{EdgeKind, Meta, MetaGraph};

--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -5,6 +5,7 @@ use crate::{
     compile::{
         Block, Flow, FlowGraph, Meta, MetaGraph, NodeConns, RoseTree,
         error::{CodegenError, InvalidInputIndex, TooManyConns},
+        flow_graph_roots,
     },
     node,
 };
@@ -33,8 +34,6 @@ enum NodeFnCallArg {
 
 /// Binding used for `state` local to each node fn.
 const STATE: &str = "state";
-/// Binding used for the current branch index.
-const BRANCH_IX: &str = "branch-ix";
 
 /// The expression for a call to a node function.
 fn node_fn_call(
@@ -74,6 +73,49 @@ fn node_output_var(node_ix: node::Id, out_ix: usize) -> String {
 /// The binding name given to the node's output.
 fn node_outputs_var(node_ix: node::Id) -> String {
     format!("node-{node_ix}")
+}
+
+/// The hoisted binding holding an outlet's value within a nested graph body.
+///
+/// Declared once in the body's enclosing scope and `set!` wherever the outlet
+/// is reached, so its value survives out of any branch arm that produced it.
+fn outlet_var(outlet_id: node::Id) -> String {
+    format!("outlet-{outlet_id}")
+}
+
+/// The hoisted boolean flag recording whether an outlet was reached.
+///
+/// Only used when the nested graph branches externally; the final branch
+/// selector reads these flags to determine which branch was taken.
+fn outlet_active_var(outlet_id: node::Id) -> String {
+    format!("outlet-active-{outlet_id}")
+}
+
+/// The per-branching-node binding holding its selected branch index.
+///
+/// Declared once per body (see [`declare_branch_ix_placeholders`]) and `set!`
+/// when the branch destructures, so it is readable from any arm scope without
+/// colliding with sibling branches' selectors.
+fn branch_ix_var(node_ix: node::Id) -> String {
+    format!("branch-ix-{node_ix}")
+}
+
+/// `(define branch-ix-{id} -1)` placeholders for every branching node, declared
+/// at the top of a body before any branch `set!`s them.
+fn declare_branch_ix_placeholders(branching: &BTreeMap<node::Id, usize>) -> Vec<ExprKind> {
+    branching
+        .keys()
+        .map(|&id| emit_one(&format!("(define {} -1)", branch_ix_var(id))))
+        .collect()
+}
+
+/// Parse a single Steel statement string into its AST node.
+fn emit_one(src: &str) -> ExprKind {
+    Engine::emit_ast(src)
+        .expect("failed to emit AST")
+        .into_iter()
+        .next()
+        .unwrap()
 }
 
 /// Find the arguments for a call to the node with the given ID with the given
@@ -132,6 +174,7 @@ fn eval_stmt(
     inputs: &node::Conns,
     outputs: &node::Conns,
     stateful: bool,
+    track_outlet_active: bool,
 ) -> Result<Option<ExprKind>, CodegenError> {
     // An expression for a node's key into the graph state hashmap.
     fn node_state_key(node_id: usize) -> ExprKind {
@@ -190,13 +233,7 @@ fn eval_stmt(
         )));
     }
 
-    // Skip outlet nodes entirely - their values are read directly from source
-    // node output bindings by nested_expr.
-    if outlets.contains(&node_ix) {
-        return Ok(None);
-    }
-
-    // Determine the input arg names.
+    // Determine the input arg names (used for outlet hoisting and node calls).
     let input_args: Vec<_> = node_fn_call_args(mg, reachable, node_ix, inputs)?
         .into_iter()
         .enumerate()
@@ -207,6 +244,27 @@ fn eval_stmt(
             })
         })
         .collect();
+
+    // For outlet nodes, set the hoisted `outlet-{id}` var (and, in branching
+    // mode, its active flag) from the connected input rather than calling a node
+    // function. Placed by the surrounding flow recursion within whatever branch
+    // arm reaches the outlet; the parent reads the hoisted var. A disconnected
+    // outlet leaves its var at the `'()` default.
+    if outlets.contains(&node_ix) {
+        let Some(src) = input_args.first().and_then(Option::as_ref) else {
+            return Ok(None);
+        };
+        let set_value = format!("(set! {} {src})", outlet_var(node_ix));
+        let s = if track_outlet_active {
+            format!(
+                "(begin {set_value} (set! {} #t))",
+                outlet_active_var(node_ix)
+            )
+        } else {
+            set_value
+        };
+        return Ok(Some(emit_one(&s)));
+    }
 
     // The expression for the node function call.
     let node_fn_call_expr = node_fn_call(node_path, &input_args, outputs, stateful)?;
@@ -262,15 +320,16 @@ fn destructure_node_outputs_stmt(n: node::Id, outputs: node::Conns) -> Option<Ex
     )
 }
 
-/// Create a statement that destructures the node
+/// Destructure a branching node's `(branch-ix value)` output: store the branch
+/// index in its pre-declared `branch-ix-{n}` var and rebind the node's var to
+/// the value. Uses `set!` (not a fresh `define`) so it works from any arm scope.
 fn destructure_node_branch_stmt(n: node::Id) -> ExprKind {
     let outputs_var = node_outputs_var(n);
-    let stmt = format!("(define-values (branch-ix {outputs_var}) {outputs_var})");
-    Engine::emit_ast(&stmt)
-        .expect("failed to emit AST")
-        .into_iter()
-        .next()
-        .unwrap()
+    let branch_ix = branch_ix_var(n);
+    emit_one(&format!(
+        "(begin (set! {branch_ix} (list-ref {outputs_var} 0)) \
+               (set! {outputs_var} (list-ref {outputs_var} 1)))"
+    ))
 }
 
 /// Generate a function for performing evaluation of the given statements.
@@ -505,6 +564,7 @@ pub(crate) fn eval_fn_block_stmts(
     in_scope: &mut HashSet<node::Id>,
     active_phi: &HashSet<(node::Id, usize)>,
     bridge_nodes: &BTreeSet<node::Id>,
+    track_outlet_active: bool,
 ) -> Result<Vec<ExprKind>, CodegenError> {
     let mut stmts = Vec::new();
     let mut iter = block.0.iter().peekable();
@@ -534,7 +594,15 @@ pub(crate) fn eval_fn_block_stmts(
         let stateful = stateful.contains(&conf.id);
         let NodeConns { inputs, outputs } = conf.conns;
         let Some(stmt) = eval_stmt(
-            mg, reachable, inlets, outlets, &node_path, &inputs, &outputs, stateful,
+            mg,
+            reachable,
+            inlets,
+            outlets,
+            &node_path,
+            &inputs,
+            &outputs,
+            stateful,
+            track_outlet_active,
         )?
         else {
             continue;
@@ -552,20 +620,6 @@ pub(crate) fn eval_fn_block_stmts(
         in_scope.insert(conf.id);
     }
     Ok(stmts)
-}
-
-/// Find the entrypoint to the flow graph.
-fn flow_graph_entry(fg: &FlowGraph) -> Option<NodeIndex<u32>> {
-    let mut iter = fg
-        .node_references()
-        .map(|n_ref| n_ref.id())
-        .filter(|&n| fg.edges_directed(n, petgraph::Incoming).next().is_none());
-    let entry = iter.next();
-    assert!(
-        iter.next().is_none(),
-        "flow graph should have only one entry"
-    );
-    entry
 }
 
 /// The set of unique nodes in the flow graph.
@@ -662,6 +716,7 @@ fn flow_node_stmts(
     active_phi: &HashSet<(node::Id, usize)>,
     stop_at: Option<NodeIndex>,
     bridge_nodes: &BTreeSet<node::Id>,
+    track_outlet_active: bool,
 ) -> Result<Vec<ExprKind>, CodegenError> {
     // Add the block.
     let block = &fg[flow_ix];
@@ -676,6 +731,7 @@ fn flow_node_stmts(
         in_scope,
         active_phi,
         bridge_nodes,
+        track_outlet_active,
     )?;
 
     // Collect the output branching edges.
@@ -724,6 +780,7 @@ fn flow_node_stmts(
             active_phi,
             stop_at,
             bridge_nodes,
+            track_outlet_active,
         )?);
         return Ok(stmts);
     }
@@ -810,6 +867,7 @@ fn flow_node_stmts(
                     &inner_phi,
                     Some(join_ix),
                     bridge_nodes,
+                    track_outlet_active,
                 )?);
             }
 
@@ -819,8 +877,9 @@ fn flow_node_stmts(
                 .collect::<Vec<_>>()
                 .join(" ");
             expr = format!(
-                "(if (= {} {BRANCH_IX}) (begin {branch_str}) {expr})",
-                branch.ix
+                "(if (= {} {}) (begin {branch_str}) {expr})",
+                branch.ix,
+                branch_ix_var(conf.id),
             );
         }
 
@@ -848,6 +907,7 @@ fn flow_node_stmts(
             &inner_phi,
             stop_at,
             bridge_nodes,
+            track_outlet_active,
         )?);
 
         return Ok(stmts);
@@ -876,6 +936,7 @@ fn flow_node_stmts(
             active_phi,
             stop_at,
             bridge_nodes,
+            track_outlet_active,
         )?;
         let dst_stmts_str = dst_stmts
             .into_iter()
@@ -886,7 +947,11 @@ fn flow_node_stmts(
             .map(|e| format!("{e}"))
             .unwrap_or_default();
         let dst_expr = format!("(begin {} {} '())", destructure_str, dst_stmts_str,);
-        expr = format!("(if (= {} {BRANCH_IX}) {dst_expr} {expr})", branch.ix);
+        expr = format!(
+            "(if (= {} {}) {dst_expr} {expr})",
+            branch.ix,
+            branch_ix_var(conf.id),
+        );
     }
 
     let expr = Engine::emit_ast(&expr)
@@ -910,10 +975,12 @@ pub fn entry_fn_body(
     outlets: &BTreeSet<node::Id>,
     fg: &FlowGraph,
     bridge_nodes: &BTreeSet<node::Id>,
+    track_outlet_active: bool,
 ) -> Result<Vec<ExprKind>, CodegenError> {
-    let Some(entry) = flow_graph_entry(fg) else {
+    let roots = flow_graph_roots(fg);
+    if roots.is_empty() {
         return Ok(vec![]);
-    };
+    }
     let reachable = flow_graph_nodes(fg);
     let join_points = find_join_points(fg);
     let post_dom = compute_post_dominators(fg);
@@ -921,23 +988,34 @@ pub fn entry_fn_body(
     for &j in &join_points {
         phi_params_map.insert(j, join_phi_params(mg, &reachable, &fg[j])?);
     }
-    flow_node_stmts(
-        path,
-        entry.id(),
-        mg,
-        stateful,
-        branching,
-        inlets,
-        outlets,
-        &reachable,
-        fg,
-        &post_dom,
-        &phi_params_map,
-        &mut HashSet::new(),
-        &HashSet::new(),
-        None,
-        bridge_nodes,
-    )
+    // A flow graph may contain multiple disconnected components (e.g. parallel
+    // branches, or independent inlet→outlet chains). Generate each from its
+    // root, sharing scope so bindings remain visible across the whole body.
+    // Per-node `branch-ix-{id}` placeholders are declared up-front so each
+    // branch can `set!` its selector and any arm can read it.
+    let mut in_scope = HashSet::new();
+    let mut stmts = declare_branch_ix_placeholders(branching);
+    for root in roots {
+        stmts.extend(flow_node_stmts(
+            path,
+            root,
+            mg,
+            stateful,
+            branching,
+            inlets,
+            outlets,
+            &reachable,
+            fg,
+            &post_dom,
+            &phi_params_map,
+            &mut in_scope,
+            &HashSet::new(),
+            None,
+            bridge_nodes,
+            track_outlet_active,
+        )?);
+    }
+    Ok(stmts)
 }
 
 /// Wrap statements from a nested graph level with state scope enter/exit.
@@ -989,7 +1067,6 @@ fn wrap_state_scope(path: &[node::Id], stmts: Vec<ExprKind>) -> Vec<ExprKind> {
 fn wrap_outlet_bridge(
     inner_stmts: Vec<ExprKind>,
     graph_node_id: node::Id,
-    inner_mg: &MetaGraph,
     inner_outlets: &BTreeSet<node::Id>,
     reached_outlets: &BTreeSet<node::Id>,
 ) -> Vec<ExprKind> {
@@ -997,27 +1074,17 @@ fn wrap_outlet_bridge(
         return inner_stmts;
     }
 
-    // For each outlet (ordered by node ID), find the source node's output
-    // that feeds into it. Same logic as `nested_expr` outlet extraction.
-    let outlet_values: Vec<String> = inner_outlets
+    // Outlets write their values to hoisted `outlet-{id}` vars (see `eval_stmt`).
+    // Declare them within the `let` so the inner statements set them and we read
+    // them back as the graph node's output. Unreached outlets keep their `'()`
+    // default.
+    let declares: String = inner_outlets
         .iter()
-        .map(|&outlet_id| {
-            if !reached_outlets.contains(&outlet_id) {
-                return "'()".to_string();
-            }
-            // Find the edge incoming to this outlet in the inner MetaGraph.
-            for e_ref in inner_mg.edges_directed(outlet_id, petgraph::Incoming) {
-                let (src_id, _, edges) = (e_ref.source(), e_ref.target(), e_ref.weight());
-                for (edge, _kind) in edges {
-                    if edge.input.0 == 0 {
-                        return format!("node-{src_id}-o{}", edge.output.0);
-                    }
-                }
-            }
-            "'()".to_string()
-        })
-        .collect();
+        .map(|&id| format!("(define {} '())", outlet_var(id)))
+        .collect::<Vec<_>>()
+        .join(" ");
 
+    let outlet_values: Vec<String> = inner_outlets.iter().map(|&id| outlet_var(id)).collect();
     let outlet_values_expr = match outlet_values.len() {
         0 => "'()".to_string(),
         1 => outlet_values[0].clone(),
@@ -1031,7 +1098,9 @@ fn wrap_outlet_bridge(
         .join(" ");
 
     let output_var = node_outputs_var(graph_node_id);
-    let wrapped = format!("(define {output_var} (let () {inner_stmts_str} {outlet_values_expr}))");
+    let wrapped = format!(
+        "(define {output_var} (let () {declares} {inner_stmts_str} {outlet_values_expr}))"
+    );
 
     Engine::emit_ast(&wrapped).expect("failed to emit AST for outlet bridge")
 }
@@ -1089,7 +1158,6 @@ fn entry_fns_collect(
                 let bridge = wrap_outlet_bridge(
                     stmts,
                     graph_node_id,
-                    &child_meta.graph,
                     &child_meta.outlets,
                     reached_outlets,
                 );
@@ -1126,6 +1194,9 @@ fn entry_fns_collect(
             &meta.outlets,
             fg,
             bn,
+            // Top-level/push-through entrypoints don't track outlet activation;
+            // branch-aware outlet propagation is node-style only (`nested_expr`).
+            false,
         )?;
         let scoped = wrap_state_scope(path, stmts);
 

--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -1110,9 +1110,8 @@ fn wrap_outlet_bridge(
         .join(" ");
 
     let output_var = node_outputs_var(graph_node_id);
-    let wrapped = format!(
-        "(define {output_var} (let () {declares} {inner_stmts_str} {outlet_values_expr}))"
-    );
+    let wrapped =
+        format!("(define {output_var} (let () {declares} {inner_stmts_str} {outlet_values_expr}))");
 
     Engine::emit_ast(&wrapped).expect("failed to emit AST for outlet bridge")
 }
@@ -1167,12 +1166,8 @@ fn entry_fns_collect(
             if let Some(reached_outlets) = child_flow.outlet_reach.get(&ep_id) {
                 // Child stmts already include state scope wrapping from the
                 // child's own entry_fns_collect. Wrap in outlet bridge.
-                let bridge = wrap_outlet_bridge(
-                    stmts,
-                    graph_node_id,
-                    &child_meta.outlets,
-                    reached_outlets,
-                );
+                let bridge =
+                    wrap_outlet_bridge(stmts, graph_node_id, &child_meta.outlets, reached_outlets);
                 bridged.entry(ep_id.clone()).or_default().extend(bridge);
                 bridge_node_ids
                     .entry(ep_id)

--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -35,6 +35,18 @@ enum NodeFnCallArg {
 /// Binding used for `state` local to each node fn.
 const STATE: &str = "state";
 
+/// Whether a nested graph's outlets should record their activation.
+///
+/// `Tracked` makes each outlet also `set!` an `outlet-active-{id}` flag (in
+/// addition to its value), which the external branch selector reads to pick
+/// which branch fired. Only needed when the graph branches externally;
+/// top-level and push-through evaluation use `Untracked`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OutletActivity {
+    Tracked,
+    Untracked,
+}
+
 /// The expression for a call to a node function.
 fn node_fn_call(
     node_path: &[node::Id],
@@ -174,7 +186,7 @@ fn eval_stmt(
     inputs: &node::Conns,
     outputs: &node::Conns,
     stateful: bool,
-    track_outlet_active: bool,
+    outlet_activity: OutletActivity,
 ) -> Result<Option<ExprKind>, CodegenError> {
     // An expression for a node's key into the graph state hashmap.
     fn node_state_key(node_id: usize) -> ExprKind {
@@ -255,7 +267,7 @@ fn eval_stmt(
             return Ok(None);
         };
         let set_value = format!("(set! {} {src})", outlet_var(node_ix));
-        let s = if track_outlet_active {
+        let s = if outlet_activity == OutletActivity::Tracked {
             format!(
                 "(begin {set_value} (set! {} #t))",
                 outlet_active_var(node_ix)
@@ -564,7 +576,7 @@ pub(crate) fn eval_fn_block_stmts(
     in_scope: &mut HashSet<node::Id>,
     active_phi: &HashSet<(node::Id, usize)>,
     bridge_nodes: &BTreeSet<node::Id>,
-    track_outlet_active: bool,
+    outlet_activity: OutletActivity,
 ) -> Result<Vec<ExprKind>, CodegenError> {
     let mut stmts = Vec::new();
     let mut iter = block.0.iter().peekable();
@@ -602,7 +614,7 @@ pub(crate) fn eval_fn_block_stmts(
             &inputs,
             &outputs,
             stateful,
-            track_outlet_active,
+            outlet_activity,
         )?
         else {
             continue;
@@ -716,7 +728,7 @@ fn flow_node_stmts(
     active_phi: &HashSet<(node::Id, usize)>,
     stop_at: Option<NodeIndex>,
     bridge_nodes: &BTreeSet<node::Id>,
-    track_outlet_active: bool,
+    outlet_activity: OutletActivity,
 ) -> Result<Vec<ExprKind>, CodegenError> {
     // Add the block.
     let block = &fg[flow_ix];
@@ -731,7 +743,7 @@ fn flow_node_stmts(
         in_scope,
         active_phi,
         bridge_nodes,
-        track_outlet_active,
+        outlet_activity,
     )?;
 
     // Collect the output branching edges.
@@ -780,7 +792,7 @@ fn flow_node_stmts(
             active_phi,
             stop_at,
             bridge_nodes,
-            track_outlet_active,
+            outlet_activity,
         )?);
         return Ok(stmts);
     }
@@ -867,7 +879,7 @@ fn flow_node_stmts(
                     &inner_phi,
                     Some(join_ix),
                     bridge_nodes,
-                    track_outlet_active,
+                    outlet_activity,
                 )?);
             }
 
@@ -907,7 +919,7 @@ fn flow_node_stmts(
             &inner_phi,
             stop_at,
             bridge_nodes,
-            track_outlet_active,
+            outlet_activity,
         )?);
 
         return Ok(stmts);
@@ -936,7 +948,7 @@ fn flow_node_stmts(
             active_phi,
             stop_at,
             bridge_nodes,
-            track_outlet_active,
+            outlet_activity,
         )?;
         let dst_stmts_str = dst_stmts
             .into_iter()
@@ -975,7 +987,7 @@ pub fn entry_fn_body(
     outlets: &BTreeSet<node::Id>,
     fg: &FlowGraph,
     bridge_nodes: &BTreeSet<node::Id>,
-    track_outlet_active: bool,
+    outlet_activity: OutletActivity,
 ) -> Result<Vec<ExprKind>, CodegenError> {
     let roots = flow_graph_roots(fg);
     if roots.is_empty() {
@@ -1012,7 +1024,7 @@ pub fn entry_fn_body(
             &HashSet::new(),
             None,
             bridge_nodes,
-            track_outlet_active,
+            outlet_activity,
         )?);
     }
     Ok(stmts)
@@ -1196,7 +1208,7 @@ fn entry_fns_collect(
             bn,
             // Top-level/push-through entrypoints don't track outlet activation;
             // branch-aware outlet propagation is node-style only (`nested_expr`).
-            false,
+            OutletActivity::Untracked,
         )?;
         let scoped = wrap_state_scope(path, stmts);
 

--- a/crates/gantz_core/src/compile/flow.rs
+++ b/crates/gantz_core/src/compile/flow.rs
@@ -3,12 +3,16 @@
 use super::{
     EntrypointId, Meta, MetaGraph,
     error::{InvalidInputIndex, InvalidOutputIndex, NodeConnsError, TooManyConns},
+    meta::EdgeKind,
     push_eval_neighbors, push_reachable,
 };
 use crate::node;
-use petgraph::visit::{EdgeRef, IntoEdgeReferences};
+use petgraph::{
+    graph::NodeIndex,
+    visit::{EdgeRef, IntoEdgeReferences},
+};
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     fmt, ops,
 };
 
@@ -70,52 +74,6 @@ pub struct Branch {
     pub conns: node::Conns,
 }
 
-/// A control flow graph describing individual node function call dependency.
-///
-/// Each `NodeConf` node represents a node function call statement that should
-/// be made.
-///
-/// This is derived from the `Meta` graph and is used to construct the
-/// `FlowGraph` via edge contraction.
-///
-/// Uses a simple edge list rather than `DiGraphMap` because `DiGraphMap` only
-/// supports one edge per (source, target) pair. When multiple branch outputs
-/// feed the same target `NodeConf`, all branch edges must be preserved.
-struct NodeConfGraph {
-    nodes: BTreeSet<NodeConf>,
-    edges: BTreeSet<(NodeConf, NodeConf, Branch)>,
-}
-
-impl NodeConfGraph {
-    fn new() -> Self {
-        Self {
-            nodes: BTreeSet::new(),
-            edges: BTreeSet::new(),
-        }
-    }
-
-    fn add_node(&mut self, conf: NodeConf) {
-        self.nodes.insert(conf);
-    }
-
-    fn add_edge(&mut self, a: NodeConf, b: NodeConf, branch: Branch) {
-        self.nodes.insert(a);
-        self.nodes.insert(b);
-        self.edges.insert((a, b, branch));
-    }
-
-    fn all_edges(&self) -> impl Iterator<Item = (NodeConf, NodeConf, &Branch)> {
-        self.edges.iter().map(|(a, b, w)| (*a, *b, w))
-    }
-
-    fn node_count(&self) -> usize {
-        self.nodes.len()
-    }
-
-    fn edge_count(&self) -> usize {
-        self.edges.len()
-    }
-}
 
 /// A node within the control flow graph.
 ///
@@ -180,6 +138,10 @@ impl From<NodeOutputsError> for NodeConnsError {
 
 /// Given a meta graph and set of push and pull eval fn nodes, construct a full
 /// control flow graph.
+///
+/// Each weakly-connected component of the reachable subgraph is lowered
+/// independently - so independent chains and parallel branches each form their
+/// own flow-graph component - then merged into a single flow graph.
 pub fn flow_graph(
     meta: &Meta,
     push: impl IntoIterator<Item = (node::Id, node::Conns)>,
@@ -188,9 +150,264 @@ pub fn flow_graph(
     let order: Vec<_> = super::eval_order(&meta.graph, push, pull).collect();
     let included: HashSet<_> = order.iter().copied().collect();
     let mg = reachable_subgraph(&meta.graph, &included);
+    let mut fg = FlowGraph::default();
+    let no_shared = HashMap::new();
+    build_flow_graph(meta, &mg, &mg, &mut fg, &no_shared, None)?;
     let branching: BTreeSet<node::Id> = meta.branches.keys().copied().collect();
-    let conf_graph = node_conf_graph(meta, &mg, None)?;
-    Ok(flow_graph_from_conf_graph(&conf_graph, &branching))
+    flow_graph_edge_contraction(&mut fg, &branching);
+    Ok(fg)
+}
+
+/// Build a [`NodeConf`] for `n` from its connectivity within the (possibly
+/// arm-local) `mg`, treating `Static` edges from `outer_mg` as still in scope.
+fn make_conf(
+    meta: &Meta,
+    mg: &MetaGraph,
+    outer_mg: &MetaGraph,
+    n: node::Id,
+) -> Result<NodeConf, NodeConnsError> {
+    let n_inputs = meta.inputs.get(&n).copied().unwrap_or(0);
+    let n_outputs = meta.outputs.get(&n).copied().unwrap_or(0);
+    let inputs = node_inputs_in_scope(mg, outer_mg, n, n_inputs)?;
+    let outputs = node_outputs(mg, n, n_outputs)?;
+    Ok(NodeConf {
+        id: n,
+        conns: NodeConns { inputs, outputs },
+    })
+}
+
+/// The connected inputs of `n`, counting an incoming edge when its source is in
+/// the current arm subgraph `mg`, or when the edge is `Static` (always active,
+/// so reachable from an enclosing scope).
+fn node_inputs_in_scope(
+    mg: &MetaGraph,
+    outer_mg: &MetaGraph,
+    n: node::Id,
+    n_inputs: usize,
+) -> Result<node::Conns, NodeInputsError> {
+    let mut inputs = node::Conns::unconnected(n_inputs).map_err(|_| TooManyConns(n_inputs))?;
+    for e_ref in outer_mg.edges_directed(n, petgraph::Incoming) {
+        let src = e_ref.source();
+        for (edge, kind) in e_ref.weight() {
+            let in_arm = mg.contains_node(src);
+            let static_from_outer = matches!(kind, EdgeKind::Static);
+            if !(in_arm || static_from_outer) {
+                continue;
+            }
+            let index = edge.input.0 as usize;
+            inputs
+                .set(index, true)
+                .map_err(|_| InvalidInputIndex { index, n_inputs })?;
+        }
+    }
+    Ok(inputs)
+}
+
+/// Lower the meta graph `mg` into flow-graph blocks, returning this call's entry
+/// blocks (those with no incoming edge added here).
+///
+/// Branches are lowered by *duplicating* per-arm: each arm recursion allocates
+/// fresh blocks, so a node reached by only some arms appears once per reaching
+/// arm. A node reached by *every* live arm via either an intermediate or
+/// multiple distinct outputs is a true reconvergence point ("join"); it is
+/// pre-allocated as a single shared block so all arms converge on it, and a
+/// continuation pass lowers its downstream exactly once.
+///
+/// - `outer_mg` is the full graph (for `Static`-edge input scoping in arms).
+/// - `shared` maps join node ids to their pre-allocated block.
+/// - `skip` is the branching node owning this arm recursion (already emitted by
+///   the caller); present only in arm recursions.
+fn build_flow_graph(
+    meta: &Meta,
+    mg: &MetaGraph,
+    outer_mg: &MetaGraph,
+    fg: &mut FlowGraph,
+    shared: &HashMap<node::Id, NodeIndex>,
+    skip: Option<node::Id>,
+) -> Result<Vec<NodeIndex>, NodeConnsError> {
+    let mut topo = petgraph::visit::Topo::new(mg);
+    let mut last: Option<NodeIndex> = None;
+    let mut entries: Vec<NodeIndex> = Vec::new();
+    let mut consumed: HashSet<node::Id> = HashSet::new();
+    // Blocks allocated/reused in this call, so a shared block can link from real
+    // meta predecessors processed earlier here.
+    let mut local_blocks: HashMap<node::Id, NodeIndex> = HashMap::new();
+    // In an arm recursion, shared (join) blocks are arm terminals: chain into
+    // them but stop; the owner's continuation pass chains out of them once.
+    let stop_at_shared = skip.is_some();
+
+    while let Some(n) = topo.next(mg) {
+        if consumed.contains(&n) || Some(n) == skip {
+            continue;
+        }
+
+        // Reuse a shared join block, else allocate a fresh one. Fresh allocation
+        // gives the same node id distinct identity in sibling arms (duplication).
+        let is_shared = shared.contains_key(&n);
+        let block_ix = match shared.get(&n) {
+            Some(&ix) => ix,
+            None => {
+                let conf = make_conf(meta, mg, outer_mg, n)?;
+                fg.add_node(Block(vec![conf]))
+            }
+        };
+        local_blocks.insert(n, block_ix);
+
+        // Incoming edges: shared blocks link from their real meta predecessors
+        // (so sibling joins don't get fake chain edges); non-shared blocks chain
+        // via `last` so parallel siblings collapse into one block after
+        // contraction.
+        let mut incoming_added = false;
+        if is_shared {
+            for e_ref in mg.edges_directed(n, petgraph::Incoming) {
+                let src_id = e_ref.source();
+                if Some(src_id) == skip {
+                    continue;
+                }
+                if let Some(&src_block) = local_blocks.get(&src_id) {
+                    let branch = default_branch(fg, src_block);
+                    fg.add_edge(src_block, block_ix, branch);
+                    incoming_added = true;
+                }
+            }
+        } else if let Some(prev_ix) = last {
+            let branch = default_branch(fg, prev_ix);
+            fg.add_edge(prev_ix, block_ix, branch);
+            incoming_added = true;
+        }
+
+        // No incoming edge added: a fresh entry into this recursion. The arm
+        // caller links the arm-branch edge to it.
+        if !incoming_added {
+            entries.push(block_ix);
+        }
+
+        // In an arm recursion, stop at shared blocks; the continuation owns them.
+        if is_shared && stop_at_shared {
+            last = None;
+            continue;
+        }
+
+        if let Some(branches) = meta.branches.get(&n) {
+            let per_arm: Vec<HashSet<node::Id>> = branches
+                .iter()
+                .map(|conns| push_reachable(mg, n, &push_eval_neighbors(mg, n, conns)).collect())
+                .collect();
+
+            // Live arms reach beyond `n`; a dead arm reaching nothing must not
+            // veto a join.
+            let live_arms = per_arm.iter().filter(|r| r.iter().any(|&id| id != n)).count();
+            let mut arm_count: HashMap<node::Id, usize> = HashMap::new();
+            for r in &per_arm {
+                for &id in r.iter().filter(|&&id| id != n) {
+                    *arm_count.entry(id).or_default() += 1;
+                }
+            }
+
+            // Joins: reached by every live arm AND fed via an intermediate or by
+            // multiple distinct outputs of `n` (so a phi var must consolidate
+            // the per-arm value). A "pure parallel sibling" - a direct successor
+            // via a single output reached by every arm - is excluded and instead
+            // duplicated per arm, so codegen keeps each arm body intact.
+            let joins: HashSet<node::Id> = arm_count
+                .iter()
+                .filter(|&(_, &c)| c == live_arms && c > 1)
+                .filter(|&(&id, _)| is_join(mg, n, id))
+                .map(|(&id, _)| id)
+                .collect();
+
+            // Pre-allocate fresh blocks for newly-discovered joins so all arms
+            // converge on the same block; inherited joins keep their block.
+            let mut sub_shared = shared.clone();
+            for &id in &joins {
+                if !sub_shared.contains_key(&id) {
+                    let conf = make_conf(meta, mg, outer_mg, id)?;
+                    let join_ix = fg.add_node(Block(vec![conf]));
+                    sub_shared.insert(id, join_ix);
+                }
+            }
+
+            // Nodes strictly downstream of any join: lowered once in the
+            // continuation pass, excluded from arm recursions.
+            let downstream = strictly_downstream(mg, &joins);
+
+            for (ix, (conns, reachable)) in branches.iter().zip(&per_arm).enumerate() {
+                let arm_reachable: HashSet<_> =
+                    reachable.iter().copied().filter(|id| !downstream.contains(id)).collect();
+                let arm_mg = reachable_subgraph(mg, &arm_reachable);
+                let arm_entries = build_flow_graph(meta, &arm_mg, outer_mg, fg, &sub_shared, Some(n))?;
+                let arm_branch = Branch { ix, conns: *conns };
+                for entry in arm_entries {
+                    fg.add_edge(block_ix, entry, arm_branch);
+                }
+            }
+
+            // Continuation: chain each newly-allocated join's downstream once.
+            if !joins.is_empty() {
+                let mut cont: HashSet<node::Id> = HashSet::new();
+                for &j in &joins {
+                    let mut bfs = petgraph::visit::Bfs::new(mg, j);
+                    while let Some(d) = bfs.next(mg) {
+                        cont.insert(d);
+                    }
+                }
+                let cont_mg = reachable_subgraph(mg, &cont);
+                build_flow_graph(meta, &cont_mg, outer_mg, fg, &sub_shared, None)?;
+            }
+
+            for r in &per_arm {
+                consumed.extend(r.iter().copied().filter(|&id| id != n));
+            }
+            last = None;
+            continue;
+        }
+
+        last = Some(block_ix);
+    }
+
+    Ok(entries)
+}
+
+/// The default (non-branching) [`Branch`] label for an edge out of `src_block`.
+fn default_branch(fg: &FlowGraph, src_block: NodeIndex) -> Branch {
+    let conns = fg[src_block]
+        .last()
+        .expect("flow graph block must be non-empty")
+        .conns
+        .outputs;
+    Branch { ix: 0, conns }
+}
+
+/// Whether `id` (reached by every live arm of branch `n`) is a true phi-join:
+/// fed via an intermediate (a source other than `n`) or by more than one
+/// distinct output of `n`.
+fn is_join(mg: &MetaGraph, n: node::Id, id: node::Id) -> bool {
+    let via_intermediate = mg
+        .edges_directed(id, petgraph::Incoming)
+        .any(|e_ref| e_ref.source() != n);
+    if via_intermediate {
+        return true;
+    }
+    let mut outputs: HashSet<usize> = HashSet::new();
+    for e_ref in mg.edges_directed(n, petgraph::Outgoing) {
+        if e_ref.target() == id {
+            outputs.extend(e_ref.weight().iter().map(|(e, _)| e.output.0 as usize));
+        }
+    }
+    outputs.len() > 1
+}
+
+/// The nodes strictly downstream of any node in `roots` (excluding the roots).
+fn strictly_downstream(mg: &MetaGraph, roots: &HashSet<node::Id>) -> HashSet<node::Id> {
+    let mut downstream = HashSet::new();
+    for &r in roots {
+        let mut bfs = petgraph::visit::Bfs::new(mg, r);
+        let _ = bfs.next(mg); // skip `r` itself
+        while let Some(d) = bfs.next(mg) {
+            downstream.insert(d);
+        }
+    }
+    downstream
 }
 
 /// Filter unreachable nodes from the given metagraph.
@@ -199,25 +416,6 @@ fn reachable_subgraph(g: &MetaGraph, reachable: &HashSet<node::Id>) -> MetaGraph
         .filter(|(a, b, _)| reachable.contains(a) && reachable.contains(b))
         .map(|(a, b, w)| (a, b, w.clone()))
         .collect()
-}
-
-/// Given a node configuration flow graph, return the reduced control flow graph
-/// of basic blocks.
-fn flow_graph_from_conf_graph(cg: &NodeConfGraph, branching: &BTreeSet<node::Id>) -> FlowGraph {
-    // Initialise the flow graph with the same nodes and edges.
-    let mut g = FlowGraph::with_capacity(cg.node_count(), cg.edge_count());
-    let mut visited = HashMap::with_capacity(cg.node_count());
-    for (a, b, &branch) in cg.all_edges() {
-        let na = *visited
-            .entry(a)
-            .or_insert_with(|| g.add_node(Block(vec![a])));
-        let nb = *visited
-            .entry(b)
-            .or_insert_with(|| g.add_node(Block(vec![b])));
-        g.add_edge(na, nb, branch);
-    }
-    flow_graph_edge_contraction(&mut g, branching);
-    g
 }
 
 /// For the given flow graph, contract all edges into basic blocks where
@@ -273,25 +471,6 @@ fn flow_graph_edge_contraction(g: &mut FlowGraph, branching: &BTreeSet<node::Id>
 }
 
 /// Given some node within a given meta graph with an expected total number of
-/// inputs, return the list of inputs that are actually connected.
-fn node_inputs(
-    g: &MetaGraph,
-    n: node::Id,
-    n_inputs: usize,
-) -> Result<node::Conns, NodeInputsError> {
-    let mut inputs = node::Conns::unconnected(n_inputs).map_err(|_| TooManyConns(n_inputs))?;
-    for e_ref in g.edges_directed(n, petgraph::Incoming) {
-        for (edge, _kind) in e_ref.weight() {
-            let index = edge.input.0 as usize;
-            inputs
-                .set(index, true)
-                .map_err(|_| InvalidInputIndex { index, n_inputs })?;
-        }
-    }
-    Ok(inputs)
-}
-
-/// Given some node within a given meta graph with an expected total number of
 /// outputs, return the list of outputs that are actually connected.
 fn node_outputs(
     g: &MetaGraph,
@@ -310,82 +489,116 @@ fn node_outputs(
     Ok(outputs)
 }
 
-/// For the given meta graph `mg`, produce its control flow graph.
+/// All root blocks (no incoming edges) of the flow graph.
 ///
-/// The given meta graph should only contain the nodes reachable in the desired
-/// evaluation path.
-//
-// FIXME:
-// - The first edge from branching nodes should use `branch` - is this
-//   happening?
-// - Refactor this to not use recursion on branching.
-// TODO:
-// - Refactor to avoid gross `first_node_conns` and `first_branch_ix` inputs.
-fn node_conf_graph(
-    meta: &Meta,
-    mg: &MetaGraph,
-    // The `NodeConns` is the conns of the branching node.
-    mut from_branch: Option<(NodeConns, Branch)>,
-) -> Result<NodeConfGraph, NodeConnsError> {
-    let mut g = NodeConfGraph::new();
+/// A flow graph may comprise multiple disconnected components - e.g. when
+/// independent inlet→outlet chains (such as parallel inner branches) are
+/// evaluated together - and each component contributes its own root.
+pub(crate) fn flow_graph_roots(fg: &FlowGraph) -> Vec<NodeIndex> {
+    let mut roots: Vec<_> = fg
+        .node_indices()
+        .filter(|&n| fg.edges_directed(n, petgraph::Incoming).next().is_none())
+        .collect();
+    // Sort by the block's first node id for stable output independent of block
+    // allocation order.
+    roots.sort_by_key(|&ix| fg[ix].first().map(|c| c.id).unwrap_or(node::Id::MAX));
+    roots
+}
 
-    // Walk nodes in topological order until we hit a branch.
-    let mut topo = petgraph::visit::Topo::new(mg);
-    let mut last = None;
-    while let Some(n) = topo.next(mg) {
-        // Determine the configuration and add it.
-        let n_inputs = meta.inputs.get(&n).copied().unwrap_or(0);
-        let n_outputs = meta.outputs.get(&n).copied().unwrap_or(0);
-        let inputs = node_inputs(mg, n, n_inputs)?;
-        let outputs = node_outputs(mg, n, n_outputs)?;
-        let conns = NodeConns { inputs, outputs };
-        let mut conf = NodeConf { id: n, conns };
-
-        // Add an edge from the prev node.
-        if let Some(prev) = last {
-            let branch = from_branch.take().map(|(_, b)| b).unwrap_or_else(|| {
-                let conns = outputs;
-                Branch { ix: 0, conns }
-            });
-            g.add_edge(prev, conf, branch);
-
-        // If there is no last node, this is the first node.
-        } else {
-            // If a set of outputs were provided for the first node, this is for
-            // the beginning node in a branch.
-            if let Some((conns, _branch)) = from_branch {
-                conf.conns = conns;
+/// The distinct sets of outlets that may be simultaneously active across every
+/// combination of inner branch outcomes, computed by walking the flow graph as
+/// a decision tree.
+///
+/// `branching` maps each branching node's id to its declared arm count. A
+/// *world* assigns one arm to each branch block actually reached; the reached
+/// outlets of a world are the outlets appearing in blocks reachable when each
+/// branch follows only its assigned arm's edge. A declared arm with no matching
+/// edge is dead - it extends reachability no further.
+///
+/// Because this walks the *same* flow graph the codegen lowers, the resulting
+/// patterns are aligned with the code that actually sets each outlet.
+pub(crate) fn outlet_patterns(
+    fg: &FlowGraph,
+    outlets: &BTreeSet<node::Id>,
+    branching: &BTreeMap<node::Id, usize>,
+) -> BTreeSet<BTreeSet<node::Id>> {
+    let roots = flow_graph_roots(fg);
+    let mut patterns = BTreeSet::new();
+    // Each entry is a partial world: an arm assignment per branch block.
+    let mut stack: Vec<BTreeMap<NodeIndex, usize>> = vec![BTreeMap::new()];
+    while let Some(world) = stack.pop() {
+        match reach_world(fg, &roots, outlets, branching, &world) {
+            WorldReach::Complete(reached) => {
+                patterns.insert(reached);
             }
-            g.add_node(conf);
-        }
-
-        // If this is not the first node, and the node branches,
-        // determine all possible branching outputs from this node.
-        if let (Some(branches), true) = (meta.branches.get(&n), last.is_some()) {
-            // For each branch, collect the subgraph.
-            // FIXME: Make this non-recursive.
-
-            for (ix, branch) in branches.iter().enumerate() {
-                let nbs = push_eval_neighbors(mg, n, branch);
-                let reachable: HashSet<_> = push_reachable(mg, n, &nbs).collect();
-                let sub_mg = reachable_subgraph(mg, &reachable);
-                let branch = Branch { ix, conns: *branch };
-                // FIXME: This adds the branching node, but with a subset of
-                // outputs. We only want the branching node at the end of the
-                // block with all connected outputs in the config, then the
-                // *edges* should have the branch subsets.
-                let sub_ncg = node_conf_graph(meta, &sub_mg, Some((conns, branch)))?;
-                for (a, b, &w) in sub_ncg.all_edges() {
-                    g.add_edge(a, b, w);
+            WorldReach::Frontier(block, n_arms) => {
+                for arm in 0..n_arms {
+                    let mut next = world.clone();
+                    next.insert(block, arm);
+                    stack.push(next);
                 }
             }
-
-            // We've handled the branches in the recursive cases - we're done.
-            break;
         }
-
-        last = Some(conf);
     }
+    patterns
+}
 
-    Ok(g)
+/// Outcome of walking one (partial) world in [`outlet_patterns`].
+enum WorldReach {
+    /// Every reached branch block was assigned; these outlets were reached.
+    Complete(BTreeSet<node::Id>),
+    /// A reached branch block (with the given arm count) was unassigned.
+    Frontier(NodeIndex, usize),
+}
+
+/// BFS the flow graph following only assigned branch arms. Returns the
+/// deterministic-min unassigned reached branch block, or - when every reached
+/// branch is assigned - the reached outlets.
+fn reach_world(
+    fg: &FlowGraph,
+    roots: &[NodeIndex],
+    outlets: &BTreeSet<node::Id>,
+    branching: &BTreeMap<node::Id, usize>,
+    world: &BTreeMap<NodeIndex, usize>,
+) -> WorldReach {
+    let mut visited: HashSet<NodeIndex> = HashSet::new();
+    let mut queue: VecDeque<NodeIndex> = roots.iter().copied().collect();
+    let mut reached: BTreeSet<node::Id> = BTreeSet::new();
+    let mut frontier: Option<NodeIndex> = None;
+    while let Some(blk) = queue.pop_front() {
+        if !visited.insert(blk) {
+            continue;
+        }
+        let block = &fg[blk];
+        for conf in block.iter() {
+            if outlets.contains(&conf.id) {
+                reached.insert(conf.id);
+            }
+        }
+        let last = block.last().expect("flow block must not be empty");
+        if branching.contains_key(&last.id) {
+            // A branch block only proceeds along its assigned arm's edge.
+            match world.get(&blk) {
+                None => frontier = Some(frontier.map_or(blk, |f| f.min(blk))),
+                Some(&arm) => {
+                    for e_ref in fg.edges_directed(blk, petgraph::Outgoing) {
+                        if e_ref.weight().ix == arm {
+                            queue.push_back(e_ref.target());
+                        }
+                    }
+                }
+            }
+        } else {
+            for e_ref in fg.edges_directed(blk, petgraph::Outgoing) {
+                queue.push_back(e_ref.target());
+            }
+        }
+    }
+    match frontier {
+        Some(blk) => {
+            let id = fg[blk].last().expect("non-empty block").id;
+            WorldReach::Frontier(blk, branching[&id])
+        }
+        None => WorldReach::Complete(reached),
+    }
 }

--- a/crates/gantz_core/src/compile/flow.rs
+++ b/crates/gantz_core/src/compile/flow.rs
@@ -74,7 +74,6 @@ pub struct Branch {
     pub conns: node::Conns,
 }
 
-
 /// A node within the control flow graph.
 ///
 /// Maps directly to a node function.
@@ -296,7 +295,10 @@ fn build_flow_graph(
 
             // Live arms reach beyond `n`; a dead arm reaching nothing must not
             // veto a join.
-            let live_arms = per_arm.iter().filter(|r| r.iter().any(|&id| id != n)).count();
+            let live_arms = per_arm
+                .iter()
+                .filter(|r| r.iter().any(|&id| id != n))
+                .count();
             let mut arm_count: HashMap<node::Id, usize> = HashMap::new();
             for r in &per_arm {
                 for &id in r.iter().filter(|&&id| id != n) {
@@ -332,10 +334,14 @@ fn build_flow_graph(
             let downstream = strictly_downstream(mg, &joins);
 
             for (ix, (conns, reachable)) in branches.iter().zip(&per_arm).enumerate() {
-                let arm_reachable: HashSet<_> =
-                    reachable.iter().copied().filter(|id| !downstream.contains(id)).collect();
+                let arm_reachable: HashSet<_> = reachable
+                    .iter()
+                    .copied()
+                    .filter(|id| !downstream.contains(id))
+                    .collect();
                 let arm_mg = reachable_subgraph(mg, &arm_reachable);
-                let arm_entries = build_flow_graph(meta, &arm_mg, outer_mg, fg, &sub_shared, Some(n))?;
+                let arm_entries =
+                    build_flow_graph(meta, &arm_mg, outer_mg, fg, &sub_shared, Some(n))?;
                 let arm_branch = Branch { ix, conns: *conns };
                 for entry in arm_entries {
                     fg.add_edge(block_ix, entry, arm_branch);

--- a/crates/gantz_core/src/node.rs
+++ b/crates/gantz_core/src/node.rs
@@ -278,6 +278,11 @@ impl<'a> MetaCtx<'a> {
     pub fn node(&self, ca: &gantz_ca::ContentAddr) -> Option<&'a dyn Node> {
         (self.get_node)(ca)
     }
+
+    /// Access to the node lookup function.
+    pub fn get_node(&self) -> GetNode<'a> {
+        self.get_node
+    }
 }
 
 impl<'env, 'data> RegCtx<'env, 'data> {

--- a/crates/gantz_core/src/node/graph.rs
+++ b/crates/gantz_core/src/node/graph.rs
@@ -484,6 +484,11 @@ where
     // The external branch patterns (empty => not externally branching).
     let patterns = branch_patterns_from_flow(&fg, &outlet_ids, &arm_counts)?;
     let branching = !patterns.is_empty();
+    let outlet_activity = if branching {
+        compile::OutletActivity::Tracked
+    } else {
+        compile::OutletActivity::Untracked
+    };
 
     // Bind each inlet from the corresponding node input (input i -> inlet i).
     let mut bindings: Vec<String> = inlet_ids
@@ -516,7 +521,7 @@ where
         &meta.outlets,
         &fg,
         &BTreeSet::new(),
-        branching,
+        outlet_activity,
     )
     .map_err(node::ExprError::custom)?;
 

--- a/crates/gantz_core/src/node/graph.rs
+++ b/crates/gantz_core/src/node/graph.rs
@@ -1,7 +1,7 @@
 //! An implementation of a node acting as a nested graph.
 
 use crate::{
-    Edge, GRAPH_STATE,
+    Edge, GRAPH_STATE, compile,
     node::{self, Node},
     visit,
 };
@@ -16,6 +16,7 @@ use petgraph::{
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
+    collections::{BTreeMap, BTreeSet},
     hash::{Hash, Hasher},
     ops::{Deref, DerefMut},
 };
@@ -89,9 +90,15 @@ impl<N: Node> Node for Graph<N> {
             .count()
     }
 
-    fn branches(&self, _ctx: node::MetaCtx) -> Vec<node::EvalConf> {
-        // TODO: generate branches based on inner node branching
-        vec![]
+    fn branches(&self, ctx: node::MetaCtx) -> Vec<node::EvalConf> {
+        // Any malformed-graph error surfaces authoritatively when `module()`
+        // builds this same graph, so falling back to "not branching" here is
+        // safe and keeps `branches()` consistent with `nested_expr`.
+        graph_branches(ctx.get_node(), self)
+            .unwrap_or_default()
+            .into_iter()
+            .map(node::EvalConf::Set)
+            .collect()
     }
 
     fn expr(&self, ctx: node::ExprCtx<'_, '_>) -> node::ExprResult {
@@ -318,7 +325,145 @@ pub fn graph_partial_eq<N: PartialEq>(a: &Graph<N>, b: &Graph<N>) -> bool {
             .all(|(a, b)| a == b)
 }
 
+/// Map a nested graph's branch arm counts (`id -> n_arms`) from its `Meta`.
+fn branch_arm_counts(meta: &compile::Meta) -> BTreeMap<node::Id, usize> {
+    meta.branches.iter().map(|(&id, v)| (id, v.len())).collect()
+}
+
+/// The distinct external branches of a nested graph, as output masks over its
+/// outlets (ascending id order), or an empty `Vec` when it does not branch.
+///
+/// Each pattern is one set of outlets that may be simultaneously active under
+/// some combination of inner branch outcomes (see [`compile::outlet_patterns`]).
+/// Fewer than two distinct patterns means the graph always produces the same
+/// outlets, i.e. it has no external branching.
+fn branch_patterns_from_flow(
+    fg: &compile::FlowGraph,
+    outlet_ids: &[node::Id],
+    branching: &BTreeMap<node::Id, usize>,
+) -> Result<Vec<node::Conns>, node::ExprError> {
+    let outlets: BTreeSet<node::Id> = outlet_ids.iter().copied().collect();
+    let mut patterns: BTreeSet<node::Conns> = BTreeSet::new();
+    for reached in compile::outlet_patterns(fg, &outlets, branching) {
+        let mut conns = node::Conns::unconnected(outlet_ids.len()).map_err(node::ExprError::custom)?;
+        for (i, id) in outlet_ids.iter().enumerate() {
+            if reached.contains(id) {
+                conns.set(i, true).map_err(node::ExprError::custom)?;
+            }
+        }
+        patterns.insert(conns);
+    }
+    if patterns.len() < 2 {
+        return Ok(vec![]);
+    }
+    Ok(patterns.into_iter().collect())
+}
+
+/// Compute the external branch masks for a nested graph (see [`Node::branches`]).
+fn graph_branches<'a, G>(
+    get_node: node::GetNode<'a>,
+    g: G,
+) -> Result<Vec<node::Conns>, node::ExprError>
+where
+    G: IntoEdgesDirected + IntoNodeReferences + NodeIndexable + Visitable + Data<EdgeWeight = Edge>,
+    G::NodeWeight: Node,
+    G::NodeId: Eq + Hash,
+{
+    let meta = compile::Meta::from_graph(get_node, g).map_err(node::ExprError::custom)?;
+    // No inner branching => no external branching.
+    if meta.branches.is_empty() {
+        return Ok(vec![]);
+    }
+    let outlet_ids: Vec<node::Id> = meta.outlets.iter().copied().collect();
+    let fg = inner_flow_graph(&meta)?;
+    branch_patterns_from_flow(&fg, &outlet_ids, &branch_arm_counts(&meta))
+}
+
+/// Build the control flow graph for a nested graph: inlets push, outlets pull.
+fn inner_flow_graph(meta: &compile::Meta) -> Result<compile::FlowGraph, node::ExprError> {
+    let conn = || node::Conns::connected(1).unwrap();
+    compile::flow_graph(
+        meta,
+        meta.inlets.iter().map(|&n| (n, conn())),
+        meta.outlets.iter().map(|&n| (n, conn())),
+    )
+    .map_err(node::ExprError::custom)
+}
+
+/// The Steel expression that yields a nested graph's outlet values, shaped by
+/// the given outlets: a single raw value for one outlet, a `(list ...)` for
+/// several, or `'()` for none. Each value is read from its hoisted `outlet-{id}`
+/// var.
+fn outlet_values_expr(outlet_ids: &[node::Id]) -> String {
+    match outlet_ids {
+        [] => "'()".to_string(),
+        [id] => format!("outlet-{id}"),
+        ids => {
+            let values: Vec<_> = ids.iter().map(|id| format!("outlet-{id}")).collect();
+            format!("(list {})", values.join(" "))
+        }
+    }
+}
+
+/// The Steel expression selecting `(list branch-ix value)` for a branching
+/// nested graph.
+///
+/// Each distinct outlet-activation pattern has a unique integer signature
+/// (outlet `i` contributes `2^i` when active); the runtime signature is built
+/// from the hoisted `outlet-active-{id}` flags and matched against each
+/// pattern's signature with a nested `if` (the last pattern is the exhaustive
+/// fallthrough). Only primitive Steel forms are used, since the VM runs the
+/// base engine without the `cond`/`and` prelude macros.
+fn branch_selector(patterns: &[node::Conns], outlet_ids: &[node::Id]) -> String {
+    // The value to return for a pattern, shaped by its active outlet count.
+    let value = |conns: &node::Conns| -> String {
+        let active: Vec<node::Id> = outlet_ids
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &id)| conns.get(i).unwrap_or(false).then_some(id))
+            .collect();
+        outlet_values_expr(&active)
+    };
+    // The unique signature of a pattern's active outlets.
+    let signature = |conns: &node::Conns| -> u128 {
+        (0..outlet_ids.len())
+            .filter(|&i| conns.get(i).unwrap_or(false))
+            .map(|i| 1u128 << i)
+            .sum()
+    };
+
+    // The runtime signature, summed from the active flags.
+    let terms: Vec<String> = outlet_ids
+        .iter()
+        .enumerate()
+        .map(|(i, &id)| format!("(if outlet-active-{id} {} 0)", 1u128 << i))
+        .collect();
+    let sig_expr = match terms.as_slice() {
+        [] => "0".to_string(),
+        [t] => t.clone(),
+        _ => format!("(+ {})", terms.join(" ")),
+    };
+
+    // Nested `if` over patterns; the last is the exhaustive fallthrough.
+    let last = patterns.len() - 1;
+    let mut expr = format!("(list {last} {})", value(&patterns[last]));
+    for k in (0..last).rev() {
+        expr = format!(
+            "(if (= __branch-sig {}) (list {k} {}) {expr})",
+            signature(&patterns[k]),
+            value(&patterns[k]),
+        );
+    }
+    format!("(let ((__branch-sig {sig_expr})) {expr})")
+}
+
 /// The implementation of the `GraphNode`'s `Node::expr` fn.
+///
+/// The nested graph is inlined as an expression. Inlet values are bound from the
+/// node's inputs; the inner control flow runs with outlets writing their values
+/// (and, when the graph branches externally, their "active" flags) to hoisted
+/// vars. The result is the outlet values, or - when branching - a
+/// `(list branch-ix value)` pair matching [`graph_branches`].
 pub fn nested_expr<'a, G>(
     get_node: node::GetNode<'a>,
     g: G,
@@ -330,105 +475,73 @@ where
     G::NodeWeight: Node,
     G::NodeId: Eq + Hash,
 {
-    use crate::compile;
-    use petgraph::visit::EdgeRef;
+    let meta = compile::Meta::from_graph(get_node, g).map_err(node::ExprError::custom)?;
+    let inlet_ids: Vec<node::Id> = meta.inlets.iter().copied().collect();
+    let outlet_ids: Vec<node::Id> = meta.outlets.iter().copied().collect();
+    let fg = inner_flow_graph(&meta)?;
+    let arm_counts = branch_arm_counts(&meta);
 
-    let meta_ctx = node::MetaCtx::new(get_node);
+    // The external branch patterns (empty => not externally branching).
+    let patterns = branch_patterns_from_flow(&fg, &outlet_ids, &arm_counts)?;
+    let branching = !patterns.is_empty();
 
-    // Create define bindings for inlet values.
-    let inlet_ids: Vec<_> = g
-        .node_references()
-        .filter(|n_ref| n_ref.weight().inlet(meta_ctx))
-        .map(|n_ref| n_ref.id())
+    // Bind each inlet from the corresponding node input (input i -> inlet i).
+    let mut bindings: Vec<String> = inlet_ids
+        .iter()
+        .enumerate()
+        .map(|(i, &inlet_id)| {
+            let input = inputs
+                .get(i)
+                .and_then(Clone::clone)
+                .unwrap_or_else(|| "'()".to_string());
+            format!("(define inlet-{inlet_id} {input})")
+        })
         .collect();
-    let mut inlet_bindings = Vec::new();
-    for (i, &inlet_id) in inlet_ids.iter().enumerate() {
-        let node_ix = g.to_index(inlet_id);
-        let input_expr = if i < inputs.len() && inputs[i].is_some() {
-            inputs[i].as_ref().unwrap().clone()
-        } else {
-            "'()".to_string()
-        };
-        let binding = format!("(define inlet-{node_ix} {input_expr})");
-        inlet_bindings.push(binding);
+
+    // Declare the hoisted outlet value vars (and active flags when branching)
+    // that the flow statements `set!` wherever an outlet is reached.
+    for &id in &outlet_ids {
+        bindings.push(format!("(define outlet-{id} '())"));
+        if branching {
+            bindings.push(format!("(define outlet-active-{id} #f)"));
+        }
     }
 
-    // Use compile to create the evaluation order, steps, and statements.
-    let meta = compile::Meta::from_graph(get_node, g).map_err(|e| node::ExprError::custom(e))?;
-    let outlet_ids: Vec<_> = g
-        .node_references()
-        .filter(|n_ref| n_ref.weight().outlet(meta_ctx))
-        .map(|n_ref| n_ref.id())
-        .collect();
-    let flow_graph = compile::flow_graph(
-        &meta,
-        inlet_ids
-            .iter()
-            .map(|&n| (g.to_index(n), node::Conns::connected(1).unwrap())),
-        outlet_ids
-            .iter()
-            .map(|&n| (g.to_index(n), node::Conns::connected(1).unwrap())),
-    )
-    .map_err(|e| node::ExprError::custom(e))?;
-    let branching: std::collections::BTreeMap<node::Id, usize> =
-        meta.branches.iter().map(|(&id, v)| (id, v.len())).collect();
     let stmts = compile::entry_fn_body(
         path,
         &meta.graph,
         &meta.stateful,
-        &branching,
+        &arm_counts,
         &meta.inlets,
         &meta.outlets,
-        &flow_graph,
-        &std::collections::BTreeSet::new(),
+        &fg,
+        &BTreeSet::new(),
+        branching,
     )
-    .map_err(|e| node::ExprError::custom(e))?;
+    .map_err(node::ExprError::custom)?;
 
-    // Combine inlet bindings with graph evaluation steps
-    let all_stmts = inlet_bindings
+    let body = bindings
         .into_iter()
-        .chain(stmts.iter().map(|stmt| format!("{}", stmt)))
+        .chain(stmts.iter().map(|stmt| format!("{stmt}")))
         .collect::<Vec<_>>()
         .join(" ");
 
-    // For the return values, find the source node connected to each outlet's input.
-    let outlet_values = outlet_ids
-        .iter()
-        .map(|&outlet_id| {
-            // Find the edge coming into this outlet (input index 0).
-            let incoming: Vec<_> = g.edges_directed(outlet_id, petgraph::Incoming).collect();
-            if let Some(edge_ref) = incoming.first() {
-                let src_ix = g.to_index(edge_ref.source());
-                let src_out = edge_ref.weight().output.0;
-                format!("node-{src_ix}-o{src_out}")
-            } else {
-                // No incoming edge, outlet is disconnected.
-                "'()".to_string()
-            }
-        })
-        .collect::<Vec<_>>();
-
-    // Construct the final expression based on number of outputs
-    let outlet_values_expr = if outlet_values.len() > 1 {
-        let ret_values = outlet_values.join(" ");
-        format!("(list {})", ret_values)
-    } else if outlet_values.len() == 1 {
-        outlet_values[0].clone()
+    // The node's output: a `(list branch-ix value)` when branching, else the
+    // outlet values directly.
+    let tail = if branching {
+        branch_selector(&patterns, &outlet_ids)
     } else {
-        "'()".to_string()
+        outlet_values_expr(&outlet_ids)
     };
 
-    // Only include state handling if the graph has stateful nodes.
+    // Wrap in `(let () ...)` so the inner statements form a *body*: unlike a
+    // bare `(begin ...)` used as an expression, a body permits `define`s
+    // interleaved with the branch `if` expressions of multiple components.
+    // Include state handling only if the graph has stateful nodes.
     let expr_str = if meta.stateful.is_empty() {
-        format!("(begin {} {outlet_values_expr})", all_stmts)
+        format!("(let () {body} {tail})")
     } else {
-        format!(
-            "(begin (define {GRAPH_STATE} state)
-               {}
-               (set! state {GRAPH_STATE})
-               {outlet_values_expr})",
-            all_stmts
-        )
+        format!("(let () (define {GRAPH_STATE} state) {body} (set! state {GRAPH_STATE}) {tail})")
     };
     node::parse_expr(&expr_str)
 }

--- a/crates/gantz_core/src/node/graph.rs
+++ b/crates/gantz_core/src/node/graph.rs
@@ -345,7 +345,8 @@ fn branch_patterns_from_flow(
     let outlets: BTreeSet<node::Id> = outlet_ids.iter().copied().collect();
     let mut patterns: BTreeSet<node::Conns> = BTreeSet::new();
     for reached in compile::outlet_patterns(fg, &outlets, branching) {
-        let mut conns = node::Conns::unconnected(outlet_ids.len()).map_err(node::ExprError::custom)?;
+        let mut conns =
+            node::Conns::unconnected(outlet_ids.len()).map_err(node::ExprError::custom)?;
         for (i, id) in outlet_ids.iter().enumerate() {
             if reached.contains(id) {
                 conns.set(i, true).map_err(node::ExprError::custom)?;

--- a/crates/gantz_core/src/node/graph.rs
+++ b/crates/gantz_core/src/node/graph.rs
@@ -464,7 +464,7 @@ fn branch_selector(patterns: &[node::Conns], outlet_ids: &[node::Id]) -> String 
 /// node's inputs; the inner control flow runs with outlets writing their values
 /// (and, when the graph branches externally, their "active" flags) to hoisted
 /// vars. The result is the outlet values, or - when branching - a
-/// `(list branch-ix value)` pair matching [`graph_branches`].
+/// `(list branch-ix value)` pair matching `graph_branches`.
 pub fn nested_expr<'a, G>(
     get_node: node::GetNode<'a>,
     g: G,

--- a/crates/gantz_core/tests/nested.rs
+++ b/crates/gantz_core/tests/nested.rs
@@ -971,3 +971,826 @@ fn test_graph_nested_mixed_level_multi_source() {
         .expect("number state was None");
     assert_eq!(val, 30);
 }
+
+// ===========================================================================
+// Nested-graph branching tests.
+//
+// A nested graph whose interior branches should report that branching to the
+// outer graph via `Node::branches`, so the outer graph only evaluates the
+// downstream of outlets actually produced by the taken inner branch.
+//
+// Each test's INNER graph is sketched above it. `branches()` lists the sets of
+// outputs active per external branch (`{}` = a branch producing nothing).
+// Diagram legend:
+//   [In]     inlet            [Out X]  outlet
+//   [Sel]    node_select: input ==0 -> o0(42), else -> o1(99)
+//   oN       branch output N    /  \   the two arms of a branch
+// The OUTER graph is uniform: push -> int value(s) -> [GraphNode] -> a `number`
+// store per output (which records the value it receives).
+// ===========================================================================
+
+// A 1-input, 2-output branch primitive. Routes to output 0 (value 42) when the
+// input is 0, else to output 1 (value 99).
+fn node_select() -> node::Branch {
+    node::branch(
+        "(if (= 0 $x) (list 0 42) (list 1 99))",
+        vec![
+            node::Conns::try_from([true, false]).unwrap(),
+            node::Conns::try_from([false, true]).unwrap(),
+        ],
+    )
+    .unwrap()
+}
+
+// Assert that `inner.branches()` reports exactly `expected` (order-insensitive),
+// where each entry lists the output indices active in that branch.
+fn assert_inner_branches<N: Node + ?Sized>(inner: &N, n_outputs: usize, expected: &[&[u16]]) {
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let got: std::collections::BTreeSet<Vec<u16>> = inner
+        .branches(ctx)
+        .iter()
+        .map(|b| {
+            let node::EvalConf::Set(c) = b else {
+                panic!("expected EvalConf::Set, got {b:?}");
+            };
+            (0..n_outputs as u16)
+                .filter(|&i| c.get(i as usize).unwrap_or(false))
+                .collect()
+        })
+        .collect();
+    let want: std::collections::BTreeSet<Vec<u16>> = expected
+        .iter()
+        .map(|e| {
+            let mut v = e.to_vec();
+            v.sort();
+            v
+        })
+        .collect();
+    assert_eq!(got, want, "branch patterns mismatch");
+}
+
+// Build, compile and run a graph from `push`; returns the VM for state queries.
+fn compile_and_push<N: DebugNode + ?Sized>(
+    g: &petgraph::graph::DiGraph<Box<N>, Edge>,
+    push: petgraph::graph::NodeIndex,
+) -> Engine {
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let eps = push_pull_entrypoints(&no_lookup, g);
+    let module = gantz_core::compile::module(&no_lookup, g, &eps).unwrap();
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, g, &[], &mut vm);
+    for f in &module {
+        vm.run(f.to_pretty(100)).unwrap();
+    }
+    let ep = entrypoint::push(vec![push.index()], g[push].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep.id()), vec![])
+        .unwrap();
+    vm
+}
+
+// `Some(v)` if the store node holds a number, else `None` (never evaluated).
+fn store_val(vm: &Engine, store: petgraph::graph::NodeIndex) -> Option<i32> {
+    node::state::extract::<i32>(vm, &[store.index()]).ok().flatten()
+}
+
+// Divergent branch: each arm routes to its own outlet.  branches: [{A}, {B}]
+//
+//        [In]
+//         |
+//       [Sel]
+//      o0/  \o1
+//   [Out A]  [Out B]
+#[test]
+fn test_graph_nested_divergent_branch() {
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let inlet = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let select = inner.add_node(Box::new(node_select()) as Box<_>);
+        let outlet_a = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let outlet_b = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(inlet, select, Edge::from((0, 0)));
+        inner.add_edge(select, outlet_a, Edge::from((0, 0)));
+        inner.add_edge(select, outlet_b, Edge::from((1, 0)));
+        inner
+    };
+
+    // Two arms: arm 0 -> outlet A only, arm 1 -> outlet B only.
+    assert_inner_branches(&make_inner(), 2, &[&[0], &[1]]);
+
+    let build = |sel: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = g.add_node(Box::new(node_int(sel)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let store_a = g.add_node(Box::new(node_number()) as Box<_>);
+        let store_b = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push, int, Edge::from((0, 0)));
+        g.add_edge(int, inner_node, Edge::from((0, 0)));
+        g.add_edge(inner_node, store_a, Edge::from((0, 0)));
+        g.add_edge(inner_node, store_b, Edge::from((1, 0)));
+        let vm = compile_and_push(&g, push);
+        (store_val(&vm, store_a), store_val(&vm, store_b))
+    };
+
+    // sel == 0 -> arm 0 -> only store_a written (42).
+    assert_eq!(build(0), (Some(42), None));
+    // sel != 0 -> arm 1 -> only store_b written (99).
+    assert_eq!(build(1), (None, Some(99)));
+}
+
+// Reconvergent: both arms feed the SAME outlet, so it is always produced and
+// there is no external branching (the value still differs per arm).  branches: []
+//
+//        [In]
+//         |
+//       [Sel]
+//      o0\  /o1
+//       [Out A]
+#[test]
+fn test_graph_nested_reconvergent_branch() {
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let inlet = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let select = inner.add_node(Box::new(node_select()) as Box<_>);
+        let outlet = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(inlet, select, Edge::from((0, 0)));
+        inner.add_edge(select, outlet, Edge::from((0, 0)));
+        inner.add_edge(select, outlet, Edge::from((1, 0)));
+        inner
+    };
+
+    // No external branching: the outlet is always produced.
+    assert_inner_branches(&make_inner(), 1, &[]);
+
+    let build = |sel: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = g.add_node(Box::new(node_int(sel)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let store = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push, int, Edge::from((0, 0)));
+        g.add_edge(int, inner_node, Edge::from((0, 0)));
+        g.add_edge(inner_node, store, Edge::from((0, 0)));
+        store_val(&compile_and_push(&g, push), store)
+    };
+
+    // Outlet always written; the value differs per arm (phi reconvergence).
+    assert_eq!(build(0), Some(42));
+    assert_eq!(build(1), Some(99));
+}
+
+// Dead arm: arm 1's output is unconnected, so it produces nothing.
+// branches: [{}, {A}]
+//
+//        [In]
+//         |
+//       [Sel]
+//      o0|   \o1   (unconnected = dead arm)
+//   [Out A]    x
+#[test]
+fn test_graph_nested_dead_arm() {
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let inlet = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let select = inner.add_node(Box::new(node_select()) as Box<_>);
+        let outlet = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(inlet, select, Edge::from((0, 0)));
+        inner.add_edge(select, outlet, Edge::from((0, 0)));
+        // Output 1 of Select is left unconnected (a dead arm).
+        inner
+    };
+
+    // Two patterns: empty (dead arm) and {outlet}.
+    assert_inner_branches(&make_inner(), 1, &[&[], &[0]]);
+
+    let build = |sel: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = g.add_node(Box::new(node_int(sel)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let store = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push, int, Edge::from((0, 0)));
+        g.add_edge(int, inner_node, Edge::from((0, 0)));
+        g.add_edge(inner_node, store, Edge::from((0, 0)));
+        store_val(&compile_and_push(&g, push), store)
+    };
+
+    assert_eq!(build(0), Some(42)); // arm 0 -> outlet
+    assert_eq!(build(1), None); // arm 1 -> dead, nothing downstream evaluated
+}
+
+// Per-arm intermediates: each arm transforms its value before its outlet.
+// branches: [{A}, {B}]
+//
+//         [In]
+//          |
+//        [Sel]
+//      o0/    \o1
+//    [+10]    [+20]
+//      |        |
+//   [Out A]   [Out B]
+#[test]
+fn test_graph_nested_branch_intermediates() {
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let inlet = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let select = inner.add_node(Box::new(node_select()) as Box<_>);
+        let add10 = inner.add_node(Box::new(node::expr("(+ $x 10)").unwrap()) as Box<_>);
+        let add20 = inner.add_node(Box::new(node::expr("(+ $x 20)").unwrap()) as Box<_>);
+        let outlet_a = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let outlet_b = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(inlet, select, Edge::from((0, 0)));
+        inner.add_edge(select, add10, Edge::from((0, 0)));
+        inner.add_edge(add10, outlet_a, Edge::from((0, 0)));
+        inner.add_edge(select, add20, Edge::from((1, 0)));
+        inner.add_edge(add20, outlet_b, Edge::from((0, 0)));
+        inner
+    };
+
+    assert_inner_branches(&make_inner(), 2, &[&[0], &[1]]);
+
+    let build = |sel: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = g.add_node(Box::new(node_int(sel)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let store_a = g.add_node(Box::new(node_number()) as Box<_>);
+        let store_b = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push, int, Edge::from((0, 0)));
+        g.add_edge(int, inner_node, Edge::from((0, 0)));
+        g.add_edge(inner_node, store_a, Edge::from((0, 0)));
+        g.add_edge(inner_node, store_b, Edge::from((1, 0)));
+        let vm = compile_and_push(&g, push);
+        (store_val(&vm, store_a), store_val(&vm, store_b))
+    };
+
+    assert_eq!(build(0), (Some(52), None)); // 42 + 10
+    assert_eq!(build(1), (None, Some(119))); // 99 + 20
+}
+
+// Multi-output arm: arm 0 fires TWO outputs (a list value); arm 1 fires one.
+// branches: [{A, B}, {C}]
+//
+//          [In]
+//           |
+//        [Branch]              arm 0 -> o0,o1  (value (10 20))
+//      o0/ o1|  \o2            arm 1 -> o2     (value 30)
+//  [Out A][Out B][Out C]
+#[test]
+fn test_graph_nested_branch_multi_outlet_arm() {
+    let branch3 = || {
+        node::branch(
+            "(if (= 0 $x) (list 0 (list 10 20)) (list 1 30))",
+            vec![
+                node::Conns::try_from([true, true, false]).unwrap(),
+                node::Conns::try_from([false, false, true]).unwrap(),
+            ],
+        )
+        .unwrap()
+    };
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let inlet = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let br = inner.add_node(Box::new(branch3()) as Box<_>);
+        let outlet_a = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let outlet_b = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let outlet_c = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(inlet, br, Edge::from((0, 0)));
+        inner.add_edge(br, outlet_a, Edge::from((0, 0)));
+        inner.add_edge(br, outlet_b, Edge::from((1, 0)));
+        inner.add_edge(br, outlet_c, Edge::from((2, 0)));
+        inner
+    };
+
+    assert_inner_branches(&make_inner(), 3, &[&[0, 1], &[2]]);
+
+    let build = |sel: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = g.add_node(Box::new(node_int(sel)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let store_a = g.add_node(Box::new(node_number()) as Box<_>);
+        let store_b = g.add_node(Box::new(node_number()) as Box<_>);
+        let store_c = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push, int, Edge::from((0, 0)));
+        g.add_edge(int, inner_node, Edge::from((0, 0)));
+        g.add_edge(inner_node, store_a, Edge::from((0, 0)));
+        g.add_edge(inner_node, store_b, Edge::from((1, 0)));
+        g.add_edge(inner_node, store_c, Edge::from((2, 0)));
+        let vm = compile_and_push(&g, push);
+        (
+            store_val(&vm, store_a),
+            store_val(&vm, store_b),
+            store_val(&vm, store_c),
+        )
+    };
+
+    assert_eq!(build(0), (Some(10), Some(20), None)); // arm 0 -> a,b
+    assert_eq!(build(1), (None, None, Some(30))); // arm 1 -> c
+}
+
+// Parallel branches: two independent Selects -> Cartesian product of 4 branches.
+// Exercises a multi-component (multi-root) inner flow graph.
+// branches: [{A,C}, {A,D}, {B,C}, {B,D}]
+//
+//   [In a]        [In b]
+//     |             |
+//   [Sel1]        [Sel2]
+//  o0/  \o1      o0/  \o1
+// [A]    [B]    [C]    [D]
+#[test]
+fn test_graph_nested_parallel_branches() {
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let inlet_a = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let inlet_b = inner.add_node(Box::new(node::graph::Inlet) as Box<_>);
+        let sel1 = inner.add_node(Box::new(node_select()) as Box<_>);
+        let sel2 = inner.add_node(Box::new(node_select()) as Box<_>);
+        let oa = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let ob = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let oc = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let od = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(inlet_a, sel1, Edge::from((0, 0)));
+        inner.add_edge(inlet_b, sel2, Edge::from((0, 0)));
+        inner.add_edge(sel1, oa, Edge::from((0, 0)));
+        inner.add_edge(sel1, ob, Edge::from((1, 0)));
+        inner.add_edge(sel2, oc, Edge::from((0, 0)));
+        inner.add_edge(sel2, od, Edge::from((1, 0)));
+        inner
+    };
+
+    // Outputs A=0, B=1, C=2, D=3; 4 Cartesian arms.
+    assert_inner_branches(&make_inner(), 4, &[&[0, 2], &[0, 3], &[1, 2], &[1, 3]]);
+
+    let build = |s1: i32, s2: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let i1 = g.add_node(Box::new(node_int(s1)) as Box<_>);
+        let i2 = g.add_node(Box::new(node_int(s2)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let sa = g.add_node(Box::new(node_number()) as Box<_>);
+        let sb = g.add_node(Box::new(node_number()) as Box<_>);
+        let sc = g.add_node(Box::new(node_number()) as Box<_>);
+        let sd = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push, i1, Edge::from((0, 0)));
+        g.add_edge(push, i2, Edge::from((0, 0)));
+        g.add_edge(i1, inner_node, Edge::from((0, 0)));
+        g.add_edge(i2, inner_node, Edge::from((0, 1)));
+        g.add_edge(inner_node, sa, Edge::from((0, 0)));
+        g.add_edge(inner_node, sb, Edge::from((1, 0)));
+        g.add_edge(inner_node, sc, Edge::from((2, 0)));
+        g.add_edge(inner_node, sd, Edge::from((3, 0)));
+        let vm = compile_and_push(&g, push);
+        [
+            store_val(&vm, sa),
+            store_val(&vm, sb),
+            store_val(&vm, sc),
+            store_val(&vm, sd),
+        ]
+    };
+
+    assert_eq!(build(0, 0), [Some(42), None, Some(42), None]); // A + C
+    assert_eq!(build(0, 1), [Some(42), None, None, Some(99)]); // A + D
+    assert_eq!(build(1, 0), [None, Some(99), Some(42), None]); // B + C
+    assert_eq!(build(1, 1), [None, Some(99), None, Some(99)]); // B + D
+}
+
+// Nested/sequential: Gate exists only under Sel1's arm 0, so the result is
+// PRUNED to 3 branches (not the Cartesian 4).  branches: [{A}, {B}, {C}]
+//
+//  [In sel]  [In val]
+//       \      /
+//      ($sel,$val)
+//        [Sel1]            Sel1: ==0 -> o0=$val, else -> o1=88
+//      o0/    \o1
+//   [Gate]   [Out C]       Gate reached only via Sel1 arm 0,
+//  o0/  \o1                then routes by ($val == 0)
+// [Out A][Out B]
+#[test]
+fn test_graph_nested_sequential_branches() {
+    // 2-input outer select: $sel picks the arm, $val is passed on arm 0.
+    let outer_sel = || {
+        node::branch(
+            "(if (= 0 $sel) (list 0 $val) (list 1 88))",
+            vec![
+                node::Conns::try_from([true, false]).unwrap(),
+                node::Conns::try_from([false, true]).unwrap(),
+            ],
+        )
+        .unwrap()
+    };
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let inlet_sel = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let inlet_val = inner.add_node(Box::new(node::graph::Inlet) as Box<_>);
+        let sel1 = inner.add_node(Box::new(outer_sel()) as Box<_>);
+        let gate = inner.add_node(Box::new(node_select()) as Box<_>);
+        let oa = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let ob = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let oc = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(inlet_sel, sel1, Edge::from((0, 0))); // $sel
+        inner.add_edge(inlet_val, sel1, Edge::from((0, 1))); // $val
+        inner.add_edge(sel1, gate, Edge::from((0, 0))); // arm 0 -> gate input
+        inner.add_edge(sel1, oc, Edge::from((1, 0))); // arm 1 -> C
+        inner.add_edge(gate, oa, Edge::from((0, 0)));
+        inner.add_edge(gate, ob, Edge::from((1, 0)));
+        inner
+    };
+
+    // A=0, B=1, C=2. Pruned (not Cartesian): {A}, {B}, {C}.
+    assert_inner_branches(&make_inner(), 3, &[&[0], &[1], &[2]]);
+
+    let build = |sel: i32, val: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let i_sel = g.add_node(Box::new(node_int(sel)) as Box<_>);
+        let i_val = g.add_node(Box::new(node_int(val)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let sa = g.add_node(Box::new(node_number()) as Box<_>);
+        let sb = g.add_node(Box::new(node_number()) as Box<_>);
+        let sc = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push, i_sel, Edge::from((0, 0)));
+        g.add_edge(push, i_val, Edge::from((0, 0)));
+        g.add_edge(i_sel, inner_node, Edge::from((0, 0)));
+        g.add_edge(i_val, inner_node, Edge::from((0, 1)));
+        g.add_edge(inner_node, sa, Edge::from((0, 0)));
+        g.add_edge(inner_node, sb, Edge::from((1, 0)));
+        g.add_edge(inner_node, sc, Edge::from((2, 0)));
+        let vm = compile_and_push(&g, push);
+        [store_val(&vm, sa), store_val(&vm, sb), store_val(&vm, sc)]
+    };
+
+    // sel==0 reaches gate with $val; gate routes by ($val == 0).
+    assert_eq!(build(0, 0), [Some(42), None, None]); // gate arm 0 -> A
+    assert_eq!(build(0, 5), [None, Some(99), None]); // gate arm 1 -> B
+    assert_eq!(build(9, 0), [None, None, Some(88)]); // sel arm 1 -> C
+}
+
+// Branch after a join: the branch is reachable from two inlet chains, but must
+// be assigned ONCE per world (two branches, not four).  branches: [{A}, {B}]
+//
+//  [In l]  [In r]
+//      \    /
+//      [Sum]               (+ $a $b)
+//        |
+//      [Sel]
+//     o0/  \o1
+//  [Out A] [Out B]
+#[test]
+fn test_graph_nested_branch_after_join() {
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let inlet_l = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let inlet_r = inner.add_node(Box::new(node::graph::Inlet) as Box<_>);
+        let sum = inner.add_node(Box::new(node::expr("(+ $a $b)").unwrap()) as Box<_>);
+        let select = inner.add_node(Box::new(node_select()) as Box<_>);
+        let oa = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let ob = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(inlet_l, sum, Edge::from((0, 0)));
+        inner.add_edge(inlet_r, sum, Edge::from((0, 1)));
+        inner.add_edge(sum, select, Edge::from((0, 0)));
+        inner.add_edge(select, oa, Edge::from((0, 0)));
+        inner.add_edge(select, ob, Edge::from((1, 0)));
+        inner
+    };
+
+    // Two branches, NOT four (the join-fed branch is assigned once).
+    assert_inner_branches(&make_inner(), 2, &[&[0], &[1]]);
+
+    let build = |l: i32, r: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let il = g.add_node(Box::new(node_int(l)) as Box<_>);
+        let ir = g.add_node(Box::new(node_int(r)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let sa = g.add_node(Box::new(node_number()) as Box<_>);
+        let sb = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push, il, Edge::from((0, 0)));
+        g.add_edge(push, ir, Edge::from((0, 0)));
+        g.add_edge(il, inner_node, Edge::from((0, 0)));
+        g.add_edge(ir, inner_node, Edge::from((0, 1)));
+        g.add_edge(inner_node, sa, Edge::from((0, 0)));
+        g.add_edge(inner_node, sb, Edge::from((1, 0)));
+        let vm = compile_and_push(&g, push);
+        (store_val(&vm, sa), store_val(&vm, sb))
+    };
+
+    assert_eq!(build(0, 0), (Some(42), None)); // sum 0 -> arm 0
+    assert_eq!(build(1, 0), (None, Some(99))); // sum 1 -> arm 1
+}
+
+// Static outlet: C is fed by a constant (reached via pull, no inlet), so it is
+// active in EVERY branch.  branches: [{A, C}, {B, C}]
+//
+//    [In]          [const 123]
+//     |                 |
+//   [Sel]               |        (independent chain ->
+//  o0/  \o1             |         always produced)
+// [A]    [B]        [Out C]
+#[test]
+fn test_graph_nested_branch_with_constant_outlet() {
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let inlet = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let select = inner.add_node(Box::new(node_select()) as Box<_>);
+        let oa = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let ob = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let konst = inner.add_node(Box::new(node::expr("123").unwrap()) as Box<_>);
+        let oc = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(inlet, select, Edge::from((0, 0)));
+        inner.add_edge(select, oa, Edge::from((0, 0)));
+        inner.add_edge(select, ob, Edge::from((1, 0)));
+        inner.add_edge(konst, oc, Edge::from((0, 0)));
+        inner
+    };
+
+    // C (output 2) is active in both branches.
+    assert_inner_branches(&make_inner(), 3, &[&[0, 2], &[1, 2]]);
+
+    let build = |sel: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = g.add_node(Box::new(node_int(sel)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let sa = g.add_node(Box::new(node_number()) as Box<_>);
+        let sb = g.add_node(Box::new(node_number()) as Box<_>);
+        let sc = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push, int, Edge::from((0, 0)));
+        g.add_edge(int, inner_node, Edge::from((0, 0)));
+        g.add_edge(inner_node, sa, Edge::from((0, 0)));
+        g.add_edge(inner_node, sb, Edge::from((1, 0)));
+        g.add_edge(inner_node, sc, Edge::from((2, 0)));
+        let vm = compile_and_push(&g, push);
+        [store_val(&vm, sa), store_val(&vm, sb), store_val(&vm, sc)]
+    };
+
+    assert_eq!(build(0), [Some(42), None, Some(123)]); // A + C
+    assert_eq!(build(1), [None, Some(99), Some(123)]); // B + C
+}
+
+// Three-arm branch: one branch node with three arms, each to its own outlet.
+// branches: [{A}, {B}, {C}]
+//
+//         [In]
+//          |
+//       [Branch]   (3 arms)
+//     o0/ o1| \o2
+//    [A]  [B]  [C]
+#[test]
+fn test_graph_nested_three_arm_branch() {
+    let branch3 = || {
+        node::branch(
+            "(if (= 0 $x) (list 0 1) (if (= 1 $x) (list 1 2) (list 2 3)))",
+            vec![
+                node::Conns::try_from([true, false, false]).unwrap(),
+                node::Conns::try_from([false, true, false]).unwrap(),
+                node::Conns::try_from([false, false, true]).unwrap(),
+            ],
+        )
+        .unwrap()
+    };
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let inlet = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let br = inner.add_node(Box::new(branch3()) as Box<_>);
+        let oa = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let ob = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let oc = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(inlet, br, Edge::from((0, 0)));
+        inner.add_edge(br, oa, Edge::from((0, 0)));
+        inner.add_edge(br, ob, Edge::from((1, 0)));
+        inner.add_edge(br, oc, Edge::from((2, 0)));
+        inner
+    };
+
+    assert_inner_branches(&make_inner(), 3, &[&[0], &[1], &[2]]);
+
+    let build = |sel: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = g.add_node(Box::new(node_int(sel)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let sa = g.add_node(Box::new(node_number()) as Box<_>);
+        let sb = g.add_node(Box::new(node_number()) as Box<_>);
+        let sc = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push, int, Edge::from((0, 0)));
+        g.add_edge(int, inner_node, Edge::from((0, 0)));
+        g.add_edge(inner_node, sa, Edge::from((0, 0)));
+        g.add_edge(inner_node, sb, Edge::from((1, 0)));
+        g.add_edge(inner_node, sc, Edge::from((2, 0)));
+        let vm = compile_and_push(&g, push);
+        [store_val(&vm, sa), store_val(&vm, sb), store_val(&vm, sc)]
+    };
+
+    assert_eq!(build(0), [Some(1), None, None]);
+    assert_eq!(build(1), [None, Some(2), None]);
+    assert_eq!(build(2), [None, None, Some(3)]);
+}
+
+
+// Two levels of nesting: branching propagates outward through both.
+// inner1.branches: [{X}, {Y}]
+//
+//  inner2:            inner1 (wraps inner2):
+//    [In]               [In]
+//     |                  |
+//   [Sel]            [inner2]   <- itself a branching GraphNode
+//  o0/ \o1           o0/  \o1
+// [A]   [B]      [Out X]  [Out Y]
+#[test]
+fn test_graph_nested_branch_two_levels() {
+    let make_inner2 = || {
+        let mut g = GraphNode::default();
+        let inlet = g.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let select = g.add_node(Box::new(node_select()) as Box<_>);
+        let oa = g.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let ob = g.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        g.add_edge(inlet, select, Edge::from((0, 0)));
+        g.add_edge(select, oa, Edge::from((0, 0)));
+        g.add_edge(select, ob, Edge::from((1, 0)));
+        g
+    };
+    let make_inner1 = || {
+        let mut g = GraphNode::default();
+        let inlet = g.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let inner2 = g.add_node(Box::new(make_inner2()) as Box<_>);
+        let ox = g.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let oy = g.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        g.add_edge(inlet, inner2, Edge::from((0, 0)));
+        g.add_edge(inner2, ox, Edge::from((0, 0)));
+        g.add_edge(inner2, oy, Edge::from((1, 0)));
+        g
+    };
+
+    // inner1 branches because inner2 branches.
+    assert_inner_branches(&make_inner1(), 2, &[&[0], &[1]]);
+
+    let build = |sel: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = g.add_node(Box::new(node_int(sel)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner1()) as Box<_>);
+        let sx = g.add_node(Box::new(node_number()) as Box<_>);
+        let sy = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push, int, Edge::from((0, 0)));
+        g.add_edge(int, inner_node, Edge::from((0, 0)));
+        g.add_edge(inner_node, sx, Edge::from((0, 0)));
+        g.add_edge(inner_node, sy, Edge::from((1, 0)));
+        let vm = compile_and_push(&g, push);
+        (store_val(&vm, sx), store_val(&vm, sy))
+    };
+
+    assert_eq!(build(0), (Some(42), None));
+    assert_eq!(build(1), (None, Some(99)));
+}
+
+// Stateful node on a branch arm: its state persists across pushes taking arm 0.
+// branches: [{A}, {B}]
+//
+//       [In]
+//        |
+//      [Sel]
+//     o0/  \o1
+//  [Counter] |          (state persists across pushes on arm 0)
+//     |      |
+//  [Out A] [Out B]
+#[test]
+fn test_graph_nested_branch_stateful() {
+    let counter = || {
+        node::expr("(begin $bang (set! state (if (number? state) (+ state 1) 0)) state)").unwrap()
+    };
+    let mut inner = GraphNode::default();
+    let inlet = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+    let select = inner.add_node(Box::new(node_select()) as Box<_>);
+    let count = inner.add_node(Box::new(counter()) as Box<_>);
+    let oa = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    let ob = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    inner.add_edge(inlet, select, Edge::from((0, 0)));
+    inner.add_edge(select, count, Edge::from((0, 0)));
+    inner.add_edge(count, oa, Edge::from((0, 0)));
+    inner.add_edge(select, ob, Edge::from((1, 0)));
+
+    assert_inner_branches(&inner, 2, &[&[0], &[1]]);
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let int = g.add_node(Box::new(node_int(0)) as Box<_>); // always arm 0
+    let inner_node = g.add_node(Box::new(inner) as Box<_>);
+    let sa = g.add_node(Box::new(node_number()) as Box<_>);
+    g.add_edge(push, int, Edge::from((0, 0)));
+    g.add_edge(int, inner_node, Edge::from((0, 0)));
+    g.add_edge(inner_node, sa, Edge::from((0, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    for f in &module {
+        vm.run(f.to_pretty(100)).unwrap();
+    }
+    let ep = entrypoint::push(vec![push.index()], g[push].n_outputs(ctx) as u8);
+    let fname = entry_fn_name(&ep.id());
+    vm.call_function_by_name_with_args(&fname, vec![]).unwrap();
+    vm.call_function_by_name_with_args(&fname, vec![]).unwrap();
+
+    // Counter incremented twice on arm 0: 0 then 1.
+    let count_state = node::state::extract::<i32>(&vm, &[inner_node.index(), count.index()])
+        .unwrap()
+        .unwrap();
+    assert_eq!(count_state, 1);
+    assert_eq!(store_val(&vm, sa), Some(1));
+}
+
+// Alignment: same inner shape as `parallel_branches` (two parallel Sels -> 4
+// branches); asserts Node::branches() == outer meta.branches[inner_node],
+// pointwise.
+//
+//   [In a]        [In b]
+//     |             |
+//   [Sel1]        [Sel2]
+//  o0/  \o1      o0/  \o1
+// [A]    [B]    [C]    [D]
+#[test]
+fn test_graph_nested_branches_align_with_meta() {
+    let mut inner = GraphNode::default();
+    let inlet_a = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+    let inlet_b = inner.add_node(Box::new(node::graph::Inlet) as Box<_>);
+    let sel1 = inner.add_node(Box::new(node_select()) as Box<_>);
+    let sel2 = inner.add_node(Box::new(node_select()) as Box<_>);
+    let oa = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    let ob = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    let oc = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    let od = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    inner.add_edge(inlet_a, sel1, Edge::from((0, 0)));
+    inner.add_edge(inlet_b, sel2, Edge::from((0, 0)));
+    inner.add_edge(sel1, oa, Edge::from((0, 0)));
+    inner.add_edge(sel1, ob, Edge::from((1, 0)));
+    inner.add_edge(sel2, oc, Edge::from((0, 0)));
+    inner.add_edge(sel2, od, Edge::from((1, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let declared = inner.branches(ctx);
+    assert_eq!(declared.len(), 4);
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let va = g.add_node(Box::new(node_int(0)) as Box<dyn DebugNode>);
+    let vb = g.add_node(Box::new(node_int(0)) as Box<_>);
+    let inner_node = g.add_node(Box::new(inner) as Box<_>);
+    g.add_edge(va, inner_node, Edge::from((0, 0)));
+    g.add_edge(vb, inner_node, Edge::from((0, 1)));
+    let meta = gantz_core::compile::Meta::from_graph(&no_lookup, &g).unwrap();
+    let observed = meta.branches.get(&inner_node.index()).unwrap();
+
+    assert_eq!(observed.len(), declared.len());
+    for (got, want) in observed.iter().zip(&declared) {
+        let node::EvalConf::Set(want) = want else { panic!("expected Set") };
+        assert_eq!(got, want);
+    }
+}
+
+// Regression: two independent (non-branching) chains form a multi-component
+// flow graph. It must compile (previously the single-entry assertion panicked)
+// and report no external branching.  branches: []
+//
+//  [In a]   [In b]
+//    |        |
+//  [+1]     [+2]
+//    |        |
+// [Out A]  [Out B]
+#[test]
+fn test_graph_nested_multi_component_no_branch() {
+    let mut inner = GraphNode::default();
+    let inlet_a = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+    let inlet_b = inner.add_node(Box::new(node::graph::Inlet) as Box<_>);
+    let id_a = inner.add_node(Box::new(node::expr("(+ $x 1)").unwrap()) as Box<_>);
+    let id_b = inner.add_node(Box::new(node::expr("(+ $x 2)").unwrap()) as Box<_>);
+    let oa = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    let ob = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    inner.add_edge(inlet_a, id_a, Edge::from((0, 0)));
+    inner.add_edge(id_a, oa, Edge::from((0, 0)));
+    inner.add_edge(inlet_b, id_b, Edge::from((0, 0)));
+    inner.add_edge(id_b, ob, Edge::from((0, 0)));
+
+    // No external branching.
+    assert_inner_branches(&inner, 2, &[]);
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let i10 = g.add_node(Box::new(node_int(10)) as Box<_>);
+    let i20 = g.add_node(Box::new(node_int(20)) as Box<_>);
+    let inner_node = g.add_node(Box::new(inner) as Box<_>);
+    let sa = g.add_node(Box::new(node_number()) as Box<_>);
+    let sb = g.add_node(Box::new(node_number()) as Box<_>);
+    g.add_edge(push, i10, Edge::from((0, 0)));
+    g.add_edge(push, i20, Edge::from((0, 0)));
+    g.add_edge(i10, inner_node, Edge::from((0, 0)));
+    g.add_edge(i20, inner_node, Edge::from((0, 1)));
+    g.add_edge(inner_node, sa, Edge::from((0, 0)));
+    g.add_edge(inner_node, sb, Edge::from((1, 0)));
+    let vm = compile_and_push(&g, push);
+    assert_eq!(store_val(&vm, sa), Some(11)); // 10 + 1
+    assert_eq!(store_val(&vm, sb), Some(22)); // 20 + 2
+}

--- a/crates/gantz_core/tests/nested.rs
+++ b/crates/gantz_core/tests/nested.rs
@@ -1794,3 +1794,361 @@ fn test_graph_nested_multi_component_no_branch() {
     assert_eq!(store_val(&vm, sa), Some(11)); // 10 + 1
     assert_eq!(store_val(&vm, sb), Some(22)); // 20 + 2
 }
+
+// Reconvergent intermediates: both arms pass through a distinct intermediate
+// then feed the SAME outlet -> no external branching (exercises is_join via an
+// intermediate). branches: []
+//
+//        [In]
+//         |
+//       [Sel]
+//      o0/  \o1
+//    [+10]  [+1]
+//       \   /
+//      [Out A]
+#[test]
+fn test_graph_nested_branch_reconvergent_intermediates() {
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let inlet = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let select = inner.add_node(Box::new(node_select()) as Box<_>);
+        let add10 = inner.add_node(Box::new(node::expr("(+ $x 10)").unwrap()) as Box<_>);
+        let add1 = inner.add_node(Box::new(node::expr("(+ $x 1)").unwrap()) as Box<_>);
+        let outlet = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(inlet, select, Edge::from((0, 0)));
+        inner.add_edge(select, add10, Edge::from((0, 0)));
+        inner.add_edge(add10, outlet, Edge::from((0, 0)));
+        inner.add_edge(select, add1, Edge::from((1, 0)));
+        inner.add_edge(add1, outlet, Edge::from((0, 0)));
+        inner
+    };
+    assert_inner_branches(&make_inner(), 1, &[]);
+    let build = |sel: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = g.add_node(Box::new(node_int(sel)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let store = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push, int, Edge::from((0, 0)));
+        g.add_edge(int, inner_node, Edge::from((0, 0)));
+        g.add_edge(inner_node, store, Edge::from((0, 0)));
+        store_val(&compile_and_push(&g, push), store)
+    };
+    assert_eq!(build(0), Some(52)); // 42 + 10
+    assert_eq!(build(1), Some(100)); // 99 + 1
+}
+
+// Mixed direct/intermediate arms: arm 0 goes straight to its outlet, arm 1 via
+// an intermediate. branches: [{A}, {B}]
+#[test]
+fn test_graph_nested_branch_mixed_direct_intermediate() {
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let inlet = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let select = inner.add_node(Box::new(node_select()) as Box<_>);
+        let add1 = inner.add_node(Box::new(node::expr("(+ $x 1)").unwrap()) as Box<_>);
+        let outlet_a = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let outlet_b = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(inlet, select, Edge::from((0, 0)));
+        inner.add_edge(select, outlet_a, Edge::from((0, 0)));
+        inner.add_edge(select, add1, Edge::from((1, 0)));
+        inner.add_edge(add1, outlet_b, Edge::from((0, 0)));
+        inner
+    };
+    assert_inner_branches(&make_inner(), 2, &[&[0], &[1]]);
+    let build = |sel: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = g.add_node(Box::new(node_int(sel)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let sa = g.add_node(Box::new(node_number()) as Box<_>);
+        let sb = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push, int, Edge::from((0, 0)));
+        g.add_edge(int, inner_node, Edge::from((0, 0)));
+        g.add_edge(inner_node, sa, Edge::from((0, 0)));
+        g.add_edge(inner_node, sb, Edge::from((1, 0)));
+        let vm = compile_and_push(&g, push);
+        (store_val(&vm, sa), store_val(&vm, sb))
+    };
+    assert_eq!(build(0), (Some(42), None)); // direct
+    assert_eq!(build(1), (None, Some(100))); // 99 + 1
+}
+
+// Chained intermediates: each arm passes through a two-node chain.
+// branches: [{A}, {B}]
+#[test]
+fn test_graph_nested_branch_chained_intermediates() {
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let inlet = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let select = inner.add_node(Box::new(node_select()) as Box<_>);
+        let a10 = inner.add_node(Box::new(node::expr("(+ $x 10)").unwrap()) as Box<_>);
+        let a1 = inner.add_node(Box::new(node::expr("(+ $x 1)").unwrap()) as Box<_>);
+        let b10 = inner.add_node(Box::new(node::expr("(+ $x 10)").unwrap()) as Box<_>);
+        let b1 = inner.add_node(Box::new(node::expr("(+ $x 1)").unwrap()) as Box<_>);
+        let outlet_a = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let outlet_b = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(inlet, select, Edge::from((0, 0)));
+        inner.add_edge(select, a10, Edge::from((0, 0)));
+        inner.add_edge(a10, a1, Edge::from((0, 0)));
+        inner.add_edge(a1, outlet_a, Edge::from((0, 0)));
+        inner.add_edge(select, b10, Edge::from((1, 0)));
+        inner.add_edge(b10, b1, Edge::from((0, 0)));
+        inner.add_edge(b1, outlet_b, Edge::from((0, 0)));
+        inner
+    };
+    assert_inner_branches(&make_inner(), 2, &[&[0], &[1]]);
+    let build = |sel: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = g.add_node(Box::new(node_int(sel)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let sa = g.add_node(Box::new(node_number()) as Box<_>);
+        let sb = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push, int, Edge::from((0, 0)));
+        g.add_edge(int, inner_node, Edge::from((0, 0)));
+        g.add_edge(inner_node, sa, Edge::from((0, 0)));
+        g.add_edge(inner_node, sb, Edge::from((1, 0)));
+        let vm = compile_and_push(&g, push);
+        (store_val(&vm, sa), store_val(&vm, sb))
+    };
+    assert_eq!(build(0), (Some(53), None)); // 42 + 10 + 1
+    assert_eq!(build(1), (None, Some(110))); // 99 + 10 + 1
+}
+
+// Cascading reconvergence: three sequential branches, but Select A and Select B
+// each reconverge at a join, so only Select C affects the outlet. The 2^3 = 8
+// inner worlds collapse to just TWO external branches (dedup by outlet set;
+// the prior implementation reported 8). branches: [{A}, {B}]
+#[test]
+fn test_graph_nested_cascading_reconvergence() {
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let in1 = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let in2 = inner.add_node(Box::new(node::graph::Inlet) as Box<_>);
+        let in3 = inner.add_node(Box::new(node::graph::Inlet) as Box<_>);
+        let sa = inner.add_node(Box::new(node_select()) as Box<_>);
+        let a10 = inner.add_node(Box::new(node::expr("(+ $x 10)").unwrap()) as Box<_>);
+        let a20 = inner.add_node(Box::new(node::expr("(+ $x 20)").unwrap()) as Box<_>);
+        let joina = inner.add_node(Box::new(node::expr("(begin $x)").unwrap()) as Box<_>);
+        let passa = inner.add_node(Box::new(node::expr("(begin $l $r)").unwrap()) as Box<_>);
+        let sb = inner.add_node(Box::new(node_select()) as Box<_>);
+        let b30 = inner.add_node(Box::new(node::expr("(+ $x 30)").unwrap()) as Box<_>);
+        let b40 = inner.add_node(Box::new(node::expr("(+ $x 40)").unwrap()) as Box<_>);
+        let joinb = inner.add_node(Box::new(node::expr("(begin $x)").unwrap()) as Box<_>);
+        let passb = inner.add_node(Box::new(node::expr("(begin $l $r)").unwrap()) as Box<_>);
+        let sc = inner.add_node(Box::new(node_select()) as Box<_>);
+        let oa = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let ob = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(in1, sa, Edge::from((0, 0)));
+        inner.add_edge(sa, a10, Edge::from((0, 0)));
+        inner.add_edge(sa, a20, Edge::from((1, 0)));
+        inner.add_edge(a10, joina, Edge::from((0, 0)));
+        inner.add_edge(a20, joina, Edge::from((0, 0)));
+        inner.add_edge(joina, passa, Edge::from((0, 0)));
+        inner.add_edge(in2, passa, Edge::from((0, 1)));
+        inner.add_edge(passa, sb, Edge::from((0, 0)));
+        inner.add_edge(sb, b30, Edge::from((0, 0)));
+        inner.add_edge(sb, b40, Edge::from((1, 0)));
+        inner.add_edge(b30, joinb, Edge::from((0, 0)));
+        inner.add_edge(b40, joinb, Edge::from((0, 0)));
+        inner.add_edge(joinb, passb, Edge::from((0, 0)));
+        inner.add_edge(in3, passb, Edge::from((0, 1)));
+        inner.add_edge(passb, sc, Edge::from((0, 0)));
+        inner.add_edge(sc, oa, Edge::from((0, 0)));
+        inner.add_edge(sc, ob, Edge::from((1, 0)));
+        inner
+    };
+    assert_inner_branches(&make_inner(), 2, &[&[0], &[1]]);
+    let build = |c: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let v1 = g.add_node(Box::new(node_int(1)) as Box<_>);
+        let v2 = g.add_node(Box::new(node_int(1)) as Box<_>);
+        let v3 = g.add_node(Box::new(node_int(c)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let sa = g.add_node(Box::new(node_number()) as Box<_>);
+        let sb = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push, v1, Edge::from((0, 0)));
+        g.add_edge(push, v2, Edge::from((0, 0)));
+        g.add_edge(push, v3, Edge::from((0, 0)));
+        g.add_edge(v1, inner_node, Edge::from((0, 0)));
+        g.add_edge(v2, inner_node, Edge::from((0, 1)));
+        g.add_edge(v3, inner_node, Edge::from((0, 2)));
+        g.add_edge(inner_node, sa, Edge::from((0, 0)));
+        g.add_edge(inner_node, sb, Edge::from((1, 0)));
+        let vm = compile_and_push(&g, push);
+        (store_val(&vm, sa), store_val(&vm, sb))
+    };
+    assert_eq!(build(0), (Some(42), None)); // SelectC arm 0 -> A
+    assert_eq!(build(1), (None, Some(99))); // SelectC arm 1 -> B
+}
+
+// Inner reconvergence + an independent outer branch in the same graph:
+// Select1 reconverges to A (always active); Select2 picks B or C.
+// branches: [{A, B}, {A, C}]
+#[test]
+fn test_graph_nested_inner_reconvergence_outer_branching() {
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let in1 = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let in2 = inner.add_node(Box::new(node::graph::Inlet) as Box<_>);
+        let s1 = inner.add_node(Box::new(node_select()) as Box<_>);
+        let a10 = inner.add_node(Box::new(node::expr("(+ $x 10)").unwrap()) as Box<_>);
+        let a20 = inner.add_node(Box::new(node::expr("(+ $x 20)").unwrap()) as Box<_>);
+        let join = inner.add_node(Box::new(node::expr("(begin $x)").unwrap()) as Box<_>);
+        let s2 = inner.add_node(Box::new(node_select()) as Box<_>);
+        let oa = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let ob = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let oc = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(in1, s1, Edge::from((0, 0)));
+        inner.add_edge(s1, a10, Edge::from((0, 0)));
+        inner.add_edge(s1, a20, Edge::from((1, 0)));
+        inner.add_edge(a10, join, Edge::from((0, 0)));
+        inner.add_edge(a20, join, Edge::from((0, 0)));
+        inner.add_edge(join, oa, Edge::from((0, 0)));
+        inner.add_edge(in2, s2, Edge::from((0, 0)));
+        inner.add_edge(s2, ob, Edge::from((0, 0)));
+        inner.add_edge(s2, oc, Edge::from((1, 0)));
+        inner
+    };
+    assert_inner_branches(&make_inner(), 3, &[&[0, 1], &[0, 2]]);
+    let build = |x: i32, y: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let v1 = g.add_node(Box::new(node_int(x)) as Box<_>);
+        let v2 = g.add_node(Box::new(node_int(y)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let sa = g.add_node(Box::new(node_number()) as Box<_>);
+        let sb = g.add_node(Box::new(node_number()) as Box<_>);
+        let sc = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push, v1, Edge::from((0, 0)));
+        g.add_edge(push, v2, Edge::from((0, 0)));
+        g.add_edge(v1, inner_node, Edge::from((0, 0)));
+        g.add_edge(v2, inner_node, Edge::from((0, 1)));
+        g.add_edge(inner_node, sa, Edge::from((0, 0)));
+        g.add_edge(inner_node, sb, Edge::from((1, 0)));
+        g.add_edge(inner_node, sc, Edge::from((2, 0)));
+        let vm = compile_and_push(&g, push);
+        [store_val(&vm, sa), store_val(&vm, sb), store_val(&vm, sc)]
+    };
+    assert_eq!(build(0, 0), [Some(52), Some(42), None]); // A=42+10, B
+    assert_eq!(build(0, 1), [Some(52), None, Some(99)]); // A, C
+    assert_eq!(build(1, 0), [Some(119), Some(42), None]); // A=99+20, B
+}
+
+// A Static inlet used at branch depth 3: `value` feeds `depth3`, which sits on
+// Select3's arm 0. node_inputs_in_scope must keep `value` in scope inside that
+// arm even though it enters from outside the arm. Sequential -> 4 branches.
+// branches: [{A}, {B}, {C}, {D}]
+#[test]
+fn test_graph_nested_static_inlet_at_depth_three() {
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let f1 = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let f2 = inner.add_node(Box::new(node::graph::Inlet) as Box<_>);
+        let f3 = inner.add_node(Box::new(node::graph::Inlet) as Box<_>);
+        let value = inner.add_node(Box::new(node::graph::Inlet) as Box<_>);
+        let s1 = inner.add_node(Box::new(node_select()) as Box<_>);
+        let pa = inner.add_node(Box::new(node::expr("(begin $l $r)").unwrap()) as Box<_>);
+        let s2 = inner.add_node(Box::new(node_select()) as Box<_>);
+        let pb = inner.add_node(Box::new(node::expr("(begin $l $r)").unwrap()) as Box<_>);
+        let s3 = inner.add_node(Box::new(node_select()) as Box<_>);
+        let d3 = inner.add_node(Box::new(node::expr("(begin $l $r)").unwrap()) as Box<_>);
+        let oa = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let ob = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let oc = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let od = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(f1, s1, Edge::from((0, 0)));
+        inner.add_edge(s1, oa, Edge::from((0, 0)));
+        inner.add_edge(s1, pa, Edge::from((1, 0)));
+        inner.add_edge(f2, pa, Edge::from((0, 1)));
+        inner.add_edge(pa, s2, Edge::from((0, 0)));
+        inner.add_edge(s2, ob, Edge::from((0, 0)));
+        inner.add_edge(s2, pb, Edge::from((1, 0)));
+        inner.add_edge(f3, pb, Edge::from((0, 1)));
+        inner.add_edge(pb, s3, Edge::from((0, 0)));
+        inner.add_edge(s3, d3, Edge::from((0, 0)));
+        inner.add_edge(value, d3, Edge::from((0, 1)));
+        inner.add_edge(d3, oc, Edge::from((0, 0)));
+        inner.add_edge(s3, od, Edge::from((1, 0)));
+        inner
+    };
+    assert_inner_branches(&make_inner(), 4, &[&[0], &[1], &[2], &[3]]);
+    let build = |a: i32, b: i32, c: i32, v: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let n1 = g.add_node(Box::new(node_int(a)) as Box<_>);
+        let n2 = g.add_node(Box::new(node_int(b)) as Box<_>);
+        let n3 = g.add_node(Box::new(node_int(c)) as Box<_>);
+        let nv = g.add_node(Box::new(node_int(v)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let st: Vec<_> = (0..4).map(|_| g.add_node(Box::new(node_number()) as Box<_>)).collect();
+        for n in [n1, n2, n3, nv] { g.add_edge(push, n, Edge::from((0, 0))); }
+        g.add_edge(n1, inner_node, Edge::from((0, 0)));
+        g.add_edge(n2, inner_node, Edge::from((0, 1)));
+        g.add_edge(n3, inner_node, Edge::from((0, 2)));
+        g.add_edge(nv, inner_node, Edge::from((0, 3)));
+        for (k, &s) in st.iter().enumerate() { g.add_edge(inner_node, s, Edge::from((k as u16, 0))); }
+        let vm = compile_and_push(&g, push);
+        st.iter().map(|&s| store_val(&vm, s)).collect::<Vec<_>>()
+    };
+    assert_eq!(build(0, 9, 9, 7), [Some(42), None, None, None]); // f1==0 -> A
+    assert_eq!(build(9, 0, 9, 7), [None, Some(42), None, None]); // f2==0 -> B
+    assert_eq!(build(9, 9, 0, 7), [None, None, Some(7), None]); // f3==0 -> depth3 = value 7
+    assert_eq!(build(9, 9, 9, 7), [None, None, None, Some(99)]); // all !=0 -> D
+}
+
+// Three independent parallel branches -> 2^3 = 8 external branches (a 3-component
+// flow graph). branches: all 8 of {A|B} x {C|D} x {E|F}.
+#[test]
+fn test_graph_nested_multi_branch_three() {
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let i1 = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let i2 = inner.add_node(Box::new(node::graph::Inlet) as Box<_>);
+        let i3 = inner.add_node(Box::new(node::graph::Inlet) as Box<_>);
+        let s1 = inner.add_node(Box::new(node_select()) as Box<_>);
+        let s2 = inner.add_node(Box::new(node_select()) as Box<_>);
+        let s3 = inner.add_node(Box::new(node_select()) as Box<_>);
+        let mut add = |n: i32| inner.add_node(Box::new(node::expr(format!("(+ $x {n})")).unwrap()) as Box<_>);
+        let (a10, a20, a30, a40, a50, a60) = (add(10), add(20), add(30), add(40), add(50), add(60));
+        let o: Vec<_> = (0..6).map(|_| inner.add_node(Box::new(node::graph::Outlet) as Box<_>)).collect();
+        inner.add_edge(i1, s1, Edge::from((0, 0)));
+        inner.add_edge(i2, s2, Edge::from((0, 0)));
+        inner.add_edge(i3, s3, Edge::from((0, 0)));
+        for (sel, lo, hi, ol, oh) in [(s1, a10, a20, o[0], o[1]), (s2, a30, a40, o[2], o[3]), (s3, a50, a60, o[4], o[5])] {
+            inner.add_edge(sel, lo, Edge::from((0, 0)));
+            inner.add_edge(lo, ol, Edge::from((0, 0)));
+            inner.add_edge(sel, hi, Edge::from((1, 0)));
+            inner.add_edge(hi, oh, Edge::from((0, 0)));
+        }
+        inner
+    };
+    assert_inner_branches(&make_inner(), 6, &[
+        &[0, 2, 4], &[0, 2, 5], &[0, 3, 4], &[0, 3, 5],
+        &[1, 2, 4], &[1, 2, 5], &[1, 3, 4], &[1, 3, 5],
+    ]);
+    let build = |a: i32, b: i32, c: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let n1 = g.add_node(Box::new(node_int(a)) as Box<_>);
+        let n2 = g.add_node(Box::new(node_int(b)) as Box<_>);
+        let n3 = g.add_node(Box::new(node_int(c)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let st: Vec<_> = (0..6).map(|_| g.add_node(Box::new(node_number()) as Box<_>)).collect();
+        for n in [n1, n2, n3] { g.add_edge(push, n, Edge::from((0, 0))); }
+        g.add_edge(n1, inner_node, Edge::from((0, 0)));
+        g.add_edge(n2, inner_node, Edge::from((0, 1)));
+        g.add_edge(n3, inner_node, Edge::from((0, 2)));
+        for (k, &s) in st.iter().enumerate() { g.add_edge(inner_node, s, Edge::from((k as u16, 0))); }
+        let vm = compile_and_push(&g, push);
+        st.iter().map(|&s| store_val(&vm, s)).collect::<Vec<_>>()
+    };
+    // (0,0,0): A=42+10, C=42+30, E=42+50 fire; B,D,F dead.
+    assert_eq!(build(0, 0, 0), [Some(52), None, Some(72), None, Some(92), None]);
+    // (1,1,1): B=99+20, D=99+40, F=99+60.
+    assert_eq!(build(1, 1, 1), [None, Some(119), None, Some(139), None, Some(159)]);
+    // (0,1,0): A, D, E.
+    assert_eq!(build(0, 1, 0), [Some(52), None, None, Some(139), Some(92), None]);
+}

--- a/crates/gantz_core/tests/nested.rs
+++ b/crates/gantz_core/tests/nested.rs
@@ -1051,7 +1051,9 @@ fn compile_and_push<N: DebugNode + ?Sized>(
 
 // `Some(v)` if the store node holds a number, else `None` (never evaluated).
 fn store_val(vm: &Engine, store: petgraph::graph::NodeIndex) -> Option<i32> {
-    node::state::extract::<i32>(vm, &[store.index()]).ok().flatten()
+    node::state::extract::<i32>(vm, &[store.index()])
+        .ok()
+        .flatten()
 }
 
 // Divergent branch: each arm routes to its own outlet.  branches: [{A}, {B}]
@@ -1588,7 +1590,6 @@ fn test_graph_nested_three_arm_branch() {
     assert_eq!(build(2), [None, None, Some(3)]);
 }
 
-
 // Two levels of nesting: branching propagates outward through both.
 // inner1.branches: [{X}, {Y}]
 //
@@ -1746,7 +1747,9 @@ fn test_graph_nested_branches_align_with_meta() {
 
     assert_eq!(observed.len(), declared.len());
     for (got, want) in observed.iter().zip(&declared) {
-        let node::EvalConf::Set(want) = want else { panic!("expected Set") };
+        let node::EvalConf::Set(want) = want else {
+            panic!("expected Set")
+        };
         assert_eq!(got, want);
     }
 }
@@ -2083,13 +2086,19 @@ fn test_graph_nested_static_inlet_at_depth_three() {
         let n3 = g.add_node(Box::new(node_int(c)) as Box<_>);
         let nv = g.add_node(Box::new(node_int(v)) as Box<_>);
         let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
-        let st: Vec<_> = (0..4).map(|_| g.add_node(Box::new(node_number()) as Box<_>)).collect();
-        for n in [n1, n2, n3, nv] { g.add_edge(push, n, Edge::from((0, 0))); }
+        let st: Vec<_> = (0..4)
+            .map(|_| g.add_node(Box::new(node_number()) as Box<_>))
+            .collect();
+        for n in [n1, n2, n3, nv] {
+            g.add_edge(push, n, Edge::from((0, 0)));
+        }
         g.add_edge(n1, inner_node, Edge::from((0, 0)));
         g.add_edge(n2, inner_node, Edge::from((0, 1)));
         g.add_edge(n3, inner_node, Edge::from((0, 2)));
         g.add_edge(nv, inner_node, Edge::from((0, 3)));
-        for (k, &s) in st.iter().enumerate() { g.add_edge(inner_node, s, Edge::from((k as u16, 0))); }
+        for (k, &s) in st.iter().enumerate() {
+            g.add_edge(inner_node, s, Edge::from((k as u16, 0)));
+        }
         let vm = compile_and_push(&g, push);
         st.iter().map(|&s| store_val(&vm, s)).collect::<Vec<_>>()
     };
@@ -2111,13 +2120,20 @@ fn test_graph_nested_multi_branch_three() {
         let s1 = inner.add_node(Box::new(node_select()) as Box<_>);
         let s2 = inner.add_node(Box::new(node_select()) as Box<_>);
         let s3 = inner.add_node(Box::new(node_select()) as Box<_>);
-        let mut add = |n: i32| inner.add_node(Box::new(node::expr(format!("(+ $x {n})")).unwrap()) as Box<_>);
+        let mut add =
+            |n: i32| inner.add_node(Box::new(node::expr(format!("(+ $x {n})")).unwrap()) as Box<_>);
         let (a10, a20, a30, a40, a50, a60) = (add(10), add(20), add(30), add(40), add(50), add(60));
-        let o: Vec<_> = (0..6).map(|_| inner.add_node(Box::new(node::graph::Outlet) as Box<_>)).collect();
+        let o: Vec<_> = (0..6)
+            .map(|_| inner.add_node(Box::new(node::graph::Outlet) as Box<_>))
+            .collect();
         inner.add_edge(i1, s1, Edge::from((0, 0)));
         inner.add_edge(i2, s2, Edge::from((0, 0)));
         inner.add_edge(i3, s3, Edge::from((0, 0)));
-        for (sel, lo, hi, ol, oh) in [(s1, a10, a20, o[0], o[1]), (s2, a30, a40, o[2], o[3]), (s3, a50, a60, o[4], o[5])] {
+        for (sel, lo, hi, ol, oh) in [
+            (s1, a10, a20, o[0], o[1]),
+            (s2, a30, a40, o[2], o[3]),
+            (s3, a50, a60, o[4], o[5]),
+        ] {
             inner.add_edge(sel, lo, Edge::from((0, 0)));
             inner.add_edge(lo, ol, Edge::from((0, 0)));
             inner.add_edge(sel, hi, Edge::from((1, 0)));
@@ -2125,10 +2141,20 @@ fn test_graph_nested_multi_branch_three() {
         }
         inner
     };
-    assert_inner_branches(&make_inner(), 6, &[
-        &[0, 2, 4], &[0, 2, 5], &[0, 3, 4], &[0, 3, 5],
-        &[1, 2, 4], &[1, 2, 5], &[1, 3, 4], &[1, 3, 5],
-    ]);
+    assert_inner_branches(
+        &make_inner(),
+        6,
+        &[
+            &[0, 2, 4],
+            &[0, 2, 5],
+            &[0, 3, 4],
+            &[0, 3, 5],
+            &[1, 2, 4],
+            &[1, 2, 5],
+            &[1, 3, 4],
+            &[1, 3, 5],
+        ],
+    );
     let build = |a: i32, b: i32, c: i32| {
         let mut g = petgraph::graph::DiGraph::new();
         let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
@@ -2136,19 +2162,34 @@ fn test_graph_nested_multi_branch_three() {
         let n2 = g.add_node(Box::new(node_int(b)) as Box<_>);
         let n3 = g.add_node(Box::new(node_int(c)) as Box<_>);
         let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
-        let st: Vec<_> = (0..6).map(|_| g.add_node(Box::new(node_number()) as Box<_>)).collect();
-        for n in [n1, n2, n3] { g.add_edge(push, n, Edge::from((0, 0))); }
+        let st: Vec<_> = (0..6)
+            .map(|_| g.add_node(Box::new(node_number()) as Box<_>))
+            .collect();
+        for n in [n1, n2, n3] {
+            g.add_edge(push, n, Edge::from((0, 0)));
+        }
         g.add_edge(n1, inner_node, Edge::from((0, 0)));
         g.add_edge(n2, inner_node, Edge::from((0, 1)));
         g.add_edge(n3, inner_node, Edge::from((0, 2)));
-        for (k, &s) in st.iter().enumerate() { g.add_edge(inner_node, s, Edge::from((k as u16, 0))); }
+        for (k, &s) in st.iter().enumerate() {
+            g.add_edge(inner_node, s, Edge::from((k as u16, 0)));
+        }
         let vm = compile_and_push(&g, push);
         st.iter().map(|&s| store_val(&vm, s)).collect::<Vec<_>>()
     };
     // (0,0,0): A=42+10, C=42+30, E=42+50 fire; B,D,F dead.
-    assert_eq!(build(0, 0, 0), [Some(52), None, Some(72), None, Some(92), None]);
+    assert_eq!(
+        build(0, 0, 0),
+        [Some(52), None, Some(72), None, Some(92), None]
+    );
     // (1,1,1): B=99+20, D=99+40, F=99+60.
-    assert_eq!(build(1, 1, 1), [None, Some(119), None, Some(139), None, Some(159)]);
+    assert_eq!(
+        build(1, 1, 1),
+        [None, Some(119), None, Some(139), None, Some(159)]
+    );
     // (0,1,0): A, D, E.
-    assert_eq!(build(0, 1, 0), [Some(52), None, None, Some(139), Some(92), None]);
+    assert_eq!(
+        build(0, 1, 0),
+        [Some(52), None, None, Some(139), Some(92), None]
+    );
 }

--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,7 @@
   lib,
   libGL,
   mkShell,
+  rustfmt,
   stdenv,
   trunk,
   binaryen,
@@ -14,6 +15,11 @@ mkShell {
   inputsFrom = [
     gantz-unwrapped
     gantz-website
+  ];
+  # The rust toolchain comes via `inputsFrom` (gantz-unwrapped) but does not
+  # include rustfmt, which `nix develop -c cargo fmt` (and CI) requires.
+  packages = [
+    rustfmt
   ];
   # FIXME: Remove this, see #122.
   buildInputs = [


### PR DESCRIPTION
A `GraphNode` (a sub-graph used as a single node) whose interior branches now reports that branching to its parent. The parent evaluates only the downstream of outlets the taken inner branch actually produces, instead of unconditionally evaluating every outlet's downstream.

This lets you build custom branching nodes by composing graphs - the node's external branching reflects its internal structure.

## How it works

- `Graph::branches()` enumerates the distinct sets of outlets that can be simultaneously active and reports them to the parent exactly like a primitive `Branch` node, so the parent's existing branch-aware compilation is unchanged.
- The `GraphNode`'s body emits (list branch-ix value) to match: outlets compile to hoisted vars set! inside whichever arm reaches them, and the external branch index is read back from per-outlet "active" flags.
- The flow-graph builder now lowers branches by per-arm duplication, sharing a block only at true reconvergence (phi) points — this is what enables parallel branches and outputs shared across arms.

Handles divergent, dead-arm, reconvergent (collapses to non-branching), multi-output arms, N-way branches, parallel (Cartesian product), nested/sequential (pruned, not Cartesian), an always-active outlet alongside a branch, multi-level nesting, and stateful arms.

## To-Do

- [ ] branch-aware push-through-outlet propagation (an internal `push_eval` that reaches outlets conditionally). Non-branching push-through is unchanged; making it branch-aware needs separate work in `build_flow_tree`.