### PR TITLE
Branch-aware push-through-outlet propagation + multi-root branch-join ordering fix

### DIFF
--- a/crates/gantz_core/src/compile.rs
+++ b/crates/gantz_core/src/compile.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 #[doc(inline)]
 pub use codegen::{OutletActivity, entry_fn_body, entry_fn_name};
+pub(crate) use codegen::{branch_selector, outlet_values_expr};
 #[doc(inline)]
 pub use entrypoint::{
     Entrypoint, EntrypointId, EvalKind, EvalSource, pull_source, push_pull_entrypoints, push_source,
@@ -14,8 +15,8 @@ pub use entrypoint::{
 #[doc(inline)]
 pub use error::ModuleError;
 #[doc(inline)]
-pub use flow::{Block, Flow, FlowGraph, NodeConf, NodeConns, flow_graph};
-pub(crate) use flow::{flow_graph_roots, outlet_patterns};
+pub use flow::{Block, Flow, FlowGraph, NodeConf, NodeConns, OutletReach, flow_graph};
+pub(crate) use flow::{branch_patterns_from_flow, flow_graph_roots};
 use meta::MetaTree;
 #[doc(inline)]
 pub use meta::{EdgeKind, Meta, MetaGraph};
@@ -290,6 +291,16 @@ fn group_sources_by_level(
         .collect()
 }
 
+/// Bitwise-OR of the branch patterns (all of equal width): the set of outputs a
+/// branching push-through can produce across all its branch outcomes.
+fn or_patterns(patterns: &[node::Conns]) -> Result<node::Conns, error::NodeConnsError> {
+    let n = patterns.first().map_or(0, node::Conns::len);
+    let bits: Vec<bool> = (0..n)
+        .map(|i| patterns.iter().any(|p| p.get(i).unwrap_or(false)))
+        .collect();
+    node::Conns::try_from_slice(&bits).map_err(|_| error::TooManyConns(n).into())
+}
+
 /// Recursively build a flow tree, routing entrypoint sources to each nesting
 /// level.
 ///
@@ -324,18 +335,34 @@ fn build_flow_tree<'a>(
     )?;
     let mut nested = std::collections::BTreeMap::new();
 
-    // 1. Recurse into children, collect outlet-reaching push sources.
+    // 1. Recurse into children, collect outlet-reaching push sources. When a
+    //    child's push reaches its outlets through branching (>= 2 distinct outlet
+    //    patterns), record those patterns as the bridged graph node's branches
+    //    for this entrypoint, so the parent gates its continuation per branch.
     let mut outlet_push: std::collections::BTreeMap<EntrypointId, Vec<(node::Id, node::Conns)>> =
         std::collections::BTreeMap::new();
+    let mut extra_branches: std::collections::BTreeMap<
+        EntrypointId,
+        std::collections::BTreeMap<node::Id, Vec<node::Conns>>,
+    > = std::collections::BTreeMap::new();
     for (&id, subtree) in &meta_tree.nested {
         let mut child_path = current_path.clone();
         child_path.push(id);
         let child_tree = build_flow_tree(subtree, level_sources, child_path)?;
         let (_, ref child_flow) = child_tree.elem;
-        for ep_id in child_flow.outlet_reach.keys() {
-            let n_outputs = meta_tree.elem.outputs.get(&id).copied().unwrap_or(0);
-            if n_outputs > 0 {
-                let conns = node::Conns::connected(n_outputs).unwrap();
+        let n_outputs = meta_tree.elem.outputs.get(&id).copied().unwrap_or(0);
+        if n_outputs > 0 {
+            for (ep_id, reach) in &child_flow.outlet_reach {
+                let conns = if reach.patterns.len() >= 2 {
+                    extra_branches
+                        .entry(ep_id.clone())
+                        .or_default()
+                        .insert(id, reach.patterns.clone());
+                    // Only the outputs some branch can produce reach downstream.
+                    or_patterns(&reach.patterns)?
+                } else {
+                    node::Conns::connected(n_outputs).map_err(|_| error::TooManyConns(n_outputs))?
+                };
                 outlet_push
                     .entry(ep_id.clone())
                     .or_default()
@@ -366,15 +393,18 @@ fn build_flow_tree<'a>(
         ep_push.entry(ep_id).or_default().extend(srcs);
     }
 
-    // 3. Build one flow graph per entrypoint with complete sources.
+    // 3. Build one flow graph per entrypoint with complete sources, treating any
+    //    branch-aware bridged graph nodes as branch nodes for that entrypoint.
     let mut entrypoints = std::collections::BTreeMap::new();
     let mut outlet_reach = std::collections::BTreeMap::new();
     let ep_ids: std::collections::BTreeSet<_> =
         ep_push.keys().chain(ep_pull.keys()).cloned().collect();
+    let outlet_ids: Vec<node::Id> = meta_tree.elem.outlets.iter().copied().collect();
     for ep_id in ep_ids {
         let push = ep_push.remove(&ep_id).unwrap_or_default();
         let pull = ep_pull.remove(&ep_id).unwrap_or_default();
-        let fg = flow::flow_graph(&meta_tree.elem, push, pull)?;
+        let extra = extra_branches.remove(&ep_id).unwrap_or_default();
+        let fg = flow::flow_graph_with_extra(&meta_tree.elem, push, pull, &extra)?;
         let reached: std::collections::BTreeSet<node::Id> = fg
             .node_weights()
             .flat_map(|blk| blk.iter())
@@ -382,7 +412,18 @@ fn build_flow_tree<'a>(
             .filter(|nid| meta_tree.elem.outlets.contains(nid))
             .collect();
         if !reached.is_empty() {
-            outlet_reach.insert(ep_id.clone(), reached);
+            // Patterns of this graph's outlets reachable from this entrypoint -
+            // for the parent's branch-aware propagation. Account for this graph's
+            // own branches plus this entrypoint's push-through (extra) branches.
+            let mut arm_counts: std::collections::BTreeMap<node::Id, usize> = meta_tree
+                .elem
+                .branches
+                .iter()
+                .map(|(&i, v)| (i, v.len()))
+                .collect();
+            arm_counts.extend(extra.iter().map(|(&i, m)| (i, m.len())));
+            let patterns = flow::branch_patterns_from_flow(&fg, &outlet_ids, &arm_counts)?;
+            outlet_reach.insert(ep_id.clone(), flow::OutletReach { reached, patterns });
         }
         entrypoints.insert(ep_id, fg);
     }

--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -822,8 +822,17 @@ fn flow_node_stmts(
         .collect();
     edges.sort();
 
-    // If there are no edges, we're done.
+    // If there are no edges, we're done. Destructure the block's last node so a
+    // consumer in another flow component - e.g. a branch's reconvergence join on
+    // a different root, emitted later after `order_roots` - can reference its
+    // outputs. (Within a component, a downstream node would do this; a terminal
+    // node otherwise leaves them undefined.) A terminal branch is left alone.
     if edges.is_empty() {
+        let conf = *block.last().unwrap();
+        if !branching.contains_key(&conf.id) {
+            stmts.extend(destructure_node_outputs_stmt(conf.id, conf.conns.outputs));
+            in_scope.insert(conf.id);
+        }
         return Ok(stmts);
 
     // Single successor: either a linear continuation or leads to a join.
@@ -1045,6 +1054,75 @@ fn flow_node_stmts(
     Ok(stmts)
 }
 
+/// Order flow-graph roots so that a root whose component produces a value
+/// consumed by another root's component is emitted first.
+///
+/// `build_flow_graph` can leave a branch's reconvergence join in a different
+/// flow component from a predecessor it depends on: the predecessor was lowered
+/// on a separate root with no flow edge to the join (a branch resets the
+/// topological chaining). The join is emitted inline with its branch, so its
+/// cross-component predecessor must be emitted *before* that branch - otherwise
+/// codegen references the predecessor's output before it is defined.
+///
+/// Components are stably topologically sorted by the cross-component data
+/// dependencies in `mg`; the incoming (id-sorted) order breaks ties so output
+/// stays deterministic.
+fn order_roots(mg: &MetaGraph, fg: &FlowGraph, roots: Vec<NodeIndex>) -> Vec<NodeIndex> {
+    if roots.len() < 2 {
+        return roots;
+    }
+    // Forward-reachable node ids for each root (its flow component).
+    let reach: Vec<HashSet<node::Id>> = roots
+        .iter()
+        .map(|&r| {
+            let mut set = HashSet::new();
+            let mut dfs = petgraph::visit::Dfs::new(fg, r);
+            while let Some(b) = dfs.next(fg) {
+                set.extend(fg[b].iter().map(|c| c.id));
+            }
+            set
+        })
+        .collect();
+
+    // `preceded_by[i]` = roots that must be emitted before root `i`, because a
+    // meta edge feeds from their (exclusive) reach into root `i`'s reach.
+    let n = roots.len();
+    let mut preceded_by: Vec<HashSet<usize>> = vec![HashSet::new(); n];
+    for (u, v, _) in mg.all_edges() {
+        for i in 0..n {
+            if !reach[i].contains(&v) || reach[i].contains(&u) {
+                continue;
+            }
+            for j in 0..n {
+                if j != i && reach[j].contains(&u) {
+                    preceded_by[i].insert(j);
+                }
+            }
+        }
+    }
+
+    // Stable topological sort (Kahn): repeatedly emit the lowest-index root with
+    // no remaining predecessor.
+    let mut indegree: Vec<usize> = preceded_by.iter().map(|s| s.len()).collect();
+    let mut emitted = vec![false; n];
+    let mut order = Vec::with_capacity(n);
+    while order.len() < n {
+        let Some(i) = (0..n).find(|&i| !emitted[i] && indegree[i] == 0) else {
+            // Unexpected cycle (the dataflow is acyclic); emit the rest in order.
+            order.extend((0..n).filter(|&k| !emitted[k]).map(|k| roots[k]));
+            break;
+        };
+        emitted[i] = true;
+        order.push(roots[i]);
+        for k in 0..n {
+            if !emitted[k] && preceded_by[k].contains(&i) {
+                indegree[k] -= 1;
+            }
+        }
+    }
+    order
+}
+
 /// Given the flow graph for an entry point eval fn, generate the body for the
 /// fn. as a list of statements.
 pub fn entry_fn_body(
@@ -1058,7 +1136,7 @@ pub fn entry_fn_body(
     bridge_nodes: &BTreeSet<node::Id>,
     outlet_activity: OutletActivity,
 ) -> Result<Vec<ExprKind>, CodegenError> {
-    let roots = flow_graph_roots(fg);
+    let roots = order_roots(mg, fg, flow_graph_roots(fg));
     if roots.is_empty() {
         return Ok(vec![]);
     }

--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -103,6 +103,75 @@ fn outlet_active_var(outlet_id: node::Id) -> String {
     format!("outlet-active-{outlet_id}")
 }
 
+/// The Steel expression yielding the outlet values shaped by `outlet_ids`: a
+/// single raw value for one outlet, a `(list ...)` for several, or `'()` for
+/// none. Each value is read from its hoisted `outlet-{id}` var.
+pub(crate) fn outlet_values_expr(outlet_ids: &[node::Id]) -> String {
+    match outlet_ids {
+        [] => "'()".to_string(),
+        [id] => outlet_var(*id),
+        ids => {
+            let values: Vec<_> = ids.iter().map(|&id| outlet_var(id)).collect();
+            format!("(list {})", values.join(" "))
+        }
+    }
+}
+
+/// The Steel expression selecting `(list branch-ix value)` for an externally
+/// branching nested graph.
+///
+/// Each distinct outlet-activation pattern has a unique integer signature
+/// (outlet `i` contributes `2^i` when active); the runtime signature is built
+/// from the hoisted `outlet-active-{id}` flags and matched against each
+/// pattern's signature with a nested `if` (the last pattern is the exhaustive
+/// fallthrough). Only primitive Steel forms are used, since the VM runs the base
+/// engine without the `cond`/`and` prelude macros.
+///
+/// Reused by both `nested_expr` (node-style branching) and `wrap_outlet_bridge`
+/// (branch-aware push-through-outlet propagation).
+pub(crate) fn branch_selector(patterns: &[node::Conns], outlet_ids: &[node::Id]) -> String {
+    // The value to return for a pattern, shaped by its active outlet count.
+    let value = |conns: &node::Conns| -> String {
+        let active: Vec<node::Id> = outlet_ids
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &id)| conns.get(i).unwrap_or(false).then_some(id))
+            .collect();
+        outlet_values_expr(&active)
+    };
+    // The unique signature of a pattern's active outlets.
+    let signature = |conns: &node::Conns| -> u128 {
+        (0..outlet_ids.len())
+            .filter(|&i| conns.get(i).unwrap_or(false))
+            .map(|i| 1u128 << i)
+            .sum()
+    };
+
+    // The runtime signature, summed from the active flags.
+    let terms: Vec<String> = outlet_ids
+        .iter()
+        .enumerate()
+        .map(|(i, &id)| format!("(if {} {} 0)", outlet_active_var(id), 1u128 << i))
+        .collect();
+    let sig_expr = match terms.as_slice() {
+        [] => "0".to_string(),
+        [t] => t.clone(),
+        _ => format!("(+ {})", terms.join(" ")),
+    };
+
+    // Nested `if` over patterns; the last is the exhaustive fallthrough.
+    let last = patterns.len() - 1;
+    let mut expr = format!("(list {last} {})", value(&patterns[last]));
+    for k in (0..last).rev() {
+        expr = format!(
+            "(if (= __branch-sig {}) (list {k} {}) {expr})",
+            signature(&patterns[k]),
+            value(&patterns[k]),
+        );
+    }
+    format!("(let ((__branch-sig {sig_expr})) {expr})")
+}
+
 /// The per-branching-node binding holding its selected branch index.
 ///
 /// Declared once per body (see [`declare_branch_ix_placeholders`]) and `set!`
@@ -1070,37 +1139,45 @@ fn wrap_state_scope(path: &[node::Id], stmts: Vec<ExprKind>) -> Vec<ExprKind> {
     result
 }
 
-/// Wrap inner-level statements in a `let` block that returns outlet values,
+/// Wrap inner-level statements in a `let` block that returns the outlet values,
 /// binding the result as the graph node's output in the parent scope.
 ///
 /// The `let` block creates a new scope so inner node bindings (e.g. `node-0`)
-/// don't collide with parent-level bindings. The outlet value(s) are the last
-/// expression in the `let` body, returned as the graph node's output.
+/// don't collide with parent-level bindings. The tail expression - the graph
+/// node's output - is the outlet values directly, or, when the push reaches the
+/// outlets through branching (`patterns.len() >= 2`), a `(list branch-ix value)`
+/// the parent branch-selects on (mirroring `node::graph::nested_expr`).
 fn wrap_outlet_bridge(
     inner_stmts: Vec<ExprKind>,
     graph_node_id: node::Id,
     inner_outlets: &BTreeSet<node::Id>,
     reached_outlets: &BTreeSet<node::Id>,
+    patterns: &[node::Conns],
 ) -> Vec<ExprKind> {
     if inner_stmts.is_empty() || reached_outlets.is_empty() {
         return inner_stmts;
     }
 
-    // Outlets write their values to hoisted `outlet-{id}` vars (see `eval_stmt`).
-    // Declare them within the `let` so the inner statements set them and we read
-    // them back as the graph node's output. Unreached outlets keep their `'()`
-    // default.
-    let declares: String = inner_outlets
-        .iter()
-        .map(|&id| format!("(define {} '())", outlet_var(id)))
-        .collect::<Vec<_>>()
-        .join(" ");
+    let branching = patterns.len() >= 2;
 
-    let outlet_values: Vec<String> = inner_outlets.iter().map(|&id| outlet_var(id)).collect();
-    let outlet_values_expr = match outlet_values.len() {
-        0 => "'()".to_string(),
-        1 => outlet_values[0].clone(),
-        _ => format!("(list {})", outlet_values.join(" ")),
+    // Outlets write their values to hoisted `outlet-{id}` vars (see `eval_stmt`),
+    // and - when branching - their `outlet-active-{id}` flags. Declare them
+    // within the `let` so the inner statements set them and we read them back as
+    // the graph node's output. Unreached outlets keep their `'()`/`#f` defaults.
+    let mut declares: Vec<String> = Vec::new();
+    for &id in inner_outlets {
+        declares.push(format!("(define {} '())", outlet_var(id)));
+        if branching {
+            declares.push(format!("(define {} #f)", outlet_active_var(id)));
+        }
+    }
+    let declares = declares.join(" ");
+
+    let outlet_ids: Vec<node::Id> = inner_outlets.iter().copied().collect();
+    let tail = if branching {
+        branch_selector(patterns, &outlet_ids)
+    } else {
+        outlet_values_expr(&outlet_ids)
     };
 
     let inner_stmts_str = inner_stmts
@@ -1110,8 +1187,7 @@ fn wrap_outlet_bridge(
         .join(" ");
 
     let output_var = node_outputs_var(graph_node_id);
-    let wrapped =
-        format!("(define {output_var} (let () {declares} {inner_stmts_str} {outlet_values_expr}))");
+    let wrapped = format!("(define {output_var} (let () {declares} {inner_stmts_str} {tail}))");
 
     Engine::emit_ast(&wrapped).expect("failed to emit AST for outlet bridge")
 }
@@ -1149,6 +1225,10 @@ fn entry_fns_collect(
     // (EntrypointId, graph_node_id) -> bridged stmts.
     let mut bridged: BTreeMap<super::EntrypointId, Vec<ExprKind>> = BTreeMap::new();
     let mut bridge_node_ids: BTreeMap<super::EntrypointId, BTreeSet<node::Id>> = BTreeMap::new();
+    // Bridge graph nodes whose push reaches outlets through branching, so the
+    // parent treats them as branch nodes for that entrypoint: node -> arm count.
+    let mut branch_bridges: BTreeMap<super::EntrypointId, BTreeMap<node::Id, usize>> =
+        BTreeMap::new();
 
     // 1. Recurse into children (post-order).
     for (&graph_node_id, child_tree) in &tree.nested {
@@ -1163,16 +1243,30 @@ fn entry_fns_collect(
         let (child_meta, ref child_flow) = child_tree.elem;
 
         for (ep_id, stmts) in child_stmts {
-            if let Some(reached_outlets) = child_flow.outlet_reach.get(&ep_id) {
+            if let Some(reach) = child_flow.outlet_reach.get(&ep_id) {
                 // Child stmts already include state scope wrapping from the
-                // child's own entry_fns_collect. Wrap in outlet bridge.
-                let bridge =
-                    wrap_outlet_bridge(stmts, graph_node_id, &child_meta.outlets, reached_outlets);
+                // child's own entry_fns_collect. Wrap in an outlet bridge that
+                // binds `node-{graph_node}`; when the child's push reaches its
+                // outlets through branching, the bridge yields a
+                // `(list branch-ix value)` the parent branch-selects on.
+                let bridge = wrap_outlet_bridge(
+                    stmts,
+                    graph_node_id,
+                    &child_meta.outlets,
+                    &reach.reached,
+                    &reach.patterns,
+                );
                 bridged.entry(ep_id.clone()).or_default().extend(bridge);
                 bridge_node_ids
-                    .entry(ep_id)
+                    .entry(ep_id.clone())
                     .or_default()
                     .insert(graph_node_id);
+                if reach.patterns.len() >= 2 {
+                    branch_bridges
+                        .entry(ep_id)
+                        .or_default()
+                        .insert(graph_node_id, reach.patterns.len());
+                }
             } else {
                 // No outlet propagation. Child stmts already include state
                 // scope wrapping from the child's own entry_fns_collect.
@@ -1183,15 +1277,38 @@ fn entry_fns_collect(
 
     // 2. Generate this level's own entrypoint stmts.
     let (meta, flow) = &tree.elem;
-    let branching: BTreeMap<node::Id, usize> =
+    let graph_branching: BTreeMap<node::Id, usize> =
         meta.branches.iter().map(|(&id, v)| (id, v.len())).collect();
 
     // Determine bridge_nodes for each entrypoint (graph nodes whose output
     // is already bound by an outlet bridge).
     let empty_bridges = BTreeSet::new();
+    let empty_branch_bridges = BTreeMap::new();
 
     for (ep_id, fg) in &flow.entrypoints {
         let bn = bridge_node_ids.get(ep_id).unwrap_or(&empty_bridges);
+        // Per-entrypoint branch nodes: this graph's own branches plus any
+        // branch-aware push-through bridges for this entrypoint.
+        let mut branching = graph_branching.clone();
+        branching.extend(
+            branch_bridges
+                .get(ep_id)
+                .unwrap_or(&empty_branch_bridges)
+                .iter()
+                .map(|(&id, &n)| (id, n)),
+        );
+        // Track outlet activation iff this graph's own push reaches its outlets
+        // through branching, so its parent can branch-select on the flags
+        // (mirrors `node::graph::nested_expr`).
+        let outlet_activity = if flow
+            .outlet_reach
+            .get(ep_id)
+            .map_or(false, |reach| reach.patterns.len() >= 2)
+        {
+            OutletActivity::Tracked
+        } else {
+            OutletActivity::Untracked
+        };
         let stmts = entry_fn_body(
             path,
             &meta.graph,
@@ -1201,9 +1318,7 @@ fn entry_fns_collect(
             &meta.outlets,
             fg,
             bn,
-            // Top-level/push-through entrypoints don't track outlet activation;
-            // branch-aware outlet propagation is node-style only (`nested_expr`).
-            OutletActivity::Untracked,
+            outlet_activity,
         )?;
         let scoped = wrap_state_scope(path, stmts);
 

--- a/crates/gantz_core/src/compile/flow.rs
+++ b/crates/gantz_core/src/compile/flow.rs
@@ -50,9 +50,22 @@ pub struct Flow {
     /// Control flow graph for each entrypoint at this graph level.
     /// An entrypoint appears here only if it has sources at this level.
     pub entrypoints: BTreeMap<EntrypointId, FlowGraph>,
-    /// For each entrypoint, the outlet node IDs its FlowGraph reaches.
-    /// Only populated for entrypoints whose flow reaches at least one outlet.
-    pub outlet_reach: BTreeMap<EntrypointId, BTreeSet<node::Id>>,
+    /// For each entrypoint, what its FlowGraph reaches in terms of this graph's
+    /// outlets. Only populated for entrypoints whose flow reaches at least one
+    /// outlet.
+    pub outlet_reach: BTreeMap<EntrypointId, OutletReach>,
+}
+
+/// What one entrypoint's flow graph reaches among its graph's outlets, for
+/// push-through-outlet propagation to the parent.
+#[derive(Clone, Debug)]
+pub struct OutletReach {
+    /// The outlet node ids reached (the union over all branch outcomes).
+    pub reached: BTreeSet<node::Id>,
+    /// The distinct external branch masks (over this graph's outputs) the push
+    /// can produce, or empty when it always produces the same outlets (so no
+    /// branch-aware propagation is needed). See `branch_patterns_from_flow`.
+    pub patterns: Vec<node::Conns>,
 }
 
 /// Represents a basic, linear block of node function calls.
@@ -146,13 +159,31 @@ pub fn flow_graph(
     push: impl IntoIterator<Item = (node::Id, node::Conns)>,
     pull: impl IntoIterator<Item = (node::Id, node::Conns)>,
 ) -> Result<FlowGraph, NodeConnsError> {
+    flow_graph_with_extra(meta, push, pull, &BTreeMap::new())
+}
+
+/// Like [`flow_graph`], but treats `extra_branches` (graph-node id -> per-arm
+/// output masks) as branch nodes in addition to `meta.branches`.
+///
+/// Used for branch-aware push-through-outlet propagation, where a bridged graph
+/// node branches for a *specific entrypoint only* (so its masks can't live in
+/// the graph-wide `meta.branches`).
+pub(crate) fn flow_graph_with_extra(
+    meta: &Meta,
+    push: impl IntoIterator<Item = (node::Id, node::Conns)>,
+    pull: impl IntoIterator<Item = (node::Id, node::Conns)>,
+    extra_branches: &BTreeMap<node::Id, Vec<node::Conns>>,
+) -> Result<FlowGraph, NodeConnsError> {
     let order: Vec<_> = super::eval_order(&meta.graph, push, pull).collect();
     let included: HashSet<_> = order.iter().copied().collect();
     let mg = reachable_subgraph(&meta.graph, &included);
+    // Graph-wide branches plus this entrypoint's push-through branch nodes.
+    let mut all_branches = meta.branches.clone();
+    all_branches.extend(extra_branches.iter().map(|(&id, m)| (id, m.clone())));
     let mut fg = FlowGraph::default();
     let no_shared = HashMap::new();
-    build_flow_graph(meta, &mg, &mg, &mut fg, &no_shared, None)?;
-    let branching: BTreeSet<node::Id> = meta.branches.keys().copied().collect();
+    build_flow_graph(meta, &mg, &mg, &mut fg, &no_shared, None, &all_branches)?;
+    let branching: BTreeSet<node::Id> = all_branches.keys().copied().collect();
     flow_graph_edge_contraction(&mut fg, &branching);
     Ok(fg)
 }
@@ -223,6 +254,7 @@ fn build_flow_graph(
     fg: &mut FlowGraph,
     shared: &HashMap<node::Id, NodeIndex>,
     skip: Option<node::Id>,
+    all_branches: &BTreeMap<node::Id, Vec<node::Conns>>,
 ) -> Result<Vec<NodeIndex>, NodeConnsError> {
     let mut topo = petgraph::visit::Topo::new(mg);
     let mut last: Option<NodeIndex> = None;
@@ -287,7 +319,7 @@ fn build_flow_graph(
             continue;
         }
 
-        if let Some(branches) = meta.branches.get(&n) {
+        if let Some(branches) = all_branches.get(&n) {
             let per_arm: Vec<HashSet<node::Id>> = branches
                 .iter()
                 .map(|conns| push_reachable(mg, n, &push_eval_neighbors(mg, n, conns)).collect())
@@ -340,8 +372,15 @@ fn build_flow_graph(
                     .filter(|id| !downstream.contains(id))
                     .collect();
                 let arm_mg = reachable_subgraph(mg, &arm_reachable);
-                let arm_entries =
-                    build_flow_graph(meta, &arm_mg, outer_mg, fg, &sub_shared, Some(n))?;
+                let arm_entries = build_flow_graph(
+                    meta,
+                    &arm_mg,
+                    outer_mg,
+                    fg,
+                    &sub_shared,
+                    Some(n),
+                    all_branches,
+                )?;
                 let arm_branch = Branch { ix, conns: *conns };
                 for entry in arm_entries {
                     fg.add_edge(block_ix, entry, arm_branch);
@@ -358,7 +397,15 @@ fn build_flow_graph(
                     }
                 }
                 let cont_mg = reachable_subgraph(mg, &cont);
-                build_flow_graph(meta, &cont_mg, outer_mg, fg, &sub_shared, None)?;
+                build_flow_graph(
+                    meta,
+                    &cont_mg,
+                    outer_mg,
+                    fg,
+                    &sub_shared,
+                    None,
+                    all_branches,
+                )?;
             }
 
             for r in &per_arm {
@@ -547,6 +594,37 @@ pub(crate) fn outlet_patterns(
         }
     }
     patterns
+}
+
+/// The distinct external branch masks for a flow graph reaching `outlet_ids`
+/// (ascending id order), or an empty `Vec` when fewer than two distinct outlet
+/// patterns are reachable (i.e. no external branching).
+///
+/// Maps each reached-outlet set from [`outlet_patterns`] to a `Conns` over
+/// `outlet_ids`. Used both by `GraphNode`'s node-style `branches()` (inlets ->
+/// outlets) and by branch-aware push-through-outlet propagation (a push source
+/// inside the graph -> outlets).
+pub(crate) fn branch_patterns_from_flow(
+    fg: &FlowGraph,
+    outlet_ids: &[node::Id],
+    branching: &BTreeMap<node::Id, usize>,
+) -> Result<Vec<node::Conns>, TooManyConns> {
+    let n = outlet_ids.len();
+    let outlets: BTreeSet<node::Id> = outlet_ids.iter().copied().collect();
+    let mut patterns: BTreeSet<node::Conns> = BTreeSet::new();
+    for reached in outlet_patterns(fg, &outlets, branching) {
+        let mut conns = node::Conns::unconnected(n).map_err(|_| TooManyConns(n))?;
+        for (i, id) in outlet_ids.iter().enumerate() {
+            if reached.contains(id) {
+                conns.set(i, true).map_err(|_| TooManyConns(n))?;
+            }
+        }
+        patterns.insert(conns);
+    }
+    if patterns.len() < 2 {
+        return Ok(vec![]);
+    }
+    Ok(patterns.into_iter().collect())
 }
 
 /// Outcome of walking one (partial) world in [`outlet_patterns`].

--- a/crates/gantz_core/src/node/graph.rs
+++ b/crates/gantz_core/src/node/graph.rs
@@ -330,36 +330,6 @@ fn branch_arm_counts(meta: &compile::Meta) -> BTreeMap<node::Id, usize> {
     meta.branches.iter().map(|(&id, v)| (id, v.len())).collect()
 }
 
-/// The distinct external branches of a nested graph, as output masks over its
-/// outlets (ascending id order), or an empty `Vec` when it does not branch.
-///
-/// Each pattern is one set of outlets that may be simultaneously active under
-/// some combination of inner branch outcomes (see [`compile::outlet_patterns`]).
-/// Fewer than two distinct patterns means the graph always produces the same
-/// outlets, i.e. it has no external branching.
-fn branch_patterns_from_flow(
-    fg: &compile::FlowGraph,
-    outlet_ids: &[node::Id],
-    branching: &BTreeMap<node::Id, usize>,
-) -> Result<Vec<node::Conns>, node::ExprError> {
-    let outlets: BTreeSet<node::Id> = outlet_ids.iter().copied().collect();
-    let mut patterns: BTreeSet<node::Conns> = BTreeSet::new();
-    for reached in compile::outlet_patterns(fg, &outlets, branching) {
-        let mut conns =
-            node::Conns::unconnected(outlet_ids.len()).map_err(node::ExprError::custom)?;
-        for (i, id) in outlet_ids.iter().enumerate() {
-            if reached.contains(id) {
-                conns.set(i, true).map_err(node::ExprError::custom)?;
-            }
-        }
-        patterns.insert(conns);
-    }
-    if patterns.len() < 2 {
-        return Ok(vec![]);
-    }
-    Ok(patterns.into_iter().collect())
-}
-
 /// Compute the external branch masks for a nested graph (see [`Node::branches`]).
 fn graph_branches<'a, G>(
     get_node: node::GetNode<'a>,
@@ -377,7 +347,8 @@ where
     }
     let outlet_ids: Vec<node::Id> = meta.outlets.iter().copied().collect();
     let fg = inner_flow_graph(&meta)?;
-    branch_patterns_from_flow(&fg, &outlet_ids, &branch_arm_counts(&meta))
+    compile::branch_patterns_from_flow(&fg, &outlet_ids, &branch_arm_counts(&meta))
+        .map_err(node::ExprError::custom)
 }
 
 /// Build the control flow graph for a nested graph: inlets push, outlets pull.
@@ -389,73 +360,6 @@ fn inner_flow_graph(meta: &compile::Meta) -> Result<compile::FlowGraph, node::Ex
         meta.outlets.iter().map(|&n| (n, conn())),
     )
     .map_err(node::ExprError::custom)
-}
-
-/// The Steel expression that yields a nested graph's outlet values, shaped by
-/// the given outlets: a single raw value for one outlet, a `(list ...)` for
-/// several, or `'()` for none. Each value is read from its hoisted `outlet-{id}`
-/// var.
-fn outlet_values_expr(outlet_ids: &[node::Id]) -> String {
-    match outlet_ids {
-        [] => "'()".to_string(),
-        [id] => format!("outlet-{id}"),
-        ids => {
-            let values: Vec<_> = ids.iter().map(|id| format!("outlet-{id}")).collect();
-            format!("(list {})", values.join(" "))
-        }
-    }
-}
-
-/// The Steel expression selecting `(list branch-ix value)` for a branching
-/// nested graph.
-///
-/// Each distinct outlet-activation pattern has a unique integer signature
-/// (outlet `i` contributes `2^i` when active); the runtime signature is built
-/// from the hoisted `outlet-active-{id}` flags and matched against each
-/// pattern's signature with a nested `if` (the last pattern is the exhaustive
-/// fallthrough). Only primitive Steel forms are used, since the VM runs the
-/// base engine without the `cond`/`and` prelude macros.
-fn branch_selector(patterns: &[node::Conns], outlet_ids: &[node::Id]) -> String {
-    // The value to return for a pattern, shaped by its active outlet count.
-    let value = |conns: &node::Conns| -> String {
-        let active: Vec<node::Id> = outlet_ids
-            .iter()
-            .enumerate()
-            .filter_map(|(i, &id)| conns.get(i).unwrap_or(false).then_some(id))
-            .collect();
-        outlet_values_expr(&active)
-    };
-    // The unique signature of a pattern's active outlets.
-    let signature = |conns: &node::Conns| -> u128 {
-        (0..outlet_ids.len())
-            .filter(|&i| conns.get(i).unwrap_or(false))
-            .map(|i| 1u128 << i)
-            .sum()
-    };
-
-    // The runtime signature, summed from the active flags.
-    let terms: Vec<String> = outlet_ids
-        .iter()
-        .enumerate()
-        .map(|(i, &id)| format!("(if outlet-active-{id} {} 0)", 1u128 << i))
-        .collect();
-    let sig_expr = match terms.as_slice() {
-        [] => "0".to_string(),
-        [t] => t.clone(),
-        _ => format!("(+ {})", terms.join(" ")),
-    };
-
-    // Nested `if` over patterns; the last is the exhaustive fallthrough.
-    let last = patterns.len() - 1;
-    let mut expr = format!("(list {last} {})", value(&patterns[last]));
-    for k in (0..last).rev() {
-        expr = format!(
-            "(if (= __branch-sig {}) (list {k} {}) {expr})",
-            signature(&patterns[k]),
-            value(&patterns[k]),
-        );
-    }
-    format!("(let ((__branch-sig {sig_expr})) {expr})")
 }
 
 /// The implementation of the `GraphNode`'s `Node::expr` fn.
@@ -483,7 +387,8 @@ where
     let arm_counts = branch_arm_counts(&meta);
 
     // The external branch patterns (empty => not externally branching).
-    let patterns = branch_patterns_from_flow(&fg, &outlet_ids, &arm_counts)?;
+    let patterns = compile::branch_patterns_from_flow(&fg, &outlet_ids, &arm_counts)
+        .map_err(node::ExprError::custom)?;
     let branching = !patterns.is_empty();
     let outlet_activity = if branching {
         compile::OutletActivity::Tracked
@@ -535,9 +440,9 @@ where
     // The node's output: a `(list branch-ix value)` when branching, else the
     // outlet values directly.
     let tail = if branching {
-        branch_selector(&patterns, &outlet_ids)
+        compile::branch_selector(&patterns, &outlet_ids)
     } else {
-        outlet_values_expr(&outlet_ids)
+        compile::outlet_values_expr(&outlet_ids)
     };
 
     // Wrap in `(let () ...)` so the inner statements form a *body*: unlike a

--- a/crates/gantz_core/tests/nested.rs
+++ b/crates/gantz_core/tests/nested.rs
@@ -2492,3 +2492,139 @@ fn test_graph_nested_push_through_branch_with_constant_outlet() {
     assert_eq!(build(1), (None, Some(99), Some(7))); // arm 1 -> b, plus constant c
 }
 
+// ===========================================================================
+// Multi-root branch-reconvergence ordering tests.
+//
+// A single entrypoint with two flow roots, where one root branches and its arms
+// reconverge at a join that ALSO consumes the other root's value. The join is
+// the branch's post-dominator yet depends on a second root: previously the
+// branch root was emitted first and the join referenced the second root's output
+// before it was defined (a `FreeIdentifier` VM error). Fixed by `order_roots`
+// (emit a producing component before a consuming one) plus destructuring a
+// terminal block's last node so its outputs are available cross-component.
+// ===========================================================================
+
+// Build, compile and run `g` from two push sources in one entrypoint; returns
+// the VM for state queries.
+fn run_two_push<N: DebugNode + ?Sized>(
+    g: &petgraph::graph::DiGraph<Box<N>, Edge>,
+    a: (Vec<usize>, u8),
+    b: (Vec<usize>, u8),
+) -> Engine {
+    let ep = entrypoint::from_sources([push_source(a.0, a.1), push_source(b.0, b.1)]);
+    let module = gantz_core::compile::module(&no_lookup, g, &[ep.clone()]).unwrap();
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, g, &[], &mut vm);
+    for f in &module {
+        vm.run(f.to_pretty(100)).unwrap();
+    }
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep.id()), vec![])
+        .unwrap();
+    vm
+}
+
+// Two push roots; Root A branches and its arms reconverge at `add`, which also
+// takes Root B's `int(20)`.
+//
+//   ROOT A: [push_a]->[int sel]->[select]   o0,o1 -> add.$l (phi)
+//   ROOT B: [push_b]->[int 20] -------------------> add.$r ;  add -> store
+#[test]
+fn test_multiroot_branch_join_external_pred() {
+    let build = |sel: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push_a = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = g.add_node(Box::new(node_int(sel)) as Box<_>);
+        let select = g.add_node(Box::new(node_select()) as Box<_>);
+        let push_b = g.add_node(Box::new(node_push()) as Box<_>);
+        let twenty = g.add_node(Box::new(node_int(20)) as Box<_>);
+        let add = g.add_node(Box::new(node::expr("(+ $l $r)").unwrap()) as Box<_>);
+        let store = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push_a, int, Edge::from((0, 0)));
+        g.add_edge(int, select, Edge::from((0, 0)));
+        g.add_edge(select, add, Edge::from((0, 0))); // arm 0 -> add.l
+        g.add_edge(select, add, Edge::from((1, 0))); // arm 1 -> add.l
+        g.add_edge(push_b, twenty, Edge::from((0, 0)));
+        g.add_edge(twenty, add, Edge::from((0, 1))); // -> add.r
+        g.add_edge(add, store, Edge::from((0, 0)));
+        let n = g[push_a].n_outputs(node::MetaCtx::new(&no_lookup)) as u8;
+        let vm = run_two_push(&g, (vec![push_a.index()], n), (vec![push_b.index()], n));
+        store_val(&vm, store)
+    };
+    assert_eq!(build(0), Some(62)); // arm 0: 42 + 20
+    assert_eq!(build(1), Some(119)); // arm 1: 99 + 20
+}
+
+// Sibling-shape guard: the same logical graph, but the predecessor's nodes are
+// added first so the topological `last`-chaining linearizes `int(20)` ahead of
+// the branch within a single component. This shape already worked; it verifies
+// the terminal-destructure / `order_roots` changes don't regress the linearized
+// form.
+#[test]
+fn test_multiroot_branch_join_external_pred_reversed() {
+    let build = |sel: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        // Root B first (lower ids).
+        let push_b = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let twenty = g.add_node(Box::new(node_int(20)) as Box<_>);
+        // Root A second.
+        let push_a = g.add_node(Box::new(node_push()) as Box<_>);
+        let int = g.add_node(Box::new(node_int(sel)) as Box<_>);
+        let select = g.add_node(Box::new(node_select()) as Box<_>);
+        let add = g.add_node(Box::new(node::expr("(+ $l $r)").unwrap()) as Box<_>);
+        let store = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push_b, twenty, Edge::from((0, 0)));
+        g.add_edge(twenty, add, Edge::from((0, 1))); // -> add.r
+        g.add_edge(push_a, int, Edge::from((0, 0)));
+        g.add_edge(int, select, Edge::from((0, 0)));
+        g.add_edge(select, add, Edge::from((0, 0))); // arm 0 -> add.l
+        g.add_edge(select, add, Edge::from((1, 0))); // arm 1 -> add.l
+        g.add_edge(add, store, Edge::from((0, 0)));
+        let n = g[push_a].n_outputs(node::MetaCtx::new(&no_lookup)) as u8;
+        let vm = run_two_push(&g, (vec![push_a.index()], n), (vec![push_b.index()], n));
+        store_val(&vm, store)
+    };
+    assert_eq!(build(0), Some(62));
+    assert_eq!(build(1), Some(119));
+}
+
+// The same branch-join shape one level down: inside a nested graph, inlet_a
+// branches and its arms reconverge at `add`, which also takes inlet_b. Here the
+// inlets linearize into one component, so it already worked - this guards the
+// node-style `nested_expr` codegen path against the terminal-destructure change.
+//
+//   INNER: [inlet_a]->[select] o0,o1 -> add.$l ;  [inlet_b] -> add.$r ;  add -> outlet
+//   OUTER: [push]->[int sel]->inlet_a ;  [push]->[int 20]->inlet_b ;  inner -> store
+#[test]
+fn test_nested_branch_join_external_inlet() {
+    let make_inner = || {
+        let mut inner = GraphNode::default();
+        let inlet_a = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+        let inlet_b = inner.add_node(Box::new(node::graph::Inlet) as Box<_>);
+        let select = inner.add_node(Box::new(node_select()) as Box<_>);
+        let add = inner.add_node(Box::new(node::expr("(+ $l $r)").unwrap()) as Box<_>);
+        let outlet = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(inlet_a, select, Edge::from((0, 0)));
+        inner.add_edge(select, add, Edge::from((0, 0)));
+        inner.add_edge(select, add, Edge::from((1, 0)));
+        inner.add_edge(inlet_b, add, Edge::from((0, 1)));
+        inner.add_edge(add, outlet, Edge::from((0, 0)));
+        inner
+    };
+    let build = |sel: i32| {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = g.add_node(Box::new(node_int(sel)) as Box<_>);
+        let twenty = g.add_node(Box::new(node_int(20)) as Box<_>);
+        let inner_node = g.add_node(Box::new(make_inner()) as Box<_>);
+        let store = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(push, int, Edge::from((0, 0)));
+        g.add_edge(push, twenty, Edge::from((0, 0)));
+        g.add_edge(int, inner_node, Edge::from((0, 0))); // -> inlet_a (input 0)
+        g.add_edge(twenty, inner_node, Edge::from((0, 1))); // -> inlet_b (input 1)
+        g.add_edge(inner_node, store, Edge::from((0, 0)));
+        store_val(&compile_and_push(&g, push), store)
+    };
+    assert_eq!(build(0), Some(62));
+    assert_eq!(build(1), Some(119));
+}

--- a/crates/gantz_core/tests/nested.rs
+++ b/crates/gantz_core/tests/nested.rs
@@ -1056,6 +1056,28 @@ fn store_val(vm: &Engine, store: petgraph::graph::NodeIndex) -> Option<i32> {
         .flatten()
 }
 
+// Build, compile and run `g` from a `push_eval` nested at `path` (e.g.
+// `[graph_node, push]`); returns the VM for state queries. Unlike
+// `compile_and_push`, the push lives *inside* a nested graph and propagates out
+// through that graph's outlets.
+fn compile_and_push_nested<N: DebugNode + ?Sized>(
+    g: &petgraph::graph::DiGraph<Box<N>, Edge>,
+    path: Vec<usize>,
+    push_n_outputs: u8,
+) -> Engine {
+    let ep = entrypoint::from_source(push_source(path, push_n_outputs));
+    let module = gantz_core::compile::module(&no_lookup, g, &[ep.clone()]).unwrap();
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, g, &[], &mut vm);
+    for f in &module {
+        vm.run(f.to_pretty(100)).unwrap();
+    }
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep.id()), vec![])
+        .unwrap();
+    vm
+}
+
 // Divergent branch: each arm routes to its own outlet.  branches: [{A}, {B}]
 //
 //        [In]
@@ -2193,3 +2215,280 @@ fn test_graph_nested_multi_branch_three() {
         [Some(52), None, None, Some(139), Some(92), None]
     );
 }
+
+// ===========================================================================
+// Push-through-outlet branching tests.
+//
+// Here the `push_eval` lives *inside* the nested graph and propagates *out*
+// through the graph's outlets via an interior branch. The bridged graph node
+// therefore acts as a branch node in the parent for that entrypoint, so the
+// parent only evaluates downstream of the outlets the taken arm produced.
+// Each test's INNER graph (with the push inside) is sketched above it; `[Sel]`
+// is `node_select` (input ==0 -> o0(42), else -> o1(99)).
+// ===========================================================================
+
+// Divergent push-through: each arm drives its own outlet -> its own outer store.
+//
+//   INNER: [push]->[int(sel)]->[Sel]        OUTER: [inner]
+//                            o0/  \o1               o0/  \o1
+//                        [OutA]   [OutB]      [store_a] [store_b]
+#[test]
+fn test_graph_nested_push_through_divergent_branch() {
+    let build = |sel: i32| {
+        let mut inner = GraphNode::default();
+        let push = inner.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = inner.add_node(Box::new(node_int(sel)) as Box<_>);
+        let select = inner.add_node(Box::new(node_select()) as Box<_>);
+        let outlet_a = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let outlet_b = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(push, int, Edge::from((0, 0)));
+        inner.add_edge(int, select, Edge::from((0, 0)));
+        inner.add_edge(select, outlet_a, Edge::from((0, 0)));
+        inner.add_edge(select, outlet_b, Edge::from((1, 0)));
+
+        let ctx = node::MetaCtx::new(&no_lookup);
+        let push_n = inner[push].n_outputs(ctx) as u8;
+
+        let mut g = petgraph::graph::DiGraph::new();
+        let inner_node = g.add_node(Box::new(inner) as Box<dyn DebugNode>);
+        let store_a = g.add_node(Box::new(node_number()) as Box<_>);
+        let store_b = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(inner_node, store_a, Edge::from((0, 0)));
+        g.add_edge(inner_node, store_b, Edge::from((1, 0)));
+
+        let vm = compile_and_push_nested(&g, vec![inner_node.index(), push.index()], push_n);
+        (store_val(&vm, store_a), store_val(&vm, store_b))
+    };
+
+    assert_eq!(build(0), (Some(42), None)); // arm 0 -> outlet A -> store_a
+    assert_eq!(build(1), (None, Some(99))); // arm 1 -> outlet B -> store_b
+}
+
+// Dead-arm push-through: arm 1 leaves the select output unconnected, so it
+// produces nothing and no outer store is written.
+//
+//   INNER: [push]->[int(sel)]->[Sel]        OUTER: [inner]
+//                            o0|  \o1 (dead)         o0|
+//                        [OutA]    x              [store]
+#[test]
+fn test_graph_nested_push_through_dead_arm() {
+    let build = |sel: i32| {
+        let mut inner = GraphNode::default();
+        let push = inner.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = inner.add_node(Box::new(node_int(sel)) as Box<_>);
+        let select = inner.add_node(Box::new(node_select()) as Box<_>);
+        let outlet = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(push, int, Edge::from((0, 0)));
+        inner.add_edge(int, select, Edge::from((0, 0)));
+        inner.add_edge(select, outlet, Edge::from((0, 0)));
+        // Select output 1 left unconnected (dead arm).
+
+        let ctx = node::MetaCtx::new(&no_lookup);
+        let push_n = inner[push].n_outputs(ctx) as u8;
+
+        let mut g = petgraph::graph::DiGraph::new();
+        let inner_node = g.add_node(Box::new(inner) as Box<dyn DebugNode>);
+        let store = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(inner_node, store, Edge::from((0, 0)));
+
+        let vm = compile_and_push_nested(&g, vec![inner_node.index(), push.index()], push_n);
+        store_val(&vm, store)
+    };
+
+    assert_eq!(build(0), Some(42)); // arm 0 -> outlet -> store
+    assert_eq!(build(1), None); // arm 1 -> dead, store never evaluated
+}
+
+// Multi-output-arm push-through: arm 0 fires two outlets, arm 1 fires one.
+//
+//   INNER: [push]->[int(sel)]->[Branch]     arm 0 -> o0,o1 (values 10,20)
+//                          o0/o1|\o2         arm 1 -> o2    (value 30)
+//                     [A][B][C]              OUTER stores: a,b,c
+#[test]
+fn test_graph_nested_push_through_multi_outlet_arm() {
+    let branch3 = || {
+        node::branch(
+            "(if (= 0 $x) (list 0 (list 10 20)) (list 1 30))",
+            vec![
+                node::Conns::try_from([true, true, false]).unwrap(),
+                node::Conns::try_from([false, false, true]).unwrap(),
+            ],
+        )
+        .unwrap()
+    };
+    let build = |sel: i32| {
+        let mut inner = GraphNode::default();
+        let push = inner.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = inner.add_node(Box::new(node_int(sel)) as Box<_>);
+        let br = inner.add_node(Box::new(branch3()) as Box<_>);
+        let outlet_a = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let outlet_b = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let outlet_c = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(push, int, Edge::from((0, 0)));
+        inner.add_edge(int, br, Edge::from((0, 0)));
+        inner.add_edge(br, outlet_a, Edge::from((0, 0)));
+        inner.add_edge(br, outlet_b, Edge::from((1, 0)));
+        inner.add_edge(br, outlet_c, Edge::from((2, 0)));
+
+        let ctx = node::MetaCtx::new(&no_lookup);
+        let push_n = inner[push].n_outputs(ctx) as u8;
+
+        let mut g = petgraph::graph::DiGraph::new();
+        let inner_node = g.add_node(Box::new(inner) as Box<dyn DebugNode>);
+        let store_a = g.add_node(Box::new(node_number()) as Box<_>);
+        let store_b = g.add_node(Box::new(node_number()) as Box<_>);
+        let store_c = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(inner_node, store_a, Edge::from((0, 0)));
+        g.add_edge(inner_node, store_b, Edge::from((1, 0)));
+        g.add_edge(inner_node, store_c, Edge::from((2, 0)));
+
+        let vm = compile_and_push_nested(&g, vec![inner_node.index(), push.index()], push_n);
+        (
+            store_val(&vm, store_a),
+            store_val(&vm, store_b),
+            store_val(&vm, store_c),
+        )
+    };
+
+    assert_eq!(build(0), (Some(10), Some(20), None)); // arm 0 -> a,b
+    assert_eq!(build(1), (None, None, Some(30))); // arm 1 -> c
+}
+
+// Two-level push-through: the push is inside the *innermost* graph; its branch
+// propagates out through two levels of outlets. The middle graph branches
+// because the inner one does (multi-level pattern threading).
+//
+//   INNER2: [push]->[int(sel)]->[Sel]->{oa,ob}
+//   INNER1: [inner2]->{ox,oy}
+//   OUTER:  [inner1]->{store_x, store_y}
+#[test]
+fn test_graph_nested_push_through_two_levels() {
+    let build = |sel: i32| {
+        let mut inner2 = GraphNode::default();
+        let push = inner2.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = inner2.add_node(Box::new(node_int(sel)) as Box<_>);
+        let select = inner2.add_node(Box::new(node_select()) as Box<_>);
+        let oa = inner2.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let ob = inner2.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner2.add_edge(push, int, Edge::from((0, 0)));
+        inner2.add_edge(int, select, Edge::from((0, 0)));
+        inner2.add_edge(select, oa, Edge::from((0, 0)));
+        inner2.add_edge(select, ob, Edge::from((1, 0)));
+
+        let ctx = node::MetaCtx::new(&no_lookup);
+        let push_n = inner2[push].n_outputs(ctx) as u8;
+
+        let mut inner1 = GraphNode::default();
+        let inner2_node = inner1.add_node(Box::new(inner2) as Box<dyn DebugNode>);
+        let ox = inner1.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let oy = inner1.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner1.add_edge(inner2_node, ox, Edge::from((0, 0)));
+        inner1.add_edge(inner2_node, oy, Edge::from((1, 0)));
+
+        let mut g = petgraph::graph::DiGraph::new();
+        let inner1_node = g.add_node(Box::new(inner1) as Box<dyn DebugNode>);
+        let store_x = g.add_node(Box::new(node_number()) as Box<_>);
+        let store_y = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(inner1_node, store_x, Edge::from((0, 0)));
+        g.add_edge(inner1_node, store_y, Edge::from((1, 0)));
+
+        let vm = compile_and_push_nested(
+            &g,
+            vec![inner1_node.index(), inner2_node.index(), push.index()],
+            push_n,
+        );
+        (store_val(&vm, store_x), store_val(&vm, store_y))
+    };
+
+    assert_eq!(build(0), (Some(42), None));
+    assert_eq!(build(1), (None, Some(99)));
+}
+
+// Reconvergent push-through: a divergent interior branch whose two arms feed
+// distinct outlets that re-join at a single outer store - a phi across the
+// bridge boundary. The store always fires, with the taken arm's value.
+//
+//   INNER: [push]->[int(sel)]->[Sel]->{oa(o0), ob(o1)}
+//   OUTER: inner.o0 -\
+//          inner.o1 --> [store]
+#[test]
+fn test_graph_nested_push_through_reconvergent_branch() {
+    let build = |sel: i32| {
+        let mut inner = GraphNode::default();
+        let push = inner.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = inner.add_node(Box::new(node_int(sel)) as Box<_>);
+        let select = inner.add_node(Box::new(node_select()) as Box<_>);
+        let oa = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let ob = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(push, int, Edge::from((0, 0)));
+        inner.add_edge(int, select, Edge::from((0, 0)));
+        inner.add_edge(select, oa, Edge::from((0, 0)));
+        inner.add_edge(select, ob, Edge::from((1, 0)));
+
+        let ctx = node::MetaCtx::new(&no_lookup);
+        let push_n = inner[push].n_outputs(ctx) as u8;
+
+        let mut g = petgraph::graph::DiGraph::new();
+        let inner_node = g.add_node(Box::new(inner) as Box<dyn DebugNode>);
+        let store = g.add_node(Box::new(node_number()) as Box<_>);
+        // Both arms route to the same store (phi reconvergence across the bridge).
+        g.add_edge(inner_node, store, Edge::from((0, 0)));
+        g.add_edge(inner_node, store, Edge::from((1, 0)));
+
+        let vm = compile_and_push_nested(&g, vec![inner_node.index(), push.index()], push_n);
+        store_val(&vm, store)
+    };
+
+    assert_eq!(build(0), Some(42)); // arm 0 -> outlet A -> store
+    assert_eq!(build(1), Some(99)); // arm 1 -> outlet B -> store
+}
+
+// Push-through branch alongside an always-active outlet: the push also drives a
+// constant-fed outlet that every arm produces, so its store always fires while
+// the branch arms route to their own stores.
+//
+//   INNER: [push]-+->[int(sel)]->[Sel]->{oa(o0), ob(o1)}
+//                 +->[int(7)]---------->{oc(o2)}   (always produced)
+//   OUTER: inner.{o0,o1,o2} -> {store_a, store_b, store_c}
+#[test]
+fn test_graph_nested_push_through_branch_with_constant_outlet() {
+    let build = |sel: i32| {
+        let mut inner = GraphNode::default();
+        let push = inner.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = inner.add_node(Box::new(node_int(sel)) as Box<_>);
+        let select = inner.add_node(Box::new(node_select()) as Box<_>);
+        let seven = inner.add_node(Box::new(node_int(7)) as Box<_>);
+        let outlet_a = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let outlet_b = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        let outlet_c = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+        inner.add_edge(push, int, Edge::from((0, 0)));
+        inner.add_edge(int, select, Edge::from((0, 0)));
+        inner.add_edge(select, outlet_a, Edge::from((0, 0)));
+        inner.add_edge(select, outlet_b, Edge::from((1, 0)));
+        inner.add_edge(push, seven, Edge::from((0, 0)));
+        inner.add_edge(seven, outlet_c, Edge::from((0, 0)));
+
+        let ctx = node::MetaCtx::new(&no_lookup);
+        let push_n = inner[push].n_outputs(ctx) as u8;
+
+        let mut g = petgraph::graph::DiGraph::new();
+        let inner_node = g.add_node(Box::new(inner) as Box<dyn DebugNode>);
+        let store_a = g.add_node(Box::new(node_number()) as Box<_>);
+        let store_b = g.add_node(Box::new(node_number()) as Box<_>);
+        let store_c = g.add_node(Box::new(node_number()) as Box<_>);
+        g.add_edge(inner_node, store_a, Edge::from((0, 0)));
+        g.add_edge(inner_node, store_b, Edge::from((1, 0)));
+        g.add_edge(inner_node, store_c, Edge::from((2, 0)));
+
+        let vm = compile_and_push_nested(&g, vec![inner_node.index(), push.index()], push_n);
+        (
+            store_val(&vm, store_a),
+            store_val(&vm, store_b),
+            store_val(&vm, store_c),
+        )
+    };
+
+    assert_eq!(build(0), (Some(42), None, Some(7))); // arm 0 -> a, plus constant c
+    assert_eq!(build(1), (None, Some(99), Some(7))); // arm 1 -> b, plus constant c
+}
+


### PR DESCRIPTION
## 1. feat: branch-aware push-through-outlet propagation

The deferred follow-up to #216. That PR made a nested graph act as a *branching node* when evaluated inlets -> outlets (via `expr`/`branches`). It explicitly deferred the other direction: a `push_eval` node *inside* a nested graph firing and propagating *out* through the graph's outlets to the parent's continuation.

Previously that push-through path was **not branch-aware** - the parent evaluated downstream of *every* reached outlet unconditionally. When the internal push passes through inner branches, which outlets are produced depends on the runtime branch, so the parent should only evaluate downstream of the outlets the taken branch actually produced. This PR makes that happen.

**Mechanism** - treat a branch-reaching push-through graph node as a *branch node in the parent flow graph for that entrypoint*, reusing the node-style branching machinery end to end:

- `Flow.outlet_reach` now carries per-entrypoint `OutletReach { reached, patterns }`.
- `flow_graph_with_extra` threads per-entrypoint "extra branches" into `build_flow_graph` so the bridged graph node stays a branch node (applies at every nesting level).
- `wrap_outlet_bridge` emits a `(list branch-ix value)` tail via `branch_selector`; `entry_fns_collect` derives per-entrypoint branching and outlet activity.
- `branch_patterns_from_flow` / `branch_selector` / `outlet_values_expr` are factored out and shared between this and node-style `nested_expr`.

New tests (each pushes from a `push_eval` *inside* the nested graph and asserts downstream stores fire per the taken branch): divergent, dead-arm, multi-output-arm, two-level, reconvergent-across-bridge, and constant-outlet.

---

## 2. fix: order multi-root flow graphs so a branch-join's predecessors precede it

A **pre-existing** bug, orthogonal to (1) - it predates push-through and reproduces without it. It was found while testing the highest-risk push-through composition, then minimized.

A multi-source entrypoint (≥2 push/pull sources) where a branch's reconvergence join (its post-dominator) *also* depends on a node on a **different** flow root emitted invalid Steel: the branch root was generated first, so the join referenced the other root's output before it was defined (`FreeIdentifier` at VM run). It reproduces with **zero nesting** - two plain direct pushes joining at `(+ $l $r)` whose `$l` is a branch's two arms:

```
   ROOT A                         ROOT B
 [push_a]                       [push_b]
    |                              |
 [int sel]                      [int 20]
    |                              |
  [select]   <- branch            |
  o0/  \o1   arms reconverge       |
    \  /                           |
   [add] <--------- $r ------------+    ($l = phi(arm0, arm1))
     |
   [store]
```

The predecessor's root is *not* linearized by the usual topological `last`-chaining because the branch resets the chain, leaving it a separate flow component.

**Fix** (`codegen.rs` only):

- `order_roots` topologically sorts flow-graph roots by cross-component data dependencies, so a producing component is emitted before a consuming one.
- The terminal (no-outgoing-edge) case in `flow_node_stmts` now destructures its last node's outputs, so a consumer in another component can reference them.

New tests: the flat two-push regression above, plus reversed-order and nested sibling-shape guards.