### PR TITLE
feat(compile): introduce a compile config

### DIFF
--- a/crates/bevy_gantz/src/lib.rs
+++ b/crates/bevy_gantz/src/lib.rs
@@ -18,7 +18,7 @@ pub use head::{
     OpenHeadDataReadOnly, WorkingGraph,
 };
 pub use reg::{Registry, lookup_node, timestamp};
-pub use vm::{EntrypointFns, EvalEntryComplete, EvalEntryEvent};
+pub use vm::{CompileConfig, EntrypointFns, EvalEntryComplete, EvalEntryEvent};
 
 /// Plugin providing core gantz functionality.
 ///
@@ -53,6 +53,7 @@ where
         .init_resource::<FocusedHead>()
         .init_resource::<HeadTabOrder>()
         .init_resource::<Registry<N>>()
+        .init_resource::<vm::CompileConfig>()
         .init_non_send_resource::<HeadVms>()
         // Register head event handlers.
         .add_observer(head::on_open::<N>)

--- a/crates/bevy_gantz/src/lib.rs
+++ b/crates/bevy_gantz/src/lib.rs
@@ -11,6 +11,9 @@ pub mod storage;
 pub mod vm;
 
 use bevy_app::{App, Plugin, Update};
+use bevy_ecs::prelude::{
+    IntoScheduleConfigs, SystemCondition, not, resource_added, resource_changed,
+};
 pub use builtin::{BuiltinNodes, Builtins};
 use gantz_core::Node;
 pub use head::{
@@ -66,8 +69,20 @@ where
         // VM init observers.
         .add_observer(vm::on_head_opened::<N>)
         .add_observer(vm::on_head_changed::<N>)
-        // Graph recompilation system.
-        .add_systems(Update, vm::update::<N>);
+        // Graph recompilation systems. `recompile_all` reacts to compile
+        // config changes; the condition order is load-bearing (`and`
+        // short-circuits, and `resource_changed` must observe every run to
+        // keep its change tick in sync).
+        .add_systems(
+            Update,
+            (
+                vm::update::<N>,
+                vm::recompile_all::<N>.run_if(
+                    resource_changed::<vm::CompileConfig>
+                        .and(not(resource_added::<vm::CompileConfig>)),
+                ),
+            ),
+        );
     }
 }
 

--- a/crates/bevy_gantz/src/vm.rs
+++ b/crates/bevy_gantz/src/vm.rs
@@ -58,6 +58,14 @@ fn collect_entrypoints<N: Node>(
     ep_fns.0.iter().flat_map(|f| f(get_node, graph)).collect()
 }
 
+/// Resource holding the [`core_compile::Config`] used whenever a head's graph
+/// is (re)compiled into its VM.
+///
+/// Defaults to the core defaults. Override (and trigger a recompile) to e.g.
+/// enable `emit_all_node_fns` when debugging codegen in the module view.
+#[derive(Default, Resource)]
+pub struct CompileConfig(pub core_compile::Config);
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -94,11 +102,12 @@ pub fn init<N>(
     get_node: GetNode,
     graph: &Graph<N>,
     entrypoints: &[core_compile::Entrypoint],
+    config: &core_compile::Config,
 ) -> Result<(Engine, String), CompileError>
 where
     N: Node,
 {
-    let (vm, module) = gantz_core::vm::init(get_node, graph, entrypoints)?;
+    let (vm, module) = gantz_core::vm::init(get_node, graph, entrypoints, config)?;
     Ok((vm, gantz_core::vm::fmt_module(&module)))
 }
 
@@ -110,11 +119,12 @@ pub fn compile<N>(
     graph: &Graph<N>,
     vm: &mut Engine,
     entrypoints: &[core_compile::Entrypoint],
+    config: &core_compile::Config,
 ) -> Result<String, CompileError>
 where
     N: Node,
 {
-    let module = gantz_core::vm::compile(get_node, graph, vm, entrypoints)?;
+    let module = gantz_core::vm::compile(get_node, graph, vm, entrypoints, config)?;
     Ok(gantz_core::vm::fmt_module(&module))
 }
 
@@ -128,6 +138,7 @@ fn init_head_vm<N>(
     registry: &Registry<N>,
     builtins: &BuiltinNodes<N>,
     ep_fns: &EntrypointFns<N>,
+    config: &CompileConfig,
     vms: &mut head::HeadVms,
     cmds: &mut Commands,
     graphs: &Query<&head::WorkingGraph<N>>,
@@ -137,7 +148,7 @@ fn init_head_vm<N>(
     let graph = graphs.get(entity).unwrap();
     let get_node = |ca: &ca::ContentAddr| lookup_node(registry, &**builtins, ca);
     let entrypoints = collect_entrypoints(ep_fns, &get_node, &**graph);
-    let (vm, module) = match init(&get_node, &**graph, &entrypoints) {
+    let (vm, module) = match init(&get_node, &**graph, &entrypoints, &config.0) {
         Ok(result) => result,
         Err(e) => {
             log::error!(
@@ -165,6 +176,7 @@ pub fn on_head_opened<N>(
     registry: Res<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
     ep_fns: Res<EntrypointFns<N>>,
+    config: Res<CompileConfig>,
     mut vms: NonSendMut<head::HeadVms>,
     mut cmds: Commands,
     graphs: Query<&head::WorkingGraph<N>>,
@@ -176,6 +188,7 @@ pub fn on_head_opened<N>(
         &registry,
         &builtins,
         &ep_fns,
+        &config,
         &mut vms,
         &mut cmds,
         &graphs,
@@ -188,6 +201,7 @@ pub fn on_head_changed<N>(
     registry: Res<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
     ep_fns: Res<EntrypointFns<N>>,
+    config: Res<CompileConfig>,
     mut vms: NonSendMut<head::HeadVms>,
     mut cmds: Commands,
     graphs: Query<&head::WorkingGraph<N>>,
@@ -199,6 +213,7 @@ pub fn on_head_changed<N>(
         &registry,
         &builtins,
         &ep_fns,
+        &config,
         &mut vms,
         &mut cmds,
         &graphs,
@@ -249,12 +264,13 @@ where
         let registry = world.resource::<Registry<N>>();
         let builtins = world.resource::<BuiltinNodes<N>>();
         let ep_fns = world.resource::<EntrypointFns<N>>();
+        let config = world.resource::<CompileConfig>();
         let get_node = |ca: &ca::ContentAddr| lookup_node(registry, &**builtins, ca);
         let Some(wg) = world.get::<head::WorkingGraph<N>>(entity) else {
             continue;
         };
         let entrypoints = collect_entrypoints(ep_fns, &get_node, &**wg);
-        let (vm, module) = match init(&get_node, &**wg, &entrypoints) {
+        let (vm, module) = match init(&get_node, &**wg, &entrypoints, &config.0) {
             Ok(result) => result,
             Err(e) => {
                 log::error!("Failed to init VM for entity {entity}: {e}");
@@ -285,6 +301,7 @@ pub fn update<N>(
     mut registry: ResMut<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
     ep_fns: Res<EntrypointFns<N>>,
+    config: Res<CompileConfig>,
     mut vms: NonSendMut<head::HeadVms>,
     mut heads_query: Query<head::OpenHeadData<N>, With<head::OpenHead>>,
 ) where
@@ -324,7 +341,7 @@ pub fn update<N>(
                 let get_node = |ca: &ca::ContentAddr| lookup_node(&registry, &**builtins, ca);
                 gantz_core::graph::register(&get_node, graph, &[], vm);
                 let entrypoints = collect_entrypoints(&ep_fns, &get_node, graph);
-                match compile(&get_node, graph, vm, &entrypoints) {
+                match compile(&get_node, graph, vm, &entrypoints, &config.0) {
                     Ok(module) => data.compiled.0 = module,
                     Err(e) => {
                         log::error!(

--- a/crates/bevy_gantz/src/vm.rs
+++ b/crates/bevy_gantz/src/vm.rs
@@ -357,3 +357,39 @@ pub fn update<N>(
         }
     }
 }
+
+/// Recompile every open head's graph into its existing VM.
+///
+/// Runs when [`CompileConfig`] changes (see `GantzPlugin`). Unlike [`update`],
+/// this never commits - the graph content is unchanged, only the codegen
+/// options - and compiling into the existing VM preserves node state.
+pub fn recompile_all<N>(
+    registry: Res<Registry<N>>,
+    builtins: Res<BuiltinNodes<N>>,
+    ep_fns: Res<EntrypointFns<N>>,
+    config: Res<CompileConfig>,
+    mut vms: NonSendMut<head::HeadVms>,
+    mut heads_query: Query<head::OpenHeadData<N>, With<head::OpenHead>>,
+) where
+    N: 'static + Node + Send + Sync,
+{
+    for mut data in heads_query.iter_mut() {
+        let graph: &Graph<N> = &*data.working_graph;
+        let Some(vm) = vms.get_mut(&data.entity) else {
+            continue;
+        };
+        let get_node = |ca: &ca::ContentAddr| lookup_node(&registry, &**builtins, ca);
+        gantz_core::graph::register(&get_node, graph, &[], vm);
+        let entrypoints = collect_entrypoints(&ep_fns, &get_node, graph);
+        match compile(&get_node, graph, vm, &entrypoints, &config.0) {
+            Ok(module) => data.compiled.0 = module,
+            Err(e) => {
+                log::error!(
+                    "Failed to compile graph: {}",
+                    gantz_core::vm::error_chain(&e)
+                );
+                data.compiled.0 = compile_error_comment(&e);
+            }
+        }
+    }
+}

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -13,7 +13,7 @@ use bevy_egui::{EguiContexts, EguiPrimaryContextPass};
 use bevy_gantz::head;
 use bevy_gantz::reg::Registry;
 use bevy_gantz::vm::EvalEntryEvent;
-use bevy_gantz::{BuiltinNodes, EvalEntryComplete};
+use bevy_gantz::{BuiltinNodes, CompileConfig, EvalEntryComplete};
 use bevy_log as log;
 use gantz_ca as ca;
 use gantz_core::Node;
@@ -1240,7 +1240,11 @@ pub fn update<N>(
     mut focused: ResMut<head::FocusedHead>,
     mut heads_query: Query<OpenHeadViews<N>, With<head::OpenHead>>,
     import_task: Option<Res<ImportTask>>,
-    (base_names, base_immutable): (Res<BaseNames>, Res<BaseImmutable>),
+    (base_names, base_immutable, mut compile_config): (
+        Res<BaseNames>,
+        Res<BaseImmutable>,
+        ResMut<CompileConfig>,
+    ),
     mut demos: ResMut<Demos>,
     mut cmds: Commands,
 ) -> Result
@@ -1272,12 +1276,14 @@ where
     let level = bevy_log::tracing_subscriber::filter::LevelFilter::current();
 
     // Build and show the Gantz widget.
+    let current_compile_config = compile_config.0;
     let response = egui::containers::CentralPanel::default()
         .frame(egui::Frame::default())
         .show(ctx, |ui| {
             gantz_egui::widget::Gantz::new(&node_reg, &base_names.0)
                 .base_immutable(base_immutable.0)
                 .demos(&demos.0)
+                .compile_config(current_compile_config)
                 .trace_capture(trace_capture.0.clone(), level)
                 .perf_captures(&mut perf_vm.0, &mut perf_gui.0)
                 .show(&mut *gui_state, focused_ix, &mut access, ui)
@@ -1366,6 +1372,15 @@ where
     if let Some(head) = &response.reset_base_graph {
         if let ca::Head::Branch(name) = head {
             cmds.trigger(ResetBaseGraphEvent(name.clone()));
+        }
+    }
+
+    // Handle compile config change. The recompile happens next frame via
+    // `bevy_gantz::vm::recompile_all` (resource change detection); the `!=`
+    // guard avoids flagging the resource changed with an equal value.
+    if let Some(cfg) = response.compile_config {
+        if compile_config.0 != cfg {
+            compile_config.0 = cfg;
         }
     }
 

--- a/crates/gantz_core/src/compile.rs
+++ b/crates/gantz_core/src/compile.rs
@@ -11,9 +11,9 @@
 //!    to an IR (`ir`) of node-call steps, branch dispatches and join points
 //!    (local fns whose parameters carry reconverging values; values consumed
 //!    outside a branch construct ride its exports). `ir::validate` checks
-//!    the IR's scoping/arity invariants on every lowering, in every build;
-//!    a violation is a compiler bug and surfaces as
-//!    [`ModuleError::InvalidIr`].
+//!    the IR's scoping/arity invariants on every lowering (on by default,
+//!    see [`Config::validate_ir`]); a violation is a compiler bug and
+//!    surfaces as [`ModuleError::InvalidIr`].
 //! 3. **Outlet-activation analysis** (`analysis`): the distinct sets of a
 //!    level's outlets that can fire together, computed by abstract
 //!    interpretation of the lowered IR itself (forking per branch arm), so
@@ -92,6 +92,41 @@ impl Edges for Edge {
 impl Edges for Vec<Edge> {
     fn edges(&self) -> impl Iterator<Item = Edge> {
         self.iter().copied()
+    }
+}
+
+/// Options controlling [`module`] compilation.
+///
+/// The defaults are what regular builds want; the toggles exist for
+/// optimisation ([`validate_ir`][Self::validate_ir]) and codegen debugging
+/// ([`emit_all_node_fns`][Self::emit_all_node_fns]).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Config {
+    /// Check the scoping/arity invariants of every lowered IR body, surfacing
+    /// a violation as [`ModuleError::InvalidIr`]. A violation is a bug in the
+    /// compiler itself, never in the compiled graph.
+    ///
+    /// On by default. Disable as an optimisation, at the cost of an internal
+    /// compiler error surfacing further downstream (e.g. as a confusing Steel
+    /// evaluation error) instead of at lowering with a precise diagnosis.
+    pub validate_ir: bool,
+    /// Emit a node fn for every node - its all-connected variant - rather
+    /// than only the variants called by some lowered evaluation.
+    ///
+    /// Off by default: node fns are normally emitted on demand, so a node
+    /// that no entrypoint's evaluation calls produces no code at all. Enable
+    /// to inspect any node's generated code (e.g. in the app's module view)
+    /// before anything calls it. The extra definitions are never called and
+    /// do not affect evaluation.
+    pub emit_all_node_fns: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            validate_ir: true,
+            emit_all_node_fns: false,
+        }
     }
 }
 
@@ -344,18 +379,19 @@ fn or_patterns(patterns: &[node::Conns]) -> Result<node::Conns, error::NodeConns
 /// configuration), a graph fn per nested level variant, and a function per
 /// entrypoint's evaluation.
 ///
-/// Lowers through the join-point IR pipeline (`lower` -> `ir` -> `emit`).
-/// Nested graphs compile *call-based*: each level becomes one
-/// `graph-fn-{path}-i{mask}` per active-inlet variant, which parents call
-/// like a node fn. An entrypoint sourced inside a nested graph becomes a
-/// per-level fn whose result - `(list value state')`, with `value` a
-/// `(list branch-ix vals)` pair when the push reaches the outlets through
-/// branching - the parent level continues from (push-through-outlet as an
-/// ordinary value return).
+/// Lowers through the join-point IR pipeline (`lower` -> `ir` -> `emit`),
+/// with the toggles in [`Config`] applied along the way. Nested graphs
+/// compile *call-based*: each level becomes one `graph-fn-{path}-i{mask}`
+/// per active-inlet variant, which parents call like a node fn. An
+/// entrypoint sourced inside a nested graph becomes a per-level fn whose
+/// result - `(list value state')`, with `value` a `(list branch-ix vals)`
+/// pair when the push reaches the outlets through branching - the parent
+/// level continues from (push-through-outlet as an ordinary value return).
 pub fn module<'a, G>(
     get_node: node::GetNode<'a>,
     g: G,
     entrypoints: &[Entrypoint],
+    config: &Config,
 ) -> Result<Vec<ExprKind>, ModuleError>
 where
     G: Data<EdgeWeight = Edge> + IntoEdgesDirected + IntoNodeReferences + NodeIndexable + Visitable,
@@ -373,6 +409,7 @@ where
     let mut builder = ModuleBuilder {
         meta_tree: &meta_tree,
         level_sources: &level_sources,
+        config,
         confs: std::collections::BTreeMap::new(),
         graph_fns: Vec::new(),
         fns: Vec::new(),
@@ -416,6 +453,14 @@ where
         if emitted.insert((gpath.clone(), imask)) {
             builder.graph_fn(&gpath, &imask)?;
         }
+    }
+
+    // With `emit_all_node_fns`, every node contributes its all-connected
+    // variant so its node fn is emitted even when nothing reachable from an
+    // entrypoint calls it. Before the fixpoint below so any graph fns these
+    // variants call are generated too.
+    if config.emit_all_node_fns {
+        all_connected_confs(&meta_tree, &mut Vec::new(), &mut builder.confs)?;
     }
 
     // Generate a graph fn per (nested level, active-inlet variant) reachable
@@ -476,6 +521,37 @@ where
         .collect())
 }
 
+/// Insert the all-connected variant conf of every node at every level of the
+/// meta tree (the [`Config::emit_all_node_fns`] set). Inlets and outlets
+/// resolve as bindings and delays are intrinsics - none have node fns - so
+/// they are skipped.
+fn all_connected_confs(
+    tree: &RoseTree<Meta>,
+    path: &mut Vec<node::Id>,
+    confs: &mut std::collections::BTreeMap<Vec<node::Id>, std::collections::BTreeSet<NodeConf>>,
+) -> Result<(), error::NodeConnsError> {
+    let conn = |n: usize| {
+        node::Conns::connected(n).map_err(|_| error::NodeConnsError::from(error::TooManyConns(n)))
+    };
+    let meta = &tree.elem;
+    let level_confs = confs.entry(path.clone()).or_default();
+    for n in meta.graph.nodes() {
+        if meta.inlets.contains(&n) || meta.outlets.contains(&n) || meta.delays.contains(&n) {
+            continue;
+        }
+        let inputs = conn(meta.inputs.get(&n).copied().unwrap_or(0))?;
+        let outputs = conn(meta.outputs.get(&n).copied().unwrap_or(0))?;
+        let conns = NodeConns { inputs, outputs };
+        level_confs.insert(NodeConf { id: n, conns });
+    }
+    for (&id, sub) in &tree.nested {
+        path.push(id);
+        all_connected_confs(sub, path, confs)?;
+        path.pop();
+    }
+    Ok(())
+}
+
 /// Collect every nested level path in the meta tree with its inlet count.
 fn collect_levels(
     tree: &RoseTree<Meta>,
@@ -510,6 +586,7 @@ struct ModuleBuilder<'a> {
     meta_tree: &'a RoseTree<Meta>,
     level_sources:
         &'a std::collections::BTreeMap<Vec<node::Id>, Vec<(EntrypointId, Vec<&'a EvalSource>)>>,
+    config: &'a Config,
     /// Node variants called by the lowered bodies, per level path.
     confs: std::collections::BTreeMap<Vec<node::Id>, std::collections::BTreeSet<NodeConf>>,
     /// Emitted graph fns with their level depth. A graph fn calls only
@@ -648,10 +725,12 @@ impl ModuleBuilder<'_> {
             prebound,
         };
         let out = lower::level_body(&cx, &lower::LevelSources::Eval { push, pull })?;
-        ir::validate(&out.body, 0, &prebound_vars).map_err(|e| ModuleError::InvalidIr {
-            path: path.to_vec(),
-            detail: e.to_string(),
-        })?;
+        if self.config.validate_ir {
+            ir::validate(&out.body, 0, &prebound_vars).map_err(|e| ModuleError::InvalidIr {
+                path: path.to_vec(),
+                detail: e.to_string(),
+            })?;
+        }
         lower::collect_confs(&out.body, self.confs.entry(path.to_vec()).or_default());
         Ok(Some((glue, out)))
     }
@@ -726,14 +805,16 @@ impl ModuleBuilder<'_> {
             prebound: std::collections::BTreeSet::new(),
         };
         let out = lower::level_body(&cx, &lower::LevelSources::Inlets(active.clone()))?;
-        let inlet_vars: Vec<ir::Var> = active
-            .iter()
-            .map(|&i| ir::Var::Output { node: i, output: 0 })
-            .collect();
-        ir::validate(&out.body, 0, &inlet_vars).map_err(|e| ModuleError::InvalidIr {
-            path: gpath.to_vec(),
-            detail: e.to_string(),
-        })?;
+        if self.config.validate_ir {
+            let inlet_vars: Vec<ir::Var> = active
+                .iter()
+                .map(|&i| ir::Var::Output { node: i, output: 0 })
+                .collect();
+            ir::validate(&out.body, 0, &inlet_vars).map_err(|e| ModuleError::InvalidIr {
+                path: gpath.to_vec(),
+                detail: e.to_string(),
+            })?;
+        }
         lower::collect_confs(&out.body, self.confs.entry(gpath.to_vec()).or_default());
 
         // The node-contract patterns: the all-active analysis, matching the

--- a/crates/gantz_core/src/compile/codegen/node_fn.rs
+++ b/crates/gantz_core/src/compile/codegen/node_fn.rs
@@ -5,7 +5,9 @@
 //! node, a function is generated.
 //!
 //! These configurations are collected by traversing from each of the push/pull
-//! evaluation entrypoints.
+//! evaluation entrypoints. With
+//! [`Config::emit_all_node_fns`][crate::compile::Config], every node's
+//! all-connected configuration is included as well.
 
 use crate::{
     Edge,

--- a/crates/gantz_core/src/compile/error.rs
+++ b/crates/gantz_core/src/compile/error.rs
@@ -144,9 +144,9 @@ pub enum ModuleError {
     #[error(transparent)]
     NodeFnErrors(#[from] NodeFnErrors),
     /// The lowering produced IR violating the compiler's own invariants.
-    /// This is a bug in gantz, not in the compiled graph; validation runs in
-    /// every build so it surfaces as a compile error rather than emitting
-    /// malformed Steel.
+    /// This is a bug in gantz, not in the compiled graph; validation runs on
+    /// every lowering (unless disabled via [`Config::validate_ir`][super::Config])
+    /// so it surfaces as a compile error rather than emitting malformed Steel.
     #[error("internal compiler error: invalid IR for level {path:?}: {detail}")]
     InvalidIr { path: Vec<node::Id>, detail: String },
 }

--- a/crates/gantz_core/src/vm.rs
+++ b/crates/gantz_core/src/vm.rs
@@ -25,6 +25,7 @@ pub fn init<'a, G>(
     get_node: node::GetNode<'a>,
     graph: G,
     entrypoints: &[crate::compile::Entrypoint],
+    config: &crate::compile::Config,
 ) -> Result<(Engine, Vec<ExprKind>), CompileError>
 where
     G: Data<EdgeWeight = Edge>
@@ -38,7 +39,7 @@ where
     let mut vm = Engine::new_base();
     vm.register_value(crate::ROOT_STATE, SteelVal::empty_hashmap());
     crate::graph::register(get_node, graph, &[], &mut vm);
-    let module = compile(get_node, graph, &mut vm, entrypoints)?;
+    let module = compile(get_node, graph, &mut vm, entrypoints, config)?;
     Ok((vm, module))
 }
 
@@ -51,6 +52,7 @@ pub fn compile<'a, G>(
     graph: G,
     vm: &mut Engine,
     entrypoints: &[crate::compile::Entrypoint],
+    config: &crate::compile::Config,
 ) -> Result<Vec<ExprKind>, CompileError>
 where
     G: Data<EdgeWeight = Edge>
@@ -61,7 +63,7 @@ where
         + Copy,
     G::NodeWeight: Node,
 {
-    let module = crate::compile::module(get_node, graph, entrypoints)?;
+    let module = crate::compile::module(get_node, graph, entrypoints, config)?;
     for expr in &module {
         vm.run(expr.to_pretty(80))?;
     }

--- a/crates/gantz_core/tests/config.rs
+++ b/crates/gantz_core/tests/config.rs
@@ -1,0 +1,149 @@
+//! Tests for the [`compile::Config`] toggles.
+
+use gantz_core::{
+    Edge,
+    compile::{Config, entry_fn_name, push_pull_entrypoints},
+    node::{self, GraphNode, Node, WithPushEval},
+};
+use std::fmt::Debug;
+
+fn node_push() -> node::Push<node::Expr> {
+    node::expr("'()").unwrap().with_push_eval()
+}
+
+fn node_int(i: i32) -> node::Expr {
+    node::expr(format!("(begin $push {})", i)).unwrap()
+}
+
+fn node_mul() -> node::Expr {
+    node::expr("(* $l $r)").unwrap()
+}
+
+fn node_assert_eq() -> node::Expr {
+    node::expr("(begin (assert! (equal? $l $r)))").unwrap()
+}
+
+// Stores the received number in state and returns it.
+fn node_number() -> node::Expr {
+    node::expr(
+        "
+        (let ((x $x))
+          (set! state (if (number? x) x state))
+          state)
+    ",
+    )
+    .unwrap()
+}
+
+// Helper trait for debugging the graph.
+trait DebugNode: Debug + Node {}
+impl<T> DebugNode for T where T: Debug + Node {}
+
+// A no-op node lookup function for tests that don't need it.
+fn no_lookup(_: &gantz_ca::ContentAddr) -> Option<&'static dyn Node> {
+    None
+}
+
+type TestGraph = petgraph::graph::DiGraph<Box<dyn DebugNode>, Edge, usize>;
+
+// A graph exercising both toggles: a reachable push chain through a nested
+// graph, an unreachable node at the root level (`mul`, id 4), an unreachable
+// *stateful* node at the root level (`number`, id 5), and an unreachable node
+// inside the nested graph (`mul`, id 2 at level 2).
+//
+//    --------
+//    | push |                      // id 0
+//    -+------
+//     |
+//    -+-----
+//    | one |                       // id 1
+//    -+-----
+//     |---------------
+//     |              |
+//    -+---------     |             ----------------------
+//    | GRAPH    |    |             | GRAPH interior:    |
+//    | inlet  0 |    |             |  inlet -> outlet   |
+//    | outlet 1 |    |             |  mul (unreachable) |
+//    | mul    2 |    |             ----------------------
+//    -+----------    |
+//     |              |
+//    -+--------------+-   -+-----   -+--------
+//    | assert_eq       |  | mul |   | number |
+//    -------------------  -------   ----------
+fn test_graph() -> TestGraph {
+    let mut inner = GraphNode::default();
+    let inlet = inner.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+    let outlet = inner.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    let _orphan = inner.add_node(Box::new(node_mul()) as Box<_>);
+    inner.add_edge(inlet, outlet, Edge::from((0, 0)));
+
+    let mut g = TestGraph::default();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let one = g.add_node(Box::new(node_int(1)) as Box<_>);
+    let nested = g.add_node(Box::new(inner) as Box<_>);
+    let assert_eq = g.add_node(Box::new(node_assert_eq()) as Box<_>);
+    let _orphan = g.add_node(Box::new(node_mul()) as Box<_>);
+    let _stateful_orphan = g.add_node(Box::new(node_number()) as Box<_>);
+    g.add_edge(push, one, Edge::from((0, 0)));
+    g.add_edge(one, nested, Edge::from((0, 0)));
+    g.add_edge(nested, assert_eq, Edge::from((0, 0)));
+    g.add_edge(one, assert_eq, Edge::from((0, 1)));
+    g
+}
+
+// The all-connected node fn names of the unreachable nodes in `test_graph`.
+const ORPHAN_FNS: &[&str] = &["node-fn-4-i11-o1", "node-fn-5-i1-o1", "node-fn-2:2-i11-o1"];
+
+// By default, node fns are emitted on demand: nodes unreachable from every
+// entrypoint produce no node fns.
+#[test]
+fn default_omits_uncalled_node_fns() {
+    let g = test_graph();
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Config::default()).unwrap();
+    let module_str = gantz_core::vm::fmt_module(&module);
+    for fn_name in ORPHAN_FNS {
+        assert!(!module_str.contains(fn_name), "unexpected {fn_name}");
+    }
+}
+
+// With `emit_all_node_fns`, every node's all-connected variant is emitted -
+// root level orphans (pure and stateful) and nested level orphans alike -
+// and the extra definitions do not disturb evaluation.
+#[test]
+fn emit_all_node_fns_includes_uncalled_nodes() {
+    let config = Config {
+        emit_all_node_fns: true,
+        ..Default::default()
+    };
+    let g = test_graph();
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let (mut vm, module) = gantz_core::vm::init(&no_lookup, &g, &eps, &config).unwrap();
+    let module_str = gantz_core::vm::fmt_module(&module);
+    for fn_name in ORPHAN_FNS {
+        assert!(module_str.contains(fn_name), "missing {fn_name}");
+    }
+
+    // The reachable chain still evaluates (the assert_eq node throws on
+    // failure), with the dead definitions loaded alongside.
+    vm.call_function_by_name_with_args(&entry_fn_name(&eps[0].id()), vec![])
+        .unwrap();
+}
+
+// Skipping IR validation only skips the check: the emitted module is
+// identical to a validated build's.
+#[test]
+fn no_validate_ir_emits_identical_module() {
+    let config = Config {
+        validate_ir: false,
+        ..Default::default()
+    };
+    let g = test_graph();
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let validated = gantz_core::compile::module(&no_lookup, &g, &eps, &Config::default()).unwrap();
+    let unvalidated = gantz_core::compile::module(&no_lookup, &g, &eps, &config).unwrap();
+    assert_eq!(
+        gantz_core::vm::fmt_module(&validated),
+        gantz_core::vm::fmt_module(&unvalidated),
+    );
+}

--- a/crates/gantz_core/tests/fn_apply.rs
+++ b/crates/gantz_core/tests/fn_apply.rs
@@ -101,7 +101,7 @@ fn test_fn_apply_identity() {
     // Generate the module.
     let ctx = node::MetaCtx::new(&get_node);
     let eps = push_pull_entrypoints(&get_node, &g);
-    let module = gantz_core::compile::module(&get_node, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&get_node, &g, &eps, &Default::default()).unwrap();
 
     // Create and setup VM.
     let mut vm = Engine::new_base();
@@ -210,7 +210,7 @@ fn test_fn_apply_graph() {
     // Generate the module.
     let ctx = node::MetaCtx::new(&get_node);
     let eps = push_pull_entrypoints(&get_node, &g);
-    let module = gantz_core::compile::module(&get_node, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&get_node, &g, &eps, &Default::default()).unwrap();
 
     // Create and setup VM.
     let mut vm = Engine::new_base();

--- a/crates/gantz_core/tests/graph.rs
+++ b/crates/gantz_core/tests/graph.rs
@@ -95,7 +95,7 @@ fn test_graph_push_eval() {
 
     // Generate the module, which should have just one top-level expr for `push`.
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
     // Function per node alongside the single push eval function.
     assert_eq!(module.len(), g.node_count() + 1);
 
@@ -156,7 +156,7 @@ fn test_graph_pull_eval() {
 
     // Generate the steel module.
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     // Prepare the VM.
     let mut vm = Engine::new_base();
@@ -259,7 +259,7 @@ fn test_graph_push_cond_eval() {
 
     // Generate the module.
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
     // Function per node alongside the two push eval functions.
     assert_eq!(module.len(), g.node_count() + 2);
 
@@ -340,7 +340,7 @@ fn test_graph_cond_eval_no_join_duplication() {
     // Build the entrypoint for push_0 only.
     let ep =
         gantz_core::compile::entrypoint::push(vec![push_0.index()], g[push_0].n_outputs(ctx) as u8);
-    let module = gantz_core::compile::module(&no_lookup, &g, &[ep]).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &[ep], &Default::default()).unwrap();
 
     // The number node's function name contains its index (5).
     // Count how many times it appears across all generated expressions.
@@ -425,7 +425,7 @@ fn test_graph_branch_target_is_join() {
     let ctx = node::MetaCtx::new(&no_lookup);
 
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -512,7 +512,7 @@ fn test_graph_branch_both_outputs_same_target() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -623,7 +623,7 @@ fn test_graph_nested_diamond() {
     let ctx = node::MetaCtx::new(&no_lookup);
 
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -766,7 +766,7 @@ fn test_graph_lattice_reconvergence() {
     let ctx = node::MetaCtx::new(&no_lookup);
 
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -847,7 +847,7 @@ fn test_graph_eval_should_panic() {
 
     // Generate the steel module.
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     // Prepare the VM.
     let mut vm = Engine::new_base();
@@ -924,7 +924,7 @@ fn test_graph_push_eval_subset() {
 
     // Generate the module
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     // Create the VM
     let mut vm = Engine::new_base();
@@ -993,7 +993,9 @@ fn test_graph_multi_source_push() {
         push_source(vec![push_a.index()], g[push_a].n_outputs(ctx) as u8),
         push_source(vec![push_b.index()], g[push_b].n_outputs(ctx) as u8),
     ]);
-    let module = gantz_core::compile::module(&no_lookup, &g, &[combined.clone()]).unwrap();
+    let module =
+        gantz_core::compile::module(&no_lookup, &g, &[combined.clone()], &Default::default())
+            .unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -1078,7 +1080,7 @@ fn test_graph_multi_output_expr() {
     let ctx = node::MetaCtx::new(&no_lookup);
 
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -1145,7 +1147,7 @@ fn test_graph_zero_output_leaf_nodes() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -1200,7 +1202,7 @@ fn test_graph_branch_node() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -1274,7 +1276,7 @@ fn test_graph_multi_edge_input_list() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     // Verify the generated code contains a list binding.
     let module_str = module
@@ -1352,7 +1354,7 @@ fn test_graph_branch_divergent_terminal() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -1450,7 +1452,7 @@ fn test_graph_multi_edge_in_branch_arm() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -1503,7 +1505,7 @@ fn test_graph_optional_input_unconnected() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -1549,7 +1551,7 @@ fn test_graph_optional_input_connected() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -1628,7 +1630,7 @@ fn test_graph_three_way_branch() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -1700,7 +1702,7 @@ fn test_graph_branch_single_output_dead_branch() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -1765,7 +1767,7 @@ fn test_graph_branch_two_outputs_one_dead() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -1832,7 +1834,7 @@ fn test_graph_branch_all_dead() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -1908,7 +1910,7 @@ fn test_graph_branch_optional_input_pd_add() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());

--- a/crates/gantz_core/tests/ir_pipeline.rs
+++ b/crates/gantz_core/tests/ir_pipeline.rs
@@ -97,7 +97,8 @@ fn run_pipeline(
 
 /// Compile `g` and run the call sequence end-to-end.
 fn assert_pipelines_agree(g: &Graph, eps: &[Entrypoint], calls: &[&Entrypoint]) {
-    let m = gantz_core::compile::module(&no_lookup, g, eps).expect("IR pipeline failed");
+    let m = gantz_core::compile::module(&no_lookup, g, eps, &Default::default())
+        .expect("IR pipeline failed");
     if std::env::var("GANTZ_DUMP").is_ok() {
         for e in &m {
             eprintln!("{}\n", e.to_pretty(100));
@@ -652,7 +653,8 @@ fn two_branch_shared_join() {
         entrypoint::push_source(vec![push_q.index()], g[push_q].n_outputs(ctx) as u8),
     ]);
     let eps = std::slice::from_ref(&combined);
-    let m2 = gantz_core::compile::module(&no_lookup, &g, eps).expect("IR pipeline failed");
+    let m2 = gantz_core::compile::module(&no_lookup, &g, eps, &Default::default())
+        .expect("IR pipeline failed");
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -1195,7 +1197,8 @@ fn nested_non_sequential_inlets() {
 
 /// Compile through the IR pipeline, run, and call each entrypoint in order.
 fn run_v2(g: &Graph, eps: &[Entrypoint], calls: &[&Entrypoint]) -> Engine {
-    let m2 = gantz_core::compile::module(&no_lookup, g, eps).expect("IR pipeline failed");
+    let m2 = gantz_core::compile::module(&no_lookup, g, eps, &Default::default())
+        .expect("IR pipeline failed");
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
     gantz_core::graph::register(&no_lookup, g, &[], &mut vm);

--- a/crates/gantz_core/tests/nested.rs
+++ b/crates/gantz_core/tests/nested.rs
@@ -122,7 +122,7 @@ fn test_graph_nested_stateless() {
     // Generate the module, which should have just one top-level expr for `push`.
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &gb);
-    let module = gantz_core::compile::module(&no_lookup, &gb, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &gb, &eps, &Default::default()).unwrap();
 
     // Create the VM.
     let mut vm = Engine::new_base();
@@ -207,7 +207,7 @@ fn test_graph_nested_counter() {
     // Generate the module.
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &gb);
-    let module = gantz_core::compile::module(&no_lookup, &gb, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &gb, &eps, &Default::default()).unwrap();
 
     // Create the VM.
     let mut vm = Engine::new_base();
@@ -319,7 +319,8 @@ fn test_graph_nested_push_eval() {
     ));
 
     // Generate the module.
-    let module = gantz_core::compile::module(&no_lookup, &gb, &[ep.clone()]).unwrap();
+    let module =
+        gantz_core::compile::module(&no_lookup, &gb, &[ep.clone()], &Default::default()).unwrap();
 
     // Create the VM.
     let mut vm = Engine::new_base();
@@ -436,7 +437,7 @@ fn test_graph_nested_non_sequential_inlets() {
     // Generate the module.
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &gb);
-    let module = gantz_core::compile::module(&no_lookup, &gb, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &gb, &eps, &Default::default()).unwrap();
 
     // Create the VM.
     let mut vm = Engine::new_base();
@@ -513,7 +514,8 @@ fn test_graph_nested_push_through_outlet() {
     ));
 
     // Generate the module.
-    let module = gantz_core::compile::module(&no_lookup, &gb, &[ep.clone()]).unwrap();
+    let module =
+        gantz_core::compile::module(&no_lookup, &gb, &[ep.clone()], &Default::default()).unwrap();
 
     // Create the VM.
     let mut vm = Engine::new_base();
@@ -600,7 +602,8 @@ fn test_graph_nested_multi_outlet() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &outer);
-    let module = gantz_core::compile::module(&no_lookup, &outer, &eps).unwrap();
+    let module =
+        gantz_core::compile::module(&no_lookup, &outer, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -664,7 +667,9 @@ fn test_graph_nested_push_through_outlet_multi() {
         push_n_outputs,
     ));
 
-    let module = gantz_core::compile::module(&no_lookup, &outer, &[ep.clone()]).unwrap();
+    let module =
+        gantz_core::compile::module(&no_lookup, &outer, &[ep.clone()], &Default::default())
+            .unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -730,7 +735,9 @@ fn test_graph_nested_push_through_outlet_deep() {
         push_n_outputs,
     ));
 
-    let module = gantz_core::compile::module(&no_lookup, &outer, &[ep.clone()]).unwrap();
+    let module =
+        gantz_core::compile::module(&no_lookup, &outer, &[ep.clone()], &Default::default())
+            .unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -801,7 +808,8 @@ fn test_push_pull_entrypoints_discovers_nested_push() {
 
     // The generated module should include the entry fn for this entrypoint,
     // and it should work end-to-end (value 42 flows through outlet to number).
-    let module = gantz_core::compile::module(&no_lookup, &outer, &eps).unwrap();
+    let module =
+        gantz_core::compile::module(&no_lookup, &outer, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -878,7 +886,9 @@ fn test_graph_nested_multi_source_outlet_propagation() {
         push_source(vec![graph_b.index(), push_b.index()], push_n_outputs),
     ]);
 
-    let module = gantz_core::compile::module(&no_lookup, &outer, &[ep.clone()]).unwrap();
+    let module =
+        gantz_core::compile::module(&no_lookup, &outer, &[ep.clone()], &Default::default())
+            .unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -952,7 +962,9 @@ fn test_graph_nested_mixed_level_multi_source() {
         push_source(vec![push_outer.index()], push_outer_n),
     ]);
 
-    let module = gantz_core::compile::module(&no_lookup, &outer, &[ep.clone()]).unwrap();
+    let module =
+        gantz_core::compile::module(&no_lookup, &outer, &[ep.clone()], &Default::default())
+            .unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -1036,7 +1048,7 @@ fn compile_and_push<N: DebugNode + ?Sized>(
 ) -> Engine {
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, g);
-    let module = gantz_core::compile::module(&no_lookup, g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, g, &eps, &Default::default()).unwrap();
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
     gantz_core::graph::register(&no_lookup, g, &[], &mut vm);
@@ -1066,7 +1078,8 @@ fn compile_and_push_nested<N: DebugNode + ?Sized>(
     push_n_outputs: u8,
 ) -> Engine {
     let ep = entrypoint::from_source(push_source(path, push_n_outputs));
-    let module = gantz_core::compile::module(&no_lookup, g, &[ep.clone()]).unwrap();
+    let module =
+        gantz_core::compile::module(&no_lookup, g, &[ep.clone()], &Default::default()).unwrap();
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
     gantz_core::graph::register(&no_lookup, g, &[], &mut vm);
@@ -1707,7 +1720,7 @@ fn test_graph_nested_branch_stateful() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
     gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
@@ -2512,7 +2525,8 @@ fn run_two_push<N: DebugNode + ?Sized>(
     b: (Vec<usize>, u8),
 ) -> Engine {
     let ep = entrypoint::from_sources([push_source(a.0, a.1), push_source(b.0, b.1)]);
-    let module = gantz_core::compile::module(&no_lookup, g, &[ep.clone()]).unwrap();
+    let module =
+        gantz_core::compile::module(&no_lookup, g, &[ep.clone()], &Default::default()).unwrap();
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
     gantz_core::graph::register(&no_lookup, g, &[], &mut vm);
@@ -2737,7 +2751,7 @@ fn pd_plus() -> (GraphNode<Box<dyn DebugNode>>, usize) {
 // Compile `g` and register fns, returning a VM ready to be pushed.
 fn compile_only<N: DebugNode + ?Sized>(g: &petgraph::graph::DiGraph<Box<N>, Edge>) -> Engine {
     let eps = push_pull_entrypoints(&no_lookup, g);
-    let module = gantz_core::compile::module(&no_lookup, g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, g, &eps, &Default::default()).unwrap();
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
     gantz_core::graph::register(&no_lookup, g, &[], &mut vm);
@@ -2929,7 +2943,7 @@ fn test_pd_plus_top_level_vs_nested_equivalence() {
 fn test_nested_pd_plus_emits_reduced_variant() {
     let (g, _l, _r, pd, branch_ix, _store) = pd_plus_root(10, 5);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
     let text: String = module
         .iter()
         .map(|f| f.to_pretty(100))

--- a/crates/gantz_core/tests/rust_fn.rs
+++ b/crates/gantz_core/tests/rust_fn.rs
@@ -103,7 +103,7 @@ fn test_stateless_rust_add() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -173,7 +173,7 @@ fn test_stateful_rust_counter() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -248,7 +248,7 @@ fn test_zero_arg_stateless() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -319,7 +319,7 @@ fn test_state_only_fn() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -393,7 +393,7 @@ fn test_stateful_typed_counter() {
 
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
@@ -470,7 +470,7 @@ fn test_closure_with_capture() {
     g.add_edge(exp_ix, aeq_ix, Edge::from((0, 1)));
 
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     let mut vm = Engine::new_base();
     vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());

--- a/crates/gantz_core/tests/state.rs
+++ b/crates/gantz_core/tests/state.rs
@@ -89,7 +89,7 @@ fn test_graph_with_counter() {
     // Generate the module, which should have just one top-level expr for `push`.
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     // Initialise the VM.
     let mut vm = Engine::new_base();
@@ -183,7 +183,7 @@ fn test_graph_with_counters() {
     // Generate the module, which should have one expr for each `push`.
     let ctx = node::MetaCtx::new(&no_lookup);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let module = gantz_core::compile::module(&no_lookup, &g, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
 
     // Initialise the VM.
     let mut vm = Engine::new_base();

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -419,7 +419,7 @@ impl App {
         for (_, graph, _) in &heads {
             let get_node = |ca: &gantz_ca::ContentAddr| env.node(ca);
             let eps = push_pull_entrypoints(&get_node, graph);
-            match gantz_core::vm::init(&get_node, graph, &eps) {
+            match gantz_core::vm::init(&get_node, graph, &eps, &Default::default()) {
                 Ok((vm, module)) => {
                     vms.push(vm);
                     compiled_modules.push(gantz_core::vm::fmt_module(&module));
@@ -489,7 +489,7 @@ impl eframe::App for App {
                 let vm = &mut self.state.vms[ix];
                 let get_node = |ca: &gantz_ca::ContentAddr| self.state.env.node(ca);
                 let eps = push_pull_entrypoints(&get_node, &*graph);
-                match gantz_core::vm::compile(&get_node, &*graph, vm, &eps) {
+                match gantz_core::vm::compile(&get_node, &*graph, vm, &eps, &Default::default()) {
                     Ok(module) => {
                         self.state.compiled_modules[ix] = gantz_core::vm::fmt_module(&module)
                     }
@@ -1348,7 +1348,7 @@ fn open_head(state: &mut State, new_head: gantz_ca::Head) {
     // Initialise the VM for the new graph and add to per-head collections.
     let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
     let eps = push_pull_entrypoints(&get_node, &new_graph);
-    match gantz_core::vm::init(&get_node, &new_graph, &eps) {
+    match gantz_core::vm::init(&get_node, &new_graph, &eps, &Default::default()) {
         Ok((vm, module)) => {
             state.vms.push(vm);
             state
@@ -1391,7 +1391,7 @@ fn replace_head(ctx: &egui::Context, state: &mut State, new_head: gantz_ca::Head
     // Reinitialize the VM for the new graph.
     let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
     let eps = push_pull_entrypoints(&get_node, &new_graph);
-    match gantz_core::vm::init(&get_node, &new_graph, &eps) {
+    match gantz_core::vm::init(&get_node, &new_graph, &eps, &Default::default()) {
         Ok((new_vm, module)) => {
             state.vms[ix] = new_vm;
             state.compiled_modules[ix] = gantz_core::vm::fmt_module(&module);
@@ -1440,7 +1440,7 @@ fn refresh_branch_head(state: &mut State) {
     *views = GraphViews::default();
     let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
     let eps = push_pull_entrypoints(&get_node, &*graph);
-    match gantz_core::vm::init(&get_node, &*graph, &eps) {
+    match gantz_core::vm::init(&get_node, &*graph, &eps, &Default::default()) {
         Ok((new_vm, module)) => {
             state.vms[ix] = new_vm;
             state.compiled_modules[ix] = gantz_core::vm::fmt_module(&module);

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -333,6 +333,8 @@ struct State {
     vms: Vec<Engine>,
     /// Index of the currently focused head.
     focused_head: usize,
+    /// The compile config used for all heads (session-only, not persisted).
+    compile_config: gantz_core::compile::Config,
     logger: gantz_egui::widget::log_view::Logger,
     gantz: gantz_egui::widget::GantzState,
     env: Environment,
@@ -414,12 +416,13 @@ impl App {
         env.registry.prune_unreachable(&required);
 
         // VM setup - initialize a VM for each open head.
+        let compile_config = gantz_core::compile::Config::default();
         let mut vms = Vec::with_capacity(heads.len());
         let mut compiled_modules = Vec::with_capacity(heads.len());
         for (_, graph, _) in &heads {
             let get_node = |ca: &gantz_ca::ContentAddr| env.node(ca);
             let eps = push_pull_entrypoints(&get_node, graph);
-            match gantz_core::vm::init(&get_node, graph, &eps, &Default::default()) {
+            match gantz_core::vm::init(&get_node, graph, &eps, &compile_config) {
                 Ok((vm, module)) => {
                     vms.push(vm);
                     compiled_modules.push(gantz_core::vm::fmt_module(&module));
@@ -445,6 +448,7 @@ impl App {
             compiled_modules,
             vms,
             focused_head: 0,
+            compile_config,
         };
 
         App { state }
@@ -489,7 +493,8 @@ impl eframe::App for App {
                 let vm = &mut self.state.vms[ix];
                 let get_node = |ca: &gantz_ca::ContentAddr| self.state.env.node(ca);
                 let eps = push_pull_entrypoints(&get_node, &*graph);
-                match gantz_core::vm::compile(&get_node, &*graph, vm, &eps, &Default::default()) {
+                let config = &self.state.compile_config;
+                match gantz_core::vm::compile(&get_node, &*graph, vm, &eps, config) {
                     Ok(module) => {
                         self.state.compiled_modules[ix] = gantz_core::vm::fmt_module(&module)
                     }
@@ -1192,6 +1197,7 @@ fn create_node(
 }
 
 fn gui(ctx: &egui::Context, state: &mut State) {
+    let compile_config = state.compile_config;
     let response = egui::containers::CentralPanel::default()
         .frame(egui::Frame::default())
         .show(ctx, |ui| {
@@ -1202,6 +1208,7 @@ fn gui(ctx: &egui::Context, state: &mut State) {
             let no_base_names = Default::default();
             gantz_egui::widget::Gantz::new(&state.env, &no_base_names)
                 .logger(state.logger.clone())
+                .compile_config(compile_config)
                 .show(&mut state.gantz, state.focused_head, &mut access, ui)
         })
         .inner;
@@ -1270,6 +1277,12 @@ fn gui(ctx: &egui::Context, state: &mut State) {
     for drop in response.file_drops {
         let open_head = drop.target == gantz_egui::widget::gantz::FileDropTarget::GraphScene;
         import_bytes(state, drop.bytes, open_head);
+    }
+
+    // Handle compile config change: recompile all open heads.
+    if let Some(cfg) = response.compile_config {
+        state.compile_config = cfg;
+        recompile_heads(state);
     }
 }
 
@@ -1348,7 +1361,7 @@ fn open_head(state: &mut State, new_head: gantz_ca::Head) {
     // Initialise the VM for the new graph and add to per-head collections.
     let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
     let eps = push_pull_entrypoints(&get_node, &new_graph);
-    match gantz_core::vm::init(&get_node, &new_graph, &eps, &Default::default()) {
+    match gantz_core::vm::init(&get_node, &new_graph, &eps, &state.compile_config) {
         Ok((vm, module)) => {
             state.vms.push(vm);
             state
@@ -1391,7 +1404,7 @@ fn replace_head(ctx: &egui::Context, state: &mut State, new_head: gantz_ca::Head
     // Reinitialize the VM for the new graph.
     let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
     let eps = push_pull_entrypoints(&get_node, &new_graph);
-    match gantz_core::vm::init(&get_node, &new_graph, &eps, &Default::default()) {
+    match gantz_core::vm::init(&get_node, &new_graph, &eps, &state.compile_config) {
         Ok((new_vm, module)) => {
             state.vms[ix] = new_vm;
             state.compiled_modules[ix] = gantz_core::vm::fmt_module(&module);
@@ -1440,13 +1453,37 @@ fn refresh_branch_head(state: &mut State) {
     *views = GraphViews::default();
     let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
     let eps = push_pull_entrypoints(&get_node, &*graph);
-    match gantz_core::vm::init(&get_node, &*graph, &eps, &Default::default()) {
+    match gantz_core::vm::init(&get_node, &*graph, &eps, &state.compile_config) {
         Ok((new_vm, module)) => {
             state.vms[ix] = new_vm;
             state.compiled_modules[ix] = gantz_core::vm::fmt_module(&module);
         }
         Err(e) => {
             log::error!("Failed to init VM for branch head refresh: {e}");
+        }
+    }
+}
+
+/// Recompile every open head's graph into its existing VM (no commit).
+///
+/// Used when the compile config changes: the graph content is unchanged, and
+/// compiling into the existing VM preserves node state.
+fn recompile_heads(state: &mut State) {
+    for (ix, (_, graph, _)) in state.heads.iter().enumerate() {
+        let vm = &mut state.vms[ix];
+        let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
+        gantz_core::graph::register(&get_node, graph, &[], vm);
+        let eps = push_pull_entrypoints(&get_node, graph);
+        match gantz_core::vm::compile(&get_node, graph, vm, &eps, &state.compile_config) {
+            Ok(module) => {
+                state.compiled_modules[ix] = gantz_core::vm::fmt_module(&module);
+            }
+            Err(e) => {
+                log::error!(
+                    "Failed to compile graph: {}",
+                    gantz_core::vm::error_chain(&e)
+                );
+            }
         }
     }
 }

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -58,6 +58,7 @@ pub struct Gantz<'a> {
     perf_vm: Option<&'a mut widget::PerfCapture>,
     perf_gui: Option<&'a mut widget::PerfCapture>,
     base_immutable: bool,
+    compile_config: Option<gantz_core::compile::Config>,
 }
 
 enum LogSource {
@@ -201,6 +202,8 @@ pub struct GantzResponse {
     pub demo_changed: Option<(gantz_ca::Head, Option<String>)>,
     /// A base graph should be reset to its original state.
     pub reset_base_graph: Option<gantz_ca::Head>,
+    /// The global compile config was changed via the Graph Config pane.
+    pub compile_config: Option<gantz_core::compile::Config>,
 }
 
 /// State for editing a tab name via double-click.
@@ -295,12 +298,21 @@ impl<'a> Gantz<'a> {
             perf_vm: None,
             perf_gui: None,
             base_immutable: true,
+            compile_config: None,
         }
     }
 
     /// Provide demo graph associations for the config dropdown.
     pub fn demos(mut self, demos: &'a HashMap<gantz_ca::CommitAddr, String>) -> Self {
         self.demos = Some(demos);
+        self
+    }
+
+    /// Provide the current compile config so the Graph Config pane shows
+    /// the compile toggles. The config is global: it applies to all open
+    /// heads, and a change is reported via [`GantzResponse::compile_config`].
+    pub fn compile_config(mut self, config: gantz_core::compile::Config) -> Self {
+        self.compile_config = Some(config);
         self
     }
 
@@ -391,6 +403,7 @@ impl<'a> Gantz<'a> {
             file_drops: Vec::new(),
             demo_changed: None,
             reset_base_graph: None,
+            compile_config: None,
         };
 
         // The context for traversing the tree of tiles.
@@ -559,13 +572,17 @@ where
                         _ => None,
                     };
 
+                    let compile_config = gantz.compile_config;
                     let res = pane_ui(ui, |ui| {
-                        widget::GraphConfig::new(&head, head_state, names)
+                        let mut graph_config = widget::GraphConfig::new(&head, head_state, names)
                             .is_base(is_base)
                             .immutable(immutable)
                             .demo_names(&demo_names_vec)
-                            .current_demo(current_demo)
-                            .show(ui)
+                            .current_demo(current_demo);
+                        if let Some(cfg) = compile_config {
+                            graph_config = graph_config.compile_config(cfg);
+                        }
+                        graph_config.show(ui)
                     });
                     if res.inner.new_branch.is_some() {
                         gantz_response.new_branch = res.inner.new_branch;
@@ -575,6 +592,9 @@ where
                     }
                     if res.inner.reset_base_graph {
                         gantz_response.reset_base_graph = Some(head.clone());
+                    }
+                    if let Some(cfg) = res.inner.compile_config {
+                        gantz_response.compile_config = Some(cfg);
                     }
                     if res.inner.export {
                         let head_state = state.open_heads.entry(head).or_default();

--- a/crates/gantz_egui/src/widget/graph_config.rs
+++ b/crates/gantz_egui/src/widget/graph_config.rs
@@ -5,8 +5,9 @@ use super::head_name_edit::{head_name, head_name_edit};
 
 /// Per-head graph configuration widget.
 ///
-/// Provides a name-editing text field and layout settings
-/// (`auto_layout`, `layout_flow`, `center_view`).
+/// Provides a name-editing text field, layout settings
+/// (`auto_layout`, `layout_flow`, `center_view`) and the global compile
+/// config toggles.
 pub struct GraphConfig<'a> {
     head: &'a gantz_ca::Head,
     head_state: &'a mut OpenHeadState,
@@ -15,6 +16,7 @@ pub struct GraphConfig<'a> {
     immutable: bool,
     demo_names: &'a [&'a str],
     current_demo: Option<&'a str>,
+    compile_config: Option<gantz_core::compile::Config>,
 }
 
 /// Response from the [`GraphConfig`] widget.
@@ -27,6 +29,8 @@ pub struct GraphConfigResponse {
     pub demo_changed: Option<Option<String>>,
     /// The "Reset" button was clicked for a base graph.
     pub reset_base_graph: bool,
+    /// The global compile config was changed via the compile toggles.
+    pub compile_config: Option<gantz_core::compile::Config>,
 }
 
 impl<'a> GraphConfig<'a> {
@@ -43,6 +47,7 @@ impl<'a> GraphConfig<'a> {
             immutable: false,
             demo_names: &[],
             current_demo: None,
+            compile_config: None,
         }
     }
 
@@ -70,6 +75,15 @@ impl<'a> GraphConfig<'a> {
     /// The current demo graph association for this graph, if any.
     pub fn current_demo(mut self, current_demo: Option<&'a str>) -> Self {
         self.current_demo = current_demo;
+        self
+    }
+
+    /// Provide the current compile config to show the "Compile" toggles.
+    ///
+    /// The config is global - it applies to all open heads - so the section
+    /// is shown (and enabled) even for immutable/base heads.
+    pub fn compile_config(mut self, config: gantz_core::compile::Config) -> Self {
+        self.compile_config = Some(config);
         self
     }
 
@@ -159,12 +173,44 @@ impl<'a> GraphConfig<'a> {
             });
         });
 
+        // Compile config toggles. Global - applies to all open heads - so
+        // intentionally not gated by `self.immutable`.
+        let mut compile_config = None;
+        if let Some(mut cfg) = self.compile_config {
+            ui.separator();
+            ui.label("Compile:");
+            let mut changed = false;
+            changed |= ui
+                .checkbox(&mut cfg.validate_ir, "Validate IR")
+                .on_hover_text(
+                    "Check the compiler's own IR invariants on every \
+                     lowering. A violation is a bug in gantz, never in your \
+                     graph. Disable as an optimisation. Applies to all open \
+                     graphs.",
+                )
+                .changed();
+            changed |= ui
+                .checkbox(&mut cfg.emit_all_node_fns, "Emit all node fns")
+                .on_hover_text(
+                    "Emit a node fn for every node, rather than only those \
+                     called by some evaluation, so any node's generated code \
+                     can be inspected in the Steel view. The extra \
+                     definitions are never called and do not affect \
+                     evaluation. Applies to all open graphs.",
+                )
+                .changed();
+            if changed {
+                compile_config = Some(cfg);
+            }
+        }
+
         let export = ui.button("Export").clicked();
         GraphConfigResponse {
             new_branch,
             export,
             demo_changed,
             reset_base_graph,
+            compile_config,
         }
     }
 }


### PR DESCRIPTION
Add `compile::Config` as an input to `compile::module` and `vm::{init, compile}`:

- `validate_ir` (on by default): toggles the per-lowering `ir::validate` pass. Disable as an optimisation, at the cost of an internal compiler error surfacing downstream (e.g. as a confusing Steel evaluation error) instead of at lowering with a diagnosis.
- `emit_all_node_fns` (off by default): node fns are normally emitted on demand, only for the variants some lowered evaluation calls, so an uncalled node produces no code at all. Enabling emits every node's all-connected variant so its codegen can be inspected (e.g. in the app's module view) before anything calls it. The extra definitions are never called and do not affect evaluation.

bevy_gantz threads the config through head VM init/recompile via a new `CompileConfig` resource, defaulting to the core defaults.

Closes #225 