### PR TITLE
feat: map compiled steel back to graph nodes (source map, diagnostics, span highlighting)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,6 +2990,7 @@ dependencies = [
  "gantz_ca",
  "gantz_core",
  "log",
+ "petgraph",
  "serde",
  "steel-core",
  "steel-derive",

--- a/crates/bevy_gantz/src/head.rs
+++ b/crates/bevy_gantz/src/head.rs
@@ -28,6 +28,8 @@ pub struct OpenHeadData<N: 'static + Send + Sync> {
     pub head_ref: &'static mut HeadRef,
     pub working_graph: &'static mut WorkingGraph<N>,
     pub compiled: &'static mut CompiledModule,
+    pub module: &'static mut Module,
+    pub diagnostics: &'static mut Diagnostics,
 }
 
 // ----------------------------------------------------------------------------
@@ -46,9 +48,23 @@ pub struct HeadRef(pub ca::Head);
 #[derive(Component)]
 pub struct WorkingGraph<N>(pub gantz_core::node::graph::Graph<N>);
 
-/// The compiled Steel module for this head (as a string).
+/// The compiled Steel module for this head as displayable text (the module
+/// source, or commented error text when compilation failed).
 #[derive(Component, Default, Clone)]
 pub struct CompiledModule(pub String);
+
+/// The latest generated module artifact (source text + source map), kept for
+/// error-span and node-span resolution. `None` when module generation
+/// failed outright.
+#[derive(Component, Default)]
+pub struct Module(pub Option<gantz_core::vm::Compiled>);
+
+/// Diagnostics from the head's latest compile and entrypoint evaluations.
+///
+/// Compile diagnostics are replaced wholesale on every (re)compile; runtime
+/// diagnostics are replaced per evaluation and cleared on success.
+#[derive(Component, Default)]
+pub struct Diagnostics(pub Vec<gantz_core::Diagnostic>);
 
 // ----------------------------------------------------------------------------
 // Events

--- a/crates/bevy_gantz/src/head.rs
+++ b/crates/bevy_gantz/src/head.rs
@@ -27,7 +27,6 @@ pub struct OpenHeadData<N: 'static + Send + Sync> {
     pub entity: Entity,
     pub head_ref: &'static mut HeadRef,
     pub working_graph: &'static mut WorkingGraph<N>,
-    pub compiled: &'static mut CompiledModule,
     pub module: &'static mut Module,
     pub diagnostics: &'static mut Diagnostics,
 }
@@ -48,16 +47,19 @@ pub struct HeadRef(pub ca::Head);
 #[derive(Component)]
 pub struct WorkingGraph<N>(pub gantz_core::node::graph::Graph<N>);
 
-/// The compiled Steel module for this head as displayable text (the module
-/// source, or commented error text when compilation failed).
-#[derive(Component, Default, Clone)]
-pub struct CompiledModule(pub String);
-
-/// The latest generated module artifact (source text + source map), kept for
-/// error-span and node-span resolution. `None` when module generation
-/// failed outright.
+/// The latest compile outcome for this head.
+///
+/// `compiled` is kept even when steel rejected the generated module, so its
+/// source remains displayable and error spans resolvable; it is `None` only
+/// when module generation itself failed. Both fields can be present (a
+/// generated module that failed evaluation).
 #[derive(Component, Default)]
-pub struct Module(pub Option<gantz_core::vm::Compiled>);
+pub struct Module {
+    /// The module artifact: source text + source map.
+    pub compiled: Option<gantz_core::vm::Compiled>,
+    /// The rendered error chain from a failed compile.
+    pub error: Option<String>,
+}
 
 /// Diagnostics from the head's latest compile and entrypoint evaluations.
 ///
@@ -190,13 +192,6 @@ impl<N> DerefMut for WorkingGraph<N> {
     }
 }
 
-impl Deref for CompiledModule {
-    type Target = str;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 impl Deref for HeadVms {
     type Target = HashMap<Entity, Engine>;
     fn deref(&self) -> &Self::Target {
@@ -291,7 +286,7 @@ pub fn on_open<N>(
         return;
     };
 
-    // Spawn entity (NO CompiledModule - app observer adds it after VM init).
+    // Spawn entity (NO Module/Diagnostics - app observer adds them after VM init).
     // Note: HeadGuiState and GraphViews are added by GantzEguiPlugin observer.
     let entity = cmds
         .spawn((OpenHead, HeadRef(new_head.clone()), WorkingGraph(graph)))
@@ -336,7 +331,7 @@ pub fn on_replace<N>(
         return;
     };
 
-    // Update entity components (NO CompiledModule - app observer adds it).
+    // Update entity components (NO Module/Diagnostics - app observer adds them).
     // Note: HeadGuiState and GraphViews are updated by GantzEguiPlugin observer.
     cmds.entity(focused_entity)
         .insert(HeadRef(new_head.clone()))

--- a/crates/bevy_gantz/src/lib.rs
+++ b/crates/bevy_gantz/src/lib.rs
@@ -17,8 +17,8 @@ use bevy_ecs::prelude::{
 pub use builtin::{BuiltinNodes, Builtins};
 use gantz_core::Node;
 pub use head::{
-    CompiledModule, FocusedHead, HeadRef, HeadTabOrder, HeadVms, OpenHead, OpenHeadData,
-    OpenHeadDataReadOnly, WorkingGraph,
+    FocusedHead, HeadRef, HeadTabOrder, HeadVms, OpenHead, OpenHeadData, OpenHeadDataReadOnly,
+    WorkingGraph,
 };
 pub use reg::{Registry, lookup_node, timestamp};
 pub use vm::{CompileConfig, EntrypointFns, EvalEntryComplete, EvalEntryEvent};

--- a/crates/bevy_gantz/src/vm.rs
+++ b/crates/bevy_gantz/src/vm.rs
@@ -13,40 +13,33 @@ use bevy_ecs::prelude::*;
 use bevy_log as log;
 use gantz_ca as ca;
 use gantz_core::node::{self, GetNode, graph::Graph};
-use gantz_core::vm::{Compiled, CompileError, compile_error_text};
+use gantz_core::vm::{Compiled, CompileError};
 use gantz_core::{Node, compile as core_compile, diagnostic};
 use std::time::Duration;
 use steel::steel_vm::engine::Engine;
 
-/// The component updates for one compile attempt: the displayable module
-/// text, the module artifact for span resolution, and the extracted compile
-/// diagnostics.
+/// The component updates for one compile attempt: the module/error outcome
+/// and the extracted compile diagnostics.
 fn compile_components(
     result: Result<Compiled, CompileError>,
-) -> (head::CompiledModule, head::Module, head::Diagnostics) {
+) -> (head::Module, head::Diagnostics) {
     match result {
         Ok(module) => (
-            head::CompiledModule(module.src.clone()),
-            head::Module(Some(module)),
+            head::Module {
+                compiled: Some(module),
+                error: None,
+            },
             head::Diagnostics(vec![]),
         ),
         Err(e) => {
-            log::error!(
-                "Failed to compile graph: {}",
-                gantz_core::vm::error_chain(&e)
-            );
-            let text = compile_error_text(&e);
+            let error = gantz_core::vm::error_chain(&e);
+            log::error!("Failed to compile graph: {error}");
             let diags = diagnostic::from_compile_error(&e);
-            // A module that failed evaluation still resolves spans.
-            let module = match e {
-                CompileError::Eval { module, .. } => Some(*module),
-                CompileError::Module(_) => None,
+            let module = head::Module {
+                compiled: e.into_module(),
+                error: Some(error),
             };
-            (
-                head::CompiledModule(text),
-                head::Module(module),
-                head::Diagnostics(diags),
-            )
+            (module, head::Diagnostics(diags))
         }
     }
 }
@@ -251,7 +244,7 @@ pub fn on_eval_entry(
             diagnostics
                 .0
                 .retain(|d| d.severity != diagnostic::Severity::Runtime);
-            if let (Err(e), Some(compiled)) = (&result, &module.0) {
+            if let (Err(e), Some(compiled)) = (&result, &module.compiled) {
                 diagnostics.0.push(diagnostic::from_eval_error(e, vm, compiled));
             }
         }
@@ -366,8 +359,7 @@ pub fn update<N>(
                 // leaving the prior module displayed, which would
                 // misleadingly look up-to-date.
                 let result = compile(&get_node, graph, vm, &entrypoints, &config.0);
-                let (compiled, module, diagnostics) = compile_components(result);
-                *data.compiled = compiled;
+                let (module, diagnostics) = compile_components(result);
                 *data.module = module;
                 *data.diagnostics = diagnostics;
             }
@@ -399,8 +391,7 @@ pub fn recompile_all<N>(
         gantz_core::graph::register(&get_node, graph, &[], vm);
         let entrypoints = collect_entrypoints(&ep_fns, &get_node, graph);
         let result = compile(&get_node, graph, vm, &entrypoints, &config.0);
-        let (compiled, module, diagnostics) = compile_components(result);
-        *data.compiled = compiled;
+        let (module, diagnostics) = compile_components(result);
         *data.module = module;
         *data.diagnostics = diagnostics;
     }

--- a/crates/bevy_gantz/src/vm.rs
+++ b/crates/bevy_gantz/src/vm.rs
@@ -13,16 +13,14 @@ use bevy_ecs::prelude::*;
 use bevy_log as log;
 use gantz_ca as ca;
 use gantz_core::node::{self, GetNode, graph::Graph};
-use gantz_core::vm::{Compiled, CompileError};
+use gantz_core::vm::{CompileError, Compiled};
 use gantz_core::{Node, compile as core_compile, diagnostic};
 use std::time::Duration;
 use steel::steel_vm::engine::Engine;
 
 /// The component updates for one compile attempt: the module/error outcome
 /// and the extracted compile diagnostics.
-fn compile_components(
-    result: Result<Compiled, CompileError>,
-) -> (head::Module, head::Diagnostics) {
+fn compile_components(result: Result<Compiled, CompileError>) -> (head::Module, head::Diagnostics) {
     match result {
         Ok(module) => (
             head::Module {
@@ -245,7 +243,9 @@ pub fn on_eval_entry(
                 .0
                 .retain(|d| d.severity != diagnostic::Severity::Runtime);
             if let (Err(e), Some(compiled)) = (&result, &module.compiled) {
-                diagnostics.0.push(diagnostic::from_eval_error(e, vm, compiled));
+                diagnostics
+                    .0
+                    .push(diagnostic::from_eval_error(e, vm, compiled));
             }
         }
         if let Err(e) = result {
@@ -298,7 +298,9 @@ where
     }
 
     for (entity, module) in compiled_updates {
-        world.entity_mut(entity).insert(compile_components(Ok(module)));
+        world
+            .entity_mut(entity)
+            .insert(compile_components(Ok(module)));
     }
 
     world.insert_non_send_resource(vms);

--- a/crates/bevy_gantz/src/vm.rs
+++ b/crates/bevy_gantz/src/vm.rs
@@ -13,27 +13,41 @@ use bevy_ecs::prelude::*;
 use bevy_log as log;
 use gantz_ca as ca;
 use gantz_core::node::{self, GetNode, graph::Graph};
-use gantz_core::vm::{Compiled, CompileError};
-use gantz_core::{Node, compile as core_compile};
+use gantz_core::vm::{Compiled, CompileError, compile_error_text};
+use gantz_core::{Node, compile as core_compile, diagnostic};
 use std::time::Duration;
 use steel::steel_vm::engine::Engine;
 
-/// Render a compile error - with its full `source()` cause chain - as Steel
-/// comment lines for the module view, so the underlying cause (e.g. a
-/// feedback-loop error) is visible instead of a bare "module generation failed".
-///
-/// When the module itself was generated but failed evaluation, its real
-/// source follows the comment so the error span context remains visible.
-fn compile_error_text(err: &CompileError) -> String {
-    let body: String = gantz_core::vm::error_chain(err)
-        .lines()
-        .map(|line| format!("; {line}"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let comment = format!("; failed to compile graph:\n{body}");
-    match err {
-        CompileError::Eval { module, .. } => format!("{comment}\n\n{}", module.src),
-        CompileError::Module(_) => comment,
+/// The component updates for one compile attempt: the displayable module
+/// text, the module artifact for span resolution, and the extracted compile
+/// diagnostics.
+fn compile_components(
+    result: Result<Compiled, CompileError>,
+) -> (head::CompiledModule, head::Module, head::Diagnostics) {
+    match result {
+        Ok(module) => (
+            head::CompiledModule(module.src.clone()),
+            head::Module(Some(module)),
+            head::Diagnostics(vec![]),
+        ),
+        Err(e) => {
+            log::error!(
+                "Failed to compile graph: {}",
+                gantz_core::vm::error_chain(&e)
+            );
+            let text = compile_error_text(&e);
+            let diags = diagnostic::from_compile_error(&e);
+            // A module that failed evaluation still resolves spans.
+            let module = match e {
+                CompileError::Eval { module, .. } => Some(*module),
+                CompileError::Module(_) => None,
+            };
+            (
+                head::CompiledModule(text),
+                head::Module(module),
+                head::Diagnostics(diags),
+            )
+        }
     }
 }
 
@@ -151,26 +165,21 @@ fn init_head_vm<N>(
     let graph = graphs.get(entity).unwrap();
     let get_node = |ca: &ca::ContentAddr| lookup_node(registry, &**builtins, ca);
     let entrypoints = collect_entrypoints(ep_fns, &get_node, &**graph);
-    let (vm, module) = match init(&get_node, &**graph, &entrypoints, &config.0) {
-        Ok(result) => result,
+    match init(&get_node, &**graph, &entrypoints, &config.0) {
+        Ok((vm, module)) => {
+            cmds.entity(entity).insert(compile_components(Ok(module)));
+            vms.insert(entity, vm);
+        }
         Err(e) => {
-            log::error!(
-                "Failed to init VM for head: {}",
-                gantz_core::vm::error_chain(&e)
-            );
             // Don't leave a stale VM/module from a previously-active graph in
             // place: surface the error in the compiled module and drop the VM so
             // eval systems (e.g. `drive_frame_bangs`, `on_eval_entry`) stop
             // driving the wrong graph - which otherwise manifests as a confusing
             // "free identifier: entry-fn-..." against an unrelated module.
-            cmds.entity(entity)
-                .insert(head::CompiledModule(compile_error_text(&e)));
+            cmds.entity(entity).insert(compile_components(Err(e)));
             vms.remove(&entity);
-            return;
         }
-    };
-    cmds.entity(entity).insert(head::CompiledModule(module.src));
-    vms.insert(entity, vm);
+    }
 }
 
 /// VM init for opened heads.
@@ -230,12 +239,23 @@ pub fn on_eval_entry(
     trigger: On<EvalEntryEvent>,
     mut vms: NonSendMut<head::HeadVms>,
     mut cmds: Commands,
+    mut heads: Query<(&head::Module, &mut head::Diagnostics)>,
 ) {
     let event = trigger.event();
     let fn_name = core_compile::entry_fn_name(&event.entrypoint.id());
     if let Some(vm) = vms.get_mut(&event.head) {
         let start = web_time::Instant::now();
-        if let Err(e) = vm.call_function_by_name_with_args(&fn_name, vec![]) {
+        let result = vm.call_function_by_name_with_args(&fn_name, vec![]);
+        // Runtime diagnostics reflect the latest evaluation only.
+        if let Ok((module, mut diagnostics)) = heads.get_mut(event.head) {
+            diagnostics
+                .0
+                .retain(|d| d.severity != diagnostic::Severity::Runtime);
+            if let (Err(e), Some(compiled)) = (&result, &module.0) {
+                diagnostics.0.push(diagnostic::from_eval_error(e, vm, compiled));
+            }
+        }
+        if let Err(e) = result {
             log::error!("{e}");
         }
         cmds.trigger(EvalEntryComplete {
@@ -262,7 +282,7 @@ where
         .collect();
 
     let mut vms = head::HeadVms::default();
-    let mut compiled_updates: Vec<(Entity, String)> = vec![];
+    let mut compiled_updates: Vec<(Entity, Compiled)> = vec![];
     for entity in entities {
         let registry = world.resource::<Registry<N>>();
         let builtins = world.resource::<BuiltinNodes<N>>();
@@ -281,13 +301,11 @@ where
             }
         };
         vms.insert(entity, vm);
-        compiled_updates.push((entity, module.src));
+        compiled_updates.push((entity, module));
     }
 
-    for (entity, compiled_module) in compiled_updates {
-        if let Some(mut compiled) = world.get_mut::<head::CompiledModule>(entity) {
-            *compiled = head::CompiledModule(compiled_module);
-        }
+    for (entity, module) in compiled_updates {
+        world.entity_mut(entity).insert(compile_components(Ok(module)));
     }
 
     world.insert_non_send_resource(vms);
@@ -344,18 +362,14 @@ pub fn update<N>(
                 let get_node = |ca: &ca::ContentAddr| lookup_node(&registry, &**builtins, ca);
                 gantz_core::graph::register(&get_node, graph, &[], vm);
                 let entrypoints = collect_entrypoints(&ep_fns, &get_node, graph);
-                match compile(&get_node, graph, vm, &entrypoints, &config.0) {
-                    Ok(module) => data.compiled.0 = module.src,
-                    Err(e) => {
-                        log::error!(
-                            "Failed to compile graph: {}",
-                            gantz_core::vm::error_chain(&e)
-                        );
-                        // Surface the error rather than leaving the prior module
-                        // displayed, which would misleadingly look up-to-date.
-                        data.compiled.0 = compile_error_text(&e);
-                    }
-                }
+                // On error this surfaces commented error text rather than
+                // leaving the prior module displayed, which would
+                // misleadingly look up-to-date.
+                let result = compile(&get_node, graph, vm, &entrypoints, &config.0);
+                let (compiled, module, diagnostics) = compile_components(result);
+                *data.compiled = compiled;
+                *data.module = module;
+                *data.diagnostics = diagnostics;
             }
         }
     }
@@ -384,15 +398,10 @@ pub fn recompile_all<N>(
         let get_node = |ca: &ca::ContentAddr| lookup_node(&registry, &**builtins, ca);
         gantz_core::graph::register(&get_node, graph, &[], vm);
         let entrypoints = collect_entrypoints(&ep_fns, &get_node, graph);
-        match compile(&get_node, graph, vm, &entrypoints, &config.0) {
-            Ok(module) => data.compiled.0 = module.src,
-            Err(e) => {
-                log::error!(
-                    "Failed to compile graph: {}",
-                    gantz_core::vm::error_chain(&e)
-                );
-                data.compiled.0 = compile_error_text(&e);
-            }
-        }
+        let result = compile(&get_node, graph, vm, &entrypoints, &config.0);
+        let (compiled, module, diagnostics) = compile_components(result);
+        *data.compiled = compiled;
+        *data.module = module;
+        *data.diagnostics = diagnostics;
     }
 }

--- a/crates/bevy_gantz/src/vm.rs
+++ b/crates/bevy_gantz/src/vm.rs
@@ -13,7 +13,7 @@ use bevy_ecs::prelude::*;
 use bevy_log as log;
 use gantz_ca as ca;
 use gantz_core::node::{self, GetNode, graph::Graph};
-use gantz_core::vm::CompileError;
+use gantz_core::vm::{Compiled, CompileError};
 use gantz_core::{Node, compile as core_compile};
 use std::time::Duration;
 use steel::steel_vm::engine::Engine;
@@ -21,13 +21,20 @@ use steel::steel_vm::engine::Engine;
 /// Render a compile error - with its full `source()` cause chain - as Steel
 /// comment lines for the module view, so the underlying cause (e.g. a
 /// feedback-loop error) is visible instead of a bare "module generation failed".
-fn compile_error_comment(err: &CompileError) -> String {
+///
+/// When the module itself was generated but failed evaluation, its real
+/// source follows the comment so the error span context remains visible.
+fn compile_error_text(err: &CompileError) -> String {
     let body: String = gantz_core::vm::error_chain(err)
         .lines()
         .map(|line| format!("; {line}"))
         .collect::<Vec<_>>()
         .join("\n");
-    format!("; failed to compile graph:\n{body}")
+    let comment = format!("; failed to compile graph:\n{body}");
+    match err {
+        CompileError::Eval { module, .. } => format!("{comment}\n\n{}", module.src),
+        CompileError::Module(_) => comment,
+    }
 }
 
 /// A function that produces entrypoints for a given graph.
@@ -97,35 +104,31 @@ pub struct EvalEntryComplete {
 
 /// Initialize a new VM with root state and register the given graph.
 ///
-/// Returns the initialized VM and the compiled module as a formatted string.
+/// Returns the initialized VM and the compiled module.
 pub fn init<N>(
     get_node: GetNode,
     graph: &Graph<N>,
     entrypoints: &[core_compile::Entrypoint],
     config: &core_compile::Config,
-) -> Result<(Engine, String), CompileError>
+) -> Result<(Engine, Compiled), CompileError>
 where
     N: Node,
 {
-    let (vm, module) = gantz_core::vm::init(get_node, graph, entrypoints, config)?;
-    Ok((vm, gantz_core::vm::fmt_module(&module)))
+    gantz_core::vm::init(get_node, graph, entrypoints, config)
 }
 
 /// Compile the graph into a Steel module and run it in the VM.
-///
-/// Returns the compiled module as a formatted string.
 pub fn compile<N>(
     get_node: GetNode,
     graph: &Graph<N>,
     vm: &mut Engine,
     entrypoints: &[core_compile::Entrypoint],
     config: &core_compile::Config,
-) -> Result<String, CompileError>
+) -> Result<Compiled, CompileError>
 where
     N: Node,
 {
-    let module = gantz_core::vm::compile(get_node, graph, vm, entrypoints, config)?;
-    Ok(gantz_core::vm::fmt_module(&module))
+    gantz_core::vm::compile(get_node, graph, vm, entrypoints, config)
 }
 
 // ---------------------------------------------------------------------------
@@ -161,12 +164,12 @@ fn init_head_vm<N>(
             // driving the wrong graph - which otherwise manifests as a confusing
             // "free identifier: entry-fn-..." against an unrelated module.
             cmds.entity(entity)
-                .insert(head::CompiledModule(compile_error_comment(&e)));
+                .insert(head::CompiledModule(compile_error_text(&e)));
             vms.remove(&entity);
             return;
         }
     };
-    cmds.entity(entity).insert(head::CompiledModule(module));
+    cmds.entity(entity).insert(head::CompiledModule(module.src));
     vms.insert(entity, vm);
 }
 
@@ -278,7 +281,7 @@ where
             }
         };
         vms.insert(entity, vm);
-        compiled_updates.push((entity, module));
+        compiled_updates.push((entity, module.src));
     }
 
     for (entity, compiled_module) in compiled_updates {
@@ -342,7 +345,7 @@ pub fn update<N>(
                 gantz_core::graph::register(&get_node, graph, &[], vm);
                 let entrypoints = collect_entrypoints(&ep_fns, &get_node, graph);
                 match compile(&get_node, graph, vm, &entrypoints, &config.0) {
-                    Ok(module) => data.compiled.0 = module,
+                    Ok(module) => data.compiled.0 = module.src,
                     Err(e) => {
                         log::error!(
                             "Failed to compile graph: {}",
@@ -350,7 +353,7 @@ pub fn update<N>(
                         );
                         // Surface the error rather than leaving the prior module
                         // displayed, which would misleadingly look up-to-date.
-                        data.compiled.0 = compile_error_comment(&e);
+                        data.compiled.0 = compile_error_text(&e);
                     }
                 }
             }
@@ -382,13 +385,13 @@ pub fn recompile_all<N>(
         gantz_core::graph::register(&get_node, graph, &[], vm);
         let entrypoints = collect_entrypoints(&ep_fns, &get_node, graph);
         match compile(&get_node, graph, vm, &entrypoints, &config.0) {
-            Ok(module) => data.compiled.0 = module,
+            Ok(module) => data.compiled.0 = module.src,
             Err(e) => {
                 log::error!(
                     "Failed to compile graph: {}",
                     gantz_core::vm::error_chain(&e)
                 );
-                data.compiled.0 = compile_error_comment(&e);
+                data.compiled.0 = compile_error_text(&e);
             }
         }
     }

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -372,16 +372,16 @@ impl<N: 'static + Send + Sync> gantz_egui::HeadAccess for HeadAccess<'_, '_, '_,
         }))
     }
 
-    fn compiled_module(&self, head: &ca::Head) -> Option<&str> {
-        let entity = *self.head_to_entity.get(head)?;
-        let data = self.query.get(entity).ok()?;
-        Some(&*data.core.compiled)
-    }
-
     fn module(&self, head: &ca::Head) -> Option<&gantz_core::vm::Compiled> {
         let entity = *self.head_to_entity.get(head)?;
         let data = self.query.get(entity).ok()?;
-        data.core.module.0.as_ref()
+        data.core.module.compiled.as_ref()
+    }
+
+    fn compile_error(&self, head: &ca::Head) -> Option<&str> {
+        let entity = *self.head_to_entity.get(head)?;
+        let data = self.query.get(entity).ok()?;
+        data.core.module.error.as_deref()
     }
 
     fn diagnostics(&self, head: &ca::Head) -> &[gantz_core::Diagnostic] {

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -377,6 +377,22 @@ impl<N: 'static + Send + Sync> gantz_egui::HeadAccess for HeadAccess<'_, '_, '_,
         let data = self.query.get(entity).ok()?;
         Some(&*data.core.compiled)
     }
+
+    fn module(&self, head: &ca::Head) -> Option<&gantz_core::vm::Compiled> {
+        let entity = *self.head_to_entity.get(head)?;
+        let data = self.query.get(entity).ok()?;
+        data.core.module.0.as_ref()
+    }
+
+    fn diagnostics(&self, head: &ca::Head) -> &[gantz_core::Diagnostic] {
+        let Some(&entity) = self.head_to_entity.get(head) else {
+            return &[];
+        };
+        let Ok(data) = self.query.get(entity) else {
+            return &[];
+        };
+        &data.core.diagnostics.0
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/gantz/src/main.rs
+++ b/crates/gantz/src/main.rs
@@ -7,7 +7,7 @@ use bevy_gantz::{
     BuiltinNodes, CompiledModule, FocusedHead, GantzPlugin, HeadRef, HeadTabOrder, OpenHead,
     OpenHeadDataReadOnly, Registry, WorkingGraph,
     debounced_input::{DebouncedInputEvent, DebouncedInputPlugin},
-    reg, timestamp, vm,
+    head, reg, timestamp, vm,
 };
 use bevy_gantz_egui::{GantzEguiPlugin, GuiState, HeadGuiState, TraceCapture, Views};
 use bevy_pkv::PkvStore;
@@ -116,6 +116,8 @@ fn setup_open(
                 WorkingGraph(graph),
                 head_views,
                 CompiledModule::default(),
+                head::Module::default(),
+                head::Diagnostics::default(),
                 HeadGuiState::default(),
             ))
             .id();

--- a/crates/gantz/src/main.rs
+++ b/crates/gantz/src/main.rs
@@ -4,7 +4,7 @@ use bevy::{
 };
 use bevy_egui::{EguiContexts, EguiPlugin, EguiPrimaryContextPass};
 use bevy_gantz::{
-    BuiltinNodes, CompiledModule, FocusedHead, GantzPlugin, HeadRef, HeadTabOrder, OpenHead,
+    BuiltinNodes, FocusedHead, GantzPlugin, HeadRef, HeadTabOrder, OpenHead,
     OpenHeadDataReadOnly, Registry, WorkingGraph,
     debounced_input::{DebouncedInputEvent, DebouncedInputPlugin},
     head, reg, timestamp, vm,
@@ -115,7 +115,6 @@ fn setup_open(
                 HeadRef(head),
                 WorkingGraph(graph),
                 head_views,
-                CompiledModule::default(),
                 head::Module::default(),
                 head::Diagnostics::default(),
                 HeadGuiState::default(),

--- a/crates/gantz/src/main.rs
+++ b/crates/gantz/src/main.rs
@@ -4,8 +4,8 @@ use bevy::{
 };
 use bevy_egui::{EguiContexts, EguiPlugin, EguiPrimaryContextPass};
 use bevy_gantz::{
-    BuiltinNodes, FocusedHead, GantzPlugin, HeadRef, HeadTabOrder, OpenHead,
-    OpenHeadDataReadOnly, Registry, WorkingGraph,
+    BuiltinNodes, FocusedHead, GantzPlugin, HeadRef, HeadTabOrder, OpenHead, OpenHeadDataReadOnly,
+    Registry, WorkingGraph,
     debounced_input::{DebouncedInputEvent, DebouncedInputPlugin},
     head, reg, timestamp, vm,
 };

--- a/crates/gantz/src/main_update_base.rs
+++ b/crates/gantz/src/main_update_base.rs
@@ -14,7 +14,7 @@ use bevy_gantz::{
     BuiltinNodes, CompiledModule, FocusedHead, GantzPlugin, HeadRef, HeadTabOrder, OpenHead,
     OpenHeadDataReadOnly, WorkingGraph,
     debounced_input::{DebouncedInputEvent, DebouncedInputPlugin},
-    timestamp, vm,
+    head, timestamp, vm,
 };
 use bevy_gantz_egui::{GantzEguiPlugin, GuiState, HeadGuiState, TraceCapture, Views};
 use bevy_pkv::PkvStore;
@@ -117,6 +117,8 @@ fn setup_open(
                 WorkingGraph(graph),
                 head_views,
                 CompiledModule::default(),
+                head::Module::default(),
+                head::Diagnostics::default(),
                 HeadGuiState::default(),
             ))
             .id();

--- a/crates/gantz/src/main_update_base.rs
+++ b/crates/gantz/src/main_update_base.rs
@@ -11,7 +11,7 @@
 use bevy::{prelude::*, window::Window};
 use bevy_egui::{EguiContexts, EguiPlugin, EguiPrimaryContextPass};
 use bevy_gantz::{
-    BuiltinNodes, CompiledModule, FocusedHead, GantzPlugin, HeadRef, HeadTabOrder, OpenHead,
+    BuiltinNodes, FocusedHead, GantzPlugin, HeadRef, HeadTabOrder, OpenHead,
     OpenHeadDataReadOnly, WorkingGraph,
     debounced_input::{DebouncedInputEvent, DebouncedInputPlugin},
     head, timestamp, vm,
@@ -116,7 +116,6 @@ fn setup_open(
                 HeadRef(head),
                 WorkingGraph(graph),
                 head_views,
-                CompiledModule::default(),
                 head::Module::default(),
                 head::Diagnostics::default(),
                 HeadGuiState::default(),

--- a/crates/gantz/src/main_update_base.rs
+++ b/crates/gantz/src/main_update_base.rs
@@ -11,8 +11,8 @@
 use bevy::{prelude::*, window::Window};
 use bevy_egui::{EguiContexts, EguiPlugin, EguiPrimaryContextPass};
 use bevy_gantz::{
-    BuiltinNodes, FocusedHead, GantzPlugin, HeadRef, HeadTabOrder, OpenHead,
-    OpenHeadDataReadOnly, WorkingGraph,
+    BuiltinNodes, FocusedHead, GantzPlugin, HeadRef, HeadTabOrder, OpenHead, OpenHeadDataReadOnly,
+    WorkingGraph,
     debounced_input::{DebouncedInputEvent, DebouncedInputPlugin},
     head, timestamp, vm,
 };

--- a/crates/gantz_core/src/compile.rs
+++ b/crates/gantz_core/src/compile.rs
@@ -452,8 +452,10 @@ where
     let mut levels = Vec::new();
     collect_levels(&meta_tree, &mut Vec::new(), &mut levels);
     for (gpath, n_inlets) in levels {
-        let imask = node::Conns::connected(n_inlets)
-            .map_err(|_| error::NodeConnsError::from(error::TooManyConns(n_inlets)))?;
+        let imask = node::Conns::connected(n_inlets).map_err(|_| ModuleError::NodeConns {
+            path: gpath.clone(),
+            error: error::TooManyConns(n_inlets).into(),
+        })?;
         if emitted.insert((gpath.clone(), imask)) {
             builder.graph_fn(&gpath, &imask)?;
         }
@@ -533,9 +535,12 @@ fn all_connected_confs(
     tree: &RoseTree<Meta>,
     path: &mut Vec<node::Id>,
     confs: &mut std::collections::BTreeMap<Vec<node::Id>, std::collections::BTreeSet<NodeConf>>,
-) -> Result<(), error::NodeConnsError> {
-    let conn = |n: usize| {
-        node::Conns::connected(n).map_err(|_| error::NodeConnsError::from(error::TooManyConns(n)))
+) -> Result<(), ModuleError> {
+    let conn = |n: usize, path: &[node::Id]| {
+        node::Conns::connected(n).map_err(|_| ModuleError::NodeConns {
+            path: path.to_vec(),
+            error: error::TooManyConns(n).into(),
+        })
     };
     let meta = &tree.elem;
     let level_confs = confs.entry(path.clone()).or_default();
@@ -543,8 +548,8 @@ fn all_connected_confs(
         if meta.inlets.contains(&n) || meta.outlets.contains(&n) || meta.delays.contains(&n) {
             continue;
         }
-        let inputs = conn(meta.inputs.get(&n).copied().unwrap_or(0))?;
-        let outputs = conn(meta.outputs.get(&n).copied().unwrap_or(0))?;
+        let inputs = conn(meta.inputs.get(&n).copied().unwrap_or(0), path)?;
+        let outputs = conn(meta.outputs.get(&n).copied().unwrap_or(0), path)?;
         let conns = NodeConns { inputs, outputs };
         level_confs.insert(NodeConf { id: n, conns });
     }
@@ -676,7 +681,12 @@ impl ModuleBuilder<'_> {
             prebound.insert(gid);
             if patterns.len() >= 2 {
                 prebound_vars.push(ir::Var::Result { node: gid });
-                push.push((gid, or_patterns(&patterns)?));
+                let pattern_union =
+                    or_patterns(&patterns).map_err(|error| ModuleError::NodeConns {
+                        path: path.to_vec(),
+                        error,
+                    })?;
+                push.push((gid, pattern_union));
                 extra_branches.insert(gid, patterns);
             } else {
                 // Destructure all outputs from the plain result.
@@ -701,8 +711,11 @@ impl ModuleBuilder<'_> {
                         output: o,
                     });
                 }
-                let conns = node::Conns::connected(n_out)
-                    .map_err(|_| error::NodeConnsError::from(error::TooManyConns(n_out)))?;
+                let conns =
+                    node::Conns::connected(n_out).map_err(|_| ModuleError::NodeConns {
+                        path: path.to_vec(),
+                        error: error::TooManyConns(n_out).into(),
+                    })?;
                 push.push((gid, conns));
             }
         }
@@ -730,7 +743,12 @@ impl ModuleBuilder<'_> {
             extra_branches,
             prebound,
         };
-        let out = lower::level_body(&cx, &lower::LevelSources::Eval { push, pull })?;
+        let out = lower::level_body(&cx, &lower::LevelSources::Eval { push, pull }).map_err(
+            |error| ModuleError::Lower {
+                path: path.to_vec(),
+                error,
+            },
+        )?;
         if self.config.validate_ir {
             ir::validate(&out.body, 0, &prebound_vars).map_err(|e| ModuleError::InvalidIr {
                 path: path.to_vec(),
@@ -758,10 +776,12 @@ impl ModuleBuilder<'_> {
         // analysed over the lowered body itself.
         let produced = out.outlets.iter().any(|o| o.atom.is_some());
         let patterns = match produced {
-            true => Some(
-                analysis::outlet_patterns(&out.body, &out.outlets)
-                    .map_err(error::NodeConnsError::from)?,
-            ),
+            true => Some(analysis::outlet_patterns(&out.body, &out.outlets).map_err(
+                |error| ModuleError::NodeConns {
+                    path: path.to_vec(),
+                    error: error.into(),
+                },
+            )?),
             false => None,
         };
         let result = match &patterns {
@@ -806,7 +826,12 @@ impl ModuleBuilder<'_> {
             extra_branches: std::collections::BTreeMap::new(),
             prebound: std::collections::BTreeSet::new(),
         };
-        let out = lower::level_body(&cx, &lower::LevelSources::Inlets(active.clone()))?;
+        let out = lower::level_body(&cx, &lower::LevelSources::Inlets(active.clone())).map_err(
+            |error| ModuleError::Lower {
+                path: gpath.to_vec(),
+                error,
+            },
+        )?;
         if self.config.validate_ir {
             let inlet_vars: Vec<ir::Var> = active
                 .iter()
@@ -821,7 +846,11 @@ impl ModuleBuilder<'_> {
 
         // The node-contract patterns: the all-active analysis, matching the
         // order `Graph::branches` reports to the parent.
-        let patterns = analysis::level_branch_patterns(meta)?;
+        let patterns =
+            analysis::level_branch_patterns(meta).map_err(|error| ModuleError::Lower {
+                path: gpath.to_vec(),
+                error,
+            })?;
         let result = emit::level_result_sexp(&out.outlets, &patterns);
         let stateful = !meta.stateful.is_empty();
         let ecx = emit::Cx { path: gpath };

--- a/crates/gantz_core/src/compile.rs
+++ b/crates/gantz_core/src/compile.rs
@@ -43,9 +43,6 @@ use crate::{
 };
 pub(crate) use analysis::level_branch_patterns;
 #[doc(inline)]
-pub use codegen::entry_fn_name;
-pub(crate) use emit::graph_fn_name;
-#[doc(inline)]
 pub use entrypoint::{
     Entrypoint, EntrypointId, EvalKind, EvalSource, pull_source, push_pull_entrypoints, push_source,
 };
@@ -53,6 +50,9 @@ pub use entrypoint::{
 pub use error::ModuleError;
 pub(crate) use lower::{NodeConf, NodeConns};
 use meta::MetaTree;
+#[doc(inline)]
+pub use names::{Name, entry_fn_name};
+pub(crate) use names::graph_fn_name;
 #[doc(inline)]
 pub use meta::{EdgeKind, Meta, MetaGraph};
 use petgraph::visit::{
@@ -71,6 +71,7 @@ pub mod error;
 mod ir;
 mod lower;
 mod meta;
+pub mod names;
 mod rosetree;
 
 /// Allows for remaining generic over graph type edges that represent one or
@@ -436,7 +437,7 @@ where
         ]));
         builder
             .fns
-            .push(emit::fn_def(&codegen::entry_fn_name(ep_id), &[], stmts));
+            .push(emit::fn_def(&names::entry_fn_name(ep_id), &[], stmts));
     }
 
     // Every nested level compiles its all-active variant unconditionally:
@@ -630,7 +631,7 @@ impl ModuleBuilder<'_> {
             };
             any_child = true;
             let key = a(format!("'{gid}"));
-            let pair = a(format!("node-{gid}"));
+            let pair = a(names::pair_name(gid));
             if piece.stateful {
                 let r = format!("%lvl-r-{gid}");
                 glue.push(l([
@@ -676,14 +677,16 @@ impl ModuleBuilder<'_> {
                 extra_branches.insert(gid, patterns);
             } else {
                 // Destructure all outputs from the plain result.
+                let out_name =
+                    |o: usize| names::var_name(&ir::Var::Output { node: gid, output: o });
                 match n_out {
                     0 => {}
-                    1 => glue.push(l([a("define"), a(format!("node-{gid}-o0")), pair])),
+                    1 => glue.push(l([a("define"), a(out_name(0)), pair])),
                     _ => {
                         for o in 0..n_out {
                             glue.push(l([
                                 a("define"),
-                                a(format!("node-{gid}-o{o}")),
+                                a(out_name(o)),
                                 l([a("list-ref"), pair.clone(), a(o.to_string())]),
                             ]));
                         }
@@ -764,11 +767,7 @@ impl ModuleBuilder<'_> {
         };
 
         let stateful = !meta_node.elem.stateful.is_empty();
-        let fn_name = format!(
-            "lvl-fn-{}-{}",
-            ep.0.display_short(),
-            codegen::path_string(path)
-        );
+        let fn_name = names::lvl_fn_name(ep, path);
         let mut body = Vec::new();
         let params: Vec<String> = if stateful {
             body.push(l([a("define"), a(crate::GRAPH_STATE), a("%lvl-state")]));
@@ -824,7 +823,10 @@ impl ModuleBuilder<'_> {
         let stateful = !meta.stateful.is_empty();
         let ecx = emit::Cx { path: gpath };
         let mut stmts = Vec::new();
-        let mut params: Vec<String> = active.iter().map(|&i| format!("node-{i}-o0")).collect();
+        let mut params: Vec<String> = active
+            .iter()
+            .map(|&i| names::var_name(&ir::Var::Output { node: i, output: 0 }))
+            .collect();
         if stateful {
             params.push("%lvl-state".to_string());
             stmts.push(l([a("define"), a(crate::GRAPH_STATE), a("%lvl-state")]));
@@ -835,7 +837,7 @@ impl ModuleBuilder<'_> {
         } else {
             stmts.push(result);
         }
-        let fn_def = emit::fn_def(&emit::graph_fn_name(gpath, imask), &params, stmts);
+        let fn_def = emit::fn_def(&names::graph_fn_name(gpath, imask), &params, stmts);
         self.graph_fns.push((gpath.len(), fn_def));
         Ok(())
     }

--- a/crates/gantz_core/src/compile.rs
+++ b/crates/gantz_core/src/compile.rs
@@ -54,6 +54,8 @@ use meta::MetaTree;
 pub use names::{Name, entry_fn_name};
 pub(crate) use names::graph_fn_name;
 #[doc(inline)]
+pub use source_map::SourceMap;
+#[doc(inline)]
 pub use meta::{EdgeKind, Meta, MetaGraph};
 use petgraph::visit::{
     Data, Dfs, EdgeRef, GraphBase, GraphRef, IntoEdgesDirected, IntoNeighbors, IntoNodeReferences,
@@ -73,6 +75,7 @@ mod lower;
 mod meta;
 pub mod names;
 mod rosetree;
+pub mod source_map;
 
 /// Allows for remaining generic over graph type edges that represent one or
 /// more gantz [`Edge`]s.

--- a/crates/gantz_core/src/compile.rs
+++ b/crates/gantz_core/src/compile.rs
@@ -51,17 +51,17 @@ pub use error::ModuleError;
 pub(crate) use lower::{NodeConf, NodeConns};
 use meta::MetaTree;
 #[doc(inline)]
-pub use names::{Name, entry_fn_name};
+pub use meta::{EdgeKind, Meta, MetaGraph};
 pub(crate) use names::graph_fn_name;
 #[doc(inline)]
-pub use source_map::SourceMap;
-#[doc(inline)]
-pub use meta::{EdgeKind, Meta, MetaGraph};
+pub use names::{Name, entry_fn_name};
 use petgraph::visit::{
     Data, Dfs, EdgeRef, GraphBase, GraphRef, IntoEdgesDirected, IntoNeighbors, IntoNodeReferences,
     NodeIndexable, Topo, Visitable, Walker,
 };
 pub(crate) use rosetree::RoseTree;
+#[doc(inline)]
+pub use source_map::SourceMap;
 use std::{collections::HashSet, hash::Hash};
 use steel::parser::ast::ExprKind;
 
@@ -690,8 +690,12 @@ impl ModuleBuilder<'_> {
                 extra_branches.insert(gid, patterns);
             } else {
                 // Destructure all outputs from the plain result.
-                let out_name =
-                    |o: usize| names::var_name(&ir::Var::Output { node: gid, output: o });
+                let out_name = |o: usize| {
+                    names::var_name(&ir::Var::Output {
+                        node: gid,
+                        output: o,
+                    })
+                };
                 match n_out {
                     0 => {}
                     1 => glue.push(l([a("define"), a(out_name(0)), pair])),
@@ -711,11 +715,10 @@ impl ModuleBuilder<'_> {
                         output: o,
                     });
                 }
-                let conns =
-                    node::Conns::connected(n_out).map_err(|_| ModuleError::NodeConns {
-                        path: path.to_vec(),
-                        error: error::TooManyConns(n_out).into(),
-                    })?;
+                let conns = node::Conns::connected(n_out).map_err(|_| ModuleError::NodeConns {
+                    path: path.to_vec(),
+                    error: error::TooManyConns(n_out).into(),
+                })?;
                 push.push((gid, conns));
             }
         }
@@ -743,12 +746,13 @@ impl ModuleBuilder<'_> {
             extra_branches,
             prebound,
         };
-        let out = lower::level_body(&cx, &lower::LevelSources::Eval { push, pull }).map_err(
-            |error| ModuleError::Lower {
-                path: path.to_vec(),
-                error,
-            },
-        )?;
+        let out =
+            lower::level_body(&cx, &lower::LevelSources::Eval { push, pull }).map_err(|error| {
+                ModuleError::Lower {
+                    path: path.to_vec(),
+                    error,
+                }
+            })?;
         if self.config.validate_ir {
             ir::validate(&out.body, 0, &prebound_vars).map_err(|e| ModuleError::InvalidIr {
                 path: path.to_vec(),
@@ -775,15 +779,16 @@ impl ModuleBuilder<'_> {
         // Whether (and how) this level's evaluation produces its outlets,
         // analysed over the lowered body itself.
         let produced = out.outlets.iter().any(|o| o.atom.is_some());
-        let patterns = match produced {
-            true => Some(analysis::outlet_patterns(&out.body, &out.outlets).map_err(
-                |error| ModuleError::NodeConns {
-                    path: path.to_vec(),
-                    error: error.into(),
-                },
-            )?),
-            false => None,
-        };
+        let patterns =
+            match produced {
+                true => Some(analysis::outlet_patterns(&out.body, &out.outlets).map_err(
+                    |error| ModuleError::NodeConns {
+                        path: path.to_vec(),
+                        error: error.into(),
+                    },
+                )?),
+                false => None,
+            };
         let result = match &patterns {
             Some(patterns) => emit::level_result_sexp(&out.outlets, patterns),
             None => emit::unit(),

--- a/crates/gantz_core/src/compile/analysis.rs
+++ b/crates/gantz_core/src/compile/analysis.rs
@@ -16,7 +16,7 @@
 use crate::{
     compile::{
         Meta,
-        error::{LowerError, NodeConnsError, TooManyConns},
+        error::{LowerError, TooManyConns},
         ir::{Atom, Body, Join, JoinId, Step, Tail, Var},
         lower::{self, LevelSources, OutletVal},
     },
@@ -54,7 +54,11 @@ pub(crate) fn level_branch_patterns(meta: &Meta) -> Result<Vec<node::Conns>, Low
         prebound: BTreeSet::new(),
     };
     let out = lower::level_body(&cx, &LevelSources::Inlets(all))?;
-    let patterns = outlet_patterns(&out.body, &out.outlets).map_err(NodeConnsError::from)?;
+    let patterns =
+        outlet_patterns(&out.body, &out.outlets).map_err(|error| LowerError::Conns {
+            node: None,
+            error: error.into(),
+        })?;
     Ok(patterns)
 }
 

--- a/crates/gantz_core/src/compile/analysis.rs
+++ b/crates/gantz_core/src/compile/analysis.rs
@@ -54,11 +54,10 @@ pub(crate) fn level_branch_patterns(meta: &Meta) -> Result<Vec<node::Conns>, Low
         prebound: BTreeSet::new(),
     };
     let out = lower::level_body(&cx, &LevelSources::Inlets(all))?;
-    let patterns =
-        outlet_patterns(&out.body, &out.outlets).map_err(|error| LowerError::Conns {
-            node: None,
-            error: error.into(),
-        })?;
+    let patterns = outlet_patterns(&out.body, &out.outlets).map_err(|error| LowerError::Conns {
+        node: None,
+        error: error.into(),
+    })?;
     Ok(patterns)
 }
 

--- a/crates/gantz_core/src/compile/codegen.rs
+++ b/crates/gantz_core/src/compile/codegen.rs
@@ -1,23 +1,5 @@
-//! Generation of the per-variant node fns (see [`node_fn`]) and the shared
-//! fn-naming helpers.
+//! Generation of the per-variant node fns (see [`node_fn`]).
 
-use crate::node;
-pub(crate) use node_fn::{name as node_fn_name, node_fns};
+pub(crate) use node_fn::node_fns;
 
 mod node_fn;
-
-/// The string used to represent a path in a fn name.
-pub(crate) fn path_string(path: &[node::Id]) -> String {
-    path.iter()
-        .map(|id| id.to_string())
-        .collect::<Vec<_>>()
-        .join(":")
-}
-
-/// Generate entry fn name from an `EntrypointId`.
-///
-/// The name is deterministic and unique - derived from the content hash
-/// (truncated to 8 hex chars).
-pub fn entry_fn_name(id: &super::EntrypointId) -> String {
-    format!("entry-fn-{}", id.0.display_short())
-}

--- a/crates/gantz_core/src/compile/codegen/node_fn.rs
+++ b/crates/gantz_core/src/compile/codegen/node_fn.rs
@@ -13,8 +13,8 @@ use crate::{
     Edge,
     compile::{
         NodeConf, NodeConns, RoseTree,
-        codegen::path_string,
         error::{NestedGraphNotFound, NodeExprError, NodeFnError, NodeFnErrors},
+        names::node_fn_name,
     },
     node::{self, Node},
     visit::{self, Visitor},
@@ -100,18 +100,6 @@ impl Visitor for NodeFns<'_> {
     }
 }
 
-/// Generate a function name for a node based on its path in the graph.
-///
-/// E.g. `node_fn_0_1_2_i0101_o1100
-pub(crate) fn name(node_path: &[node::Id], inputs: &node::Conns, outputs: &node::Conns) -> String {
-    let path_string = path_string(node_path);
-    let inputs_prefix = if inputs.is_empty() { "" } else { "-i" };
-    let outputs_prefix = if outputs.is_empty() { "" } else { "-o" };
-    let inputs_string = format!("{inputs}");
-    let outputs_string = format!("{outputs}");
-    format!("node-fn-{path_string}{inputs_prefix}{inputs_string}{outputs_prefix}{outputs_string}")
-}
-
 /// Generate a function for a single node with the given set of connected inputs.
 pub(crate) fn node_fn<'a>(
     get_node: node::GetNode<'a>,
@@ -150,7 +138,7 @@ pub(crate) fn node_fn<'a>(
 
     // Construct the full function definition
     // FIXME: Remove this when switching to `flow::NodeConf`.
-    let fn_name = name(node_path, &conns.inputs, &conns.outputs);
+    let fn_name = node_fn_name(node_path, &conns.inputs, &conns.outputs);
     let meta_ctx = node::MetaCtx::new(get_node);
     let fn_body = if node.stateful(meta_ctx) {
         input_args.push(STATE.to_string());

--- a/crates/gantz_core/src/compile/emit.rs
+++ b/crates/gantz_core/src/compile/emit.rs
@@ -18,8 +18,8 @@
 use crate::{
     GRAPH_STATE,
     compile::{
-        codegen::node_fn_name,
-        ir::{Arg, Arm, Atom, Body, JoinId, NodeCall, Step, Subject, Tail, Var},
+        ir::{Arg, Arm, Atom, Body, NodeCall, Step, Subject, Tail, Var},
+        names::{join_name, node_fn_name, pair_name, var_name},
     },
     node,
 };
@@ -76,33 +76,6 @@ pub(crate) fn l(items: impl IntoIterator<Item = Sexp>) -> Sexp {
 /// The unit value `'()`.
 pub(crate) fn unit() -> Sexp {
     a("'()")
-}
-
-/// The emitted name of a variable.
-pub(crate) fn var_name(var: &Var) -> String {
-    match var {
-        Var::Output { node, output } => format!("node-{node}-o{output}"),
-        Var::Input { node, input } => format!("node-{node}-i{input}"),
-        Var::Result { node } => pair_name(*node),
-    }
-}
-
-/// The binding holding a branching node's raw `(branch-ix value)` result.
-fn pair_name(node: node::Id) -> String {
-    format!("node-{node}")
-}
-
-/// The name of the graph fn compiled for the nested level at `path`, for the
-/// variant invoked with the given active-input mask.
-pub(crate) fn graph_fn_name(path: &[node::Id], inputs: &node::Conns) -> String {
-    let path_string = crate::compile::codegen::path_string(path);
-    let inputs_prefix = if inputs.is_empty() { "" } else { "-i" };
-    format!("graph-fn-{path_string}{inputs_prefix}{inputs}")
-}
-
-/// The emitted name of a join point fn.
-fn join_name(join: JoinId) -> String {
-    format!("join-{join}")
 }
 
 fn atom_sexp(atom: &Atom) -> Sexp {

--- a/crates/gantz_core/src/compile/error.rs
+++ b/crates/gantz_core/src/compile/error.rs
@@ -9,14 +9,6 @@ use thiserror::Error;
 #[error("too many connections ({0}), max is {max}", max = node::Conns::MAX)]
 pub struct TooManyConns(pub usize);
 
-/// An edge references an invalid input index.
-#[derive(Debug, Error)]
-#[error("edge references invalid input index {index} (node has {n_inputs} inputs)")]
-pub struct InvalidInputIndex {
-    pub index: usize,
-    pub n_inputs: usize,
-}
-
 /// An edge references an invalid output index.
 #[derive(Debug, Error)]
 #[error("edge references invalid output index {index} (node has {n_outputs} outputs)")]
@@ -60,9 +52,6 @@ pub enum NodeConnsError {
     /// The node has too many connections.
     #[error(transparent)]
     TooManyConns(#[from] TooManyConns),
-    /// An edge references an invalid input index.
-    #[error(transparent)]
-    InvalidInputIndex(#[from] InvalidInputIndex),
     /// An edge references an invalid output index.
     #[error(transparent)]
     InvalidOutputIndex(#[from] InvalidOutputIndex),
@@ -81,23 +70,18 @@ pub struct MetaError {
 #[derive(Debug)]
 pub struct MetaErrors(pub Vec<MetaError>);
 
-/// Error during code generation.
-#[derive(Debug, Error)]
-pub enum CodegenError {
-    /// The node has too many inputs.
-    #[error(transparent)]
-    TooManyInputs(#[from] TooManyConns),
-    /// An edge references an invalid input index.
-    #[error(transparent)]
-    InvalidInputIndex(#[from] InvalidInputIndex),
-}
-
 /// Error while lowering a graph to the IR.
+///
+/// Node ids are relative to the level being lowered.
 #[derive(Debug, Error)]
 pub enum LowerError {
-    /// Error computing node connections.
-    #[error(transparent)]
-    Conns(#[from] NodeConnsError),
+    /// Error computing connection masks, at a specific node when known.
+    #[error("connection error{}", at_node(node))]
+    Conns {
+        node: Option<node::Id>,
+        #[source]
+        error: NodeConnsError,
+    },
     /// A node conditional on a branch arm depends on work outside the
     /// branch's region that has not yet been evaluated, so it can neither be
     /// lowered into the arm nor deferred past the branch.
@@ -125,15 +109,23 @@ pub enum LowerError {
 /// Error when generating a module from a graph.
 #[derive(Debug, Error)]
 pub enum ModuleError {
-    /// Error computing node connections.
-    #[error(transparent)]
-    NodeConns(#[from] NodeConnsError),
-    /// Error during code generation.
-    #[error(transparent)]
-    Codegen(#[from] CodegenError),
-    /// Error during lowering to the IR.
-    #[error(transparent)]
-    Lower(#[from] LowerError),
+    /// Error computing node connections while compiling the level at `path`.
+    #[error("connection error at {}", level(path))]
+    NodeConns {
+        /// The level being compiled when the error arose.
+        path: Vec<node::Id>,
+        #[source]
+        error: NodeConnsError,
+    },
+    /// Error lowering the level at `path` to the IR. Node ids carried by the
+    /// underlying [`LowerError`] are relative to that level.
+    #[error("failed to lower {}", level(path))]
+    Lower {
+        /// The level being lowered when the error arose.
+        path: Vec<node::Id>,
+        #[source]
+        error: LowerError,
+    },
     /// A nested graph was not found.
     #[error(transparent)]
     NestedGraphNotFound(#[from] NestedGraphNotFound),
@@ -147,7 +139,7 @@ pub enum ModuleError {
     /// This is a bug in gantz, not in the compiled graph; validation runs on
     /// every lowering (unless disabled via [`Config::validate_ir`][super::Config])
     /// so it surfaces as a compile error rather than emitting malformed Steel.
-    #[error("internal compiler error: invalid IR for level {path:?}: {detail}")]
+    #[error("internal compiler error: invalid IR for {}: {detail}", level(path))]
     InvalidIr { path: Vec<node::Id>, detail: String },
 }
 
@@ -212,3 +204,17 @@ impl std::error::Error for NodeExprError {
 }
 
 impl std::error::Error for NodeFnErrors {}
+
+/// Format a level path for error messages.
+fn level(path: &[node::Id]) -> String {
+    if path.is_empty() {
+        "the root level".to_string()
+    } else {
+        format!("level {}", super::names::path_string(path))
+    }
+}
+
+/// Format an optional node id for error messages.
+fn at_node(node: &Option<node::Id>) -> String {
+    node.map(|n| format!(" at node {n}")).unwrap_or_default()
+}

--- a/crates/gantz_core/src/compile/error.rs
+++ b/crates/gantz_core/src/compile/error.rs
@@ -156,7 +156,7 @@ impl fmt::Display for MetaError {
         write!(
             f,
             "node-{}: {}",
-            super::codegen::path_string(&self.path),
+            super::names::path_string(&self.path),
             self.error
         )
     }
@@ -179,7 +179,7 @@ impl fmt::Display for NodeExprError {
         write!(
             f,
             "node-{}: {}",
-            super::codegen::path_string(&self.path),
+            super::names::path_string(&self.path),
             self.error
         )
     }

--- a/crates/gantz_core/src/compile/lower.rs
+++ b/crates/gantz_core/src/compile/lower.rs
@@ -266,7 +266,7 @@ fn strip_delay_out_edges(g: &MetaGraph, delays: &BTreeSet<node::Id>) -> MetaGrap
 /// The level's static sources: input-less interior nodes (constants), which
 /// stay live regardless of which inlets fired.
 fn static_sources(meta: &Meta) -> Result<Vec<(node::Id, node::Conns)>, LowerError> {
-    use crate::compile::error::{NodeConnsError, TooManyConns};
+    use crate::compile::error::TooManyConns;
     let mut sources = Vec::new();
     for n in meta.graph.nodes() {
         if meta.inlets.contains(&n) || meta.outlets.contains(&n) {
@@ -282,8 +282,10 @@ fn static_sources(meta: &Meta) -> Result<Vec<(node::Id, node::Conns)>, LowerErro
         }
         let n_out = meta.outputs.get(&n).copied().unwrap_or(0);
         if n_out > 0 {
-            let conns = node::Conns::connected(n_out)
-                .map_err(|_| NodeConnsError::from(TooManyConns(n_out)))?;
+            let conns = node::Conns::connected(n_out).map_err(|_| LowerError::Conns {
+                node: Some(n),
+                error: TooManyConns(n_out).into(),
+            })?;
             sources.push((n, conns));
         }
     }
@@ -480,15 +482,19 @@ fn input_sources(dag: &MetaGraph, n: node::Id, i: usize) -> Vec<(node::Id, usize
 /// The connected-outputs mask of `n` within the dag.
 fn node_outputs(meta: &Meta, dag: &MetaGraph, n: node::Id) -> Result<node::Conns, LowerError> {
     use crate::compile::error::{InvalidOutputIndex, NodeConnsError, TooManyConns};
+    let conns_err = |error: NodeConnsError| LowerError::Conns {
+        node: Some(n),
+        error,
+    };
     let n_outputs = meta.outputs.get(&n).copied().unwrap_or(0);
     let mut outputs = node::Conns::unconnected(n_outputs)
-        .map_err(|_| NodeConnsError::from(TooManyConns(n_outputs)))?;
+        .map_err(|_| conns_err(TooManyConns(n_outputs).into()))?;
     for e_ref in dag.edges_directed(n, petgraph::Outgoing) {
         for (edge, _kind) in e_ref.weight() {
             let index = edge.output.0 as usize;
             outputs
                 .set(index, true)
-                .map_err(|_| NodeConnsError::from(InvalidOutputIndex { index, n_outputs }))?;
+                .map_err(|_| conns_err(InvalidOutputIndex { index, n_outputs }.into()))?;
         }
     }
     Ok(outputs)

--- a/crates/gantz_core/src/compile/names.rs
+++ b/crates/gantz_core/src/compile/names.rs
@@ -1,0 +1,375 @@
+//! The emitted Steel identifier naming scheme.
+//!
+//! Every identifier the compiler emits is produced by a formatter in this
+//! module, and [`parse`] is its inverse: it maps an emitted identifier back
+//! to the node, graph level, entrypoint or join it was generated for. Keeping
+//! both directions here is what stops them drifting apart - if a formatter
+//! changes, the roundtrip tests below fail.
+
+use crate::{
+    compile::{
+        EntrypointId,
+        ir::{JoinId, Var},
+    },
+    node,
+};
+
+/// A parsed emitted identifier.
+///
+/// `NodeFn`, `GraphFn` and `LvlFn` carry *full* paths (from the root graph),
+/// as their formatters embed the whole path. `Output`, `Input`, `Result` and
+/// `Join` are bindings local to one emitted definition: their ids are
+/// relative to the graph level that definition was lowered from.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Name {
+    /// A per-variant node fn: `node-fn-{path}[-i{conns}][-o{conns}]`.
+    NodeFn {
+        path: Vec<node::Id>,
+        inputs: node::Conns,
+        outputs: node::Conns,
+    },
+    /// A per-variant graph fn: `graph-fn-{path}[-i{conns}]`.
+    GraphFn {
+        path: Vec<node::Id>,
+        inputs: node::Conns,
+    },
+    /// A per-entrypoint nested level fn: `lvl-fn-{ep}-{path}`.
+    LvlFn { ep: String, path: Vec<node::Id> },
+    /// An entrypoint fn: `entry-fn-{ep}`.
+    EntryFn { ep: String },
+    /// A node output binding: `node-{id}-o{output}`.
+    Output { node: node::Id, output: usize },
+    /// A join param carrying a node input: `node-{id}-i{input}`.
+    Input { node: node::Id, input: usize },
+    /// A branching node's raw `(branch-ix value)` pair: `node-{id}`.
+    Result { node: node::Id },
+    /// A join point fn: `join-{id}`.
+    Join { id: node::Id },
+}
+
+/// The string used to represent a path in a fn name.
+pub(crate) fn path_string(path: &[node::Id]) -> String {
+    path.iter()
+        .map(|id| id.to_string())
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+/// Generate a function name for a node based on its path in the graph.
+///
+/// E.g. `node-fn-0:1:2-i0101-o1100`.
+pub(crate) fn node_fn_name(
+    node_path: &[node::Id],
+    inputs: &node::Conns,
+    outputs: &node::Conns,
+) -> String {
+    let path_string = path_string(node_path);
+    let inputs_prefix = if inputs.is_empty() { "" } else { "-i" };
+    let outputs_prefix = if outputs.is_empty() { "" } else { "-o" };
+    format!("node-fn-{path_string}{inputs_prefix}{inputs}{outputs_prefix}{outputs}")
+}
+
+/// The name of the graph fn compiled for the nested level at `path`, for the
+/// variant invoked with the given active-input mask.
+pub(crate) fn graph_fn_name(path: &[node::Id], inputs: &node::Conns) -> String {
+    let path_string = path_string(path);
+    let inputs_prefix = if inputs.is_empty() { "" } else { "-i" };
+    format!("graph-fn-{path_string}{inputs_prefix}{inputs}")
+}
+
+/// The name of the fn evaluating one entrypoint's sources at the nested
+/// level `path`.
+pub(crate) fn lvl_fn_name(ep: &EntrypointId, path: &[node::Id]) -> String {
+    format!("lvl-fn-{}-{}", ep.0.display_short(), path_string(path))
+}
+
+/// Generate entry fn name from an `EntrypointId`.
+///
+/// The name is deterministic and unique - derived from the content hash
+/// (truncated to 8 hex chars).
+pub fn entry_fn_name(id: &EntrypointId) -> String {
+    format!("entry-fn-{}", id.0.display_short())
+}
+
+/// The emitted name of a variable.
+pub(crate) fn var_name(var: &Var) -> String {
+    match var {
+        Var::Output { node, output } => format!("node-{node}-o{output}"),
+        Var::Input { node, input } => format!("node-{node}-i{input}"),
+        Var::Result { node } => pair_name(*node),
+    }
+}
+
+/// The binding holding a branching node's raw `(branch-ix value)` result.
+pub(crate) fn pair_name(node: node::Id) -> String {
+    format!("node-{node}")
+}
+
+/// The emitted name of a join point fn.
+pub(crate) fn join_name(join: JoinId) -> String {
+    format!("join-{join}")
+}
+
+/// Parse an emitted identifier back to the entity it names.
+///
+/// Returns `None` for identifiers the compiler did not generate from a graph
+/// entity (params, temporaries like `%vals-*`/`%lvl-*`, user identifiers).
+pub fn parse(name: &str) -> Option<Name> {
+    if let Some(rest) = name.strip_prefix("node-fn-") {
+        let mut segs = rest.split('-');
+        let path = parse_path(segs.next()?)?;
+        let (inputs, outputs) = parse_io_conns(segs)?;
+        Some(Name::NodeFn {
+            path,
+            inputs,
+            outputs,
+        })
+    } else if let Some(rest) = name.strip_prefix("graph-fn-") {
+        let mut segs = rest.split('-');
+        let path = parse_path(segs.next()?)?;
+        let inputs = match (segs.next(), segs.next()) {
+            (None, _) => node::Conns::empty(),
+            (Some(i), None) => parse_conns(i, 'i')?,
+            _ => return None,
+        };
+        Some(Name::GraphFn { path, inputs })
+    } else if let Some(rest) = name.strip_prefix("lvl-fn-") {
+        let (ep, path) = rest.split_once('-')?;
+        is_short_hash(ep).then_some(())?;
+        let path = parse_path(path)?;
+        Some(Name::LvlFn {
+            ep: ep.to_string(),
+            path,
+        })
+    } else if let Some(rest) = name.strip_prefix("entry-fn-") {
+        is_short_hash(rest).then(|| Name::EntryFn {
+            ep: rest.to_string(),
+        })
+    } else if let Some(rest) = name.strip_prefix("join-") {
+        Some(Name::Join {
+            id: parse_id(rest)?,
+        })
+    } else if let Some(rest) = name.strip_prefix("node-") {
+        let Some((id, suffix)) = rest.split_once('-') else {
+            return Some(Name::Result {
+                node: parse_id(rest)?,
+            });
+        };
+        let node = parse_id(id)?;
+        if let Some(output) = suffix.strip_prefix('o') {
+            Some(Name::Output {
+                node,
+                output: parse_id(output)?,
+            })
+        } else if let Some(input) = suffix.strip_prefix('i') {
+            Some(Name::Input {
+                node,
+                input: parse_id(input)?,
+            })
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+/// Parse a `:`-joined node path as formatted by [`path_string`].
+fn parse_path(s: &str) -> Option<Vec<node::Id>> {
+    s.split(':').map(parse_id).collect()
+}
+
+/// Parse a plain decimal id (rejecting signs, whitespace and empty strings).
+fn parse_id(s: &str) -> Option<node::Id> {
+    if s.is_empty() || !s.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    s.parse().ok()
+}
+
+/// Parse a `i{conns}`/`o{conns}` segment with the given prefix.
+fn parse_conns(s: &str, prefix: char) -> Option<node::Conns> {
+    let bits = s.strip_prefix(prefix)?;
+    if bits.is_empty() {
+        return None;
+    }
+    bits.parse().ok()
+}
+
+/// Parse the optional `-i{conns}`/`-o{conns}` tail of a node fn name.
+fn parse_io_conns(mut segs: std::str::Split<'_, char>) -> Option<(node::Conns, node::Conns)> {
+    let empty = node::Conns::empty;
+    match (segs.next(), segs.next(), segs.next()) {
+        (None, _, _) => Some((empty(), empty())),
+        (Some(i), None, _) if i.starts_with('i') => Some((parse_conns(i, 'i')?, empty())),
+        (Some(o), None, _) if o.starts_with('o') => Some((empty(), parse_conns(o, 'o')?)),
+        (Some(i), Some(o), None) => Some((parse_conns(i, 'i')?, parse_conns(o, 'o')?)),
+        _ => None,
+    }
+}
+
+/// Whether `s` is a truncated content-address hash as formatted by
+/// `ContentAddr::display_short` (8 lowercase hex chars).
+fn is_short_hash(s: &str) -> bool {
+    s.len() == 8
+        && s.bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ep(byte: u8) -> EntrypointId {
+        EntrypointId(gantz_ca::ContentAddr::from([byte; 32]))
+    }
+
+    fn conns(s: &str) -> node::Conns {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn node_fn_roundtrip() {
+        let cases = [
+            (vec![0], conns(""), conns("")),
+            (vec![0], conns("1"), conns("")),
+            (vec![3], conns(""), conns("11")),
+            (vec![0, 1, 2], conns("0101"), conns("1100")),
+            (vec![10, 22, 333], conns("1"), conns("1")),
+        ];
+        for (path, inputs, outputs) in cases {
+            let name = node_fn_name(&path, &inputs, &outputs);
+            assert_eq!(
+                parse(&name),
+                Some(Name::NodeFn {
+                    path,
+                    inputs,
+                    outputs
+                }),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn graph_fn_roundtrip() {
+        let cases = [
+            (vec![0], conns("")),
+            (vec![1, 4], conns("101")),
+            (vec![12, 0], conns("1")),
+        ];
+        for (path, inputs) in cases {
+            let name = graph_fn_name(&path, &inputs);
+            assert_eq!(parse(&name), Some(Name::GraphFn { path, inputs }), "{name}");
+        }
+    }
+
+    #[test]
+    fn lvl_fn_roundtrip() {
+        let id = ep(0xab);
+        let path = vec![0, 7];
+        let name = lvl_fn_name(&id, &path);
+        assert_eq!(
+            parse(&name),
+            Some(Name::LvlFn {
+                ep: "abababab".to_string(),
+                path
+            }),
+            "{name}"
+        );
+    }
+
+    #[test]
+    fn entry_fn_roundtrip() {
+        let id = ep(0x1f);
+        let name = entry_fn_name(&id);
+        assert_eq!(
+            parse(&name),
+            Some(Name::EntryFn {
+                ep: "1f1f1f1f".to_string()
+            }),
+            "{name}"
+        );
+    }
+
+    #[test]
+    fn var_roundtrip() {
+        let cases = [
+            (
+                Var::Output {
+                    node: 0,
+                    output: 0,
+                },
+                Name::Output {
+                    node: 0,
+                    output: 0,
+                },
+            ),
+            (
+                Var::Output {
+                    node: 12,
+                    output: 3,
+                },
+                Name::Output {
+                    node: 12,
+                    output: 3,
+                },
+            ),
+            (
+                Var::Input { node: 4, input: 1 },
+                Name::Input { node: 4, input: 1 },
+            ),
+            (Var::Result { node: 9 }, Name::Result { node: 9 }),
+        ];
+        for (var, expected) in cases {
+            let name = var_name(&var);
+            assert_eq!(parse(&name), Some(expected), "{name}");
+        }
+    }
+
+    #[test]
+    fn join_roundtrip() {
+        let name = join_name(42);
+        assert_eq!(parse(&name), Some(Name::Join { id: 42 }), "{name}");
+    }
+
+    #[test]
+    fn non_names_rejected() {
+        let cases = [
+            "",
+            "state",
+            "input0",
+            "output",
+            "results",
+            "graph-state",
+            "%root-state",
+            "%lvl-state",
+            "%lvl-r-3",
+            "%gantz-sig",
+            "%vals-node-0-o0",
+            "'%gantz-unfired",
+            // Malformed variants of real prefixes.
+            "node-",
+            "node-fn-",
+            "node-fn-x",
+            "node-fn-0:",
+            "node-fn-0-z1",
+            "node-fn-0-i",
+            "node-0-",
+            "node-0-x1",
+            "node-1:2",
+            "graph-fn-",
+            "graph-fn-0-o1",
+            "lvl-fn-0",
+            "lvl-fn-zzzzzzzz-0",
+            "lvl-fn-abcd-0",
+            "entry-fn-xyz",
+            "entry-fn-ABABABAB",
+            "join-",
+            "join-x",
+        ];
+        for name in cases {
+            assert_eq!(parse(name), None, "{name}");
+        }
+    }
+}

--- a/crates/gantz_core/src/compile/names.rs
+++ b/crates/gantz_core/src/compile/names.rs
@@ -296,14 +296,8 @@ mod tests {
     fn var_roundtrip() {
         let cases = [
             (
-                Var::Output {
-                    node: 0,
-                    output: 0,
-                },
-                Name::Output {
-                    node: 0,
-                    output: 0,
-                },
+                Var::Output { node: 0, output: 0 },
+                Name::Output { node: 0, output: 0 },
             ),
             (
                 Var::Output {

--- a/crates/gantz_core/src/compile/source_map.rs
+++ b/crates/gantz_core/src/compile/source_map.rs
@@ -1,0 +1,374 @@
+//! A byte-offset map from the emitted module source text back to the graph
+//! entities the compiler generated it from.
+//!
+//! The map is built by lexically scanning the pretty-printed module source
+//! (see `vm::fmt_module`) and parsing every identifier with
+//! [`names::parse`]. Scanning the *final* text - rather than threading spans
+//! through emission - guarantees the offsets index the exact string that is
+//! displayed and executed.
+//!
+//! The scanner is total: malformed input never panics, it just yields fewer
+//! definitions and occurrences.
+
+use crate::{
+    compile::names::{self, Name},
+    node,
+};
+use std::ops::Range;
+
+/// Byte-offset spans into an emitted module's source text, resolvable to
+/// node paths.
+#[derive(Clone, Debug, Default)]
+pub struct SourceMap {
+    /// Top-level forms in source order.
+    defs: Vec<Def>,
+    /// Identifier occurrences that parse as emitted [`Name`]s, in source
+    /// order. The defining identifier of each [`Def`] is excluded (it is
+    /// represented by the def itself).
+    occs: Vec<Occ>,
+}
+
+/// A top-level form (almost always a `(define (name ...) ...)`).
+#[derive(Clone, Debug)]
+pub struct Def {
+    /// The byte range of the whole form, opening to closing paren inclusive.
+    pub range: Range<usize>,
+    /// The defined identifier parsed as an emitted name, if it is one.
+    pub name: Option<Name>,
+    /// The byte range of the defined identifier (empty when the form defines
+    /// nothing).
+    pub name_range: Range<usize>,
+}
+
+/// One identifier occurrence within a [`Def`].
+#[derive(Clone, Debug)]
+pub struct Occ {
+    /// The byte range of the identifier.
+    pub range: Range<usize>,
+    /// The parsed emitted name.
+    pub name: Name,
+    /// Index of the enclosing [`Def`] in [`SourceMap::defs`].
+    pub def_ix: usize,
+}
+
+/// The spans associated with one node, as returned by
+/// [`SourceMap::node_spans`].
+#[derive(Clone, Debug, Default)]
+pub struct NodeSpans {
+    /// Whole-form ranges of the defs compiled *for* the node (its node fns,
+    /// and for graph nodes their graph and level fns).
+    pub defs: Vec<Range<usize>>,
+    /// Ranges of identifiers referring to the node elsewhere (call sites and
+    /// value bindings).
+    pub refs: Vec<Range<usize>>,
+}
+
+impl SourceMap {
+    /// Build the map by scanning the emitted module source.
+    pub fn parse(src: &str) -> Self {
+        scan(src)
+    }
+
+    /// The top-level forms in source order.
+    pub fn defs(&self) -> &[Def] {
+        &self.defs
+    }
+
+    /// All resolved identifier occurrences in source order.
+    pub fn occs(&self) -> &[Occ] {
+        &self.occs
+    }
+
+    /// The spans associated with the node at the given full path: the defs
+    /// compiled for it and the identifiers referring to it.
+    pub fn node_spans(&self, path: &[node::Id]) -> NodeSpans {
+        let mut spans = NodeSpans::default();
+        for def in &self.defs {
+            if def_path(def) == Some(path) {
+                spans.defs.push(def.range.clone());
+            }
+        }
+        for occ in &self.occs {
+            let def = &self.defs[occ.def_ix];
+            if occ_path(occ, def).as_deref() == Some(path) {
+                spans.refs.push(occ.range.clone());
+            }
+        }
+        spans
+    }
+
+    /// The full path of the node best attributed to the given byte range
+    /// (e.g. a steel error span).
+    ///
+    /// Resolution: a range covering the enclosing form's defined name (e.g.
+    /// a whole-define span) attributes to the def itself; otherwise the
+    /// first intersecting fn-call identifier wins, then the first
+    /// intersecting value binding (resolved against the form's level), then
+    /// the form's own attribution. `Some(vec![])` means "the module as a
+    /// whole" (e.g. an entry fn's glue); `None` means the range lies outside
+    /// every form.
+    pub fn node_at(&self, range: Range<usize>) -> Option<Vec<node::Id>> {
+        // Treat an empty range as a point query.
+        let range = range.start..range.end.max(range.start + 1);
+        let ix = self
+            .defs
+            .partition_point(|d| d.range.start <= range.start)
+            .checked_sub(1)?;
+        let def = &self.defs[ix];
+        if range.start >= def.range.end {
+            return None;
+        }
+        let intersects = |r: &Range<usize>| r.start < range.end && range.start < r.end;
+        if intersects(&def.name_range) {
+            return Some(def_path(def).map(<[_]>::to_vec).unwrap_or_default());
+        }
+
+        let mut first_var: Option<&Occ> = None;
+        for occ in self.occs.iter().filter(|o| o.def_ix == ix) {
+            if !intersects(&occ.range) {
+                continue;
+            }
+            match occ.name {
+                Name::NodeFn { .. } | Name::GraphFn { .. } | Name::LvlFn { .. } => {
+                    return occ_path(occ, def);
+                }
+                _ => first_var = first_var.or(Some(occ)),
+            }
+        }
+        if let Some(path) = first_var.and_then(|occ| occ_path(occ, def)) {
+            return Some(path);
+        }
+        Some(def_path(def).map(<[_]>::to_vec).unwrap_or_default())
+    }
+}
+
+/// The full path of the node a def was compiled for, if any.
+fn def_path(def: &Def) -> Option<&[node::Id]> {
+    match def.name.as_ref()? {
+        Name::NodeFn { path, .. } | Name::GraphFn { path, .. } | Name::LvlFn { path, .. } => {
+            Some(path)
+        }
+        _ => None,
+    }
+}
+
+/// The graph level whose node ids are in scope within a def's body.
+fn level_path(def: &Def) -> Option<&[node::Id]> {
+    match def.name.as_ref()? {
+        // A node fn's body is the node's own expr: relative ids refer to
+        // its siblings.
+        Name::NodeFn { path, .. } => path.split_last().map(|(_, parent)| parent),
+        // Graph and level fn bodies are lowered from the level's interior.
+        Name::GraphFn { path, .. } | Name::LvlFn { path, .. } => Some(path),
+        Name::EntryFn { .. } => Some(&[]),
+        _ => None,
+    }
+}
+
+/// The full path of the node an occurrence refers to, resolving
+/// level-relative ids against the enclosing def.
+fn occ_path(occ: &Occ, def: &Def) -> Option<Vec<node::Id>> {
+    match &occ.name {
+        Name::NodeFn { path, .. } | Name::GraphFn { path, .. } | Name::LvlFn { path, .. } => {
+            Some(path.clone())
+        }
+        Name::EntryFn { .. } => Some(vec![]),
+        Name::Output { node, .. }
+        | Name::Input { node, .. }
+        | Name::Result { node }
+        | Name::Join { id: node } => {
+            let mut path = level_path(def)?.to_vec();
+            path.push(*node);
+            Some(path)
+        }
+    }
+}
+
+/// Lexically scan the module source into defs and occurrences.
+fn scan(src: &str) -> SourceMap {
+    /// The state of the currently open top-level form.
+    struct Form {
+        start: usize,
+        head_seen: bool,
+        is_define: bool,
+        name: Option<(Range<usize>, Option<Name>)>,
+    }
+
+    fn close(form: Form, end: usize) -> Def {
+        let (name_range, name) = match form.name {
+            Some((range, name)) => (range, name),
+            None => (form.start..form.start, None),
+        };
+        Def {
+            range: form.start..end,
+            name,
+            name_range,
+        }
+    }
+
+    let bytes = src.as_bytes();
+    let mut map = SourceMap::default();
+    let mut form: Option<Form> = None;
+    let mut depth = 0usize;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' | b'[' => {
+                if depth == 0 {
+                    form = Some(Form {
+                        start: i,
+                        head_seen: false,
+                        is_define: false,
+                        name: None,
+                    });
+                }
+                depth += 1;
+                i += 1;
+            }
+            b')' | b']' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    if let Some(form) = form.take() {
+                        map.defs.push(close(form, i + 1));
+                    }
+                }
+                i += 1;
+            }
+            b'"' => i = skip_string(bytes, i),
+            b';' => i = skip_comment(bytes, i),
+            b'\'' | b'`' | b',' => i += 1,
+            b if b.is_ascii_whitespace() => i += 1,
+            _ => {
+                let start = i;
+                i = scan_atom(bytes, i);
+                let Some(form) = form.as_mut() else {
+                    continue;
+                };
+                let token = &src[start..i];
+                if !form.head_seen {
+                    form.head_seen = true;
+                    form.is_define = token == "define";
+                } else if form.is_define && form.name.is_none() {
+                    form.name = Some((start..i, names::parse(token)));
+                } else if let Some(name) = names::parse(token) {
+                    map.occs.push(Occ {
+                        range: start..i,
+                        name,
+                        def_ix: map.defs.len(),
+                    });
+                }
+            }
+        }
+    }
+    // Close an unbalanced trailing form so occ def indices stay valid.
+    if let Some(form) = form.take() {
+        map.defs.push(close(form, bytes.len()));
+    }
+    map
+}
+
+/// Advance past a string literal starting at the opening quote.
+fn skip_string(bytes: &[u8], start: usize) -> usize {
+    let mut i = start + 1;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => i += 2,
+            b'"' => return i + 1,
+            _ => i += 1,
+        }
+    }
+    bytes.len()
+}
+
+/// Advance past a `;` comment to the end of the line.
+fn skip_comment(bytes: &[u8], start: usize) -> usize {
+    let mut i = start;
+    while i < bytes.len() && bytes[i] != b'\n' {
+        i += 1;
+    }
+    i
+}
+
+/// Advance past one atom token starting at `start`.
+fn scan_atom(bytes: &[u8], start: usize) -> usize {
+    let mut i = start;
+    while i < bytes.len() {
+        // A char literal's payload is consumed unconditionally so that
+        // `#\(` and friends cannot unbalance the scan.
+        if i == start + 2 && &bytes[start..i] == br"#\" {
+            i += 1;
+            continue;
+        }
+        match bytes[i] {
+            b'(' | b')' | b'[' | b']' | b'"' | b';' | b'\'' | b'`' | b',' => break,
+            b if b.is_ascii_whitespace() => break,
+            _ => i += 1,
+        }
+    }
+    i
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scan_defs_and_occs() {
+        let src = "(define (node-fn-0:1-i1-o1 input0) (+ input0 1))\n\n\
+                   (define (graph-fn-0) (node-fn-0:1-i1-o1 node-1-o0))";
+        let map = SourceMap::parse(src);
+        assert_eq!(map.defs().len(), 2);
+        assert_eq!(
+            map.defs()[0].name,
+            Some(Name::NodeFn {
+                path: vec![0, 1],
+                inputs: "1".parse().unwrap(),
+                outputs: "1".parse().unwrap(),
+            })
+        );
+        assert_eq!(&src[map.defs()[0].name_range.clone()], "node-fn-0:1-i1-o1");
+        assert_eq!(
+            map.defs()[1].name,
+            Some(Name::GraphFn {
+                path: vec![0],
+                inputs: node::Conns::empty(),
+            })
+        );
+        // The second def holds two occs: the node fn call and the var.
+        let occs: Vec<_> = map
+            .occs()
+            .iter()
+            .map(|o| (&src[o.range.clone()], o.def_ix))
+            .collect();
+        assert_eq!(occs, vec![("node-fn-0:1-i1-o1", 1), ("node-1-o0", 1)]);
+    }
+
+    #[test]
+    fn scanner_skips_strings_comments_and_char_literals() {
+        let src = "(define (node-fn-0-o1) (foo \"a ) b \\\" (\" #\\( #\\) ; node-1-o0 )\n 'node-2-o0 sym))";
+        let map = SourceMap::parse(src);
+        assert_eq!(map.defs().len(), 1);
+        assert_eq!(&src[map.defs()[0].range.clone()], src);
+        // Only the quoted (but still identifier-shaped) var is recorded; the
+        // string, char literals and comment contribute nothing.
+        let occs: Vec<_> = map.occs().iter().map(|o| &src[o.range.clone()]).collect();
+        assert_eq!(occs, vec!["node-2-o0"]);
+    }
+
+    #[test]
+    fn node_at_resolution() {
+        let src = "(define (lvl-fn-abababab-3) (define node-0-o0 (node-fn-3:0-o1)) node-0-o0)";
+        let map = SourceMap::parse(src);
+        // The call identifier resolves to the called node's full path.
+        let call = src.find("(node-fn-3:0-o1)").unwrap();
+        assert_eq!(map.node_at(call..call + 16), Some(vec![3, 0]));
+        // A var resolves relative to the def's level path.
+        let var = src.rfind("node-0-o0").unwrap();
+        assert_eq!(map.node_at(var..var + 9), Some(vec![3, 0]));
+        // A span with no identifiers falls back to the def's attribution.
+        let kw = src.find("define").unwrap();
+        assert_eq!(map.node_at(kw..kw + 6), Some(vec![3]));
+        // Out of range.
+        assert_eq!(map.node_at(src.len()..src.len() + 1), None);
+    }
+}

--- a/crates/gantz_core/src/diagnostic.rs
+++ b/crates/gantz_core/src/diagnostic.rs
@@ -53,13 +53,25 @@ impl Diagnostic {
 }
 
 /// Diagnostics for a [`vm::CompileError`] from [`vm::compile`]/[`vm::init`].
-pub fn from_compile_error(err: &vm::CompileError, vm: &Engine) -> Vec<Diagnostic> {
+pub fn from_compile_error(err: &vm::CompileError) -> Vec<Diagnostic> {
     match err {
         vm::CompileError::Module(err) => from_module_error(err),
         vm::CompileError::Eval { err, module } => {
-            let mut diag = from_eval_error(err, vm, module);
-            diag.severity = Severity::Compile;
-            vec![diag]
+            // The error came from running exactly this module, so its span
+            // needs no source verification.
+            let span = vm::steel_err_raw_span(err);
+            let path = span
+                .clone()
+                .and_then(|span| module.map.node_at(span))
+                .unwrap_or_default();
+            vec![Diagnostic {
+                path,
+                inputs: vec![],
+                outputs: vec![],
+                span,
+                message: err.to_string(),
+                severity: Severity::Compile,
+            }]
         }
     }
 }

--- a/crates/gantz_core/src/diagnostic.rs
+++ b/crates/gantz_core/src/diagnostic.rs
@@ -1,0 +1,152 @@
+//! Structured diagnostics extracted from compile and runtime errors, for
+//! frontends to surface against the graph (e.g. highlighting the offending
+//! node) and the emitted module source (e.g. highlighting the error span).
+
+use crate::{
+    compile::ModuleError,
+    compile::error::{LowerError, NodeConnsError, NodeFnError},
+    node, vm,
+};
+use std::ops::Range;
+use steel::{SteelErr, steel_vm::engine::Engine};
+
+/// When the diagnosed error arose.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Severity {
+    /// Generating or loading the module failed.
+    Compile,
+    /// Evaluating an entrypoint failed.
+    Runtime,
+}
+
+/// One error attributed to a location in the graph and, when available, the
+/// emitted module source.
+#[derive(Clone, Debug)]
+pub struct Diagnostic {
+    /// Full path of the implicated node; empty means the graph as a whole.
+    pub path: Vec<node::Id>,
+    /// Implicated input indices on the node (e.g. an edge referencing an
+    /// invalid input), for edge-level attribution.
+    pub inputs: Vec<usize>,
+    /// Implicated output indices on the node.
+    pub outputs: Vec<usize>,
+    /// Byte range into the compiled module source ([`vm::Compiled::src`]).
+    pub span: Option<Range<usize>>,
+    /// Human-readable description.
+    pub message: String,
+    /// When the error arose.
+    pub severity: Severity,
+}
+
+impl Diagnostic {
+    /// A compile diagnostic for the node at `path`.
+    fn compile(path: Vec<node::Id>, message: String) -> Self {
+        Self {
+            path,
+            inputs: vec![],
+            outputs: vec![],
+            span: None,
+            message,
+            severity: Severity::Compile,
+        }
+    }
+}
+
+/// Diagnostics for a [`vm::CompileError`] from [`vm::compile`]/[`vm::init`].
+pub fn from_compile_error(err: &vm::CompileError, vm: &Engine) -> Vec<Diagnostic> {
+    match err {
+        vm::CompileError::Module(err) => from_module_error(err),
+        vm::CompileError::Eval { err, module } => {
+            let mut diag = from_eval_error(err, vm, module);
+            diag.severity = Severity::Compile;
+            vec![diag]
+        }
+    }
+}
+
+/// Diagnostics for a module generation error.
+pub fn from_module_error(err: &ModuleError) -> Vec<Diagnostic> {
+    match err {
+        ModuleError::NodeConns { path, error } => vec![conns_diag(path.clone(), error)],
+        ModuleError::Lower { path, error } => lower_diags(path, error),
+        ModuleError::NestedGraphNotFound(error) => {
+            vec![Diagnostic::compile(error.0.clone(), error.to_string())]
+        }
+        ModuleError::MetaErrors(errors) => errors
+            .0
+            .iter()
+            .map(|e| conns_diag(e.path.clone(), &e.error))
+            .collect(),
+        ModuleError::NodeFnErrors(errors) => errors.0.iter().map(node_fn_diag).collect(),
+        ModuleError::InvalidIr { path, .. } => {
+            vec![Diagnostic::compile(path.clone(), err.to_string())]
+        }
+    }
+}
+
+/// The diagnostic for a steel error raised evaluating the compiled module
+/// (typically from an entrypoint call).
+pub fn from_eval_error(err: &SteelErr, vm: &Engine, compiled: &vm::Compiled) -> Diagnostic {
+    let span = vm::steel_err_span(err, vm, compiled);
+    let path = span
+        .clone()
+        .and_then(|span| compiled.map.node_at(span))
+        .unwrap_or_default();
+    Diagnostic {
+        path,
+        inputs: vec![],
+        outputs: vec![],
+        span,
+        message: err.to_string(),
+        severity: Severity::Runtime,
+    }
+}
+
+/// A diagnostic for a connection error at the node or level at `path`.
+fn conns_diag(path: Vec<node::Id>, error: &NodeConnsError) -> Diagnostic {
+    let mut diag = Diagnostic::compile(path, error.to_string());
+    match error {
+        NodeConnsError::InvalidOutputIndex(e) => diag.outputs.push(e.index),
+        NodeConnsError::TooManyConns(_) => {}
+    }
+    diag
+}
+
+/// Diagnostics for a lowering error, resolving the error's level-relative
+/// node ids against the level's path.
+fn lower_diags(level: &[node::Id], error: &LowerError) -> Vec<Diagnostic> {
+    let full = |id: node::Id| level.iter().copied().chain([id]).collect::<Vec<_>>();
+    let message = error.to_string();
+    match error {
+        LowerError::Conns { node, error } => {
+            let path = node.map(full).unwrap_or_else(|| level.to_vec());
+            vec![conns_diag(path, error)]
+        }
+        LowerError::Entangled { branch, node } => vec![
+            Diagnostic::compile(full(*node), message.clone()),
+            Diagnostic::compile(full(*branch), message),
+        ],
+        LowerError::MixedInputSources { node, input } => {
+            let mut diag = Diagnostic::compile(full(*node), message);
+            diag.inputs.push(*input);
+            vec![diag]
+        }
+        LowerError::Unresolved {
+            node,
+            output,
+            consumer,
+        } => {
+            let mut producer = Diagnostic::compile(full(*node), message.clone());
+            producer.outputs.push(*output);
+            vec![producer, Diagnostic::compile(full(*consumer), message)]
+        }
+    }
+}
+
+/// The diagnostic for a node fn generation error.
+fn node_fn_diag(error: &NodeFnError) -> Diagnostic {
+    match error {
+        NodeFnError::NestedGraphNotFound(e) => Diagnostic::compile(e.0.clone(), e.to_string()),
+        NodeFnError::Expr(e) => Diagnostic::compile(e.path.clone(), e.to_string()),
+    }
+}

--- a/crates/gantz_core/src/lib.rs
+++ b/crates/gantz_core/src/lib.rs
@@ -1,10 +1,12 @@
 pub use builtin::Builtins;
+pub use diagnostic::Diagnostic;
 pub use edge::Edge;
 pub use node::Node;
 pub use steel;
 
 pub mod builtin;
 pub mod compile;
+pub mod diagnostic;
 pub mod edge;
 pub mod graph;
 pub mod node;

--- a/crates/gantz_core/src/vm.rs
+++ b/crates/gantz_core/src/vm.rs
@@ -136,24 +136,42 @@ pub fn steel_err_span(
             .and_then(|id| vm.get_source(&id))
             .is_some_and(|text| text.as_ref().as_ref() == compiled.src)
     };
-    let span = err.span().filter(in_module).or_else(|| {
-        // Frames are pushed caller-first: take the innermost in-module one.
-        let trace = err.stack_trace().as_ref()?;
-        trace
-            .trace()
-            .iter()
-            .rev()
-            .filter_map(|frame| frame.span().as_ref())
-            .find(|span| in_module(span))
-            .copied()
-    })?;
-    Some(span.range())
+    steel_err_spans(err).find(in_module).map(|span| span.range())
+}
+
+/// The first span attached to a steel error, *without* verifying which
+/// source it points into.
+///
+/// Only sound when the error's provenance is already known - e.g. an error
+/// returned by [`compile`] itself, whose spans can only index the module
+/// just run.
+pub fn steel_err_raw_span(err: &SteelErr) -> Option<std::ops::Range<usize>> {
+    steel_err_spans(err).next().map(|span| span.range())
 }
 
 /// The full path of the node best attributed to a steel error (see
 /// [`steel_err_span`]).
 pub fn steel_err_node(err: &SteelErr, vm: &Engine, compiled: &Compiled) -> Option<Vec<node::Id>> {
     compiled.map.node_at(steel_err_span(err, vm, compiled)?)
+}
+
+/// Render a [`CompileError`] - with its full `source()` cause chain - as
+/// Steel comment lines for module views, so the underlying cause is visible
+/// instead of a bare "module generation failed".
+///
+/// When the module was generated but failed evaluation, its real source
+/// follows the comment so the error span context remains visible.
+pub fn compile_error_text(err: &CompileError) -> String {
+    let body: String = error_chain(err)
+        .lines()
+        .map(|line| format!("; {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let comment = format!("; failed to compile graph:\n{body}");
+    match err {
+        CompileError::Eval { module, .. } => format!("{comment}\n\n{}", module.src),
+        CompileError::Module(_) => comment,
+    }
 }
 
 /// Format an error together with its full [`std::error::Error::source`] chain.
@@ -172,4 +190,14 @@ pub fn error_chain(err: &dyn std::error::Error) -> String {
         source = e.source();
     }
     s
+}
+
+/// The spans attached to a steel error: its own span first, then its stack
+/// trace frames innermost-first (frames are pushed caller-first).
+fn steel_err_spans(err: &SteelErr) -> impl Iterator<Item = Span> + '_ {
+    err.span().into_iter().chain(
+        err.stack_trace()
+            .iter()
+            .flat_map(|trace| trace.trace().iter().rev().filter_map(|frame| *frame.span())),
+    )
 }

--- a/crates/gantz_core/src/vm.rs
+++ b/crates/gantz_core/src/vm.rs
@@ -3,9 +3,29 @@
 //! This module provides common functionality for working with the Steel VM
 //! that is shared between different gantz frontends (Bevy app, pure egui demo, etc.).
 
-use crate::{Edge, Node, compile::ModuleError, node};
+use crate::{
+    Edge, Node,
+    compile::{ModuleError, SourceMap},
+    node,
+};
 use petgraph::visit::{Data, IntoEdgesDirected, IntoNodeReferences, NodeIndexable, Visitable};
-use steel::{SteelErr, SteelVal, parser::ast::ExprKind, steel_vm::engine::Engine};
+use steel::{
+    SteelErr, SteelVal,
+    parser::{ast::ExprKind, span::Span},
+    steel_vm::engine::Engine,
+};
+
+/// A compiled gantz module.
+#[derive(Clone, Debug)]
+pub struct Compiled {
+    /// The module's top-level expressions.
+    pub exprs: Vec<ExprKind>,
+    /// The module source: exactly the text executed in the VM, so steel
+    /// error spans and [`Compiled::map`] offsets index into it directly.
+    pub src: String,
+    /// Byte-offset map from [`Compiled::src`] back to graph node paths.
+    pub map: SourceMap,
+}
 
 /// Errors that can occur during VM compilation.
 #[derive(Debug, thiserror::Error)]
@@ -13,20 +33,28 @@ pub enum CompileError {
     /// Error generating the Steel module from the graph.
     #[error("module generation failed")]
     Module(#[from] ModuleError),
-    /// Error executing a Steel expression in the VM.
-    #[error("expression evaluation failed")]
-    Eval(#[from] SteelErr),
+    /// Steel rejected or errored running the module.
+    #[error("module evaluation failed")]
+    Eval {
+        /// The underlying steel error; its span (if any) indexes into the
+        /// carried module's source.
+        #[source]
+        err: SteelErr,
+        /// The module that failed to evaluate, so frontends can still
+        /// display its source and resolve the error span.
+        module: Box<Compiled>,
+    },
 }
 
 /// Initialize a new VM with root state and register the given graph.
 ///
-/// Returns the initialized VM and the generated module expressions.
+/// Returns the initialized VM and the compiled module.
 pub fn init<'a, G>(
     get_node: node::GetNode<'a>,
     graph: G,
     entrypoints: &[crate::compile::Entrypoint],
     config: &crate::compile::Config,
-) -> Result<(Engine, Vec<ExprKind>), CompileError>
+) -> Result<(Engine, Compiled), CompileError>
 where
     G: Data<EdgeWeight = Edge>
         + IntoEdgesDirected
@@ -39,21 +67,23 @@ where
     let mut vm = Engine::new_base();
     vm.register_value(crate::ROOT_STATE, SteelVal::empty_hashmap());
     crate::graph::register(get_node, graph, &[], &mut vm);
-    let module = compile(get_node, graph, &mut vm, entrypoints, config)?;
-    Ok((vm, module))
+    let compiled = compile(get_node, graph, &mut vm, entrypoints, config)?;
+    Ok((vm, compiled))
 }
 
 /// Compile the graph into a Steel module and run it in the VM.
 ///
-/// This generates the Steel expressions for the graph and executes them
-/// in the provided VM. Returns the generated expressions.
+/// The module runs as a *single* program so that the engine registers
+/// [`Compiled::src`] verbatim as one source: subsequent steel errors then
+/// carry spans whose offsets index into it directly (see
+/// [`steel_err_node`]).
 pub fn compile<'a, G>(
     get_node: node::GetNode<'a>,
     graph: G,
     vm: &mut Engine,
     entrypoints: &[crate::compile::Entrypoint],
     config: &crate::compile::Config,
-) -> Result<Vec<ExprKind>, CompileError>
+) -> Result<Compiled, CompileError>
 where
     G: Data<EdgeWeight = Edge>
         + IntoEdgesDirected
@@ -63,11 +93,17 @@ where
         + Copy,
     G::NodeWeight: Node,
 {
-    let module = crate::compile::module(get_node, graph, entrypoints, config)?;
-    for expr in &module {
-        vm.run(expr.to_pretty(80))?;
+    let exprs = crate::compile::module(get_node, graph, entrypoints, config)?;
+    let src = fmt_module(&exprs);
+    let map = SourceMap::parse(&src);
+    let compiled = Compiled { exprs, src, map };
+    match vm.run(compiled.src.clone()) {
+        Ok(_) => Ok(compiled),
+        Err(err) => Err(CompileError::Eval {
+            err,
+            module: Box::new(compiled),
+        }),
     }
-    Ok(module)
 }
 
 /// Format a compiled module as a human-readable string.
@@ -80,6 +116,34 @@ pub fn fmt_module(module: &[ExprKind]) -> String {
         .map(|expr| expr.to_pretty(80))
         .collect::<Vec<String>>()
         .join("\n\n")
+}
+
+/// The full path of the node best attributed to a steel error.
+///
+/// Uses the error's own span when it points into the compiled module's
+/// source, otherwise the innermost stack-trace frame that does. A span
+/// belongs to the module when its source text (looked up in the engine by
+/// the span's source id) is exactly [`Compiled::src`] - so spans from other
+/// sources (e.g. snippets run by node UIs, or modules from before a
+/// recompile) and span-less errors yield `None`.
+pub fn steel_err_node(err: &SteelErr, vm: &Engine, compiled: &Compiled) -> Option<Vec<node::Id>> {
+    let in_module = |span: &Span| {
+        span.source_id()
+            .and_then(|id| vm.get_source(&id))
+            .is_some_and(|text| text.as_ref().as_ref() == compiled.src)
+    };
+    let span = err.span().filter(in_module).or_else(|| {
+        // Frames are pushed caller-first: take the innermost in-module one.
+        let trace = err.stack_trace().as_ref()?;
+        trace
+            .trace()
+            .iter()
+            .rev()
+            .filter_map(|frame| frame.span().as_ref())
+            .find(|span| in_module(span))
+            .copied()
+    })?;
+    compiled.map.node_at(span.range())
 }
 
 /// Format an error together with its full [`std::error::Error::source`] chain.

--- a/crates/gantz_core/src/vm.rs
+++ b/crates/gantz_core/src/vm.rs
@@ -118,7 +118,7 @@ pub fn fmt_module(module: &[ExprKind]) -> String {
         .join("\n\n")
 }
 
-/// The full path of the node best attributed to a steel error.
+/// The byte range into [`Compiled::src`] best attributed to a steel error.
 ///
 /// Uses the error's own span when it points into the compiled module's
 /// source, otherwise the innermost stack-trace frame that does. A span
@@ -126,7 +126,11 @@ pub fn fmt_module(module: &[ExprKind]) -> String {
 /// the span's source id) is exactly [`Compiled::src`] - so spans from other
 /// sources (e.g. snippets run by node UIs, or modules from before a
 /// recompile) and span-less errors yield `None`.
-pub fn steel_err_node(err: &SteelErr, vm: &Engine, compiled: &Compiled) -> Option<Vec<node::Id>> {
+pub fn steel_err_span(
+    err: &SteelErr,
+    vm: &Engine,
+    compiled: &Compiled,
+) -> Option<std::ops::Range<usize>> {
     let in_module = |span: &Span| {
         span.source_id()
             .and_then(|id| vm.get_source(&id))
@@ -143,7 +147,13 @@ pub fn steel_err_node(err: &SteelErr, vm: &Engine, compiled: &Compiled) -> Optio
             .find(|span| in_module(span))
             .copied()
     })?;
-    compiled.map.node_at(span.range())
+    Some(span.range())
+}
+
+/// The full path of the node best attributed to a steel error (see
+/// [`steel_err_span`]).
+pub fn steel_err_node(err: &SteelErr, vm: &Engine, compiled: &Compiled) -> Option<Vec<node::Id>> {
+    compiled.map.node_at(steel_err_span(err, vm, compiled)?)
 }
 
 /// Format an error together with its full [`std::error::Error::source`] chain.

--- a/crates/gantz_core/src/vm.rs
+++ b/crates/gantz_core/src/vm.rs
@@ -46,6 +46,18 @@ pub enum CompileError {
     },
 }
 
+impl CompileError {
+    /// The generated module, when compilation got far enough to produce one
+    /// (steel rejecting the module still yields the artifact, so its source
+    /// remains displayable and error spans resolvable).
+    pub fn into_module(self) -> Option<Compiled> {
+        match self {
+            Self::Module(_) => None,
+            Self::Eval { module, .. } => Some(*module),
+        }
+    }
+}
+
 /// Initialize a new VM with root state and register the given graph.
 ///
 /// Returns the initialized VM and the compiled module.
@@ -153,25 +165,6 @@ pub fn steel_err_raw_span(err: &SteelErr) -> Option<std::ops::Range<usize>> {
 /// [`steel_err_span`]).
 pub fn steel_err_node(err: &SteelErr, vm: &Engine, compiled: &Compiled) -> Option<Vec<node::Id>> {
     compiled.map.node_at(steel_err_span(err, vm, compiled)?)
-}
-
-/// Render a [`CompileError`] - with its full `source()` cause chain - as
-/// Steel comment lines for module views, so the underlying cause is visible
-/// instead of a bare "module generation failed".
-///
-/// When the module was generated but failed evaluation, its real source
-/// follows the comment so the error span context remains visible.
-pub fn compile_error_text(err: &CompileError) -> String {
-    let body: String = error_chain(err)
-        .lines()
-        .map(|line| format!("; {line}"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let comment = format!("; failed to compile graph:\n{body}");
-    match err {
-        CompileError::Eval { module, .. } => format!("{comment}\n\n{}", module.src),
-        CompileError::Module(_) => comment,
-    }
 }
 
 /// Format an error together with its full [`std::error::Error::source`] chain.

--- a/crates/gantz_core/src/vm.rs
+++ b/crates/gantz_core/src/vm.rs
@@ -148,7 +148,9 @@ pub fn steel_err_span(
             .and_then(|id| vm.get_source(&id))
             .is_some_and(|text| text.as_ref().as_ref() == compiled.src)
     };
-    steel_err_spans(err).find(in_module).map(|span| span.range())
+    steel_err_spans(err)
+        .find(in_module)
+        .map(|span| span.range())
 }
 
 /// The first span attached to a steel error, *without* verifying which

--- a/crates/gantz_core/tests/config.rs
+++ b/crates/gantz_core/tests/config.rs
@@ -119,7 +119,7 @@ fn emit_all_node_fns_includes_uncalled_nodes() {
     let g = test_graph();
     let eps = push_pull_entrypoints(&no_lookup, &g);
     let (mut vm, module) = gantz_core::vm::init(&no_lookup, &g, &eps, &config).unwrap();
-    let module_str = gantz_core::vm::fmt_module(&module);
+    let module_str = module.src;
     for fn_name in ORPHAN_FNS {
         assert!(module_str.contains(fn_name), "missing {fn_name}");
     }

--- a/crates/gantz_core/tests/diagnostics.rs
+++ b/crates/gantz_core/tests/diagnostics.rs
@@ -1,0 +1,76 @@
+//! Tests extracting structured diagnostics from compile and runtime errors.
+
+use gantz_core::{
+    Edge,
+    compile::push_pull_entrypoints,
+    diagnostic::{self, Severity},
+    node::{self, GraphNode, Node, WithPushEval},
+};
+use std::fmt::Debug;
+
+trait DebugNode: Debug + Node {}
+impl<T> DebugNode for T where T: Debug + Node {}
+
+// A no-op node lookup function for tests that don't need it.
+fn no_lookup(_: &gantz_ca::ContentAddr) -> Option<&'static dyn Node> {
+    None
+}
+
+fn node_push() -> node::Push<node::Expr> {
+    node::expr("'()").unwrap().with_push_eval()
+}
+
+// An edge referencing an out-of-range output index yields a compile
+// diagnostic carrying the offending node's full path and output index,
+// including inside a nested graph.
+#[test]
+fn invalid_edge_diagnostic() {
+    let mut ga = GraphNode::default();
+    let inlet = ga.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+    // `(+ $l 1)` has one output; the edge below leaves from output 5.
+    let inc = ga.add_node(Box::new(node::expr("(+ $l 1)").unwrap()) as Box<_>);
+    let outlet = ga.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    ga.add_edge(inlet, inc, Edge::from((0, 0)));
+    ga.add_edge(inc, outlet, Edge::from((5, 0)));
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let nested = g.add_node(Box::new(ga) as Box<_>);
+    g.add_edge(push, nested, Edge::from((0, 0)));
+
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let err = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap_err();
+    let diags = diagnostic::from_module_error(&err);
+
+    let diag = diags
+        .iter()
+        .find(|d| d.path == [nested.index(), inc.index()])
+        .unwrap_or_else(|| panic!("no diagnostic for the inc node in {diags:?}"));
+    assert_eq!(diag.outputs, vec![5]);
+    assert_eq!(diag.severity, Severity::Compile);
+    assert!(diag.message.contains("invalid output index"));
+}
+
+// A runtime steel error yields a diagnostic with the erroring node's path
+// and a span into the module source covering the failing expression.
+#[test]
+fn runtime_error_diagnostic() {
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let boom = g.add_node(Box::new(node::expr("(begin $push (car '()))").unwrap()) as Box<_>);
+    g.add_edge(push, boom, Edge::from((0, 0)));
+
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let (mut vm, compiled) = gantz_core::vm::init(&no_lookup, &g, &eps, &Default::default()).unwrap();
+    let ep = &eps[0];
+    let fn_name = gantz_core::compile::entry_fn_name(&ep.id());
+    let err = vm
+        .call_function_by_name_with_args(&fn_name, vec![])
+        .unwrap_err();
+
+    let diag = diagnostic::from_eval_error(&err, &vm, &compiled);
+    assert_eq!(diag.path, vec![boom.index()]);
+    assert_eq!(diag.severity, Severity::Runtime);
+    let span = diag.span.expect("runtime error carries a module span");
+    assert_eq!(&compiled.src[span], "car");
+}

--- a/crates/gantz_core/tests/diagnostics.rs
+++ b/crates/gantz_core/tests/diagnostics.rs
@@ -61,7 +61,8 @@ fn runtime_error_diagnostic() {
     g.add_edge(push, boom, Edge::from((0, 0)));
 
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let (mut vm, compiled) = gantz_core::vm::init(&no_lookup, &g, &eps, &Default::default()).unwrap();
+    let (mut vm, compiled) =
+        gantz_core::vm::init(&no_lookup, &g, &eps, &Default::default()).unwrap();
     let ep = &eps[0];
     let fn_name = gantz_core::compile::entry_fn_name(&ep.id());
     let err = vm

--- a/crates/gantz_core/tests/source_map.rs
+++ b/crates/gantz_core/tests/source_map.rs
@@ -1,0 +1,179 @@
+//! Tests mapping emitted module source text back to graph nodes via the
+//! compile::SourceMap.
+
+use gantz_core::{
+    Edge,
+    compile::{Name, SourceMap, push_pull_entrypoints},
+    node::{self, GraphNode, Node, WithPushEval},
+};
+use std::fmt::Debug;
+
+fn node_push() -> node::Push<node::Expr> {
+    node::expr("'()").unwrap().with_push_eval()
+}
+
+fn node_int(i: i32) -> node::Expr {
+    node::expr(format!("(begin $push {})", i)).unwrap()
+}
+
+fn node_mul() -> node::Expr {
+    node::expr("(* $l $r)").unwrap()
+}
+
+fn node_add() -> node::Expr {
+    node::expr("(+ $l $r)").unwrap()
+}
+
+// Helper trait for debugging the graph.
+trait DebugNode: Debug + Node {}
+impl<T> DebugNode for T where T: Debug + Node {}
+
+// A no-op node lookup function for tests that don't need it.
+fn no_lookup(_: &gantz_ca::ContentAddr) -> Option<&'static dyn Node> {
+    None
+}
+
+// A nested graph (mul of two inlets) driven by a push at the root:
+//
+//    push -> 6 -> [inlet -> mul <- inlet] -> add <- 42
+//         -> 7 ---^                  ^------ 42 --|
+//
+// Asserts that the source map built from the emitted module resolves node
+// fn defs, call sites and value bindings back to full node paths.
+#[test]
+fn source_map_roundtrip() {
+    // The nested graph: mul of two inlets.
+    let mut ga = GraphNode::default();
+    let inlet_a = ga.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+    let inlet_b = ga.add_node(Box::new(node::graph::Inlet) as Box<_>);
+    let mul = ga.add_node(Box::new(node_mul()) as Box<_>);
+    let outlet = ga.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    ga.add_edge(inlet_a, mul, Edge::from((0, 0)));
+    ga.add_edge(inlet_b, mul, Edge::from((0, 1)));
+    ga.add_edge(mul, outlet, Edge::from((0, 0)));
+
+    // The root graph.
+    let mut gb = petgraph::graph::DiGraph::new();
+    let push = gb.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let six = gb.add_node(Box::new(node_int(6)) as Box<_>);
+    let seven = gb.add_node(Box::new(node_int(7)) as Box<_>);
+    let graph_a = gb.add_node(Box::new(ga) as Box<_>);
+    let forty_two = gb.add_node(Box::new(node_int(42)) as Box<_>);
+    let add = gb.add_node(Box::new(node_add()) as Box<_>);
+    gb.add_edge(push, six, Edge::from((0, 0)));
+    gb.add_edge(push, seven, Edge::from((0, 0)));
+    gb.add_edge(push, forty_two, Edge::from((0, 0)));
+    gb.add_edge(six, graph_a, Edge::from((0, 0)));
+    gb.add_edge(seven, graph_a, Edge::from((0, 1)));
+    gb.add_edge(graph_a, add, Edge::from((0, 0)));
+    gb.add_edge(forty_two, add, Edge::from((0, 1)));
+
+    let eps = push_pull_entrypoints(&no_lookup, &gb);
+    let module = gantz_core::compile::module(&no_lookup, &gb, &eps).unwrap();
+    let src = gantz_core::vm::fmt_module(&module);
+    let map = SourceMap::parse(&src);
+
+    // One def per module expression, each a recognised emitted name.
+    assert_eq!(map.defs().len(), module.len());
+    for def in map.defs() {
+        assert!(
+            def.name.is_some(),
+            "unrecognised define `{}`",
+            &src[def.name_range.clone()]
+        );
+        assert!(src[def.range.clone()].starts_with("(define"));
+    }
+    // At least one def of each expected kind.
+    let kind_count = |f: &dyn Fn(&Name) -> bool| {
+        map.defs()
+            .iter()
+            .filter(|d| d.name.as_ref().is_some_and(f))
+            .count()
+    };
+    assert!(kind_count(&|n| matches!(n, Name::NodeFn { .. })) >= 4);
+    assert_eq!(kind_count(&|n| matches!(n, Name::GraphFn { .. })), 1);
+    assert_eq!(kind_count(&|n| matches!(n, Name::EntryFn { .. })), 1);
+
+    // The nested mul node: its node fn def, and its call + bindings inside
+    // the graph fn, all resolve to its full path.
+    let mul_path = vec![graph_a.index(), mul.index()];
+    let mul_spans = map.node_spans(&mul_path);
+    assert_eq!(mul_spans.defs.len(), 1, "one node fn def for mul");
+    assert!(!mul_spans.refs.is_empty(), "mul referenced in its level");
+    for range in mul_spans.defs.iter().chain(&mul_spans.refs) {
+        assert_eq!(map.node_at(range.clone()), Some(mul_path.clone()));
+    }
+    // The def is the mul node fn and contains the node's expr.
+    assert!(src[mul_spans.defs[0].clone()].starts_with("(define node-fn-"));
+    assert!(src[mul_spans.defs[0].clone()].contains("*"));
+
+    // The nested graph node itself owns two defs - its node fn wrapper and
+    // the graph fn it calls - and is called from the entry fn.
+    let ga_path = vec![graph_a.index()];
+    let ga_spans = map.node_spans(&ga_path);
+    assert_eq!(ga_spans.defs.len(), 2, "node fn wrapper + graph fn");
+    assert!(!ga_spans.refs.is_empty(), "graph fn called from entry fn");
+    for range in &ga_spans.refs {
+        assert_eq!(map.node_at(range.clone()), Some(ga_path.clone()));
+    }
+
+    // A root node's bindings inside the entry fn resolve to its path.
+    let add_path = vec![add.index()];
+    let add_spans = map.node_spans(&add_path);
+    assert_eq!(add_spans.defs.len(), 1);
+    assert!(!add_spans.refs.is_empty());
+    for range in &add_spans.refs {
+        assert_eq!(map.node_at(range.clone()), Some(add_path.clone()));
+    }
+}
+
+// A push *inside* the nested graph produces a per-entrypoint level fn whose
+// def and call site both resolve to the nested graph node's path.
+#[test]
+fn source_map_level_fn() {
+    let mut ga = GraphNode::default();
+    let push = ga.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let int = ga.add_node(Box::new(node_int(7)) as Box<_>);
+    let outlet = ga.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    ga.add_edge(push, int, Edge::from((0, 0)));
+    ga.add_edge(int, outlet, Edge::from((0, 0)));
+
+    let mut gb = petgraph::graph::DiGraph::new();
+    let graph_a = gb.add_node(Box::new(ga) as Box<dyn DebugNode>);
+    let add = gb.add_node(Box::new(node_add()) as Box<_>);
+    gb.add_edge(graph_a, add, Edge::from((0, 0)));
+
+    let eps = push_pull_entrypoints(&no_lookup, &gb);
+    let module = gantz_core::compile::module(&no_lookup, &gb, &eps).unwrap();
+    let src = gantz_core::vm::fmt_module(&module);
+    let map = SourceMap::parse(&src);
+
+    let ga_path = vec![graph_a.index()];
+    let lvl_defs: Vec<_> = map
+        .defs()
+        .iter()
+        .filter(|d| matches!(&d.name, Some(Name::LvlFn { path, .. }) if *path == ga_path))
+        .collect();
+    assert_eq!(lvl_defs.len(), 1, "one level fn for the nested push");
+    let spans = map.node_spans(&ga_path);
+    assert!(spans.defs.iter().any(|r| *r == lvl_defs[0].range));
+    assert!(!spans.refs.is_empty(), "level fn called from entry fn");
+    assert_eq!(
+        map.node_at(lvl_defs[0].range.clone()),
+        Some(ga_path.clone())
+    );
+
+    // The push node inside the nested level resolves through the level fn.
+    let push_path = vec![graph_a.index(), push.index()];
+    let int_path = vec![graph_a.index(), int.index()];
+    for path in [&push_path, &int_path] {
+        let spans = map.node_spans(path);
+        assert!(
+            !(spans.defs.is_empty() && spans.refs.is_empty()),
+            "no spans for {path:?}"
+        );
+        for range in spans.defs.iter().chain(&spans.refs) {
+            assert_eq!(map.node_at(range.clone()), Some(path.clone()));
+        }
+    }
+}

--- a/crates/gantz_core/tests/source_map.rs
+++ b/crates/gantz_core/tests/source_map.rs
@@ -69,7 +69,7 @@ fn source_map_roundtrip() {
     gb.add_edge(forty_two, add, Edge::from((0, 1)));
 
     let eps = push_pull_entrypoints(&no_lookup, &gb);
-    let module = gantz_core::compile::module(&no_lookup, &gb, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &gb, &eps, &Default::default()).unwrap();
     let src = gantz_core::vm::fmt_module(&module);
     let map = SourceMap::parse(&src);
 
@@ -144,7 +144,7 @@ fn source_map_level_fn() {
     gb.add_edge(graph_a, add, Edge::from((0, 0)));
 
     let eps = push_pull_entrypoints(&no_lookup, &gb);
-    let module = gantz_core::compile::module(&no_lookup, &gb, &eps).unwrap();
+    let module = gantz_core::compile::module(&no_lookup, &gb, &eps, &Default::default()).unwrap();
     let src = gantz_core::vm::fmt_module(&module);
     let map = SourceMap::parse(&src);
 

--- a/crates/gantz_core/tests/vm.rs
+++ b/crates/gantz_core/tests/vm.rs
@@ -161,7 +161,8 @@ fn steel_err_node_attribution() {
     g.add_edge(int, nested, Edge::from((0, 0)));
 
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let (mut vm, compiled) = gantz_core::vm::init(&no_lookup, &g, &eps, &Default::default()).unwrap();
+    let (mut vm, compiled) =
+        gantz_core::vm::init(&no_lookup, &g, &eps, &Default::default()).unwrap();
     let fn_name = push_fn_name(&g, push);
     let err = vm
         .call_function_by_name_with_args(&fn_name, vec![])
@@ -175,7 +176,8 @@ fn steel_err_node_attribution() {
     g[int] = Box::new(node::expr("(begin $push (car '()))").unwrap());
     gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
     let eps = push_pull_entrypoints(&no_lookup, &g);
-    let recompiled = gantz_core::vm::compile(&no_lookup, &g, &mut vm, &eps, &Default::default()).unwrap();
+    let recompiled =
+        gantz_core::vm::compile(&no_lookup, &g, &mut vm, &eps, &Default::default()).unwrap();
     let err = vm
         .call_function_by_name_with_args(&fn_name, vec![])
         .unwrap_err();

--- a/crates/gantz_core/tests/vm.rs
+++ b/crates/gantz_core/tests/vm.rs
@@ -1,0 +1,186 @@
+//! Tests for the vm module: single-program execution with a registered
+//! source, recompilation, and steel-error-to-node attribution.
+
+use gantz_core::{
+    Edge, ROOT_STATE,
+    compile::{entry_fn_name, push_pull_entrypoints},
+    node::{self, GraphNode, Node, WithPushEval},
+};
+use std::fmt::Debug;
+use steel::{SteelVal, steel_vm::engine::Engine};
+
+trait DebugNode: Debug + Node {}
+impl<T> DebugNode for T where T: Debug + Node {}
+
+// A no-op node lookup function for tests that don't need it.
+fn no_lookup(_: &gantz_ca::ContentAddr) -> Option<&'static dyn Node> {
+    None
+}
+
+fn node_push() -> node::Push<node::Expr> {
+    node::expr("'()").unwrap().with_push_eval()
+}
+
+fn node_int(i: i32) -> node::Expr {
+    node::expr(format!("(begin $push {})", i)).unwrap()
+}
+
+// A counter: increments its numeric state on every push, starting from 1.
+fn node_counter() -> node::Expr {
+    node::expr("(begin $push (set! state (if (number? state) (+ state 1) 1)) state)").unwrap()
+}
+
+// A stateful sink remembering the last value it received.
+fn node_sink() -> node::Expr {
+    node::expr("(begin (set! state $x) state)").unwrap()
+}
+
+// A graph with a stateful counter and a nested graph, ending in a stateful
+// sink so results survive evaluation:
+//
+//    push -> counter -> [inlet -> +1 -> outlet] -> sink
+fn test_graph() -> (
+    petgraph::graph::DiGraph<Box<dyn DebugNode>, Edge>,
+    petgraph::graph::NodeIndex,
+    petgraph::graph::NodeIndex,
+) {
+    let mut ga = GraphNode::default();
+    let inlet = ga.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+    let inc = ga.add_node(Box::new(node::expr("(+ $x 1)").unwrap()) as Box<_>);
+    let outlet = ga.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    ga.add_edge(inlet, inc, Edge::from((0, 0)));
+    ga.add_edge(inc, outlet, Edge::from((0, 0)));
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let counter = g.add_node(Box::new(node_counter()) as Box<_>);
+    let nested = g.add_node(Box::new(ga) as Box<_>);
+    let sink = g.add_node(Box::new(node_sink()) as Box<_>);
+    g.add_edge(push, counter, Edge::from((0, 0)));
+    g.add_edge(counter, nested, Edge::from((0, 0)));
+    g.add_edge(nested, sink, Edge::from((0, 0)));
+    (g, push, sink)
+}
+
+/// The entrypoint fn name for the push node.
+fn push_fn_name(
+    g: &petgraph::graph::DiGraph<Box<dyn DebugNode>, Edge>,
+    push: petgraph::graph::NodeIndex,
+) -> String {
+    let eps = push_pull_entrypoints(&no_lookup, g);
+    let ep = eps
+        .iter()
+        .find(|ep| ep.0.iter().any(|src| src.path == [push.index()]))
+        .unwrap();
+    entry_fn_name(&ep.id())
+}
+
+/// Extract the sink node's state from the VM's root state.
+fn sink_state(vm: &Engine, sink: petgraph::graph::NodeIndex) -> SteelVal {
+    node::state::extract_value(vm, &[sink.index()])
+        .unwrap()
+        .unwrap()
+}
+
+// The single-program run (vm::init) must behave identically to the
+// historical per-expression loop.
+#[test]
+fn single_run_parity_with_per_expr() {
+    let (g, push, sink) = test_graph();
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let fn_name = push_fn_name(&g, push);
+
+    // New path: single program with registered source.
+    let (mut vm_new, _) = gantz_core::vm::init(&no_lookup, &g, &eps, &Default::default()).unwrap();
+    // Old path: each expression run separately.
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
+    let mut vm_old = Engine::new_base();
+    vm_old.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm_old);
+    for expr in &module {
+        vm_old.run(expr.to_pretty(80)).unwrap();
+    }
+
+    for _ in 0..3 {
+        vm_new
+            .call_function_by_name_with_args(&fn_name, vec![])
+            .unwrap();
+        vm_old
+            .call_function_by_name_with_args(&fn_name, vec![])
+            .unwrap();
+        assert_eq!(sink_state(&vm_new, sink), sink_state(&vm_old, sink));
+    }
+    // Three increments through the nested `+1`.
+    assert_eq!(sink_state(&vm_new, sink), SteelVal::IntV(4));
+}
+
+// Recompiling into the same engine redefines the module and preserves node
+// state.
+#[test]
+fn recompile_redefines_module() {
+    let (mut g, push, sink) = test_graph();
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let fn_name = push_fn_name(&g, push);
+    let (mut vm, _) = gantz_core::vm::init(&no_lookup, &g, &eps, &Default::default()).unwrap();
+
+    vm.call_function_by_name_with_args(&fn_name, vec![])
+        .unwrap();
+    assert_eq!(sink_state(&vm, sink), SteelVal::IntV(2));
+
+    // Replace the sink with a scaling variant and recompile into the same
+    // engine.
+    g[sink] = Box::new(node::expr("(begin (set! state (* 100 $x)) state)").unwrap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    gantz_core::vm::compile(&no_lookup, &g, &mut vm, &eps, &Default::default()).unwrap();
+
+    vm.call_function_by_name_with_args(&fn_name, vec![])
+        .unwrap();
+    // Counter state persisted (2nd call -> 2), nested +1 -> 3, sink scales.
+    assert_eq!(sink_state(&vm, sink), SteelVal::IntV(300));
+}
+
+// A runtime steel error maps back to the erroring node's full path via the
+// registered source and the module's source map.
+#[test]
+fn steel_err_node_attribution() {
+    // The failing node lives inside a nested graph to exercise full-path
+    // resolution: push -> int -> [inlet -> car-of-int -> outlet].
+    let mut ga = GraphNode::default();
+    let inlet = ga.add_node(Box::new(node::graph::Inlet) as Box<dyn DebugNode>);
+    let boom = ga.add_node(Box::new(node::expr("(car $x)").unwrap()) as Box<_>);
+    let outlet = ga.add_node(Box::new(node::graph::Outlet) as Box<_>);
+    ga.add_edge(inlet, boom, Edge::from((0, 0)));
+    ga.add_edge(boom, outlet, Edge::from((0, 0)));
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let int = g.add_node(Box::new(node_int(7)) as Box<_>);
+    let nested = g.add_node(Box::new(ga) as Box<_>);
+    g.add_edge(push, int, Edge::from((0, 0)));
+    g.add_edge(int, nested, Edge::from((0, 0)));
+
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let (mut vm, compiled) = gantz_core::vm::init(&no_lookup, &g, &eps, &Default::default()).unwrap();
+    let fn_name = push_fn_name(&g, push);
+    let err = vm
+        .call_function_by_name_with_args(&fn_name, vec![])
+        .unwrap_err();
+
+    let path = gantz_core::vm::steel_err_node(&err, &vm, &compiled);
+    assert_eq!(path, Some(vec![nested.index(), boom.index()]));
+
+    // After a recompile, errors attribute against the *new* module: fail at
+    // the root `int` node, which evaluates before the nested graph.
+    g[int] = Box::new(node::expr("(begin $push (car '()))").unwrap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let recompiled = gantz_core::vm::compile(&no_lookup, &g, &mut vm, &eps, &Default::default()).unwrap();
+    let err = vm
+        .call_function_by_name_with_args(&fn_name, vec![])
+        .unwrap_err();
+    let path = gantz_core::vm::steel_err_node(&err, &vm, &recompiled);
+    assert_eq!(path, Some(vec![int.index()]));
+    // The stale pre-recompile error no longer attributes to the new module.
+    // (Its span belongs to the old source text.)
+}

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -263,6 +263,8 @@ struct DemoHeadAccess<'a> {
     /// The underlying data.
     data: &'a mut Vec<(gantz_ca::Head, Graph, GraphViews)>,
     compiled_modules: &'a [String],
+    modules: &'a [Option<gantz_core::vm::Compiled>],
+    diagnostics: &'a [Vec<gantz_core::Diagnostic>],
     vms: &'a mut Vec<Engine>,
 }
 
@@ -270,6 +272,8 @@ impl<'a> DemoHeadAccess<'a> {
     fn new(
         data: &'a mut Vec<(gantz_ca::Head, Graph, GraphViews)>,
         compiled_modules: &'a [String],
+        modules: &'a [Option<gantz_core::vm::Compiled>],
+        diagnostics: &'a [Vec<gantz_core::Diagnostic>],
         vms: &'a mut Vec<Engine>,
     ) -> Self {
         let head_keys: Vec<_> = data.iter().map(|(h, _, _)| h.clone()).collect();
@@ -283,6 +287,8 @@ impl<'a> DemoHeadAccess<'a> {
             head_to_ix,
             data,
             compiled_modules,
+            modules,
+            diagnostics,
             vms,
         }
     }
@@ -310,6 +316,46 @@ impl<'a> HeadAccess for DemoHeadAccess<'a> {
         let ix = *self.head_to_ix.get(head)?;
         Some(&self.compiled_modules[ix])
     }
+
+    fn module(&self, head: &gantz_ca::Head) -> Option<&gantz_core::vm::Compiled> {
+        let ix = *self.head_to_ix.get(head)?;
+        self.modules[ix].as_ref()
+    }
+
+    fn diagnostics(&self, head: &gantz_ca::Head) -> &[gantz_core::Diagnostic] {
+        self.head_to_ix
+            .get(head)
+            .map(|&ix| &self.diagnostics[ix][..])
+            .unwrap_or(&[])
+    }
+}
+
+/// The per-head artifacts of one compile attempt: the displayable module
+/// text, the module artifact for span resolution, and compile diagnostics.
+fn compile_results(
+    result: Result<gantz_core::vm::Compiled, gantz_core::vm::CompileError>,
+) -> (
+    String,
+    Option<gantz_core::vm::Compiled>,
+    Vec<gantz_core::Diagnostic>,
+) {
+    match result {
+        Ok(module) => (module.src.clone(), Some(module), vec![]),
+        Err(e) => {
+            log::error!(
+                "Failed to compile graph: {}",
+                gantz_core::vm::error_chain(&e)
+            );
+            let text = gantz_core::vm::compile_error_text(&e);
+            let diags = gantz_core::diagnostic::from_compile_error(&e);
+            // A module that failed evaluation still resolves spans.
+            let module = match e {
+                gantz_core::vm::CompileError::Eval { module, .. } => Some(*module),
+                gantz_core::vm::CompileError::Module(_) => None,
+            };
+            (text, module, diags)
+        }
+    }
 }
 
 // ----------------------------------------------
@@ -329,6 +375,10 @@ struct State {
     heads: Vec<(gantz_ca::Head, Graph, GraphViews)>,
     /// Per-head compiled modules, indexed to match `heads`.
     compiled_modules: Vec<String>,
+    /// Per-head module artifacts for span resolution, indexed to match `heads`.
+    modules: Vec<Option<gantz_core::vm::Compiled>>,
+    /// Per-head diagnostics, indexed to match `heads`.
+    diagnostics: Vec<Vec<gantz_core::Diagnostic>>,
     /// Per-head VMs, indexed to match `heads`.
     vms: Vec<Engine>,
     /// Index of the currently focused head.
@@ -419,21 +469,22 @@ impl App {
         let compile_config = gantz_core::compile::Config::default();
         let mut vms = Vec::with_capacity(heads.len());
         let mut compiled_modules = Vec::with_capacity(heads.len());
+        let mut modules = Vec::with_capacity(heads.len());
+        let mut diagnostics = Vec::with_capacity(heads.len());
         for (_, graph, _) in &heads {
             let get_node = |ca: &gantz_ca::ContentAddr| env.node(ca);
             let eps = push_pull_entrypoints(&get_node, graph);
-            match gantz_core::vm::init(&get_node, graph, &eps, &compile_config) {
-                Ok((vm, module)) => {
-                    vms.push(vm);
-                    compiled_modules.push(module.src);
-                }
-                Err(e) => {
-                    log::error!("Failed to init VM: {}", gantz_core::vm::error_chain(&e));
-                    // Push defaults to keep indices aligned
-                    vms.push(Engine::new_base());
-                    compiled_modules.push(String::new());
-                }
-            }
+            // A default engine keeps indices aligned on failure.
+            let (vm, result) = match gantz_core::vm::init(&get_node, graph, &eps, &compile_config)
+            {
+                Ok((vm, module)) => (vm, Ok(module)),
+                Err(e) => (Engine::new_base(), Err(e)),
+            };
+            let (text, module, diags) = compile_results(result);
+            vms.push(vm);
+            compiled_modules.push(text);
+            modules.push(module);
+            diagnostics.push(diags);
         }
 
         // GUI setup.
@@ -446,6 +497,8 @@ impl App {
             heads,
             env,
             compiled_modules,
+            modules,
+            diagnostics,
             vms,
             focused_head: 0,
             compile_config,
@@ -494,15 +547,11 @@ impl eframe::App for App {
                 let get_node = |ca: &gantz_ca::ContentAddr| self.state.env.node(ca);
                 let eps = push_pull_entrypoints(&get_node, &*graph);
                 let config = &self.state.compile_config;
-                match gantz_core::vm::compile(&get_node, &*graph, vm, &eps, config) {
-                    Ok(module) => self.state.compiled_modules[ix] = module.src,
-                    Err(e) => {
-                        log::error!(
-                            "Failed to compile graph: {}",
-                            gantz_core::vm::error_chain(&e)
-                        )
-                    }
-                }
+                let result = gantz_core::vm::compile(&get_node, &*graph, vm, &eps, config);
+                let (text, module, diags) = compile_results(result);
+                self.state.compiled_modules[ix] = text;
+                self.state.modules[ix] = module;
+                self.state.diagnostics[ix] = diags;
             }
         }
 
@@ -850,8 +899,15 @@ fn process_cmds(ctx: &egui::Context, state: &mut State) {
             match cmd {
                 gantz_egui::Cmd::EvalEntry(ep) => {
                     let fn_name = gantz_core::compile::entry_fn_name(&ep.id());
-                    if let Err(e) = state.vms[ix].call_function_by_name_with_args(&fn_name, vec![])
-                    {
+                    let result = state.vms[ix].call_function_by_name_with_args(&fn_name, vec![]);
+                    // Runtime diagnostics reflect the latest evaluation only.
+                    let diags = &mut state.diagnostics[ix];
+                    diags.retain(|d| d.severity != gantz_core::diagnostic::Severity::Runtime);
+                    if let Err(e) = result {
+                        if let Some(compiled) = &state.modules[ix] {
+                            let vm = &state.vms[ix];
+                            diags.push(gantz_core::diagnostic::from_eval_error(&e, vm, compiled));
+                        }
                         log::error!("{e}");
                     }
                 }
@@ -1201,7 +1257,13 @@ fn gui(ctx: &egui::Context, state: &mut State) {
         .show(ctx, |ui| {
             // Create the head access adapter.
             let mut access =
-                DemoHeadAccess::new(&mut state.heads, &state.compiled_modules, &mut state.vms);
+                DemoHeadAccess::new(
+                    &mut state.heads,
+                    &state.compiled_modules,
+                    &state.modules,
+                    &state.diagnostics,
+                    &mut state.vms,
+                );
 
             let no_base_names = Default::default();
             gantz_egui::widget::Gantz::new(&state.env, &no_base_names)
@@ -1359,18 +1421,17 @@ fn open_head(state: &mut State, new_head: gantz_ca::Head) {
     // Initialise the VM for the new graph and add to per-head collections.
     let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
     let eps = push_pull_entrypoints(&get_node, &new_graph);
-    match gantz_core::vm::init(&get_node, &new_graph, &eps, &state.compile_config) {
-        Ok((vm, module)) => {
-            state.vms.push(vm);
-            state.compiled_modules.push(module.src);
-        }
-        Err(e) => {
-            log::error!("Failed to init VM for new head: {e}");
-            // Push defaults to keep indices aligned
-            state.vms.push(Engine::new_base());
-            state.compiled_modules.push(String::new());
-        }
-    }
+    // A default engine keeps indices aligned on failure.
+    let (vm, result) =
+        match gantz_core::vm::init(&get_node, &new_graph, &eps, &state.compile_config) {
+            Ok((vm, module)) => (vm, Ok(module)),
+            Err(e) => (Engine::new_base(), Err(e)),
+        };
+    let (text, module, diags) = compile_results(result);
+    state.vms.push(vm);
+    state.compiled_modules.push(text);
+    state.modules.push(module);
+    state.diagnostics.push(diags);
 
     // Initialize GUI state for the new head.
     state.gantz.open_heads.entry(new_head).or_default();
@@ -1400,15 +1461,17 @@ fn replace_head(ctx: &egui::Context, state: &mut State, new_head: gantz_ca::Head
     // Reinitialize the VM for the new graph.
     let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
     let eps = push_pull_entrypoints(&get_node, &new_graph);
-    match gantz_core::vm::init(&get_node, &new_graph, &eps, &state.compile_config) {
+    let result = match gantz_core::vm::init(&get_node, &new_graph, &eps, &state.compile_config) {
         Ok((new_vm, module)) => {
             state.vms[ix] = new_vm;
-            state.compiled_modules[ix] = module.src;
+            Ok(module)
         }
-        Err(e) => {
-            log::error!("Failed to init VM for replaced head: {e}");
-        }
-    }
+        Err(e) => Err(e),
+    };
+    let (text, module, diags) = compile_results(result);
+    state.compiled_modules[ix] = text;
+    state.modules[ix] = module;
+    state.diagnostics[ix] = diags;
 
     // Update the graph pane to show the new head.
     gantz_egui::widget::update_graph_pane_head(ctx, &old_head, &new_head);
@@ -1449,15 +1512,17 @@ fn refresh_branch_head(state: &mut State) {
     *views = GraphViews::default();
     let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
     let eps = push_pull_entrypoints(&get_node, &*graph);
-    match gantz_core::vm::init(&get_node, &*graph, &eps, &state.compile_config) {
+    let result = match gantz_core::vm::init(&get_node, &*graph, &eps, &state.compile_config) {
         Ok((new_vm, module)) => {
             state.vms[ix] = new_vm;
-            state.compiled_modules[ix] = module.src;
+            Ok(module)
         }
-        Err(e) => {
-            log::error!("Failed to init VM for branch head refresh: {e}");
-        }
-    }
+        Err(e) => Err(e),
+    };
+    let (text, module, diags) = compile_results(result);
+    state.compiled_modules[ix] = text;
+    state.modules[ix] = module;
+    state.diagnostics[ix] = diags;
 }
 
 /// Recompile every open head's graph into its existing VM (no commit).
@@ -1470,17 +1535,11 @@ fn recompile_heads(state: &mut State) {
         let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
         gantz_core::graph::register(&get_node, graph, &[], vm);
         let eps = push_pull_entrypoints(&get_node, graph);
-        match gantz_core::vm::compile(&get_node, graph, vm, &eps, &state.compile_config) {
-            Ok(module) => {
-                state.compiled_modules[ix] = module.src;
-            }
-            Err(e) => {
-                log::error!(
-                    "Failed to compile graph: {}",
-                    gantz_core::vm::error_chain(&e)
-                );
-            }
-        }
+        let result = gantz_core::vm::compile(&get_node, graph, vm, &eps, &state.compile_config);
+        let (text, module, diags) = compile_results(result);
+        state.compiled_modules[ix] = text;
+        state.modules[ix] = module;
+        state.diagnostics[ix] = diags;
     }
 }
 
@@ -1497,6 +1556,8 @@ fn close_head(state: &mut State, head: &gantz_ca::Head) {
         state.heads.remove(ix);
         state.vms.remove(ix);
         state.compiled_modules.remove(ix);
+        state.modules.remove(ix);
+        state.diagnostics.remove(ix);
         state.gantz.open_heads.remove(head);
         state.gantz.redo_stacks.remove(head);
 

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -1472,7 +1472,7 @@ fn recompile_heads(state: &mut State) {
         let eps = push_pull_entrypoints(&get_node, graph);
         match gantz_core::vm::compile(&get_node, graph, vm, &eps, &state.compile_config) {
             Ok(module) => {
-                state.compiled_modules[ix] = gantz_core::vm::fmt_module(&module);
+                state.compiled_modules[ix] = module.src;
             }
             Err(e) => {
                 log::error!(

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -262,8 +262,8 @@ struct DemoHeadAccess<'a> {
     head_to_ix: HashMap<gantz_ca::Head, usize>,
     /// The underlying data.
     data: &'a mut Vec<(gantz_ca::Head, Graph, GraphViews)>,
-    compiled_modules: &'a [String],
     modules: &'a [Option<gantz_core::vm::Compiled>],
+    compile_errors: &'a [Option<String>],
     diagnostics: &'a [Vec<gantz_core::Diagnostic>],
     vms: &'a mut Vec<Engine>,
 }
@@ -271,8 +271,8 @@ struct DemoHeadAccess<'a> {
 impl<'a> DemoHeadAccess<'a> {
     fn new(
         data: &'a mut Vec<(gantz_ca::Head, Graph, GraphViews)>,
-        compiled_modules: &'a [String],
         modules: &'a [Option<gantz_core::vm::Compiled>],
+        compile_errors: &'a [Option<String>],
         diagnostics: &'a [Vec<gantz_core::Diagnostic>],
         vms: &'a mut Vec<Engine>,
     ) -> Self {
@@ -286,8 +286,8 @@ impl<'a> DemoHeadAccess<'a> {
             head_keys,
             head_to_ix,
             data,
-            compiled_modules,
             modules,
+            compile_errors,
             diagnostics,
             vms,
         }
@@ -312,14 +312,14 @@ impl<'a> HeadAccess for DemoHeadAccess<'a> {
         Some(f(HeadDataMut { graph, views, vm }))
     }
 
-    fn compiled_module(&self, head: &gantz_ca::Head) -> Option<&str> {
-        let ix = *self.head_to_ix.get(head)?;
-        Some(&self.compiled_modules[ix])
-    }
-
     fn module(&self, head: &gantz_ca::Head) -> Option<&gantz_core::vm::Compiled> {
         let ix = *self.head_to_ix.get(head)?;
         self.modules[ix].as_ref()
+    }
+
+    fn compile_error(&self, head: &gantz_ca::Head) -> Option<&str> {
+        let ix = *self.head_to_ix.get(head)?;
+        self.compile_errors[ix].as_deref()
     }
 
     fn diagnostics(&self, head: &gantz_ca::Head) -> &[gantz_core::Diagnostic] {
@@ -330,30 +330,23 @@ impl<'a> HeadAccess for DemoHeadAccess<'a> {
     }
 }
 
-/// The per-head artifacts of one compile attempt: the displayable module
-/// text, the module artifact for span resolution, and compile diagnostics.
+/// The per-head artifacts of one compile attempt: the module artifact (kept
+/// even when steel rejected it, for display and span resolution), the
+/// rendered error chain on failure, and compile diagnostics.
 fn compile_results(
     result: Result<gantz_core::vm::Compiled, gantz_core::vm::CompileError>,
 ) -> (
-    String,
     Option<gantz_core::vm::Compiled>,
+    Option<String>,
     Vec<gantz_core::Diagnostic>,
 ) {
     match result {
-        Ok(module) => (module.src.clone(), Some(module), vec![]),
+        Ok(module) => (Some(module), None, vec![]),
         Err(e) => {
-            log::error!(
-                "Failed to compile graph: {}",
-                gantz_core::vm::error_chain(&e)
-            );
-            let text = gantz_core::vm::compile_error_text(&e);
+            let error = gantz_core::vm::error_chain(&e);
+            log::error!("Failed to compile graph: {error}");
             let diags = gantz_core::diagnostic::from_compile_error(&e);
-            // A module that failed evaluation still resolves spans.
-            let module = match e {
-                gantz_core::vm::CompileError::Eval { module, .. } => Some(*module),
-                gantz_core::vm::CompileError::Module(_) => None,
-            };
-            (text, module, diags)
+            (e.into_module(), Some(error), diags)
         }
     }
 }
@@ -374,7 +367,7 @@ struct State {
     /// Each entry is a head (branch or commit), its associated graph, and view state.
     heads: Vec<(gantz_ca::Head, Graph, GraphViews)>,
     /// Per-head compiled modules, indexed to match `heads`.
-    compiled_modules: Vec<String>,
+    compile_errors: Vec<Option<String>>,
     /// Per-head module artifacts for span resolution, indexed to match `heads`.
     modules: Vec<Option<gantz_core::vm::Compiled>>,
     /// Per-head diagnostics, indexed to match `heads`.
@@ -468,7 +461,7 @@ impl App {
         // VM setup - initialize a VM for each open head.
         let compile_config = gantz_core::compile::Config::default();
         let mut vms = Vec::with_capacity(heads.len());
-        let mut compiled_modules = Vec::with_capacity(heads.len());
+        let mut compile_errors = Vec::with_capacity(heads.len());
         let mut modules = Vec::with_capacity(heads.len());
         let mut diagnostics = Vec::with_capacity(heads.len());
         for (_, graph, _) in &heads {
@@ -480,9 +473,9 @@ impl App {
                 Ok((vm, module)) => (vm, Ok(module)),
                 Err(e) => (Engine::new_base(), Err(e)),
             };
-            let (text, module, diags) = compile_results(result);
+            let (module, error, diags) = compile_results(result);
             vms.push(vm);
-            compiled_modules.push(text);
+            compile_errors.push(error);
             modules.push(module);
             diagnostics.push(diags);
         }
@@ -496,7 +489,7 @@ impl App {
             gantz,
             heads,
             env,
-            compiled_modules,
+            compile_errors,
             modules,
             diagnostics,
             vms,
@@ -548,8 +541,8 @@ impl eframe::App for App {
                 let eps = push_pull_entrypoints(&get_node, &*graph);
                 let config = &self.state.compile_config;
                 let result = gantz_core::vm::compile(&get_node, &*graph, vm, &eps, config);
-                let (text, module, diags) = compile_results(result);
-                self.state.compiled_modules[ix] = text;
+                let (module, error, diags) = compile_results(result);
+                self.state.compile_errors[ix] = error;
                 self.state.modules[ix] = module;
                 self.state.diagnostics[ix] = diags;
             }
@@ -1256,14 +1249,13 @@ fn gui(ctx: &egui::Context, state: &mut State) {
         .frame(egui::Frame::default())
         .show(ctx, |ui| {
             // Create the head access adapter.
-            let mut access =
-                DemoHeadAccess::new(
-                    &mut state.heads,
-                    &state.compiled_modules,
-                    &state.modules,
-                    &state.diagnostics,
-                    &mut state.vms,
-                );
+            let mut access = DemoHeadAccess::new(
+                &mut state.heads,
+                &state.modules,
+                &state.compile_errors,
+                &state.diagnostics,
+                &mut state.vms,
+            );
 
             let no_base_names = Default::default();
             gantz_egui::widget::Gantz::new(&state.env, &no_base_names)
@@ -1427,9 +1419,9 @@ fn open_head(state: &mut State, new_head: gantz_ca::Head) {
             Ok((vm, module)) => (vm, Ok(module)),
             Err(e) => (Engine::new_base(), Err(e)),
         };
-    let (text, module, diags) = compile_results(result);
+    let (module, error, diags) = compile_results(result);
     state.vms.push(vm);
-    state.compiled_modules.push(text);
+    state.compile_errors.push(error);
     state.modules.push(module);
     state.diagnostics.push(diags);
 
@@ -1468,8 +1460,8 @@ fn replace_head(ctx: &egui::Context, state: &mut State, new_head: gantz_ca::Head
         }
         Err(e) => Err(e),
     };
-    let (text, module, diags) = compile_results(result);
-    state.compiled_modules[ix] = text;
+    let (module, error, diags) = compile_results(result);
+    state.compile_errors[ix] = error;
     state.modules[ix] = module;
     state.diagnostics[ix] = diags;
 
@@ -1519,8 +1511,8 @@ fn refresh_branch_head(state: &mut State) {
         }
         Err(e) => Err(e),
     };
-    let (text, module, diags) = compile_results(result);
-    state.compiled_modules[ix] = text;
+    let (module, error, diags) = compile_results(result);
+    state.compile_errors[ix] = error;
     state.modules[ix] = module;
     state.diagnostics[ix] = diags;
 }
@@ -1536,8 +1528,8 @@ fn recompile_heads(state: &mut State) {
         gantz_core::graph::register(&get_node, graph, &[], vm);
         let eps = push_pull_entrypoints(&get_node, graph);
         let result = gantz_core::vm::compile(&get_node, graph, vm, &eps, &state.compile_config);
-        let (text, module, diags) = compile_results(result);
-        state.compiled_modules[ix] = text;
+        let (module, error, diags) = compile_results(result);
+        state.compile_errors[ix] = error;
         state.modules[ix] = module;
         state.diagnostics[ix] = diags;
     }
@@ -1555,7 +1547,7 @@ fn close_head(state: &mut State, head: &gantz_ca::Head) {
     if let Some(ix) = state.heads.iter().position(|(h, _, _)| h == head) {
         state.heads.remove(ix);
         state.vms.remove(ix);
-        state.compiled_modules.remove(ix);
+        state.compile_errors.remove(ix);
         state.modules.remove(ix);
         state.diagnostics.remove(ix);
         state.gantz.open_heads.remove(head);

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -468,8 +468,7 @@ impl App {
             let get_node = |ca: &gantz_ca::ContentAddr| env.node(ca);
             let eps = push_pull_entrypoints(&get_node, graph);
             // A default engine keeps indices aligned on failure.
-            let (vm, result) = match gantz_core::vm::init(&get_node, graph, &eps, &compile_config)
-            {
+            let (vm, result) = match gantz_core::vm::init(&get_node, graph, &eps, &compile_config) {
                 Ok((vm, module)) => (vm, Ok(module)),
                 Err(e) => (Engine::new_base(), Err(e)),
             };

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -425,7 +425,7 @@ impl App {
             match gantz_core::vm::init(&get_node, graph, &eps, &compile_config) {
                 Ok((vm, module)) => {
                     vms.push(vm);
-                    compiled_modules.push(gantz_core::vm::fmt_module(&module));
+                    compiled_modules.push(module.src);
                 }
                 Err(e) => {
                     log::error!("Failed to init VM: {}", gantz_core::vm::error_chain(&e));
@@ -495,9 +495,7 @@ impl eframe::App for App {
                 let eps = push_pull_entrypoints(&get_node, &*graph);
                 let config = &self.state.compile_config;
                 match gantz_core::vm::compile(&get_node, &*graph, vm, &eps, config) {
-                    Ok(module) => {
-                        self.state.compiled_modules[ix] = gantz_core::vm::fmt_module(&module)
-                    }
+                    Ok(module) => self.state.compiled_modules[ix] = module.src,
                     Err(e) => {
                         log::error!(
                             "Failed to compile graph: {}",
@@ -1364,9 +1362,7 @@ fn open_head(state: &mut State, new_head: gantz_ca::Head) {
     match gantz_core::vm::init(&get_node, &new_graph, &eps, &state.compile_config) {
         Ok((vm, module)) => {
             state.vms.push(vm);
-            state
-                .compiled_modules
-                .push(gantz_core::vm::fmt_module(&module));
+            state.compiled_modules.push(module.src);
         }
         Err(e) => {
             log::error!("Failed to init VM for new head: {e}");
@@ -1407,7 +1403,7 @@ fn replace_head(ctx: &egui::Context, state: &mut State, new_head: gantz_ca::Head
     match gantz_core::vm::init(&get_node, &new_graph, &eps, &state.compile_config) {
         Ok((new_vm, module)) => {
             state.vms[ix] = new_vm;
-            state.compiled_modules[ix] = gantz_core::vm::fmt_module(&module);
+            state.compiled_modules[ix] = module.src;
         }
         Err(e) => {
             log::error!("Failed to init VM for replaced head: {e}");
@@ -1456,7 +1452,7 @@ fn refresh_branch_head(state: &mut State) {
     match gantz_core::vm::init(&get_node, &*graph, &eps, &state.compile_config) {
         Ok((new_vm, module)) => {
             state.vms[ix] = new_vm;
-            state.compiled_modules[ix] = gantz_core::vm::fmt_module(&module);
+            state.compiled_modules[ix] = module.src;
         }
         Err(e) => {
             log::error!("Failed to init VM for branch head refresh: {e}");

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -81,6 +81,18 @@ pub trait HeadAccess {
 
     /// Get the compiled module string for a head.
     fn compiled_module(&self, head: &gantz_ca::Head) -> Option<&str>;
+
+    /// The head's latest module artifact (source text + source map), for
+    /// resolving node/error spans into the compiled module source.
+    fn module(&self, _head: &gantz_ca::Head) -> Option<&gantz_core::vm::Compiled> {
+        None
+    }
+
+    /// Diagnostics from the head's latest compile and entrypoint
+    /// evaluations.
+    fn diagnostics(&self, _head: &gantz_ca::Head) -> &[gantz_core::Diagnostic] {
+        &[]
+    }
 }
 
 /// Mutable access to a head's data, provided via [`HeadAccess::with_head_mut`].

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -79,12 +79,16 @@ pub trait HeadAccess {
         f: impl FnOnce(HeadDataMut<'_, Self::Node>) -> R,
     ) -> Option<R>;
 
-    /// Get the compiled module string for a head.
-    fn compiled_module(&self, head: &gantz_ca::Head) -> Option<&str>;
-
     /// The head's latest module artifact (source text + source map), for
-    /// resolving node/error spans into the compiled module source.
+    /// display and for resolving node/error spans into the module source.
     fn module(&self, _head: &gantz_ca::Head) -> Option<&gantz_core::vm::Compiled> {
+        None
+    }
+
+    /// The rendered error chain from the head's latest compile, when it
+    /// failed. May coexist with [`module`][Self::module] (a generated module
+    /// that steel rejected).
+    fn compile_error(&self, _head: &gantz_ca::Head) -> Option<&str> {
         None
     }
 

--- a/crates/gantz_egui/src/widget.rs
+++ b/crates/gantz_egui/src/widget.rs
@@ -16,6 +16,7 @@ pub use log_view::LogView;
 pub use node_inspector::NodeInspector;
 pub use pane_menu::PaneMenu;
 pub use perf_view::{PerfCapture, PerfView};
+pub use steel_view::SteelView;
 
 pub mod command_palette;
 pub mod gantz;
@@ -32,6 +33,7 @@ pub mod log_view;
 pub mod node_inspector;
 pub mod pane_menu;
 pub mod perf_view;
+pub mod steel_view;
 #[cfg(feature = "tracing")]
 pub mod trace_view;
 
@@ -53,9 +55,7 @@ pub(crate) fn format_local_datetime(system_time: std::time::SystemTime) -> Strin
         .unwrap_or_else(|_| "<invalid-timestamp>".to_string())
 }
 
-/// Simple shorthand for viewing steel code.
+/// Simple shorthand for viewing steel code without highlights.
 pub fn steel_view(ui: &mut egui::Ui, code: &str) {
-    let language = "scm";
-    let theme = egui_extras::syntax_highlighting::CodeTheme::from_memory(ui.ctx(), ui.style());
-    egui_extras::syntax_highlighting::code_view_ui(ui, &theme, code, language);
+    SteelView::new(code).show(ui);
 }

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use gantz_core::{Node, node};
 use petgraph::visit::{IntoNodeReferences, NodeRef};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use steel::steel_vm::engine::Engine;
 
 /// A file dropped onto a gantz pane.
@@ -761,7 +761,43 @@ where
             Pane::Logs => match &gantz.log_source {
                 None => (),
                 Some(LogSource::Logger(logger)) => {
-                    log_view(logger, ui);
+                    // Resolve labels for entries emitted by nodes of the
+                    // focused head (the target encodes the node's path).
+                    let focused = access.heads().get(*focused_head).cloned();
+                    let mut labels: HashMap<Vec<node::Id>, String> = HashMap::new();
+                    if let Some(fh) = &focused {
+                        let paths: BTreeSet<Vec<node::Id>> = logger
+                            .get_entries()
+                            .iter()
+                            .filter_map(|e| gantz_std::log::parse_log_target(&e.target))
+                            .collect();
+                        if !paths.is_empty() {
+                            let env = gantz.env;
+                            access.with_head_mut(fh, |data| {
+                                for path in paths {
+                                    let Some(node) =
+                                        graph_scene::index_path_node_mut(data.graph, &path)
+                                    else {
+                                        continue;
+                                    };
+                                    labels.insert(path, node.name(env).to_string());
+                                }
+                            });
+                        }
+                    }
+                    let res = log_view(logger, &labels, ui);
+                    // Clicking an entry navigates to and selects its node.
+                    if let (Some(path), Some(fh)) = (res.inner.clicked_path, focused) {
+                        if let Some((&node_id, parent)) = path.split_last() {
+                            let head_state = state.open_heads.entry(fh).or_default();
+                            head_state.scene.cmds.push(Cmd::OpenPath(parent.to_vec()));
+                            let selection = &mut head_state.scene.interaction.selection;
+                            selection.clear();
+                            selection
+                                .nodes
+                                .insert(graph_scene::NodeIndex::new(node_id));
+                        }
+                    }
                 }
                 #[cfg(feature = "tracing")]
                 Some(LogSource::TraceCapture(trace_capture, level)) => {
@@ -1539,9 +1575,15 @@ fn command_palette(
     }
 }
 
-fn log_view(logger: &widget::log_view::Logger, ui: &mut egui::Ui) -> egui::InnerResponse<()> {
+fn log_view(
+    logger: &widget::log_view::Logger,
+    node_labels: &HashMap<Vec<node::Id>, String>,
+    ui: &mut egui::Ui,
+) -> egui::InnerResponse<widget::log_view::LogViewResponse> {
     pane_ui(ui, |ui| {
-        widget::log_view::LogView::new("log-view".into(), logger.clone()).show(ui);
+        widget::log_view::LogView::new("log-view".into(), logger.clone())
+            .node_labels(node_labels)
+            .show(ui)
     })
 }
 

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -817,11 +817,13 @@ where
             Pane::Steel => {
                 // Use the focused head's compiled module, highlighting the
                 // selected nodes' emitted fns/call sites and any diagnostic
-                // spans.
+                // spans. A failed compile's error renders above the code.
                 let focused = access.heads().get(*focused_head).cloned();
+                let compile_error = focused.as_ref().and_then(|h| access.compile_error(h));
                 let compiled_steel = focused
                     .as_ref()
-                    .and_then(|h| access.compiled_module(h))
+                    .and_then(|h| access.module(h))
+                    .map(|m| m.src.as_str())
                     .unwrap_or("");
                 let mut highlights: Vec<std::ops::Range<usize>> = vec![];
                 let mut scroll_to = None;
@@ -862,7 +864,14 @@ where
                         }
                     }
                 }
-                steel_view(compiled_steel, &highlights, &errors, scroll_to, ui);
+                steel_view(
+                    compiled_steel,
+                    compile_error,
+                    &highlights,
+                    &errors,
+                    scroll_to,
+                    ui,
+                );
             }
             Pane::VmPerf => {
                 if let Some(ref mut capture) = gantz.perf_vm {
@@ -1672,6 +1681,7 @@ where
 
 fn steel_view(
     compiled_steel: &str,
+    compile_error: Option<&str>,
     highlights: &[std::ops::Range<usize>],
     errors: &[std::ops::Range<usize>],
     scroll_to: Option<usize>,
@@ -1681,6 +1691,14 @@ fn steel_view(
         egui::ScrollArea::vertical()
             .auto_shrink(egui::Vec2b::FALSE)
             .show(ui, |ui| {
+                if let Some(error) = compile_error {
+                    let color = ui.visuals().error_fg_color;
+                    let text = egui::RichText::new(error).monospace().color(color);
+                    ui.add(egui::Label::new(text).selectable(true));
+                    if !compiled_steel.is_empty() {
+                        ui.separator();
+                    }
+                }
                 widget::SteelView::new(compiled_steel)
                     .highlights(highlights)
                     .errors(errors)

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -793,9 +793,7 @@ where
                             head_state.scene.cmds.push(Cmd::OpenPath(parent.to_vec()));
                             let selection = &mut head_state.scene.interaction.selection;
                             selection.clear();
-                            selection
-                                .nodes
-                                .insert(graph_scene::NodeIndex::new(node_id));
+                            selection.nodes.insert(graph_scene::NodeIndex::new(node_id));
                         }
                     }
                 }
@@ -847,8 +845,7 @@ where
                             .collect();
                         selected.sort_unstable();
                         for &ix in &selected {
-                            let path: Vec<node::Id> =
-                                level.iter().copied().chain([ix]).collect();
+                            let path: Vec<node::Id> = level.iter().copied().chain([ix]).collect();
                             let spans = module.map.node_spans(&path);
                             highlights.extend(spans.defs);
                             highlights.extend(spans.refs);

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -1003,6 +1003,7 @@ where
             .expect("pane head not found in heads");
 
         let immutable = head_immutable(pane_head, self.base_immutable, self.base_names);
+        let diagnostics = self.access.diagnostics(pane_head).to_vec();
 
         let head_state = self.state.open_heads.entry(pane_head.clone()).or_default();
         let auto_layout = head_state.auto_layout;
@@ -1021,6 +1022,7 @@ where
                 layout_flow,
                 center_view,
                 immutable,
+                &diagnostics,
                 data.vm,
                 ui,
             )
@@ -1369,6 +1371,7 @@ fn graph_scene<N>(
     layout_flow: egui::Direction,
     center_view: bool,
     immutable: bool,
+    diagnostics: &[gantz_core::Diagnostic],
     vm: &mut Engine,
     ui: &mut egui::Ui,
 ) -> Option<graph_scene::GraphSceneResponse>
@@ -1406,6 +1409,8 @@ where
                 .center_view(center_view)
                 .immutable(immutable)
                 .show(view, &mut head_state.scene, vm, ui);
+
+            graph_scene::paint_diagnostics(diagnostics, &head_state.path, &response, ui);
 
             Some(response)
         }

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -779,13 +779,54 @@ where
                 }
             }
             Pane::Steel => {
-                // Use the focused head's compiled module.
-                let compiled_steel = access
-                    .heads()
-                    .get(*focused_head)
+                // Use the focused head's compiled module, highlighting the
+                // selected nodes' emitted fns/call sites and any diagnostic
+                // spans.
+                let focused = access.heads().get(*focused_head).cloned();
+                let compiled_steel = focused
+                    .as_ref()
                     .and_then(|h| access.compiled_module(h))
                     .unwrap_or("");
-                steel_view(compiled_steel, ui);
+                let mut highlights: Vec<std::ops::Range<usize>> = vec![];
+                let mut scroll_to = None;
+                let mut errors: Vec<std::ops::Range<usize>> = vec![];
+                if let Some(h) = &focused {
+                    errors = access
+                        .diagnostics(h)
+                        .iter()
+                        .filter_map(|d| d.span.clone())
+                        .collect();
+                    let head_state = state.open_heads.get(h);
+                    if let (Some(module), Some(head_state)) = (access.module(h), head_state) {
+                        let level = &head_state.path;
+                        let mut selected: Vec<node::Id> = head_state
+                            .scene
+                            .interaction
+                            .selection
+                            .nodes
+                            .iter()
+                            .map(|n| n.index())
+                            .collect();
+                        selected.sort_unstable();
+                        for &ix in &selected {
+                            let path: Vec<node::Id> =
+                                level.iter().copied().chain([ix]).collect();
+                            let spans = module.map.node_spans(&path);
+                            highlights.extend(spans.defs);
+                            highlights.extend(spans.refs);
+                        }
+                        // Scroll to the first highlighted span when the
+                        // selection changes.
+                        let state_id = egui::Id::new("steel_view_selection");
+                        let current = egui::Id::new(("steel_sel", h, level, &selected));
+                        let prev: Option<egui::Id> = ui.ctx().data(|d| d.get_temp(state_id));
+                        if prev != Some(current) {
+                            ui.ctx().data_mut(|d| d.insert_temp(state_id, current));
+                            scroll_to = highlights.iter().map(|r| r.start).min();
+                        }
+                    }
+                }
+                steel_view(compiled_steel, &highlights, &errors, scroll_to, ui);
             }
             Pane::VmPerf => {
                 if let Some(ref mut capture) = gantz.perf_vm {
@@ -1587,12 +1628,22 @@ where
     })
 }
 
-fn steel_view(compiled_steel: &str, ui: &mut egui::Ui) -> egui::InnerResponse<()> {
+fn steel_view(
+    compiled_steel: &str,
+    highlights: &[std::ops::Range<usize>],
+    errors: &[std::ops::Range<usize>],
+    scroll_to: Option<usize>,
+    ui: &mut egui::Ui,
+) -> egui::InnerResponse<()> {
     pane_ui(ui, |ui| {
         egui::ScrollArea::vertical()
             .auto_shrink(egui::Vec2b::FALSE)
             .show(ui, |ui| {
-                widget::steel_view(ui, &compiled_steel);
+                widget::SteelView::new(compiled_steel)
+                    .highlights(highlights)
+                    .errors(errors)
+                    .scroll_to(scroll_to)
+                    .show(ui);
             });
     })
 }

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -587,8 +587,16 @@ pub fn paint_diagnostics(
             unattributed = true;
             continue;
         };
-        // Paint on the node's own layer so the scene transform applies.
-        let painter = ui.ctx().layer_painter(node_response.layer_id);
+        // Paint on the node's own layer so the scene transform applies. The
+        // node's rect (and therefore the painter's clip) must be layer-local:
+        // egui maps a transformed layer's clip rects through its transform at
+        // tessellation, so the default (global) clip would land elsewhere in
+        // the scene and cut the glow off.
+        let glow_rect = node_response.rect.expand(8.0);
+        let painter = ui
+            .ctx()
+            .layer_painter(node_response.layer_id)
+            .with_clip_rect(glow_rect.expand(8.0));
         for i in 0..3 {
             let expand = 2.0 + i as f32 * 3.0;
             let alpha = [0.9, 0.45, 0.2][i];

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -595,12 +595,15 @@ pub fn paint_diagnostics(
         // in the wrong coordinate space and cuts the glow off.
         let mut painter = ui.ctx().layer_painter(node_response.layer_id);
         painter.set_clip_rect(node_response.rect.expand(16.0));
-        // A soft glow: thin rings hugging the frame, fading quickly.
-        let rings = [(1.0, 1.5, 0.45), (3.0, 2.0, 0.16), (5.5, 2.5, 0.06)];
+        // A soft glow: thin rings hugging the frame, fading quickly. Ring
+        // corners grow from the node frame's radius (`Frame::window`, see
+        // `egui_graph::node::default_frame`) so the arcs stay concentric.
+        let frame_radius = ui.visuals().window_corner_radius;
+        let rings = [(1.0f32, 1.5, 0.45), (3.0, 2.0, 0.16), (5.5, 2.5, 0.06)];
         for (expand, width, alpha) in rings {
             painter.rect_stroke(
                 node_response.rect.expand(expand),
-                egui::CornerRadius::same((4.0 + expand) as u8),
+                frame_radius + expand.round() as u8,
                 egui::Stroke::new(width, color.gamma_multiply(alpha)),
                 egui::StrokeKind::Outside,
             );

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -595,13 +595,13 @@ pub fn paint_diagnostics(
         // in the wrong coordinate space and cuts the glow off.
         let mut painter = ui.ctx().layer_painter(node_response.layer_id);
         painter.set_clip_rect(node_response.rect.expand(16.0));
-        for i in 0..3 {
-            let expand = 2.0 + i as f32 * 3.0;
-            let alpha = [0.9, 0.45, 0.2][i];
+        // A soft glow: thin rings hugging the frame, fading quickly.
+        let rings = [(1.0, 1.5, 0.45), (3.0, 2.0, 0.16), (5.5, 2.5, 0.06)];
+        for (expand, width, alpha) in rings {
             painter.rect_stroke(
                 node_response.rect.expand(expand),
                 egui::CornerRadius::same((4.0 + expand) as u8),
-                egui::Stroke::new(2.0, color.gamma_multiply(alpha)),
+                egui::Stroke::new(width, color.gamma_multiply(alpha)),
                 egui::StrokeKind::Outside,
             );
         }

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -588,15 +588,13 @@ pub fn paint_diagnostics(
             continue;
         };
         // Paint on the node's own layer so the scene transform applies. The
-        // node's rect (and therefore the painter's clip) must be layer-local:
-        // egui maps a transformed layer's clip rects through its transform at
-        // tessellation, so the default (global) clip would land elsewhere in
-        // the scene and cut the glow off.
-        let glow_rect = node_response.rect.expand(8.0);
-        let painter = ui
-            .ctx()
-            .layer_painter(node_response.layer_id)
-            .with_clip_rect(glow_rect.expand(8.0));
+        // clip must be *replaced* with a layer-local rect: egui maps a
+        // transformed layer's clip rects through its transform at
+        // tessellation, so the painter's default (global) clip - and
+        // anything intersected with it via `with_clip_rect` - is interpreted
+        // in the wrong coordinate space and cuts the glow off.
+        let mut painter = ui.ctx().layer_painter(node_response.layer_id);
+        painter.set_clip_rect(node_response.rect.expand(16.0));
         for i in 0..3 {
             let expand = 2.0 + i as f32 * 3.0;
             let alpha = [0.9, 0.45, 0.2][i];

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -577,7 +577,10 @@ pub fn paint_diagnostics(
     let mut unattributed = false;
     for diag in diagnostics {
         let flagged = diagnostic_node_at_level(&diag.path, level).and_then(|flag| {
-            let ix = response.nodes.iter().position(|(ix, _)| ix.index() == flag)?;
+            let ix = response
+                .nodes
+                .iter()
+                .position(|(ix, _)| ix.index() == flag)?;
             Some(&response.nodes[ix].1)
         });
         let Some(node_response) = flagged else {

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -551,3 +551,79 @@ where
     }
     index_path_node_mut(graph, path).and_then(|node| node.to_graph_mut())
 }
+
+/// The id of the node to flag at the viewed level for a diagnostic path: the
+/// next id under the level, so diagnostics within nested graphs flag the
+/// enclosing graph node. `None` when the path is empty or lies outside the
+/// level.
+fn diagnostic_node_at_level(diag_path: &[node::Id], level: &[node::Id]) -> Option<node::Id> {
+    diag_path.strip_prefix(level)?.first().copied()
+}
+
+/// Paint a glow and hover message over the nodes implicated by diagnostics,
+/// and tint the scene border when any diagnostic cannot be attributed to a
+/// node visible at this level (e.g. a whole-graph error, or one in a level
+/// not currently viewed).
+pub fn paint_diagnostics(
+    diagnostics: &[gantz_core::Diagnostic],
+    level: &[node::Id],
+    response: &GraphSceneResponse,
+    ui: &egui::Ui,
+) {
+    if diagnostics.is_empty() {
+        return;
+    }
+    let color = ui.visuals().error_fg_color;
+    let mut unattributed = false;
+    for diag in diagnostics {
+        let flagged = diagnostic_node_at_level(&diag.path, level).and_then(|flag| {
+            let ix = response.nodes.iter().position(|(ix, _)| ix.index() == flag)?;
+            Some(&response.nodes[ix].1)
+        });
+        let Some(node_response) = flagged else {
+            unattributed = true;
+            continue;
+        };
+        // Paint on the node's own layer so the scene transform applies.
+        let painter = ui.ctx().layer_painter(node_response.layer_id);
+        for i in 0..3 {
+            let expand = 2.0 + i as f32 * 3.0;
+            let alpha = [0.9, 0.45, 0.2][i];
+            painter.rect_stroke(
+                node_response.rect.expand(expand),
+                egui::CornerRadius::same((4.0 + expand) as u8),
+                egui::Stroke::new(2.0, color.gamma_multiply(alpha)),
+                egui::StrokeKind::Outside,
+            );
+        }
+        (**node_response).clone().on_hover_text(&diag.message);
+    }
+    if unattributed {
+        ui.painter().rect_stroke(
+            response.scene.rect,
+            0,
+            egui::Stroke::new(2.0, color.gamma_multiply(0.6)),
+            egui::StrokeKind::Inside,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::diagnostic_node_at_level;
+
+    #[test]
+    fn diagnostic_level_resolution() {
+        // A node at the viewed level flags itself.
+        assert_eq!(diagnostic_node_at_level(&[3], &[]), Some(3));
+        // A node within a nested graph flags the enclosing graph node.
+        assert_eq!(diagnostic_node_at_level(&[3, 2, 1], &[]), Some(3));
+        // Viewing inside the nested graph flags the inner node.
+        assert_eq!(diagnostic_node_at_level(&[3, 2, 1], &[3]), Some(2));
+        assert_eq!(diagnostic_node_at_level(&[3, 2, 1], &[3, 2]), Some(1));
+        // Outside the viewed level or empty: unattributable.
+        assert_eq!(diagnostic_node_at_level(&[3, 2], &[4]), None);
+        assert_eq!(diagnostic_node_at_level(&[], &[]), None);
+        assert_eq!(diagnostic_node_at_level(&[3], &[3]), None);
+    }
+}

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -1,4 +1,5 @@
 use crate::{Cmd, NodeUi, PastePos, Registry};
+use egui::emath::GuiRounding;
 use egui_graph::{self, SocketKind, node::EdgeEvent};
 use gantz_core::{
     Edge, Node,
@@ -587,25 +588,40 @@ pub fn paint_diagnostics(
             unattributed = true;
             continue;
         };
-        // Paint on the node's own layer so the scene transform applies. The
-        // clip must be *replaced* with a layer-local rect: egui maps a
-        // transformed layer's clip rects through its transform at
-        // tessellation, so the painter's default (global) clip - and
-        // anything intersected with it via `with_clip_rect` - is interpreted
-        // in the wrong coordinate space and cuts the glow off.
+        // Paint on the node's own layer so the scene transform applies.
+        // Everything the painter receives must be in layer-local
+        // coordinates: egui maps a transformed layer's clip rects through
+        // its transform at tessellation, so the pane's (global) clip is
+        // mapped into local space rather than intersected as-is.
+        let to_global = ui
+            .ctx()
+            .layer_transform_to_global(node_response.layer_id)
+            .unwrap_or(egui::emath::TSTransform::IDENTITY);
+        let inv = to_global.inverse();
+        // The tessellator snaps each rect to physical pixels independently
+        // (`round_rects_to_pixels`), which at fractional transforms lets the
+        // rings land +-1px off the frame's own snapped edges. Snap the frame
+        // rect the same way the frame's shape will be, derive the rings from
+        // it, and disable their re-rounding so the gap stays even.
+        let ppp = ui.ctx().pixels_per_point();
+        let frame = inv.mul_rect(to_global.mul_rect(node_response.rect).round_to_pixels(ppp));
         let mut painter = ui.ctx().layer_painter(node_response.layer_id);
-        painter.set_clip_rect(node_response.rect.expand(16.0));
+        let local_clip = inv.mul_rect(ui.clip_rect());
+        painter.set_clip_rect(local_clip.intersect(frame.expand(16.0)));
         // A soft glow: thin rings hugging the frame, fading quickly. Ring
         // corners grow from the node frame's radius (`Frame::window`, see
         // `egui_graph::node::default_frame`) so the arcs stay concentric.
         let frame_radius = ui.visuals().window_corner_radius;
         let rings = [(1.0f32, 1.5, 0.45), (3.0, 2.0, 0.16), (5.5, 2.5, 0.06)];
         for (expand, width, alpha) in rings {
-            painter.rect_stroke(
-                node_response.rect.expand(expand),
-                frame_radius + expand.round() as u8,
-                egui::Stroke::new(width, color.gamma_multiply(alpha)),
-                egui::StrokeKind::Outside,
+            painter.add(
+                egui::epaint::RectShape::stroke(
+                    frame.expand(expand),
+                    frame_radius + expand.round() as u8,
+                    egui::Stroke::new(width, color.gamma_multiply(alpha)),
+                    egui::StrokeKind::Outside,
+                )
+                .with_round_to_pixels(false),
             );
         }
         (**node_response).clone().on_hover_text(&diag.message);

--- a/crates/gantz_egui/src/widget/log_view.rs
+++ b/crates/gantz_egui/src/widget/log_view.rs
@@ -1,15 +1,26 @@
 use egui_extras::{Column, TableBuilder};
+use gantz_core::node;
 use log::{Level, Metadata, Record};
 use std::{
-    collections::VecDeque,
+    collections::{HashMap, VecDeque},
     sync::{Arc, Mutex},
 };
 use web_time::SystemTime;
 
-/// A table presenting the
-pub struct LogView {
+/// A table presenting the log entries.
+pub struct LogView<'a> {
     logger: Logger,
     id: egui::Id,
+    /// Labels for entries whose target identifies an emitting node (see
+    /// `gantz_std::log::log_target`), keyed by node path.
+    node_labels: Option<&'a HashMap<Vec<node::Id>, String>>,
+}
+
+/// The response returned by [`LogView::show`].
+#[derive(Default)]
+pub struct LogViewResponse {
+    /// The node path of a clicked gantz-target entry, for navigation.
+    pub clicked_path: Option<Vec<node::Id>>,
 }
 
 // State that needs to persist between frames.
@@ -101,12 +112,24 @@ impl log::Log for Logger {
     fn flush(&self) {}
 }
 
-impl LogView {
+impl<'a> LogView<'a> {
     pub fn new(id: egui::Id, logger: Logger) -> Self {
-        Self { logger, id }
+        Self {
+            logger,
+            id,
+            node_labels: None,
+        }
     }
 
-    pub fn show(&mut self, ui: &mut egui::Ui) {
+    /// Provide node labels for gantz-target entries; their target cells
+    /// then show `label (path)` and become clickable for navigation.
+    pub fn node_labels(mut self, labels: &'a HashMap<Vec<node::Id>, String>) -> Self {
+        self.node_labels = Some(labels);
+        self
+    }
+
+    pub fn show(&mut self, ui: &mut egui::Ui) -> LogViewResponse {
+        let mut response = LogViewResponse::default();
         // Get or initialize our state from memory
         let state_id = self.id.with("state");
         let mut state = ui
@@ -217,7 +240,27 @@ impl LogView {
                     });
 
                     row.col(|ui| {
-                        ui.colored_label(text_color, &entry.target);
+                        let node_path = gantz_std::log::parse_log_target(&entry.target);
+                        match node_path {
+                            Some(path) => {
+                                let label = self
+                                    .node_labels
+                                    .and_then(|labels| labels.get(&path))
+                                    .map(String::as_str);
+                                let ids: Vec<String> =
+                                    path.iter().map(ToString::to_string).collect();
+                                let text = match label {
+                                    Some(label) => format!("{label} ({})", ids.join(":")),
+                                    None => ids.join(":"),
+                                };
+                                if ui.link(text).on_hover_text("select node").clicked() {
+                                    response.clicked_path = Some(path);
+                                }
+                            }
+                            None => {
+                                ui.colored_label(text_color, &entry.target);
+                            }
+                        }
                     });
 
                     row.col(|ui| {
@@ -236,5 +279,7 @@ impl LogView {
 
         // Store the modified state back in memory
         ui.memory_mut(|mem| mem.data.insert_temp(state_id, state));
+
+        response
     }
 }

--- a/crates/gantz_egui/src/widget/steel_view.rs
+++ b/crates/gantz_egui/src/widget/steel_view.rs
@@ -1,0 +1,170 @@
+//! A read-only view of compiled steel source with byte-range highlighting
+//! (e.g. the selected node's emitted fns and call sites, diagnostic spans)
+//! and scroll-to support.
+
+use egui::text::{LayoutJob, LayoutSection};
+use std::ops::Range;
+
+/// A syntax-highlighted, read-only steel source view.
+pub struct SteelView<'a> {
+    code: &'a str,
+    /// Byte ranges to emphasise (e.g. the selected node's spans).
+    highlights: &'a [Range<usize>],
+    /// Byte ranges of diagnostic spans, tinted with the error colour.
+    errors: &'a [Range<usize>],
+    /// A byte offset to scroll into view this frame.
+    scroll_to: Option<usize>,
+}
+
+impl<'a> SteelView<'a> {
+    pub fn new(code: &'a str) -> Self {
+        Self {
+            code,
+            highlights: &[],
+            errors: &[],
+            scroll_to: None,
+        }
+    }
+
+    /// Byte ranges to emphasise with the selection colour.
+    pub fn highlights(mut self, ranges: &'a [Range<usize>]) -> Self {
+        self.highlights = ranges;
+        self
+    }
+
+    /// Byte ranges to tint with the error colour.
+    pub fn errors(mut self, ranges: &'a [Range<usize>]) -> Self {
+        self.errors = ranges;
+        self
+    }
+
+    /// Scroll the row containing this byte offset into view this frame.
+    pub fn scroll_to(mut self, offset: Option<usize>) -> Self {
+        self.scroll_to = offset;
+        self
+    }
+
+    /// Render the view (expects to be shown within a `ScrollArea`).
+    pub fn show(self, ui: &mut egui::Ui) -> egui::Response {
+        let theme =
+            egui_extras::syntax_highlighting::CodeTheme::from_memory(ui.ctx(), ui.style());
+        let mut job = egui_extras::syntax_highlighting::highlight(
+            ui.ctx(),
+            ui.style(),
+            &theme,
+            self.code,
+            "scm",
+        );
+        let highlight_bg = ui.visuals().selection.bg_fill.gamma_multiply(0.4);
+        let error_bg = ui.visuals().error_fg_color.gamma_multiply(0.3);
+        apply_background(&mut job, self.highlights, highlight_bg);
+        apply_background(&mut job, self.errors, error_bg);
+        job.wrap.max_width = f32::INFINITY;
+
+        let galley = ui.painter().layout_job(job);
+        let response = ui.add(egui::Label::new(galley.clone()).selectable(true));
+
+        if let Some(offset) = self.scroll_to {
+            let chars = self.code[..offset.min(self.code.len())].chars().count();
+            let row = galley.pos_from_cursor(egui::text::CCursor::new(chars));
+            let target = row.translate(response.rect.min.to_vec2());
+            ui.scroll_to_rect(target, Some(egui::Align::Center));
+        }
+        response
+    }
+}
+
+/// Set the background colour of the given byte ranges, splitting the job's
+/// sections at range boundaries as needed.
+pub(crate) fn apply_background(job: &mut LayoutJob, ranges: &[Range<usize>], color: egui::Color32) {
+    for range in ranges {
+        if range.start >= range.end {
+            continue;
+        }
+        let mut sections = Vec::with_capacity(job.sections.len() + 2);
+        for section in job.sections.drain(..) {
+            let sr = section.byte_range.clone();
+            if sr.end <= range.start || range.end <= sr.start {
+                sections.push(section);
+                continue;
+            }
+            let mid = sr.start.max(range.start)..sr.end.min(range.end);
+            let mut first = true;
+            for (bytes, within) in [
+                (sr.start..mid.start, false),
+                (mid.clone(), true),
+                (mid.end..sr.end, false),
+            ] {
+                if bytes.start >= bytes.end {
+                    continue;
+                }
+                let mut format = section.format.clone();
+                if within {
+                    format.background = color;
+                }
+                sections.push(LayoutSection {
+                    // Leading space belongs to the first sub-section only.
+                    leading_space: if first { section.leading_space } else { 0.0 },
+                    byte_range: bytes,
+                    format,
+                });
+                first = false;
+            }
+        }
+        job.sections = sections;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use egui::Color32;
+
+    fn job() -> LayoutJob {
+        let mut job = LayoutJob::default();
+        job.append("hello", 0.0, Default::default());
+        job.append(" world!", 0.0, Default::default());
+        job
+    }
+
+    fn ranges(job: &LayoutJob) -> Vec<(Range<usize>, bool)> {
+        job.sections
+            .iter()
+            .map(|s| {
+                (
+                    s.byte_range.clone(),
+                    s.format.background != Color32::default(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn splits_sections_at_range_boundaries() {
+        let mut job = job();
+        apply_background(&mut job, &[3..8], Color32::YELLOW);
+        assert_eq!(
+            ranges(&job),
+            vec![(0..3, false), (3..5, true), (5..8, true), (8..12, false)]
+        );
+        // Full text preserved in order.
+        assert_eq!(job.sections.last().unwrap().byte_range.end, job.text.len());
+    }
+
+    #[test]
+    fn empty_and_out_of_range_are_noops() {
+        let mut job = job();
+        apply_background(&mut job, &[4..4, 50..60], Color32::YELLOW);
+        assert_eq!(ranges(&job), vec![(0..5, false), (5..12, false)]);
+    }
+
+    #[test]
+    fn overlapping_ranges_compose() {
+        let mut job = job();
+        apply_background(&mut job, &[0..4, 2..6], Color32::YELLOW);
+        let r = ranges(&job);
+        // Every byte in 0..6 highlighted, the rest untouched.
+        assert!(r.iter().all(|(range, bg)| *bg == (range.start < 6)));
+        assert_eq!(r.last().unwrap().0.end, 12);
+    }
+}

--- a/crates/gantz_egui/src/widget/steel_view.rs
+++ b/crates/gantz_egui/src/widget/steel_view.rs
@@ -46,8 +46,7 @@ impl<'a> SteelView<'a> {
 
     /// Render the view (expects to be shown within a `ScrollArea`).
     pub fn show(self, ui: &mut egui::Ui) -> egui::Response {
-        let theme =
-            egui_extras::syntax_highlighting::CodeTheme::from_memory(ui.ctx(), ui.style());
+        let theme = egui_extras::syntax_highlighting::CodeTheme::from_memory(ui.ctx(), ui.style());
         let mut job = egui_extras::syntax_highlighting::highlight(
             ui.ctx(),
             ui.style(),

--- a/crates/gantz_std/Cargo.toml
+++ b/crates/gantz_std/Cargo.toml
@@ -16,3 +16,6 @@ serde.workspace = true
 steel-core.workspace = true
 steel-derive.workspace = true
 typetag.workspace = true
+
+[dev-dependencies]
+petgraph.workspace = true

--- a/crates/gantz_std/src/log.rs
+++ b/crates/gantz_std/src/log.rs
@@ -1,8 +1,11 @@
-use gantz_core::node::{ExprCtx, ExprResult, MetaCtx, RegCtx};
+use gantz_core::node::{self, ExprCtx, ExprResult, MetaCtx, RegCtx};
 use gantz_core::steel::{SteelVal, steel_vm::register_fn::RegisterFn};
 use serde::{Deserialize, Serialize};
 
 /// A simple node that logs whatever value is received at a given log level.
+///
+/// The emitted expression passes the node's own path so the log entry's
+/// target identifies the emitting node (see [`log_target`]).
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct Log {
     pub level: log::Level,
@@ -32,26 +35,36 @@ impl gantz_core::Node for Log {
             log::Level::Debug => "debug",
             log::Level::Trace => "trace",
         };
+        let path = ctx
+            .path()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(" ");
         // TODO: Switch to proper logging. Reference steel logging.scm example.
-        let expr = format!("(log/{level} {input})");
+        let expr = format!("(log/{level} '({path}) {input})");
         gantz_core::node::parse_expr(&expr)
     }
 
     fn register(&self, mut ctx: RegCtx<'_, '_>) {
-        fn error(val: SteelVal) {
-            log::error!("{}", val);
+        fn log_val(level: log::Level, path: &SteelVal, val: &SteelVal) {
+            let path = path_from_val(path);
+            log::log!(target: &log_target(&path), level, "{val}");
         }
-        fn warn(val: SteelVal) {
-            log::warn!("{}", val);
+        fn error(path: SteelVal, val: SteelVal) {
+            log_val(log::Level::Error, &path, &val);
         }
-        fn info(val: SteelVal) {
-            log::info!("{}", val);
+        fn warn(path: SteelVal, val: SteelVal) {
+            log_val(log::Level::Warn, &path, &val);
         }
-        fn debug(val: SteelVal) {
-            log::debug!("{}", val);
+        fn info(path: SteelVal, val: SteelVal) {
+            log_val(log::Level::Info, &path, &val);
         }
-        fn trace(val: SteelVal) {
-            log::trace!("{}", val);
+        fn debug(path: SteelVal, val: SteelVal) {
+            log_val(log::Level::Debug, &path, &val);
+        }
+        fn trace(path: SteelVal, val: SteelVal) {
+            log_val(log::Level::Trace, &path, &val);
         }
         ctx.vm().register_fn("log/error", error);
         ctx.vm().register_fn("log/warn", warn);
@@ -64,5 +77,50 @@ impl gantz_core::Node for Log {
 impl gantz_ca::CaHash for Log {
     fn hash(&self, hasher: &mut gantz_ca::Hasher) {
         format!("gantz_std::Log::{:?}", self.level).hash(hasher);
+    }
+}
+
+/// The log target identifying the node at the given path, e.g. `gantz:0:3:2`.
+pub fn log_target(path: &[node::Id]) -> String {
+    let path: Vec<String> = path.iter().map(ToString::to_string).collect();
+    format!("gantz:{}", path.join(":"))
+}
+
+/// Parse the node path back out of a [`log_target`]-formatted target.
+pub fn parse_log_target(target: &str) -> Option<Vec<node::Id>> {
+    let path = target.strip_prefix("gantz:")?;
+    path.split(':').map(|id| id.parse().ok()).collect()
+}
+
+/// The node path carried in a log fn's first argument (a quoted id list).
+fn path_from_val(val: &SteelVal) -> Vec<node::Id> {
+    match val {
+        SteelVal::ListV(ids) => ids
+            .iter()
+            .filter_map(|id| match id {
+                SteelVal::IntV(id) => usize::try_from(*id).ok(),
+                _ => None,
+            })
+            .collect(),
+        _ => vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_target_roundtrip() {
+        for path in [vec![0], vec![3, 2, 1], vec![10, 200]] {
+            assert_eq!(parse_log_target(&log_target(&path)), Some(path));
+        }
+    }
+
+    #[test]
+    fn non_gantz_targets_rejected() {
+        for target in ["", "gantz_std::log", "gantz:", "gantz:x", "gantz:1:x"] {
+            assert_eq!(parse_log_target(target), None, "{target}");
+        }
     }
 }

--- a/crates/gantz_std/tests/log.rs
+++ b/crates/gantz_std/tests/log.rs
@@ -1,0 +1,38 @@
+//! Tests for the log node's provenance: the emitted expression carries the
+//! node's own path so log entries identify their emitting node.
+
+use gantz_core::{
+    Edge, Node,
+    compile::push_pull_entrypoints,
+    node::{self, WithPushEval},
+};
+use std::fmt::Debug;
+
+trait DebugNode: Debug + Node {}
+impl<T> DebugNode for T where T: Debug + Node {}
+
+// A no-op node lookup function for tests that don't need it.
+fn no_lookup(_: &gantz_ca::ContentAddr) -> Option<&'static dyn Node> {
+    None
+}
+
+// The emitted module passes the log node's path as a quoted literal to the
+// registered log fn.
+#[test]
+fn log_expr_carries_node_path() {
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node::expr("'()").unwrap().with_push_eval()) as Box<dyn DebugNode>);
+    let int = g.add_node(Box::new(node::expr("(begin $push 7)").unwrap()) as Box<_>);
+    let log = g.add_node(Box::new(gantz_std::Log::default()) as Box<_>);
+    g.add_edge(push, int, Edge::from((0, 0)));
+    g.add_edge(int, log, Edge::from((0, 0)));
+
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
+    let src = gantz_core::vm::fmt_module(&module);
+    let expected = format!("(log/info (quote ({})) ", log.index());
+    assert!(
+        src.contains(&expected) || src.contains(&format!("(log/info '({})", log.index())),
+        "module does not pass the log node's path:\n{src}"
+    );
+}

--- a/crates/gantz_std/tests/log.rs
+++ b/crates/gantz_std/tests/log.rs
@@ -21,7 +21,8 @@ fn no_lookup(_: &gantz_ca::ContentAddr) -> Option<&'static dyn Node> {
 #[test]
 fn log_expr_carries_node_path() {
     let mut g = petgraph::graph::DiGraph::new();
-    let push = g.add_node(Box::new(node::expr("'()").unwrap().with_push_eval()) as Box<dyn DebugNode>);
+    let push =
+        g.add_node(Box::new(node::expr("'()").unwrap().with_push_eval()) as Box<dyn DebugNode>);
     let int = g.add_node(Box::new(node::expr("(begin $push 7)").unwrap()) as Box<_>);
     let log = g.add_node(Box::new(gantz_std::Log::default()) as Box<_>);
     g.add_edge(push, int, Edge::from((0, 0)));


### PR DESCRIPTION
Compilation feedback was text-only: errors were logged and dumped into the module view as comments, and nothing connected the emitted steel to the graph it came from. This PR makes the mapping explicit in both directions and surfaces it throughout the GUI.

## Newly Added

### `compile::names`

Every emitted-identifier formatter consolidated into one module, plus the inverse: a public `Name` enum and `parse` fn resolving emitted identifiers (`node-fn-{path}`, `graph-fn-{path}`, `lvl-fn-`, `entry-fn-`, value bindings, joins) back to node paths. Keeping format and parse together stops them drifting; roundtrip tests cover every formatter.

### `compile::SourceMap`

A lexical scan of the pretty-printed module text recording every top-level define and gantz-named identifier occurrence. `node_spans(path)` returns a node's emitted defs + call sites; `node_at(range)` attributes any byte range to a full node path, resolving level-relative bindings against the enclosing define. Scanning the final text (rather than threading spans through emission) keeps offsets correct by construction; steel's own AST is unusable here since `emit_ast` lowering collapses define spans to the keyword token.

### Single-program execution + error attribution

`vm::compile` now runs the whole module as one steel program, so the engine registers the exact displayed source and every steel error span indexes it byte-for-byte. The new `vm::Compiled { exprs, src, map }` carries the artifact; `steel_err_node` attributes compile *and* runtime errors to node paths, accepting a span only when its source text matches the module verbatim (so node-UI snippets and stale pre-recompile spans are never misattributed).

**`gantz_core::diagnostic`** - structured `Diagnostic { path, inputs, outputs, span, message, severity }` extracted from any `ModuleError`/`CompileError`/`SteelErr`. `ModuleError::Lower`/`NodeConns` now carry the level path and `LowerError::Conns` the offending node id, so every compile error identifies its graph location. Dead `CodegenError` and `InvalidInputIndex` types (flow.rs leftovers) are pruned.

### GUI

- Diagnostic nodes get a red glow with the message on hover; errors inside nested graphs flag the enclosing graph node at the viewed level, and unattributable errors tint the scene border.
- The steel view highlights the selected nodes' emitted fns and call sites (and diagnostic spans in red), scrolling to the first span on selection change. Compile errors render as their own monospace region above the code - the module source displays verbatim, so span offsets always align.
- Log nodes pass their own path: entries get target `gantz:0:3:2`, the log view shows the node's label + path, and clicking navigates to and selects the emitting node.
- The compile outcome flows through a new `head::Module { compiled, error }` component (replacing the `CompiledModule` display string) plus `head::Diagnostics`, exposed via defaulted `HeadAccess::{module, compile_error, diagnostics}` methods (bevy + demo). Compile diagnostics are replaced per recompile; runtime diagnostics per evaluation, cleared on success.

## Notes

- `head::Module { compiled, error }` replaces the old `CompiledModule` display string entirely: the steel pane shows the module source verbatim (so span offsets always align) with any compile error as its own monospace region above it.
- Follow-ups deliberately out of scope: edge error highlighting (needs an `egui_graph` per-edge stroke override; `Diagnostic::{inputs,outputs}` already carry the data), click-in-steel-view -> select node, per-node emitted-code tooltips.

Closes #223 