### PR TITLE
Fix nested `$?` optional `Expr`/`Branch` inputs (pd-style cold/hot inlets)

### DIFF
--- a/crates/gantz_core/src/compile.rs
+++ b/crates/gantz_core/src/compile.rs
@@ -16,7 +16,7 @@ pub use entrypoint::{
 pub use error::ModuleError;
 #[doc(inline)]
 pub use flow::{Block, Flow, FlowGraph, NodeConf, NodeConns, OutletReach, flow_graph};
-pub(crate) use flow::{branch_patterns_from_flow, flow_graph_roots};
+pub(crate) use flow::{branch_patterns_from_flow, flow_graph_roots, inner_flow_graph_for};
 use meta::MetaTree;
 #[doc(inline)]
 pub use meta::{EdgeKind, Meta, MetaGraph};
@@ -468,11 +468,116 @@ where
     let level_sources = group_sources_by_level(entrypoints);
     let flow_tree = build_flow_tree(&meta_tree.tree, &level_sources, vec![])?;
 
-    // Collect node fns.
-    let node_confs_tree = flow_tree.map_ref(&mut |(_, flow)| codegen::unique_node_confs(flow));
+    // Collect node fns. `unique_node_confs` only sees the all-connected nested
+    // flow, so the post-pass additionally defines the reduced inner variants a
+    // nested graph needs when invoked with a subset of its inlets active.
+    let mut node_confs_tree = flow_tree.map_ref(&mut |(_, flow)| codegen::unique_node_confs(flow));
+    augment_reduced_inner_confs(&meta_tree.tree, &flow_tree, &mut node_confs_tree)?;
     let node_fns = codegen::node_fns(get_node, g, &node_confs_tree)?;
 
     // Collect eval fns.
     let entry_fns = codegen::entry_fns(&flow_tree)?;
     Ok(node_fns.into_iter().chain(entry_fns).collect())
+}
+
+/// Define the *reduced* inner node-fn variants a nested `GraphNode`'s interior
+/// needs when invoked with only a subset of its inlets active.
+///
+/// `build_flow_tree`'s `nested_fg` is all-connected, so `unique_node_confs` only
+/// yields each inner node's all-inlets-active variant. But a `GraphNode` invoked
+/// with a reduced active-input-set (e.g. a "cold" inlet push) lowers its interior
+/// via [`inner_flow_graph_for`] with that subset (see `node::graph::nested_expr`),
+/// calling reduced inner variants that must also be *defined*. This additive pass
+/// collects, for each nested child, the distinct active-input-sets it is invoked
+/// with (from its parent's flow graphs), builds the matching reduced inner flow,
+/// and unions the resulting `NodeConf`s into the child level's conf set. Because
+/// `nested_expr` (call site) and this pass (definition site) both use
+/// `inner_flow_graph_for` with the same active set, every emitted call resolves.
+fn augment_reduced_inner_confs(
+    meta_tree: &RoseTree<Meta>,
+    flow_tree: &RoseTree<(&Meta, Flow)>,
+    confs_tree: &mut RoseTree<std::collections::BTreeSet<NodeConf>>,
+) -> Result<(), error::NodeConnsError> {
+    // The root graph isn't itself a nested node; its children's active-sets come
+    // from the root's own flow graphs.
+    let (_, root_flow) = &flow_tree.elem;
+    for (&cid, child_meta) in &meta_tree.nested {
+        let Some(child_confs) = confs_tree.nested.get_mut(&cid) else {
+            continue;
+        };
+        let sets = active_input_sets_for(root_flow, cid);
+        augment_node_reduced_confs(child_meta, child_confs, &sets)?;
+    }
+    Ok(())
+}
+
+/// Recursive worker for [`augment_reduced_inner_confs`]: given the
+/// active-input-sets a nested graph is invoked with, build its reduced inner flow
+/// per set, add the resulting confs, and propagate each grandchild `GraphNode`'s
+/// reduced active-sets downward.
+fn augment_node_reduced_confs(
+    meta_tree: &RoseTree<Meta>,
+    confs_tree: &mut RoseTree<std::collections::BTreeSet<NodeConf>>,
+    active_sets: &std::collections::BTreeSet<node::Conns>,
+) -> Result<(), error::NodeConnsError> {
+    let meta = &meta_tree.elem;
+    let inlet_ids: Vec<node::Id> = meta.inlets.iter().copied().collect();
+    let mut grandchild_sets: std::collections::BTreeMap<
+        node::Id,
+        std::collections::BTreeSet<node::Conns>,
+    > = std::collections::BTreeMap::new();
+    for active in active_sets {
+        let active_inlets = active_inlets_from_conns(&inlet_ids, active);
+        let fg = inner_flow_graph_for(meta, &active_inlets)?;
+        for conf in fg.node_weights().flat_map(|blk| blk.iter()) {
+            confs_tree.elem.insert(*conf);
+            if meta_tree.nested.contains_key(&conf.id) {
+                grandchild_sets
+                    .entry(conf.id)
+                    .or_default()
+                    .insert(conf.conns.inputs);
+            }
+        }
+    }
+    for (gcid, sets) in grandchild_sets {
+        if let (Some(gc_meta), Some(gc_confs)) = (
+            meta_tree.nested.get(&gcid),
+            confs_tree.nested.get_mut(&gcid),
+        ) {
+            augment_node_reduced_confs(gc_meta, gc_confs, &sets)?;
+        }
+    }
+    Ok(())
+}
+
+/// The distinct active-input-sets node `id` is invoked with across `flow`'s
+/// entrypoint flow graphs and its all-connected `nested` flow.
+fn active_input_sets_for(flow: &Flow, id: node::Id) -> std::collections::BTreeSet<node::Conns> {
+    let mut sets = std::collections::BTreeSet::new();
+    for fg in flow
+        .entrypoints
+        .values()
+        .chain(std::iter::once(&flow.nested))
+    {
+        for conf in fg.node_weights().flat_map(|blk| blk.iter()) {
+            if conf.id == id {
+                sets.insert(conf.conns.inputs);
+            }
+        }
+    }
+    sets
+}
+
+/// The inlet ids active for a parent input-conns mask (bit `i` <=> `inlet_ids[i]`,
+/// the existing "input i -> inlet i" contract in `node::graph::nested_expr`).
+fn active_inlets_from_conns(
+    inlet_ids: &[node::Id],
+    conns: &node::Conns,
+) -> std::collections::BTreeSet<node::Id> {
+    inlet_ids
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| conns.get(*i).unwrap_or(false))
+        .map(|(_, &id)| id)
+        .collect()
 }

--- a/crates/gantz_core/src/compile.rs
+++ b/crates/gantz_core/src/compile.rs
@@ -468,11 +468,11 @@ where
     let level_sources = group_sources_by_level(entrypoints);
     let flow_tree = build_flow_tree(&meta_tree.tree, &level_sources, vec![])?;
 
-    // Collect node fns. `unique_node_confs` only sees the all-connected nested
-    // flow, so the post-pass additionally defines the reduced inner variants a
-    // nested graph needs when invoked with a subset of its inlets active.
-    let mut node_confs_tree = flow_tree.map_ref(&mut |(_, flow)| codegen::unique_node_confs(flow));
-    augment_reduced_inner_confs(&meta_tree.tree, &flow_tree, &mut node_confs_tree)?;
+    // Collect node fns. Build the per-level conf tree top-down so each node is
+    // defined for every variant it is actually called with - including the
+    // reduced inner variants a nested graph needs when invoked with a subset of
+    // its inlets active.
+    let node_confs_tree = build_node_confs_tree(&meta_tree.tree, &flow_tree)?;
     let node_fns = codegen::node_fns(get_node, g, &node_confs_tree)?;
 
     // Collect eval fns.
@@ -480,74 +480,69 @@ where
     Ok(node_fns.into_iter().chain(entry_fns).collect())
 }
 
-/// Define the *reduced* inner node-fn variants a nested `GraphNode`'s interior
-/// needs when invoked with only a subset of its inlets active.
+/// Build the per-level node-conf tree consumed by `node_fns`, defining every
+/// variant each node is actually called with.
 ///
-/// `build_flow_tree`'s `nested_fg` is all-connected, so `unique_node_confs` only
-/// yields each inner node's all-inlets-active variant. But a `GraphNode` invoked
-/// with a reduced active-input-set (e.g. a "cold" inlet push) lowers its interior
-/// via [`inner_flow_graph_for`] with that subset (see `node::graph::nested_expr`),
-/// calling reduced inner variants that must also be *defined*. This additive pass
-/// collects, for each nested child, the distinct active-input-sets it is invoked
-/// with (from its parent's flow graphs), builds the matching reduced inner flow,
-/// and unions the resulting `NodeConf`s into the child level's conf set. Because
-/// `nested_expr` (call site) and this pass (definition site) both use
-/// `inner_flow_graph_for` with the same active set, every emitted call resolves.
-fn augment_reduced_inner_confs(
+/// A level's confs come from its own flow graphs ([`codegen::unique_node_confs`]:
+/// this level's entrypoint flows + all-connected `nested` flow) plus, when the
+/// level is a nested graph invoked with a reduced active-input-set, the confs
+/// from [`inner_flow_graph_for`] for that subset. Active-sets propagate top-down:
+/// a child's are the distinct confs it takes across every flow graph that lowers
+/// its parent (the parent's entrypoint + nested flows, and its reduced flows). So
+/// when `node::graph::nested_expr` lowers a nested graph with a reduced active set
+/// (a "cold" inlet push, or a push-through reaching only some inlets) the reduced
+/// inner variants it calls are also defined here.
+fn build_node_confs_tree(
     meta_tree: &RoseTree<Meta>,
     flow_tree: &RoseTree<(&Meta, Flow)>,
-    confs_tree: &mut RoseTree<std::collections::BTreeSet<NodeConf>>,
-) -> Result<(), error::NodeConnsError> {
-    // The root graph isn't itself a nested node; its children's active-sets come
-    // from the root's own flow graphs.
-    let (_, root_flow) = &flow_tree.elem;
-    for (&cid, child_meta) in &meta_tree.nested {
-        let Some(child_confs) = confs_tree.nested.get_mut(&cid) else {
-            continue;
-        };
-        let sets = active_input_sets_for(root_flow, cid);
-        augment_node_reduced_confs(child_meta, child_confs, &sets)?;
-    }
-    Ok(())
+) -> Result<RoseTree<std::collections::BTreeSet<NodeConf>>, error::NodeConnsError> {
+    // The root graph is not invoked as a node, so it has no reduced active-sets.
+    build_level_confs(meta_tree, flow_tree, &std::collections::BTreeSet::new())
 }
 
-/// Recursive worker for [`augment_reduced_inner_confs`]: given the
-/// active-input-sets a nested graph is invoked with, build its reduced inner flow
-/// per set, add the resulting confs, and propagate each grandchild `GraphNode`'s
-/// reduced active-sets downward.
-fn augment_node_reduced_confs(
+/// Recursive worker for [`build_node_confs_tree`]: build the confs for one level
+/// (and its descendants) given the active-input-sets this level is invoked with.
+fn build_level_confs(
     meta_tree: &RoseTree<Meta>,
-    confs_tree: &mut RoseTree<std::collections::BTreeSet<NodeConf>>,
+    flow_tree: &RoseTree<(&Meta, Flow)>,
     active_sets: &std::collections::BTreeSet<node::Conns>,
-) -> Result<(), error::NodeConnsError> {
+) -> Result<RoseTree<std::collections::BTreeSet<NodeConf>>, error::NodeConnsError> {
     let meta = &meta_tree.elem;
+    let (_, flow) = &flow_tree.elem;
     let inlet_ids: Vec<node::Id> = meta.inlets.iter().copied().collect();
-    let mut grandchild_sets: std::collections::BTreeMap<
-        node::Id,
-        std::collections::BTreeSet<node::Conns>,
-    > = std::collections::BTreeMap::new();
+
+    // This level's own flow graphs, plus a reduced flow per proper-subset active
+    // set it is invoked with. Keep the reduced flows so children can read their
+    // confs from them too.
+    let mut confs = codegen::unique_node_confs(flow);
+    let mut reduced: Vec<FlowGraph> = Vec::new();
     for active in active_sets {
         let active_inlets = active_inlets_from_conns(&inlet_ids, active);
+        // All-active coincides with the `nested` flow already in `confs`.
+        if active_inlets.len() == meta.inlets.len() {
+            continue;
+        }
         let fg = inner_flow_graph_for(meta, &active_inlets)?;
-        for conf in fg.node_weights().flat_map(|blk| blk.iter()) {
-            confs_tree.elem.insert(*conf);
-            if meta_tree.nested.contains_key(&conf.id) {
-                grandchild_sets
-                    .entry(conf.id)
-                    .or_default()
-                    .insert(conf.conns.inputs);
-            }
-        }
+        confs.extend(fg.node_weights().flat_map(|blk| blk.iter().copied()));
+        reduced.push(fg);
     }
-    for (gcid, sets) in grandchild_sets {
-        if let (Some(gc_meta), Some(gc_confs)) = (
-            meta_tree.nested.get(&gcid),
-            confs_tree.nested.get_mut(&gcid),
-        ) {
-            augment_node_reduced_confs(gc_meta, gc_confs, &sets)?;
+
+    // Each child's active-sets = the distinct confs it takes across every flow
+    // graph that lowers this level (entrypoints + nested + the reduced flows).
+    let mut nested = std::collections::BTreeMap::new();
+    for (&cid, child_meta) in &meta_tree.nested {
+        let mut child_sets = active_input_sets_for(flow, cid);
+        for fg in &reduced {
+            child_sets.extend(confs_of(fg, cid).map(|conf| conf.conns.inputs));
         }
+        let child_flow = &flow_tree.nested[&cid];
+        nested.insert(cid, build_level_confs(child_meta, child_flow, &child_sets)?);
     }
-    Ok(())
+
+    Ok(RoseTree {
+        elem: confs,
+        nested,
+    })
 }
 
 /// The distinct active-input-sets node `id` is invoked with across `flow`'s
@@ -559,13 +554,16 @@ fn active_input_sets_for(flow: &Flow, id: node::Id) -> std::collections::BTreeSe
         .values()
         .chain(std::iter::once(&flow.nested))
     {
-        for conf in fg.node_weights().flat_map(|blk| blk.iter()) {
-            if conf.id == id {
-                sets.insert(conf.conns.inputs);
-            }
-        }
+        sets.extend(confs_of(fg, id).map(|conf| conf.conns.inputs));
     }
     sets
+}
+
+/// The `NodeConf`s for node `id` appearing in flow graph `fg`.
+fn confs_of(fg: &FlowGraph, id: node::Id) -> impl Iterator<Item = &NodeConf> {
+    fg.node_weights()
+        .flat_map(|blk| blk.iter())
+        .filter(move |conf| conf.id == id)
 }
 
 /// The inlet ids active for a parent input-conns mask (bit `i` <=> `inlet_ids[i]`,

--- a/crates/gantz_core/src/compile/flow.rs
+++ b/crates/gantz_core/src/compile/flow.rs
@@ -188,6 +188,63 @@ pub(crate) fn flow_graph_with_extra(
     Ok(fg)
 }
 
+/// Build the interior control-flow graph of a nested graph, honoring which
+/// inlets fired this evaluation (`active_inlets`, always a subset of
+/// `meta.inlets`).
+///
+/// When every inlet is active this is the all-connected view (inlets push,
+/// outlets pull) - the dominant path, kept byte-identical to the prior
+/// behaviour. When only a subset fired, the interior is built by forward
+/// reachability from the active inlets *and* the graph's own static sources
+/// (constants / in-degree-0 non-inlet nodes), with **no outlet pull**. Dropping
+/// the pull prevents the backward `outlet <- ... <- inactive-inlet` walk from
+/// re-marking a node's input connected, so an inlet that did not fire (and its
+/// exclusive subtree) is excluded - and a `$?` optional input bound only to it
+/// compiles to `(None)`.
+pub(crate) fn inner_flow_graph_for(
+    meta: &Meta,
+    active_inlets: &BTreeSet<node::Id>,
+) -> Result<FlowGraph, NodeConnsError> {
+    let conn1 = || node::Conns::connected(1).unwrap();
+
+    // `active_inlets` is a subset of `meta.inlets`, so equal length => all
+    // inlets active: reuse the unchanged all-connected construction.
+    if active_inlets.len() == meta.inlets.len() {
+        return flow_graph(
+            meta,
+            meta.inlets.iter().map(|&n| (n, conn1())),
+            meta.outlets.iter().map(|&n| (n, conn1())),
+        );
+    }
+
+    let mut push: Vec<(node::Id, node::Conns)> =
+        active_inlets.iter().map(|&n| (n, conn1())).collect();
+
+    // Static sources (constants / input-less interior nodes) are always live
+    // regardless of which inlets fired, so they seed the forward traversal to
+    // keep static/constant-fed outlets reachable without the outlet pull.
+    for n in meta.graph.nodes() {
+        if meta.inlets.contains(&n) || meta.outlets.contains(&n) {
+            continue;
+        }
+        if meta
+            .graph
+            .edges_directed(n, petgraph::Incoming)
+            .next()
+            .is_some()
+        {
+            continue;
+        }
+        let n_out = meta.outputs.get(&n).copied().unwrap_or(0);
+        if n_out > 0 {
+            let conns = node::Conns::connected(n_out).map_err(|_| TooManyConns(n_out))?;
+            push.push((n, conns));
+        }
+    }
+
+    flow_graph(meta, push, std::iter::empty::<(node::Id, node::Conns)>())
+}
+
 /// Build a [`NodeConf`] for `n` from its connectivity within the (possibly
 /// arm-local) `mg`, treating `Static` edges from `outer_mg` as still in scope.
 fn make_conf(

--- a/crates/gantz_core/src/compile/rosetree.rs
+++ b/crates/gantz_core/src/compile/rosetree.rs
@@ -50,12 +50,12 @@ impl<T> RoseTree<T> {
     ///
     /// This is useful if the resulting tree requires holding references to the
     /// original tree.
-    pub(crate) fn map_ref<'a, U>(&'a self, f: &mut impl FnMut(&'a T) -> U) -> RoseTree<U> {
+    pub(crate) fn _map_ref<'a, U>(&'a self, f: &mut impl FnMut(&'a T) -> U) -> RoseTree<U> {
         let Self { elem, nested } = self;
         let elem = f(elem);
         let nested = nested
             .into_iter()
-            .map(|(&k, r)| (k, r.map_ref(f)))
+            .map(|(&k, r)| (k, r._map_ref(f)))
             .collect();
         RoseTree { elem, nested }
     }

--- a/crates/gantz_core/src/node/graph.rs
+++ b/crates/gantz_core/src/node/graph.rs
@@ -351,15 +351,29 @@ where
         .map_err(node::ExprError::custom)
 }
 
-/// Build the control flow graph for a nested graph: inlets push, outlets pull.
+/// Build the all-inlets-active interior control flow graph (inlets push,
+/// outlets pull), used by [`graph_branches`] - which must report the
+/// union/over-approximation of external branch patterns - and as the `fg_all`
+/// in [`nested_expr`]. See [`compile::inner_flow_graph_for`] for the active-set
+/// aware variant.
 fn inner_flow_graph(meta: &compile::Meta) -> Result<compile::FlowGraph, node::ExprError> {
-    let conn = || node::Conns::connected(1).unwrap();
-    compile::flow_graph(
-        meta,
-        meta.inlets.iter().map(|&n| (n, conn())),
-        meta.outlets.iter().map(|&n| (n, conn())),
-    )
-    .map_err(node::ExprError::custom)
+    let all: BTreeSet<node::Id> = meta.inlets.iter().copied().collect();
+    compile::inner_flow_graph_for(meta, &all).map_err(node::ExprError::custom)
+}
+
+/// The set of inlet ids that fired this evaluation, derived from the parent's
+/// active-input-set (`inputs[i]` is `Some` iff input `i` - i.e. the `i`th inlet
+/// in id order - is connected/active for this node-fn variant).
+fn active_inlets_from_inputs(
+    inlet_ids: &[node::Id],
+    inputs: &[Option<String>],
+) -> BTreeSet<node::Id> {
+    inlet_ids
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| inputs.get(*i).map(Option::is_some).unwrap_or(false))
+        .map(|(_, &id)| id)
+        .collect()
 }
 
 /// The implementation of the `GraphNode`'s `Node::expr` fn.
@@ -383,11 +397,25 @@ where
     let meta = compile::Meta::from_graph(get_node, g).map_err(node::ExprError::custom)?;
     let inlet_ids: Vec<node::Id> = meta.inlets.iter().copied().collect();
     let outlet_ids: Vec<node::Id> = meta.outlets.iter().copied().collect();
-    let fg = inner_flow_graph(&meta)?;
+    // The all-connected flow drives the external branch patterns and selector
+    // (which must match the parent's all-connected `Node::branches`); the
+    // active-set flow drives the body so unfired inlets' subtrees collapse and
+    // optional inputs bound only to them compile to `(None)`. The two coincide
+    // when every inlet is active (the dominant path), so avoid rebuilding then.
+    let active_inlets = active_inlets_from_inputs(&inlet_ids, inputs);
+    let fg_all = inner_flow_graph(&meta)?;
+    let fg_active;
+    let fg_body = if active_inlets.len() == inlet_ids.len() {
+        &fg_all
+    } else {
+        fg_active = compile::inner_flow_graph_for(&meta, &active_inlets)
+            .map_err(node::ExprError::custom)?;
+        &fg_active
+    };
     let arm_counts = branch_arm_counts(&meta);
 
     // The external branch patterns (empty => not externally branching).
-    let patterns = compile::branch_patterns_from_flow(&fg, &outlet_ids, &arm_counts)
+    let patterns = compile::branch_patterns_from_flow(&fg_all, &outlet_ids, &arm_counts)
         .map_err(node::ExprError::custom)?;
     let branching = !patterns.is_empty();
     let outlet_activity = if branching {
@@ -425,7 +453,7 @@ where
         &arm_counts,
         &meta.inlets,
         &meta.outlets,
-        &fg,
+        fg_body,
         &BTreeSet::new(),
         outlet_activity,
     )

--- a/crates/gantz_core/tests/nested.rs
+++ b/crates/gantz_core/tests/nested.rs
@@ -2679,3 +2679,353 @@ fn test_graph_root_outlet_disconnected() {
 
     assert_eq!(store_val(&compile_and_push(&g, push), store), Some(42));
 }
+
+// === pd+ optional-input ($?) cold/hot inlet tests ===
+//
+// Emulates Pure Data's stateful `+`: a left "hot" inlet (always outputs the
+// sum) and a right "cold" inlet (updates internal state only, no output). The
+// node is a nested `GraphNode` whose interior is a single `Branch` reading two
+// optional inputs (`$?l`, `$?r`). The cold/hot behaviour relies on the inner
+// branch seeing `(None)` for the inlet that did not fire - which only works once
+// the active-input-set is propagated into the nested graph's interior.
+
+// The pd+ Branch: cold (`$?r`) sets state; hot (`$?l`) outputs `left + state`.
+// Branch 0 activates the single output (hot fired), branch 1 activates nothing
+// (cold-only, no output).
+fn pd_plus_branch() -> node::Branch {
+    node::Branch::new(
+        r#"
+        (begin
+          (if (Some? $?r) (set! state (Some->value $?r)) '())
+          (if (Some? $?l)
+            (list 0 (+ (Some->value $?l) (if (number? state) state 0)))
+            (list 1 '())))
+        "#,
+        vec![
+            node::Conns::try_from([true]).unwrap(),
+            node::Conns::try_from([false]).unwrap(),
+        ],
+    )
+    .unwrap()
+}
+
+// A pd+ nested graph. Input 0 = left/hot inlet, input 1 = right/cold inlet,
+// output 0 = the sum. Returns the graph and the inner branch node id (for state
+// queries via the path `[pd_node, branch]`).
+//
+//    [In L]   [In R]
+//       \       /        (In R -> $?r branch input 0, In L -> $?l branch input 1)
+//      -+-------+-
+//      | Branch |
+//      -+--------
+//       |
+//    -+--------
+//    | Outlet |
+//    ----------
+fn pd_plus() -> (GraphNode<Box<dyn DebugNode>>, usize) {
+    let mut g = GraphNode::default();
+    let inlet_l = g.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+    let inlet_r = g.add_node(Box::new(node::graph::Inlet) as Box<_>);
+    let branch = g.add_node(Box::new(pd_plus_branch()) as Box<_>);
+    let outlet = g.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    g.add_edge(inlet_r, branch, Edge::from((0, 0))); // In R -> $?r (branch input 0)
+    g.add_edge(inlet_l, branch, Edge::from((0, 1))); // In L -> $?l (branch input 1)
+    g.add_edge(branch, outlet, Edge::from((0, 0)));
+    (g, branch.index())
+}
+
+// Compile `g` and register fns, returning a VM ready to be pushed.
+fn compile_only<N: DebugNode + ?Sized>(g: &petgraph::graph::DiGraph<Box<N>, Edge>) -> Engine {
+    let eps = push_pull_entrypoints(&no_lookup, g);
+    let module = gantz_core::compile::module(&no_lookup, g, &eps).unwrap();
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, g, &[], &mut vm);
+    for f in &module {
+        vm.run(f.to_pretty(100)).unwrap();
+    }
+    vm
+}
+
+// Fire the entrypoint that pushes from `push`.
+fn push_from<N: DebugNode + ?Sized>(
+    vm: &mut Engine,
+    g: &petgraph::graph::DiGraph<Box<N>, Edge>,
+    push: petgraph::graph::NodeIndex,
+) {
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let ep = entrypoint::push(vec![push.index()], g[push].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep.id()), vec![])
+        .unwrap();
+}
+
+// Root graph wiring a left push -> left value, a right push -> right value, into
+// a pd+ node whose output feeds a `store`. Returns (graph, left_push,
+// right_push, pd, branch_id, store).
+type PdPlusRoot = (
+    petgraph::graph::DiGraph<Box<dyn DebugNode>, Edge>,
+    petgraph::graph::NodeIndex,
+    petgraph::graph::NodeIndex,
+    petgraph::graph::NodeIndex,
+    usize,
+    petgraph::graph::NodeIndex,
+);
+fn pd_plus_root(left: i32, right: i32) -> PdPlusRoot {
+    let (inner, branch_ix) = pd_plus();
+    let mut g = petgraph::graph::DiGraph::new();
+    let left_push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let right_push = g.add_node(Box::new(node_push()) as Box<_>);
+    let left_val = g.add_node(Box::new(node_int(left)) as Box<_>);
+    let right_val = g.add_node(Box::new(node_int(right)) as Box<_>);
+    let pd = g.add_node(Box::new(inner) as Box<_>);
+    let store = g.add_node(Box::new(node_number()) as Box<_>);
+    g.add_edge(left_push, left_val, Edge::from((0, 0)));
+    g.add_edge(right_push, right_val, Edge::from((0, 0)));
+    g.add_edge(left_val, pd, Edge::from((0, 0))); // left -> pd input 0 (hot)
+    g.add_edge(right_val, pd, Edge::from((0, 1))); // right -> pd input 1 (cold)
+    g.add_edge(pd, store, Edge::from((0, 0)));
+    (g, left_push, right_push, pd, branch_ix, store)
+}
+
+fn branch_state(vm: &Engine, pd: petgraph::graph::NodeIndex, branch_ix: usize) -> Option<i32> {
+    node::state::extract::<i32>(vm, &[pd.index(), branch_ix])
+        .ok()
+        .flatten()
+}
+
+// Pushing ONLY the cold (right) inlet must set state and produce no output -
+// and crucially must NOT raise `+ expects a number, found '()`.
+#[test]
+fn test_nested_pd_plus_cold_only() {
+    let (g, _left_push, right_push, pd, branch_ix, store) = pd_plus_root(10, 5);
+    let mut vm = compile_only(&g);
+    push_from(&mut vm, &g, right_push);
+    assert_eq!(branch_state(&vm, pd, branch_ix), Some(5), "cold sets state");
+    assert_eq!(store_val(&vm, store), None, "cold produces no output");
+}
+
+// Cold (right) then hot (left): state is seeded by the cold push, the hot push
+// outputs `left + state`.
+#[test]
+fn test_nested_pd_plus_hot_after_cold() {
+    let (g, left_push, right_push, pd, branch_ix, store) = pd_plus_root(10, 5);
+    let mut vm = compile_only(&g);
+    push_from(&mut vm, &g, right_push); // cold: state = 5
+    push_from(&mut vm, &g, left_push); // hot: 10 + 5 = 15
+    assert_eq!(branch_state(&vm, pd, branch_ix), Some(5));
+    assert_eq!(store_val(&vm, store), Some(15));
+}
+
+// Firing both inlets in one push: the cold value updates state first, then the
+// hot arm outputs `left + state`.
+#[test]
+fn test_nested_pd_plus_both() {
+    let (inner, branch_ix) = pd_plus();
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let left_val = g.add_node(Box::new(node_int(10)) as Box<_>);
+    let right_val = g.add_node(Box::new(node_int(5)) as Box<_>);
+    let pd = g.add_node(Box::new(inner) as Box<_>);
+    let store = g.add_node(Box::new(node_number()) as Box<_>);
+    g.add_edge(push, left_val, Edge::from((0, 0)));
+    g.add_edge(push, right_val, Edge::from((0, 0)));
+    g.add_edge(left_val, pd, Edge::from((0, 0)));
+    g.add_edge(right_val, pd, Edge::from((0, 1)));
+    g.add_edge(pd, store, Edge::from((0, 0)));
+
+    let mut vm = compile_only(&g);
+    push_from(&mut vm, &g, push);
+    assert_eq!(branch_state(&vm, pd, branch_ix), Some(5));
+    assert_eq!(store_val(&vm, store), Some(15)); // 10 + 5
+}
+
+// A sequence of pushes across multiple entrypoint calls: two cold updates then
+// a hot output, exercising state persistence.
+#[test]
+fn test_nested_pd_plus_sequence() {
+    let (inner, branch_ix) = pd_plus();
+    let mut g = petgraph::graph::DiGraph::new();
+    let cold_a = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let cold_b = g.add_node(Box::new(node_push()) as Box<_>);
+    let hot = g.add_node(Box::new(node_push()) as Box<_>);
+    let cold_a_val = g.add_node(Box::new(node_int(3)) as Box<_>);
+    let cold_b_val = g.add_node(Box::new(node_int(7)) as Box<_>);
+    let hot_val = g.add_node(Box::new(node_int(10)) as Box<_>);
+    let pd = g.add_node(Box::new(inner) as Box<_>);
+    let store = g.add_node(Box::new(node_number()) as Box<_>);
+    g.add_edge(cold_a, cold_a_val, Edge::from((0, 0)));
+    g.add_edge(cold_b, cold_b_val, Edge::from((0, 0)));
+    g.add_edge(hot, hot_val, Edge::from((0, 0)));
+    g.add_edge(cold_a_val, pd, Edge::from((0, 1))); // cold -> right
+    g.add_edge(cold_b_val, pd, Edge::from((0, 1))); // cold -> right
+    g.add_edge(hot_val, pd, Edge::from((0, 0))); // hot -> left
+    g.add_edge(pd, store, Edge::from((0, 0)));
+
+    let mut vm = compile_only(&g);
+    push_from(&mut vm, &g, cold_a); // state = 3
+    assert_eq!(branch_state(&vm, pd, branch_ix), Some(3));
+    assert_eq!(store_val(&vm, store), None);
+    push_from(&mut vm, &g, cold_b); // state = 7
+    assert_eq!(branch_state(&vm, pd, branch_ix), Some(7));
+    assert_eq!(store_val(&vm, store), None);
+    push_from(&mut vm, &g, hot); // 10 + 7 = 17
+    assert_eq!(store_val(&vm, store), Some(17));
+}
+
+// The same Branch at top level (where `$?` already works) and nested must
+// behave identically.
+fn pd_plus_top_level(
+    left: i32,
+    right: i32,
+) -> (
+    petgraph::graph::DiGraph<Box<dyn DebugNode>, Edge>,
+    petgraph::graph::NodeIndex,
+    petgraph::graph::NodeIndex,
+    petgraph::graph::NodeIndex,
+) {
+    let mut g = petgraph::graph::DiGraph::new();
+    let left_push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let right_push = g.add_node(Box::new(node_push()) as Box<_>);
+    let left_val = g.add_node(Box::new(node_int(left)) as Box<_>);
+    let right_val = g.add_node(Box::new(node_int(right)) as Box<_>);
+    let branch = g.add_node(Box::new(pd_plus_branch()) as Box<_>);
+    let store = g.add_node(Box::new(node_number()) as Box<_>);
+    g.add_edge(left_push, left_val, Edge::from((0, 0)));
+    g.add_edge(right_push, right_val, Edge::from((0, 0)));
+    g.add_edge(right_val, branch, Edge::from((0, 0))); // right -> $?r (input 0)
+    g.add_edge(left_val, branch, Edge::from((0, 1))); // left -> $?l (input 1)
+    g.add_edge(branch, store, Edge::from((0, 0)));
+    (g, left_push, right_push, store)
+}
+
+#[test]
+fn test_pd_plus_top_level_vs_nested_equivalence() {
+    // Nested: cold(5) then hot(10).
+    let (gn, ln, rn, _pd, _bix, sn) = pd_plus_root(10, 5);
+    let mut vmn = compile_only(&gn);
+    push_from(&mut vmn, &gn, rn);
+    let cold_n = store_val(&vmn, sn);
+    push_from(&mut vmn, &gn, ln);
+    let hot_n = store_val(&vmn, sn);
+
+    // Top level: same sequence.
+    let (gt, lt, rt, st) = pd_plus_top_level(10, 5);
+    let mut vmt = compile_only(&gt);
+    push_from(&mut vmt, &gt, rt);
+    let cold_t = store_val(&vmt, st);
+    push_from(&mut vmt, &gt, lt);
+    let hot_t = store_val(&vmt, st);
+
+    assert_eq!(cold_n, cold_t);
+    assert_eq!(hot_n, hot_t);
+    assert_eq!(cold_n, None);
+    assert_eq!(hot_n, Some(15));
+}
+
+// The reduced inner-branch variants (cold push -> i10, hot push -> i01) must be
+// DEFINED in the module, not just the all-connected i11. Guards the conf
+// post-pass and call/def agreement.
+#[test]
+fn test_nested_pd_plus_emits_reduced_variant() {
+    let (g, _l, _r, pd, branch_ix, _store) = pd_plus_root(10, 5);
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let text: String = module
+        .iter()
+        .map(|f| f.to_pretty(100))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let prefix = format!("node-fn-{}:{}-", pd.index(), branch_ix);
+    assert!(
+        text.contains(&format!("{prefix}i10-o1")),
+        "missing reduced inner branch variant {prefix}i10-o1"
+    );
+    assert!(
+        text.contains(&format!("{prefix}i01-o1")),
+        "missing reduced inner branch variant {prefix}i01-o1"
+    );
+}
+
+// pd+ wrapped in a second `GraphNode`. Returns (outer, pd_id_in_outer,
+// branch_id_in_pd). Outer input 0 -> pd left (hot), input 1 -> pd right (cold).
+fn pd_plus_wrapped() -> (GraphNode<Box<dyn DebugNode>>, usize, usize) {
+    let (pd_inner, branch_ix) = pd_plus();
+    let mut outer = GraphNode::default();
+    let inlet_l = outer.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+    let inlet_r = outer.add_node(Box::new(node::graph::Inlet) as Box<_>);
+    let pd = outer.add_node(Box::new(pd_inner) as Box<_>);
+    let outlet = outer.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    outer.add_edge(inlet_l, pd, Edge::from((0, 0))); // outer in 0 -> pd in 0 (hot)
+    outer.add_edge(inlet_r, pd, Edge::from((0, 1))); // outer in 1 -> pd in 1 (cold)
+    outer.add_edge(pd, outlet, Edge::from((0, 0)));
+    (outer, pd.index(), branch_ix)
+}
+
+// Two-level nesting: cold-only push from the outside must propagate the reduced
+// active-set through BOTH graph layers (outer + pd) so the grandchild branch
+// sees `(None)` for the hot inlet - no error, state set, no output.
+#[test]
+fn test_nested_pd_plus_two_levels() {
+    let (outer, pd_in_outer, branch_in_pd) = pd_plus_wrapped();
+    let mut g = petgraph::graph::DiGraph::new();
+    let left_push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let right_push = g.add_node(Box::new(node_push()) as Box<_>);
+    let left_val = g.add_node(Box::new(node_int(10)) as Box<_>);
+    let right_val = g.add_node(Box::new(node_int(5)) as Box<_>);
+    let outer_node = g.add_node(Box::new(outer) as Box<_>);
+    let store = g.add_node(Box::new(node_number()) as Box<_>);
+    g.add_edge(left_push, left_val, Edge::from((0, 0)));
+    g.add_edge(right_push, right_val, Edge::from((0, 0)));
+    g.add_edge(left_val, outer_node, Edge::from((0, 0))); // -> outer in 0 (hot)
+    g.add_edge(right_val, outer_node, Edge::from((0, 1))); // -> outer in 1 (cold)
+    g.add_edge(outer_node, store, Edge::from((0, 0)));
+
+    let branch_path = [outer_node.index(), pd_in_outer, branch_in_pd];
+    let mut vm = compile_only(&g);
+
+    // Cold-only: state set deep inside, no output.
+    push_from(&mut vm, &g, right_push);
+    assert_eq!(
+        node::state::extract::<i32>(&vm, &branch_path)
+            .ok()
+            .flatten(),
+        Some(5),
+    );
+    assert_eq!(store_val(&vm, store), None);
+
+    // Hot: outputs 10 + 5 = 15.
+    push_from(&mut vm, &g, left_push);
+    assert_eq!(store_val(&vm, store), Some(15));
+}
+
+// A wrapper `GraphNode` exposing ONLY pd+'s hot inlet, leaving the cold inlet
+// permanently unconnected. Even when the wrapper is invoked all-active, its
+// interior invokes pd+ with a statically reduced active-set (only the hot inlet
+// wired), whose inner branch variant must still be defined. Guards the conf
+// post-pass recursing through an all-active parent into a reduced child.
+#[test]
+fn test_nested_reduced_child_under_active_parent() {
+    let (pd_inner, _branch_ix) = pd_plus();
+    let mut outer = GraphNode::default();
+    let inlet = outer.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+    let pd = outer.add_node(Box::new(pd_inner) as Box<_>);
+    let outlet = outer.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    outer.add_edge(inlet, pd, Edge::from((0, 0))); // outer inlet -> pd left (hot)
+    outer.add_edge(pd, outlet, Edge::from((0, 0))); // pd right inlet left unconnected
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let val = g.add_node(Box::new(node_int(10)) as Box<_>);
+    let outer_node = g.add_node(Box::new(outer) as Box<_>);
+    let store = g.add_node(Box::new(node_number()) as Box<_>);
+    g.add_edge(push, val, Edge::from((0, 0)));
+    g.add_edge(val, outer_node, Edge::from((0, 0)));
+    g.add_edge(outer_node, store, Edge::from((0, 0)));
+
+    let mut vm = compile_only(&g);
+    push_from(&mut vm, &g, push);
+    // The cold inlet is never wired => `$?r` is `(None)` => state stays 0 =>
+    // output = 10 + 0. Reaching this without a free-identifier error proves the
+    // reduced inner branch variant was defined and called.
+    assert_eq!(store_val(&vm, store), Some(10));
+}

--- a/crates/gantz_core/tests/nested.rs
+++ b/crates/gantz_core/tests/nested.rs
@@ -3029,3 +3029,62 @@ fn test_nested_reduced_child_under_active_parent() {
     // reduced inner branch variant was defined and called.
     assert_eq!(store_val(&vm, store), Some(10));
 }
+
+// Push-through reaching a nested-optional child: an interior push fires only the
+// hot inlet of a nested pd+, whose output propagates out through the wrapper's
+// outlet. Exercises a reduced inner-branch variant reached via push-through (not
+// via the wrapper's own inlets).
+#[test]
+fn test_push_through_into_nested_optional_hot() {
+    let (c_inner, _branch_ix) = pd_plus();
+    let mut l = GraphNode::default();
+    let p = l.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let val = l.add_node(Box::new(node_int(10)) as Box<_>);
+    let c = l.add_node(Box::new(c_inner) as Box<_>);
+    let outlet = l.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    l.add_edge(p, val, Edge::from((0, 0)));
+    l.add_edge(val, c, Edge::from((0, 0))); // -> C hot (input 0); C cold (input 1) unwired
+    l.add_edge(c, outlet, Edge::from((0, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let push_n = l[p].n_outputs(ctx) as u8;
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let l_node = g.add_node(Box::new(l) as Box<dyn DebugNode>);
+    let store = g.add_node(Box::new(node_number()) as Box<_>);
+    g.add_edge(l_node, store, Edge::from((0, 0)));
+
+    let vm = compile_and_push_nested(&g, vec![l_node.index(), p.index()], push_n);
+    assert_eq!(store_val(&vm, store), Some(10)); // 10 + state(0)
+}
+
+// Push-through into a side-effect-only nested-optional child: an interior push
+// fires only the cold inlet of a nested pd+ that produces no output and feeds no
+// outlet. The all-connected interior flow never reaches C, so C's reduced branch
+// variant is discoverable only from the interior push's flow - which the
+// all-connected nested_fg + node-style reduction miss.
+#[test]
+fn test_push_through_into_nested_optional_sideeffect() {
+    let (c_inner, branch_ix) = pd_plus();
+    let mut l = GraphNode::default();
+    let p = l.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let val = l.add_node(Box::new(node_int(5)) as Box<_>);
+    let c = l.add_node(Box::new(c_inner) as Box<_>);
+    l.add_edge(p, val, Edge::from((0, 0)));
+    l.add_edge(val, c, Edge::from((0, 1))); // -> C cold inlet (input 1); no outlet
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let push_n = l[p].n_outputs(ctx) as u8;
+    let c_in_l = c.index();
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let l_node = g.add_node(Box::new(l) as Box<dyn DebugNode>);
+
+    let vm = compile_and_push_nested(&g, vec![l_node.index(), p.index()], push_n);
+    assert_eq!(
+        node::state::extract::<i32>(&vm, &[l_node.index(), c_in_l, branch_ix])
+            .ok()
+            .flatten(),
+        Some(5),
+    );
+}


### PR DESCRIPTION
## Problem

A nested graph (`GraphNode`) reused as a node - e.g. a `pd+` subgraph emulating Pure Data's stateful `+` (left "hot" inlet outputs, right "cold" inlet only updates state) - raised `TypeMismatch: + expects a number, found '()` when only the cold inlet was pushed, and failed to persist state.

## Root cause

`$?` optional inputs rely on gantz generating a node-fn variant per active-input-set (`-iXY`), where an input absent from that set interpolates to `(None)`.

This works at the top level, but a `GraphNode`'s **interior** was always compiled with every inlet treated as a fully-connected push source (`inner_flow_graph`/`nested_fg` pushed all inlets *and pulled all outlets*). 

So an inner `Branch` only ever got its all-inlets-active variant; `$?l`/`$?r` always became `(Some inputN)`, `(Some? (Some '()))` was always true, and a cold-only push ran the hot arm's `+` on `'()`, aborting before the state write-back.

At first I thought this was a regression from the recent branching overhaul but it's not - the all-connected interior predates the `GraphNode::branches` work; only nesting collapsed the per-active-set distinction that already worked at the top level.

## Fix

Monomorphize a `GraphNode`'s interior per active-input-set, like top-level nodes:

- **`inner_flow_graph_for(meta, active_inlets)`** - all-inlets-active delegates to the unchanged all-connected build (dominant path stays byte-identical); a proper subset builds the interior from forward reachability over the active inlets plus static sources, with **no outlet pull**. Dropping the pull is the key: it's what re-included an unfired inlet via the backward `outlet <- branch <- inlet` walk and forced the all-active variant.
- **`nested_expr`** lowers its body from the active-set flow, while keeping the external branch patterns/selector from the all-connected flow (so it stays consistent with the parent's `Node::branches`; runtime `outlet-active-*` flags pick the right pattern).
- **`build_node_confs_tree`** - a single top-down builder (replacing the prior `map_ref(unique_node_confs)` + post-pass) computes each level's confs as it descends: its own flow graphs plus the reduced inner flow per active-set it's invoked with, propagating active-sets to children. This *defines* exactly the reduced inner variants `nested_expr` *calls*.

The push-through-outlet path (`flow_graph_with_extra`) is orthogonal and untouched.

## Bonus gap fix

Deriving each child's active-sets from the parent's *entrypoint* flows too closes a latent gap: an interior push reaching a side-effect-only nested-optional child (one that feeds no outlet) was never discovered, so its reduced inner variant went undefined -> `FreeIdentifier` at run time. Now defined; covered by a test that failed pre-fix.
