### PR TITLE
fix: hoist root-level outlet vars so subgraphs can open as roots

### DIFF
--- a/crates/bevy_gantz/src/vm.rs
+++ b/crates/bevy_gantz/src/vm.rs
@@ -129,6 +129,15 @@ fn init_head_vm<N>(
         Ok(result) => result,
         Err(e) => {
             log::error!("Failed to init VM for head: {e}");
+            // Don't leave a stale VM/module from a previously-active graph in
+            // place: surface the error in the compiled module and drop the VM so
+            // eval systems (e.g. `drive_frame_bangs`, `on_eval_entry`) stop
+            // driving the wrong graph - which otherwise manifests as a confusing
+            // "free identifier: entry-fn-..." against an unrelated module.
+            cmds.entity(entity).insert(head::CompiledModule(format!(
+                "; failed to compile graph:\n; {e}"
+            )));
+            vms.remove(&entity);
             return;
         }
     };
@@ -303,7 +312,12 @@ pub fn update<N>(
                 let entrypoints = collect_entrypoints(&ep_fns, &get_node, graph);
                 match compile(&get_node, graph, vm, &entrypoints) {
                     Ok(module) => data.compiled.0 = module,
-                    Err(e) => log::error!("Failed to compile graph: {e}"),
+                    Err(e) => {
+                        log::error!("Failed to compile graph: {e}");
+                        // Surface the error rather than leaving the prior module
+                        // displayed, which would misleadingly look up-to-date.
+                        data.compiled.0 = format!("; failed to compile graph:\n; {e}");
+                    }
                 }
             }
         }

--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -103,6 +103,24 @@ fn outlet_active_var(outlet_id: node::Id) -> String {
     format!("outlet-active-{outlet_id}")
 }
 
+/// The `(define outlet-{id} '())` declarations (plus `outlet-active-{id}` flags
+/// when `branching`) that hoist a graph's outlet value vars, so the
+/// `(set! outlet-{id} ...)` statements emitted by `eval_stmt` have a binding.
+///
+/// Shared by `wrap_outlet_bridge` (nested graphs, read by the parent) and
+/// `entry_fn_body` (a root graph's own outlets, which are never read - so root
+/// outlets are effectively ignored).
+fn outlet_var_declarations(outlets: &BTreeSet<node::Id>, branching: bool) -> Vec<String> {
+    let mut declares = Vec::new();
+    for &id in outlets {
+        declares.push(format!("(define {} '())", outlet_var(id)));
+        if branching {
+            declares.push(format!("(define {} #f)", outlet_active_var(id)));
+        }
+    }
+    declares
+}
+
 /// The Steel expression yielding the outlet values shaped by `outlet_ids`: a
 /// single raw value for one outlet, a `(list ...)` for several, or `'()` for
 /// none. Each value is read from its hoisted `outlet-{id}` var.
@@ -1154,6 +1172,17 @@ pub fn entry_fn_body(
     // branch can `set!` its selector and any arm can read it.
     let mut in_scope = HashSet::new();
     let mut stmts = declare_branch_ix_placeholders(branching);
+    // A root graph (no enclosing graph node) may itself contain outlets - e.g.
+    // a subgraph opened directly as a head. Nested levels have their outlet vars
+    // hoisted by `wrap_outlet_bridge`; the root has no parent to do so, so hoist
+    // them here. The values are never read at the root, so root outlets are
+    // ignored.
+    if path.is_empty() && !outlets.is_empty() {
+        let decls = outlet_var_declarations(outlets, outlet_activity == OutletActivity::Tracked);
+        for decl in decls {
+            stmts.extend(Engine::emit_ast(&decl).expect("failed to emit root outlet declaration"));
+        }
+    }
     for root in roots {
         stmts.extend(flow_node_stmts(
             path,
@@ -1242,14 +1271,7 @@ fn wrap_outlet_bridge(
     // and - when branching - their `outlet-active-{id}` flags. Declare them
     // within the `let` so the inner statements set them and we read them back as
     // the graph node's output. Unreached outlets keep their `'()`/`#f` defaults.
-    let mut declares: Vec<String> = Vec::new();
-    for &id in inner_outlets {
-        declares.push(format!("(define {} '())", outlet_var(id)));
-        if branching {
-            declares.push(format!("(define {} #f)", outlet_active_var(id)));
-        }
-    }
-    let declares = declares.join(" ");
+    let declares = outlet_var_declarations(inner_outlets, branching).join(" ");
 
     let outlet_ids: Vec<node::Id> = inner_outlets.iter().copied().collect();
     let tail = if branching {

--- a/crates/gantz_core/tests/nested.rs
+++ b/crates/gantz_core/tests/nested.rs
@@ -2628,3 +2628,54 @@ fn test_nested_branch_join_external_inlet() {
     assert_eq!(build(0), Some(62));
     assert_eq!(build(1), Some(119));
 }
+
+// An `Outlet` at the *root* level (no enclosing graph node) must compile and be
+// ignored: there is no parent to read its value, so it is a no-op while the rest
+// of the graph still evaluates.
+//
+//    --------
+//    | push | // push_eval
+//    -+------
+//     |
+//    -+----
+//    | 42 |
+//    -+----
+//     |
+//    -+--------
+//    | number | (stores received value in state)
+//    -+--------
+//     |
+//    -+--------
+//    | Outlet | (root-level: ignored)
+//    ----------
+#[test]
+fn test_graph_root_outlet_connected() {
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let int = g.add_node(Box::new(node_int(42)) as Box<_>);
+    let store = g.add_node(Box::new(node_number()) as Box<_>);
+    let outlet = g.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    g.add_edge(push, int, Edge::from((0, 0)));
+    g.add_edge(int, store, Edge::from((0, 0)));
+    g.add_edge(store, outlet, Edge::from((0, 0)));
+
+    // Compiles, runs, and the upstream `number` still receives the value even
+    // though the root outlet leads nowhere.
+    assert_eq!(store_val(&compile_and_push(&g, push), store), Some(42));
+}
+
+// A *disconnected* `Outlet` at the root level (no incoming edge) is never
+// reached by the flow, so it emits nothing and the rest of the graph evaluates
+// normally.
+#[test]
+fn test_graph_root_outlet_disconnected() {
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let int = g.add_node(Box::new(node_int(42)) as Box<_>);
+    let store = g.add_node(Box::new(node_number()) as Box<_>);
+    let _outlet = g.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    g.add_edge(push, int, Edge::from((0, 0)));
+    g.add_edge(int, store, Edge::from((0, 0)));
+
+    assert_eq!(store_val(&compile_and_push(&g, push), store), Some(42));
+}


### PR DESCRIPTION
## Problem

A graph with a top-level `Outlet` (a subgraph opened directly as a head) failed to compile: `eval_stmt` emits `(set! outlet-{id} ...)` when a flow reaches an outlet, but the matching `(define outlet-{id} '())` was hoisted only by `nested_expr` and `wrap_outlet_bridge` - never by `module()` for the root graph. The root module referenced a free `outlet-{id}`, so VM init failed; the swallowed error left the previously-active head's VM and module in place, and `drive_frame_bangs` then drove the new entrypoint against the stale VM, surfacing as `free identifier: entry-fn-...`.

This resulted in failing to compile gantz graphs where outlets appear in the root.

## Solution

Hoist a root graph's own outlet vars in `entry_fn_body` (gated on an empty path); their values are never read, so root outlets compile and are ignored. Extract the shared `outlet_var_declarations` helper, reused by `wrap_outlet_bridge`.

Also stop `init_head_vm`/`vm::update` from leaving stale state on a compile failure: surface the error in `CompiledModule` and drop the VM, so a future failure reads as a clear error rather than a confusing cross-graph desync.

Add root-outlet tests (connected and disconnected).