### PR TITLE
refactor: GUI ops dedup, dynamic response channel, input-addressed VM sync

### DIFF
--- a/crates/bevy_gantz/src/head.rs
+++ b/crates/bevy_gantz/src/head.rs
@@ -29,6 +29,7 @@ pub struct OpenHeadData<N: 'static + Send + Sync> {
     pub working_graph: &'static mut WorkingGraph<N>,
     pub module: &'static mut Module,
     pub diagnostics: &'static mut Diagnostics,
+    pub compiled_inputs: &'static mut crate::vm::CompiledInputs,
 }
 
 // ----------------------------------------------------------------------------
@@ -36,7 +37,11 @@ pub struct OpenHeadData<N: 'static + Send + Sync> {
 // ----------------------------------------------------------------------------
 
 /// Marker component for an open gantz head entity.
+///
+/// Requires the compile-outcome components so every spawn path gets them by
+/// default; `vm::sync` fills them in on the next `Update`.
 #[derive(Component)]
+#[require(Module, Diagnostics, crate::vm::CompiledInputs)]
 pub struct OpenHead;
 
 /// The gantz_ca::Head (branch or commit reference).
@@ -135,7 +140,7 @@ pub struct BranchedHeadEvent {
 
 /// Emitted when a head's working graph is committed (graph changed).
 ///
-/// This event is emitted by `vm::update` when it detects a graph change
+/// This event is emitted by `vm::sync` when it detects a graph change
 /// and commits to the registry. Apps can observe this to update UI state.
 #[derive(Event)]
 pub struct CommittedEvent {
@@ -151,6 +156,12 @@ pub struct CommittedEvent {
 /// Per-head VMs stored in a NonSend resource.
 ///
 /// VMs are keyed by Entity ID since `Engine` is not `Send`.
+///
+/// A head's VM owns its graph's runtime node state. Paths that point a head
+/// at a *different* graph (replace, branch move) remove the VM (and reset
+/// [`vm::CompiledInputs`][crate::vm::CompiledInputs]) so that `vm::sync`
+/// performs a fresh init, discarding the old graph's state; in-place edits
+/// leave the VM so recompiles preserve it.
 #[derive(Default)]
 pub struct HeadVms(pub HashMap<Entity, Engine>);
 
@@ -286,7 +297,8 @@ pub fn on_open<N>(
         return;
     };
 
-    // Spawn entity (NO Module/Diagnostics - app observer adds them after VM init).
+    // Spawn the entity. `OpenHead`'s required components cover the compile
+    // outcome; `vm::sync` initializes the VM on the next `Update`.
     // Note: HeadGuiState and GraphViews are added by GantzEguiPlugin observer.
     let entity = cmds
         .spawn((OpenHead, HeadRef(new_head.clone()), WorkingGraph(graph)))
@@ -308,6 +320,7 @@ pub fn on_replace<N>(
     mut cmds: Commands,
     registry: Res<Registry<N>>,
     mut focused: ResMut<FocusedHead>,
+    mut vms: NonSendMut<HeadVms>,
     heads: Query<(Entity, &HeadRef), With<OpenHead>>,
 ) where
     N: 'static + Clone + Send + Sync,
@@ -331,11 +344,16 @@ pub fn on_replace<N>(
         return;
     };
 
-    // Update entity components (NO Module/Diagnostics - app observer adds them).
+    // The head now points at a different graph: drop the VM (discarding the
+    // old graph's node state) and reset the compile memo so `vm::sync`
+    // performs a fresh init.
     // Note: HeadGuiState and GraphViews are updated by GantzEguiPlugin observer.
-    cmds.entity(focused_entity)
-        .insert(HeadRef(new_head.clone()))
-        .insert(WorkingGraph(graph));
+    vms.remove(&focused_entity);
+    cmds.entity(focused_entity).insert((
+        HeadRef(new_head.clone()),
+        WorkingGraph(graph),
+        crate::vm::CompiledInputs::default(),
+    ));
 
     // Emit hook.
     if let Some(old) = old_head {
@@ -443,6 +461,7 @@ pub fn on_move_branch<N>(
     trigger: On<MoveBranchEvent>,
     mut cmds: Commands,
     mut registry: ResMut<Registry<N>>,
+    mut vms: NonSendMut<HeadVms>,
 ) where
     N: 'static + Clone + Send + Sync,
 {
@@ -453,7 +472,12 @@ pub fn on_move_branch<N>(
         log::error!("MoveBranch: graph missing for target commit");
         return;
     };
-    cmds.entity(event.entity).insert(WorkingGraph(graph));
+    // The head now points at a different graph: drop the VM (discarding the
+    // old graph's node state) and reset the compile memo so `vm::sync`
+    // performs a fresh init.
+    vms.remove(&event.entity);
+    cmds.entity(event.entity)
+        .insert((WorkingGraph(graph), crate::vm::CompiledInputs::default()));
     cmds.trigger(ChangedEvent {
         entity: event.entity,
         old_head: head.clone(),

--- a/crates/bevy_gantz/src/lib.rs
+++ b/crates/bevy_gantz/src/lib.rs
@@ -2,6 +2,24 @@
 //!
 //! This crate provides core Bevy integration for gantz. For egui-based UI,
 //! see the `bevy_gantz_egui` crate.
+//!
+//! # Events vs Messages
+//!
+//! Observer events (`Event` + `On<T>`) are used for discrete, low-frequency
+//! intents and hooks where immediate, possibly-cascading handling matters.
+//! These come in two layers:
+//!
+//! - *Request* events ask for an operation: [`head::OpenEvent`],
+//!   [`head::CloseEvent`], [`head::ReplaceEvent`], [`head::BranchHeadEvent`],
+//!   [`head::MoveBranchEvent`], [`vm::EvalEntryEvent`].
+//! - *Hook* events announce that one happened, decoupling this crate from
+//!   downstream UI crates: [`head::OpenedEvent`], [`head::ClosedEvent`],
+//!   [`head::ChangedEvent`], [`head::BranchedHeadEvent`],
+//!   [`head::CommittedEvent`], [`vm::EvalEntryComplete`].
+//!
+//! Buffered messages (`Message` + `MessageReader`) are reserved for
+//! per-frame streams consumed by polling systems -
+//! [`debounced_input::DebouncedInputEvent`] is the one case.
 
 pub mod builtin;
 pub mod debounced_input;
@@ -11,9 +29,7 @@ pub mod storage;
 pub mod vm;
 
 use bevy_app::{App, Plugin, Update};
-use bevy_ecs::prelude::{
-    IntoScheduleConfigs, SystemCondition, not, resource_added, resource_changed,
-};
+use bevy_ecs::prelude::{IntoScheduleConfigs, SystemSet};
 pub use builtin::{BuiltinNodes, Builtins};
 use gantz_core::Node;
 pub use head::{
@@ -21,7 +37,15 @@ pub use head::{
     WorkingGraph,
 };
 pub use reg::{Registry, lookup_node, timestamp};
-pub use vm::{CompileConfig, EntrypointFns, EvalEntryComplete, EvalEntryEvent};
+pub use vm::{CompileConfig, CompiledInputs, EntrypointFns, EvalEntryComplete, EvalEntryEvent};
+
+/// The system set in which [`vm::sync`] runs (in the `Update` schedule).
+///
+/// Systems that evaluate head VMs each frame should run `.after(VmSet)` so
+/// they never observe the gap between a head pointing at a new graph and its
+/// VM being (re)initialized.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, SystemSet)]
+pub struct VmSet;
 
 /// Plugin providing core gantz functionality.
 ///
@@ -31,8 +55,7 @@ pub use vm::{CompileConfig, EntrypointFns, EvalEntryComplete, EvalEntryEvent};
 /// - Initializes core resources (Registry, HeadVms, etc.)
 /// - Registers event observers for head operations
 /// - Registers the eval event observer
-/// - Handles VM initialization for opened/changed heads
-/// - Detects graph changes and recompiles VMs
+/// - Keeps head VMs in sync with their compile inputs via [`vm::sync`]
 ///
 /// Apps should also:
 /// - Insert a `BuiltinNodes<N>` resource with their builtin nodes
@@ -66,23 +89,9 @@ where
         .add_observer(head::on_move_branch::<N>)
         // Register eval entry event handler.
         .add_observer(vm::on_eval_entry)
-        // VM init observers.
-        .add_observer(vm::on_head_opened::<N>)
-        .add_observer(vm::on_head_changed::<N>)
-        // Graph recompilation systems. `recompile_all` reacts to compile
-        // config changes; the condition order is load-bearing (`and`
-        // short-circuits, and `resource_changed` must observe every run to
-        // keep its change tick in sync).
-        .add_systems(
-            Update,
-            (
-                vm::update::<N>,
-                vm::recompile_all::<N>.run_if(
-                    resource_changed::<vm::CompileConfig>
-                        .and(not(resource_added::<vm::CompileConfig>)),
-                ),
-            ),
-        );
+        // Input-addressed VM synchronisation: (re)compiles whenever a head's
+        // compile inputs (graph content address + config) change.
+        .add_systems(Update, vm::sync::<N>.in_set(VmSet));
     }
 }
 

--- a/crates/bevy_gantz/src/vm.rs
+++ b/crates/bevy_gantz/src/vm.rs
@@ -3,8 +3,7 @@
 //! This module provides:
 //! - Convenience wrappers around `gantz_core::vm` (`init`, `compile`)
 //! - Evaluation events and observer (`EvalEntryEvent`, `on_eval_entry`)
-//! - Observers for VM initialization on head events (`on_head_opened`, `on_head_changed`)
-//! - Systems for VM setup and update (`setup`, `update`)
+//! - The input-addressed VM synchronisation system ([`sync`])
 
 use crate::BuiltinNodes;
 use crate::head;
@@ -82,6 +81,23 @@ pub struct CompileConfig(pub core_compile::Config);
 // Types
 // ---------------------------------------------------------------------------
 
+/// The inputs that determine a head's compiled module.
+#[derive(Clone, Copy, PartialEq)]
+struct Inputs {
+    /// The content address of the head's working graph.
+    graph: ca::GraphAddr,
+    /// The codegen configuration.
+    config: core_compile::Config,
+}
+
+/// The inputs of a head's last compile *attempt* (success or failure).
+///
+/// `None` = never attempted. [`sync`] compares this against the current
+/// inputs to decide when to (re)compile - there is no dirty flag to set or
+/// forget.
+#[derive(Component, Default)]
+pub struct CompiledInputs(Option<Inputs>);
+
 /// Event to trigger evaluation of an entrypoint.
 #[derive(Event)]
 pub struct EvalEntryEvent {
@@ -140,89 +156,6 @@ where
 // Observers
 // ---------------------------------------------------------------------------
 
-/// Initialize (or reinitialize) the VM for the given head entity.
-fn init_head_vm<N>(
-    entity: Entity,
-    registry: &Registry<N>,
-    builtins: &BuiltinNodes<N>,
-    ep_fns: &EntrypointFns<N>,
-    config: &CompileConfig,
-    vms: &mut head::HeadVms,
-    cmds: &mut Commands,
-    graphs: &Query<&head::WorkingGraph<N>>,
-) where
-    N: 'static + Node + Send + Sync,
-{
-    let graph = graphs.get(entity).unwrap();
-    let get_node = |ca: &ca::ContentAddr| lookup_node(registry, &**builtins, ca);
-    let entrypoints = collect_entrypoints(ep_fns, &get_node, &**graph);
-    match init(&get_node, &**graph, &entrypoints, &config.0) {
-        Ok((vm, module)) => {
-            cmds.entity(entity).insert(compile_components(Ok(module)));
-            vms.insert(entity, vm);
-        }
-        Err(e) => {
-            // Don't leave a stale VM/module from a previously-active graph in
-            // place: surface the error in the compiled module and drop the VM so
-            // eval systems (e.g. `drive_frame_bangs`, `on_eval_entry`) stop
-            // driving the wrong graph - which otherwise manifests as a confusing
-            // "free identifier: entry-fn-..." against an unrelated module.
-            cmds.entity(entity).insert(compile_components(Err(e)));
-            vms.remove(&entity);
-        }
-    }
-}
-
-/// VM init for opened heads.
-pub fn on_head_opened<N>(
-    trigger: On<head::OpenedEvent>,
-    registry: Res<Registry<N>>,
-    builtins: Res<BuiltinNodes<N>>,
-    ep_fns: Res<EntrypointFns<N>>,
-    config: Res<CompileConfig>,
-    mut vms: NonSendMut<head::HeadVms>,
-    mut cmds: Commands,
-    graphs: Query<&head::WorkingGraph<N>>,
-) where
-    N: 'static + Node + Send + Sync,
-{
-    init_head_vm(
-        trigger.event().entity,
-        &registry,
-        &builtins,
-        &ep_fns,
-        &config,
-        &mut vms,
-        &mut cmds,
-        &graphs,
-    );
-}
-
-/// VM init for changed heads.
-pub fn on_head_changed<N>(
-    trigger: On<head::ChangedEvent>,
-    registry: Res<Registry<N>>,
-    builtins: Res<BuiltinNodes<N>>,
-    ep_fns: Res<EntrypointFns<N>>,
-    config: Res<CompileConfig>,
-    mut vms: NonSendMut<head::HeadVms>,
-    mut cmds: Commands,
-    graphs: Query<&head::WorkingGraph<N>>,
-) where
-    N: 'static + Node + Send + Sync,
-{
-    init_head_vm(
-        trigger.event().entity,
-        &registry,
-        &builtins,
-        &ep_fns,
-        &config,
-        &mut vms,
-        &mut cmds,
-        &graphs,
-    );
-}
-
 /// Observer that handles evaluation events by calling the appropriate VM function.
 ///
 /// Emits an `EvalEntryComplete` event with timing information for UI layers to observe.
@@ -262,57 +195,25 @@ pub fn on_eval_entry(
 // Systems
 // ---------------------------------------------------------------------------
 
-/// Initialize VMs for all open heads (exclusive startup system).
-pub fn setup<N>(world: &mut World)
-where
-    N: 'static + Node + Send + Sync,
-{
-    log::info!("Setting up VMs for all open heads!");
-
-    let entities: Vec<Entity> = world
-        .query_filtered::<Entity, With<head::OpenHead>>()
-        .iter(world)
-        .collect();
-
-    let mut vms = head::HeadVms::default();
-    let mut compiled_updates: Vec<(Entity, Compiled)> = vec![];
-    for entity in entities {
-        let registry = world.resource::<Registry<N>>();
-        let builtins = world.resource::<BuiltinNodes<N>>();
-        let ep_fns = world.resource::<EntrypointFns<N>>();
-        let config = world.resource::<CompileConfig>();
-        let get_node = |ca: &ca::ContentAddr| lookup_node(registry, &**builtins, ca);
-        let Some(wg) = world.get::<head::WorkingGraph<N>>(entity) else {
-            continue;
-        };
-        let entrypoints = collect_entrypoints(ep_fns, &get_node, &**wg);
-        let (vm, module) = match init(&get_node, &**wg, &entrypoints, &config.0) {
-            Ok(result) => result,
-            Err(e) => {
-                log::error!("Failed to init VM for entity {entity}: {e}");
-                continue;
-            }
-        };
-        vms.insert(entity, vm);
-        compiled_updates.push((entity, module));
-    }
-
-    for (entity, module) in compiled_updates {
-        world
-            .entity_mut(entity)
-            .insert(compile_components(Ok(module)));
-    }
-
-    world.insert_non_send_resource(vms);
-}
-
-/// Detect graph changes and recompile into VMs.
+/// Keep every open head's VM in sync with the inputs to compilation.
 ///
-/// When a graph change is detected, this system:
-/// - Commits the new graph to the registry
-/// - Recompiles the VM
-/// - Emits a [`head::CommittedEvent`] for UI updates
-pub fn update<N>(
+/// The inputs are the working graph's content address and the
+/// [`CompileConfig`]; each head's [`CompiledInputs`] memoizes the inputs of
+/// its last compile attempt, and the VM is rebuilt whenever they differ -
+/// there is no dirty flag to set or forget. This single rule covers head
+/// open (and startup spawn), head replace/branch-move, graph edits, and
+/// config changes.
+///
+/// Whether the rebuild is a fresh `init` or an in-place `compile` is decided
+/// by VM presence in [`head::HeadVms`]: absent means a fresh init (head
+/// replace/branch-move remove the VM to discard the old graph's node state);
+/// present means an in-place compile, preserving node state (graph edits and
+/// config changes).
+///
+/// When the working graph's address has diverged from the head's commit, the
+/// graph is committed to the registry first and a [`head::CommittedEvent`]
+/// is emitted for UI state updates (handled by `GantzEguiPlugin` if present).
+pub fn sync<N>(
     mut cmds: Commands,
     mut registry: ResMut<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
@@ -324,77 +225,60 @@ pub fn update<N>(
     N: 'static + Node + Clone + ca::CaHash + Send + Sync,
 {
     for mut data in heads_query.iter_mut() {
-        let head: &mut ca::Head = &mut *data.head_ref;
         let graph: &Graph<N> = &*data.working_graph;
-
-        let new_graph_ca = ca::graph_addr(graph);
-        let Some(head_commit) = registry.head_commit(head) else {
-            continue;
+        let inputs = Inputs {
+            graph: ca::graph_addr(graph),
+            config: config.0,
         };
-        if head_commit.graph != new_graph_ca {
-            let old_head = head.clone();
-            let old_commit_ca = registry.head_commit_ca(head).copied().unwrap();
-            let new_commit_ca = registry.commit_graph_to_head(
-                crate::reg::timestamp(),
-                new_graph_ca,
-                || crate::clone_graph(graph),
-                head,
-            );
-            log::debug!(
-                "Graph changed: {} -> {}",
-                old_commit_ca.display_short(),
-                new_commit_ca.display_short()
-            );
+        if data.compiled_inputs.0 == Some(inputs) {
+            continue;
+        }
 
-            // Emit event for UI state updates (handled by GantzEguiPlugin if present).
-            cmds.trigger(head::CommittedEvent {
-                entity: data.entity,
-                old_head: old_head.clone(),
-                new_head: head.clone(),
-            });
-
-            if let Some(vm) = vms.get_mut(&data.entity) {
-                let get_node = |ca: &ca::ContentAddr| lookup_node(&registry, &**builtins, ca);
-                gantz_core::graph::register(&get_node, graph, &[], vm);
-                let entrypoints = collect_entrypoints(&ep_fns, &get_node, graph);
-                // On error this surfaces commented error text rather than
-                // leaving the prior module displayed, which would
-                // misleadingly look up-to-date.
-                let result = compile(&get_node, graph, vm, &entrypoints, &config.0);
-                let (module, diagnostics) = compile_components(result);
-                *data.module = module;
-                *data.diagnostics = diagnostics;
+        // Commit when the working copy has diverged from the head's commit.
+        let head: &mut ca::Head = &mut *data.head_ref;
+        if let Some(head_commit) = registry.head_commit(head) {
+            if head_commit.graph != inputs.graph {
+                let old_head = head.clone();
+                let old_commit_ca = registry.head_commit_ca(head).copied().unwrap();
+                let new_commit_ca = registry.commit_graph_to_head(
+                    crate::reg::timestamp(),
+                    inputs.graph,
+                    || crate::clone_graph(graph),
+                    head,
+                );
+                log::debug!(
+                    "Graph changed: {} -> {}",
+                    old_commit_ca.display_short(),
+                    new_commit_ca.display_short()
+                );
+                cmds.trigger(head::CommittedEvent {
+                    entity: data.entity,
+                    old_head,
+                    new_head: head.clone(),
+                });
             }
         }
-    }
-}
 
-/// Recompile every open head's graph into its existing VM.
-///
-/// Runs when [`CompileConfig`] changes (see `GantzPlugin`). Unlike [`update`],
-/// this never commits - the graph content is unchanged, only the codegen
-/// options - and compiling into the existing VM preserves node state.
-pub fn recompile_all<N>(
-    registry: Res<Registry<N>>,
-    builtins: Res<BuiltinNodes<N>>,
-    ep_fns: Res<EntrypointFns<N>>,
-    config: Res<CompileConfig>,
-    mut vms: NonSendMut<head::HeadVms>,
-    mut heads_query: Query<head::OpenHeadData<N>, With<head::OpenHead>>,
-) where
-    N: 'static + Node + Send + Sync,
-{
-    for mut data in heads_query.iter_mut() {
-        let graph: &Graph<N> = &*data.working_graph;
-        let Some(vm) = vms.get_mut(&data.entity) else {
-            continue;
-        };
+        // Rebuild the VM. On an in-place compile error the VM is kept (its
+        // previous module remains evaluable) and the error surfaces via the
+        // module/diagnostics components; a failed init leaves no VM, so eval
+        // systems (e.g. `drive_frame_bangs`, `on_eval_entry`) skip the head
+        // rather than driving a stale graph.
         let get_node = |ca: &ca::ContentAddr| lookup_node(&registry, &**builtins, ca);
-        gantz_core::graph::register(&get_node, graph, &[], vm);
         let entrypoints = collect_entrypoints(&ep_fns, &get_node, graph);
-        let result = compile(&get_node, graph, vm, &entrypoints, &config.0);
+        let result = match vms.get_mut(&data.entity) {
+            None => init(&get_node, graph, &entrypoints, &config.0).map(|(vm, module)| {
+                vms.insert(data.entity, vm);
+                module
+            }),
+            Some(vm) => {
+                gantz_core::graph::register(&get_node, graph, &[], vm);
+                compile(&get_node, graph, vm, &entrypoints, &config.0)
+            }
+        };
         let (module, diagnostics) = compile_components(result);
         *data.module = module;
         *data.diagnostics = diagnostics;
+        data.compiled_inputs.0 = Some(inputs);
     }
 }

--- a/crates/bevy_gantz_egui/src/base.rs
+++ b/crates/bevy_gantz_egui/src/base.rs
@@ -102,8 +102,6 @@ where
         .map(|name| gantz_ca::Head::Branch(name.clone()))
         .collect();
 
-    let export_registry = gantz_core::reg::export_heads(&get_node, registry, named_heads.iter());
-    let export = gantz_egui::export::export_with(export_registry, views, &demos.0);
-
-    ron::ser::to_string_pretty(&export, ron::ser::PrettyConfig::default()).ok()
+    gantz_egui::export::export_heads_ron(&get_node, registry, views, &demos.0, named_heads.iter())
+        .ok()
 }

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -139,11 +139,13 @@ where
             .add_observer(on_export_all_named::<N>)
             .add_observer(on_import_file::<N>)
             .add_observer(on_reset_base_graph::<N>)
-            // Systems
+            // Systems. `drive_frame_bangs` evaluates head VMs, so it must not
+            // observe the gap between a head pointing at a new graph and
+            // `vm::sync` (re)initializing its VM.
             .add_systems(
                 Update,
                 (
-                    node::frame_bang::drive_frame_bangs::<N>,
+                    node::frame_bang::drive_frame_bangs::<N>.after(bevy_gantz::VmSet),
                     persist_views::<N>,
                     poll_import_task,
                 ),
@@ -580,7 +582,7 @@ pub fn on_branch_created(
 
 /// Handle graph commit by updating egui state.
 ///
-/// This observer is triggered by `vm::update` when a graph change is committed.
+/// This observer is triggered by `vm::sync` when a graph change is committed.
 /// Also clears the redo stack, since a new edit invalidates the redo history.
 pub fn on_head_committed(
     trigger: On<head::CommittedEvent>,
@@ -1279,8 +1281,8 @@ where
     }
 
     // Handle compile config change. The recompile happens next frame via
-    // `bevy_gantz::vm::recompile_all` (resource change detection); the `!=`
-    // guard avoids flagging the resource changed with an equal value.
+    // `bevy_gantz::vm::sync`, which compares each head's compile inputs
+    // (graph content address + config) by value.
     if let Some(cfg) = response.compile_config {
         if compile_config.0 != cfg {
             compile_config.0 = cfg;
@@ -1384,7 +1386,7 @@ fn dispatch_export_all_named(_: Option<Entity>, payload: DynResponse, cmds: &mut
 /// Trigger the appropriate event to move a head to a target commit.
 ///
 /// Branch heads use `MoveBranchEvent` for atomic registry+graph updates
-/// (avoids oscillation with `vm::update`). Commit heads use `ReplaceEvent`.
+/// (avoids oscillation with `vm::sync`). Commit heads use `ReplaceEvent`.
 fn navigate_head(cmds: &mut Commands, entity: Entity, head: &ca::Head, target: ca::CommitAddr) {
     match head {
         ca::Head::Commit(_) => cmds.trigger(head::ReplaceEvent(ca::Head::Commit(target))),

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -19,7 +19,7 @@ use gantz_ca as ca;
 use gantz_core::Node;
 use gantz_core::node::graph::Graph;
 pub use gantz_egui::RegistryRef;
-use gantz_egui::{HeadDataMut, Payload, ResponseData};
+use gantz_egui::{DynResponse, HeadDataMut, ResponseData};
 use std::any::TypeId;
 use std::collections::HashMap;
 use std::marker::PhantomData;
@@ -263,7 +263,7 @@ pub struct ResetBaseGraphEvent(pub String);
 ///
 /// The `Option<Entity>` is the open-head entity resolved from the payload's
 /// head tag (`None` for app-level payloads).
-pub type DispatchFn = fn(Option<Entity>, Payload, &mut Commands);
+pub type DispatchFn = fn(Option<Entity>, DynResponse, &mut Commands);
 
 /// `TypeId`-keyed dispatchers turning the dynamic GUI response payloads into
 /// typed events. Register payload types via [`RegisterResponseExt`].
@@ -1301,7 +1301,7 @@ where
     }
 
     // Dispatch the dynamic response payloads emitted during the GUI pass.
-    // Payload types are registered in `ResponseDispatchers` (see
+    // DynResponse types are registered in `ResponseDispatchers` (see
     // `RegisterResponseExt`); unregistered payloads are reported.
     for (head, payload) in response.responses.drain() {
         log::debug!("{payload:?}");
@@ -1326,7 +1326,7 @@ where
 ///
 /// Dispatchers are keyed by the payload's `TypeId`, so the downcast cannot
 /// fail for a correctly registered dispatcher.
-fn downcast_payload<T: ResponseData>(payload: Payload) -> T {
+fn downcast_payload<T: ResponseData>(payload: DynResponse) -> T {
     payload
         .downcast::<T>()
         .expect("dispatcher registered for this payload type")
@@ -1335,7 +1335,7 @@ fn downcast_payload<T: ResponseData>(payload: Payload) -> T {
 /// Dispatch a head-scoped payload as a [`ForHead`] event.
 fn dispatch_for_head<T: ResponseData>(
     entity: Option<Entity>,
-    payload: Payload,
+    payload: DynResponse,
     cmds: &mut Commands,
 ) {
     let Some(head) = entity else {
@@ -1350,7 +1350,7 @@ fn dispatch_for_head<T: ResponseData>(
 }
 
 /// Dispatch a [`gantz_egui::EvalEntry`] payload as an [`EvalEntryEvent`].
-fn dispatch_eval_entry(entity: Option<Entity>, payload: Payload, cmds: &mut Commands) {
+fn dispatch_eval_entry(entity: Option<Entity>, payload: DynResponse, cmds: &mut Commands) {
     let Some(head) = entity else {
         log::error!("EvalEntry payload has no open-head entity");
         return;
@@ -1360,13 +1360,13 @@ fn dispatch_eval_entry(entity: Option<Entity>, payload: Payload, cmds: &mut Comm
 }
 
 /// Dispatch a [`gantz_egui::OpenHead`] payload as a [`head::OpenEvent`].
-fn dispatch_open_head(_: Option<Entity>, payload: Payload, cmds: &mut Commands) {
+fn dispatch_open_head(_: Option<Entity>, payload: DynResponse, cmds: &mut Commands) {
     let gantz_egui::OpenHead(target) = downcast_payload(payload);
     cmds.trigger(head::OpenEvent(target));
 }
 
 /// Dispatch a [`gantz_egui::ExportHead`] payload as an [`ExportHeadEvent`].
-fn dispatch_export_head(entity: Option<Entity>, payload: Payload, cmds: &mut Commands) {
+fn dispatch_export_head(entity: Option<Entity>, payload: DynResponse, cmds: &mut Commands) {
     let Some(head) = entity else {
         log::error!("ExportHead payload has no open-head entity");
         return;
@@ -1376,7 +1376,7 @@ fn dispatch_export_head(entity: Option<Entity>, payload: Payload, cmds: &mut Com
 }
 
 /// Dispatch a [`gantz_egui::ExportAllNamed`] payload as an [`ExportAllNamedEvent`].
-fn dispatch_export_all_named(_: Option<Entity>, payload: Payload, cmds: &mut Commands) {
+fn dispatch_export_all_named(_: Option<Entity>, payload: DynResponse, cmds: &mut Commands) {
     let gantz_egui::ExportAllNamed = downcast_payload(payload);
     cmds.trigger(ExportAllNamedEvent);
 }

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -18,9 +18,10 @@ use bevy_log as log;
 use gantz_ca as ca;
 use gantz_core::Node;
 use gantz_core::node::graph::Graph;
-use gantz_egui::HeadDataMut;
 pub use gantz_egui::RegistryRef;
-use std::collections::{HashMap, HashSet};
+use gantz_egui::{HeadDataMut, ResponseData};
+use std::any::TypeId;
+use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
@@ -95,6 +96,21 @@ where
                 node::frame_bang::entrypoints(get_node, graph)
             }));
 
+        // Builtin GUI response payload dispatchers. Head-scoped payloads
+        // arrive at the observers below as `ForHead<T>` events; the rest map
+        // onto existing event types via custom dispatch fns.
+        app.register_head_response::<gantz_egui::BranchNode>()
+            .register_head_response::<gantz_egui::CopyNodes>()
+            .register_head_response::<gantz_egui::CreateNode>()
+            .register_head_response::<gantz_egui::InspectEdge>()
+            .register_head_response::<gantz_egui::Paste>()
+            .register_head_response::<gantz_egui::Redo>()
+            .register_head_response::<gantz_egui::Undo>()
+            .register_response_with::<gantz_egui::EvalEntry>(dispatch_eval_entry)
+            .register_response_with::<gantz_egui::OpenHead>(dispatch_open_head)
+            .register_response_with::<gantz_egui::ExportHead>(dispatch_export_head)
+            .register_response_with::<gantz_egui::ExportAllNamed>(dispatch_export_all_named);
+
         app.insert_resource(BaseImmutable(self.base_immutable))
             .init_resource::<BaseNames>()
             .init_resource::<GuiState>()
@@ -111,12 +127,14 @@ where
             .add_observer(on_head_committed)
             // VM timing observer
             .add_observer(on_eval_entry_complete)
-            // Node creation/inspection observers
+            // GUI response payload observers
             .add_observer(on_create_node::<N>)
             .add_observer(on_branch_node::<N>)
             .add_observer(on_inspect_edge::<N>)
             .add_observer(on_copy_nodes::<N>)
             .add_observer(on_paste::<N>)
+            .add_observer(on_undo::<N>)
+            .add_observer(on_redo)
             .add_observer(on_export_head::<N>)
             .add_observer(on_export_all_named::<N>)
             .add_observer(on_import_file::<N>)
@@ -126,7 +144,6 @@ where
                 Update,
                 (
                     node::frame_bang::drive_frame_bangs::<N>,
-                    process_cmds::<N>,
                     persist_views::<N>,
                     poll_import_task,
                 ),
@@ -199,40 +216,22 @@ pub struct ImportTask(bevy_tasks::Task<Option<Vec<u8>>>);
 // Events
 // ----------------------------------------------------------------------------
 
-/// Event emitted when an edge inspection is requested.
+/// A GUI response payload targeting an open-head entity.
 ///
-/// Apps should handle this with an observer that has access to the
-/// app-specific Environment for creating and registering the inspect node.
-#[derive(Event)]
-pub struct InspectEdgeEvent {
-    /// The head entity on which the edge exists.
+/// The `update` system drains the payloads emitted during the GUI pass and
+/// dispatches each via [`ResponseDispatchers`]; head-scoped payloads arrive
+/// as this event. Observers take the mutable per-head queries that the GUI
+/// system itself cannot (ECS borrow rules).
+#[derive(EntityEvent)]
+pub struct ForHead<T: Send + Sync + 'static> {
+    /// The open-head entity the payload targets.
+    #[event_target]
     pub head: Entity,
-    /// The inspect edge command from the GUI.
-    pub cmd: gantz_egui::InspectEdge,
+    /// The payload emitted from the GUI.
+    pub data: T,
 }
 
-/// Event emitted when node creation is requested.
-///
-/// Apps should handle this with an observer that has access to the
-/// app-specific Builtins for creating nodes.
-#[derive(Event)]
-pub struct CreateNodeEvent {
-    /// The head entity where the node should be created.
-    pub head: Entity,
-    /// The create node command from the GUI.
-    pub cmd: gantz_egui::CreateNode,
-}
-
-/// Event emitted when the user copies nodes.
-#[derive(Event)]
-pub struct CopyNodesEvent {
-    /// The head entity whose selection should be copied.
-    pub head: Entity,
-    /// The nodes to copy.
-    pub nodes: HashSet<gantz_egui::widget::graph_scene::NodeIndex>,
-}
-
-/// Event emitted when the user requests exporting the focused head.
+/// Event emitted when the user requests exporting a head.
 #[derive(Event)]
 pub struct ExportHeadEvent {
     /// The head entity to export.
@@ -252,38 +251,58 @@ pub struct ImportFileEvent {
     pub open_head: bool,
 }
 
-/// Event emitted when a named node should be branched.
-///
-/// Creates a new commit (same graph, new timestamp, original as parent),
-/// inserts a new name pointing to the fresh commit, and replaces the
-/// NamedRef node in the working graph so its reference points to the new
-/// commit.
-#[derive(Event)]
-pub struct BranchNodeEvent {
-    /// The head entity containing the NamedRef node.
-    pub head: Entity,
-    /// The new branch name.
-    pub new_name: String,
-    /// Content address of the graph being branched.
-    pub ca: gantz_ca::ContentAddr,
-    /// Path from root to the NamedRef node (last element = node index).
-    pub path: Vec<gantz_core::node::Id>,
-}
-
-/// Event emitted when the user pastes from the clipboard.
-#[derive(Event)]
-pub struct PasteEvent {
-    /// The head entity to paste into.
-    pub head: Entity,
-    /// The clipboard text (RON-serialized [`gantz_egui::export::Copied`]).
-    pub text: String,
-    /// How to position the pasted nodes.
-    pub pos: gantz_egui::PastePos,
-}
-
 /// Event emitted when a base graph should be reset to its original state.
 #[derive(Event)]
 pub struct ResetBaseGraphEvent(pub String);
+
+// ----------------------------------------------------------------------------
+// Response dispatch
+// ----------------------------------------------------------------------------
+
+/// The signature of dispatch fns stored in [`ResponseDispatchers`].
+///
+/// The `Option<Entity>` is the open-head entity resolved from the payload's
+/// head tag (`None` for app-level payloads).
+pub type DispatchFn = fn(Option<Entity>, Box<dyn ResponseData>, &mut Commands);
+
+/// `TypeId`-keyed dispatchers turning the dynamic GUI response payloads into
+/// typed events. Register payload types via [`RegisterResponseExt`].
+#[derive(Default, Resource)]
+pub struct ResponseDispatchers(pub HashMap<TypeId, DispatchFn>);
+
+/// App extension for registering GUI response payload handlers.
+///
+/// This is how nodes declared in independent plugins receive custom payloads
+/// emitted from their UI (via [`gantz_egui::NodeCtx::response`]): register
+/// the payload type here and add an observer for [`ForHead<T>`]:
+///
+/// ```ignore
+/// app.register_head_response::<MyPayload>()
+///     .add_observer(|t: On<ForHead<MyPayload>>, /* any system params */| { .. });
+/// ```
+pub trait RegisterResponseExt {
+    /// Dispatch payloads of type `T` as [`ForHead<T>`] events targeting the
+    /// emitting head's entity. Pair with an observer for `On<ForHead<T>>`.
+    fn register_head_response<T: ResponseData>(&mut self) -> &mut Self;
+
+    /// Dispatch payloads of type `T` with a custom fn, e.g. to map onto an
+    /// existing event type or to handle payloads with no associated head.
+    fn register_response_with<T: ResponseData>(&mut self, f: DispatchFn) -> &mut Self;
+}
+
+impl RegisterResponseExt for App {
+    fn register_head_response<T: ResponseData>(&mut self) -> &mut Self {
+        self.register_response_with::<T>(dispatch_for_head::<T>)
+    }
+
+    fn register_response_with<T: ResponseData>(&mut self, f: DispatchFn) -> &mut Self {
+        self.world_mut()
+            .get_resource_or_init::<ResponseDispatchers>()
+            .0
+            .insert(TypeId::of::<T>(), f);
+        self
+    }
+}
 
 // ----------------------------------------------------------------------------
 // QueryData
@@ -575,9 +594,9 @@ pub fn on_head_committed(
     }
 }
 
-/// Handle create node events.
+/// Handle create node payloads.
 pub fn on_create_node<N>(
-    trigger: On<CreateNodeEvent>,
+    trigger: On<ForHead<gantz_egui::CreateNode>>,
     registry: Res<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
     demos: Res<Demos>,
@@ -614,16 +633,16 @@ pub fn on_create_node<N>(
         &mut data.working_graph,
         &mut views,
         vm,
-        event.cmd.clone(),
+        event.data.clone(),
     );
 }
 
-/// Handle branch node events.
+/// Handle branch node payloads.
 ///
 /// Creates a new commit (same graph content, new timestamp, original as parent),
 /// inserts the new name, and replaces the NamedRef node in the working graph.
 pub fn on_branch_node<N>(
-    trigger: On<BranchNodeEvent>,
+    trigger: On<ForHead<gantz_egui::BranchNode>>,
     mut registry: ResMut<Registry<N>>,
     mut heads: Query<head::OpenHeadData<N>, With<head::OpenHead>>,
 ) where
@@ -642,15 +661,15 @@ pub fn on_branch_node<N>(
         &mut registry,
         bevy_gantz::reg::timestamp(),
         &mut data.working_graph,
-        event.new_name.clone(),
-        event.ca,
-        &event.path,
+        event.data.new_name.clone(),
+        event.data.ca,
+        &event.data.path,
     );
 }
 
-/// Handle inspect edge events.
+/// Handle inspect edge payloads.
 pub fn on_inspect_edge<N>(
-    trigger: On<InspectEdgeEvent>,
+    trigger: On<ForHead<gantz_egui::InspectEdge>>,
     registry: Res<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
     demos: Res<Demos>,
@@ -687,17 +706,17 @@ pub fn on_inspect_edge<N>(
         &mut data.working_graph,
         &mut views,
         vm,
-        event.cmd.clone(),
+        event.data.clone(),
     );
 }
 
-/// Handle copy selection events.
+/// Handle copy selection payloads.
 ///
 /// Serializes the selected nodes (and their registry dependencies) to RON
 /// and writes the result directly to the system clipboard via
 /// [`bevy_egui::EguiClipboard`].
 pub fn on_copy_nodes<N>(
-    trigger: On<CopyNodesEvent>,
+    trigger: On<ForHead<gantz_egui::CopyNodes>>,
     registry: Res<Registry<N>>,
     gui_state: Res<GuiState>,
     views: Res<Views>,
@@ -731,26 +750,29 @@ pub fn on_copy_nodes<N>(
         &mut wg,
         &gv,
         &head_state.path,
-        &event.nodes,
+        &event.data.0,
     );
     if let Some(text) = text {
         clipboard.set_text(&text);
     }
 }
 
-/// Handle paste selection events.
+/// Handle paste selection payloads.
 ///
-/// Deserializes the clipboard RON text into a [`gantz_egui::export::Copied`],
-/// merges registry dependencies, adds the subgraph, maps positions, and
-/// updates the selection to the newly pasted nodes.
+/// Resolves the clipboard text (via [`bevy_egui::EguiClipboard`] when the
+/// payload doesn't carry it), deserializes it into a
+/// [`gantz_egui::export::Copied`], merges registry dependencies, adds the
+/// subgraph, maps positions, and updates the selection to the newly pasted
+/// nodes.
 pub fn on_paste<N>(
-    trigger: On<PasteEvent>,
+    trigger: On<ForHead<gantz_egui::Paste>>,
     mut registry: ResMut<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
     mut gui_state: ResMut<GuiState>,
     mut views: ResMut<Views>,
     mut demos: ResMut<Demos>,
     mut vms: NonSendMut<head::HeadVms>,
+    mut clipboard: ResMut<bevy_egui::EguiClipboard>,
     mut heads: Query<
         (&head::HeadRef, &mut head::WorkingGraph<N>, &mut GraphViews),
         With<head::OpenHead>,
@@ -765,6 +787,9 @@ pub fn on_paste<N>(
         + Sync,
 {
     let event = trigger.event();
+    let Some(text) = event.data.text.clone().or_else(|| clipboard.get_text()) else {
+        return;
+    };
     let Ok((head_ref, mut wg, mut gv)) = heads.get_mut(event.head) else {
         log::error!("PasteSelection: head not found for entity {:?}", event.head);
         return;
@@ -781,8 +806,8 @@ pub fn on_paste<N>(
         &mut wg,
         &mut gv,
         head_state,
-        &event.text,
-        &event.pos,
+        &text,
+        &event.data.pos,
     );
 
     // Re-register the full root graph so pasted nodes get their state
@@ -794,6 +819,46 @@ pub fn on_paste<N>(
             let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
             gantz_core::graph::register(&get_node, &**wg, &[], vm);
         }
+    }
+}
+
+/// Handle undo payloads: move the head back to its parent commit.
+pub fn on_undo<N>(
+    trigger: On<ForHead<gantz_egui::Undo>>,
+    registry: Res<Registry<N>>,
+    mut gui_state: ResMut<GuiState>,
+    heads: Query<&head::HeadRef, With<head::OpenHead>>,
+    mut cmds: Commands,
+) where
+    N: 'static + Send + Sync,
+{
+    let entity = trigger.event().head;
+    let Ok(head_ref) = heads.get(entity) else {
+        log::error!("Undo: head not found for entity {entity:?}");
+        return;
+    };
+    let head = (**head_ref).clone();
+    let parent = gantz_egui::ops::undo(&registry, &mut gui_state.redo_stacks, &head);
+    if let Some(parent) = parent {
+        navigate_head(&mut cmds, entity, &head, parent);
+    }
+}
+
+/// Handle redo payloads: move the head forward to a previously undone commit.
+pub fn on_redo(
+    trigger: On<ForHead<gantz_egui::Redo>>,
+    mut gui_state: ResMut<GuiState>,
+    heads: Query<&head::HeadRef, With<head::OpenHead>>,
+    mut cmds: Commands,
+) {
+    let entity = trigger.event().head;
+    let Ok(head_ref) = heads.get(entity) else {
+        log::error!("Redo: head not found for entity {entity:?}");
+        return;
+    };
+    let head = (**head_ref).clone();
+    if let Some(redo_ca) = gantz_egui::ops::redo(&mut gui_state.redo_stacks, &head) {
+        navigate_head(&mut cmds, entity, &head, redo_ca);
     }
 }
 
@@ -1048,111 +1113,12 @@ pub fn prune_views<N: 'static + Node + Send + Sync>(
     views.retain(|ca, _| required.contains(ca));
 }
 
-/// Process GUI commands from all open heads.
-///
-/// Commands are split between inline handling and event dispatch based on
-/// Bevy's ECS borrow rules. Inline-handled commands (eval, navigation,
-/// registry operations, undo/redo) only need `registry + gui_state`, which
-/// are available as system parameters. Event-dispatched commands (node
-/// creation, edge inspection, clipboard) need mutable access to per-head
-/// components (`WorkingGraph`, `GraphViews`, `HeadVms`) that would conflict
-/// with the iteration query - observers handle these with separate queries.
-///
-/// All [`gantz_egui::Cmd`] variants must be handled here *and* in the demo's
-/// `process_cmds` (see `gantz_egui/examples/demo.rs`).
-pub fn process_cmds<N: 'static + Send + Sync>(
-    registry: Res<Registry<N>>,
-    mut gui_state: ResMut<GuiState>,
-    mut clipboard: ResMut<bevy_egui::EguiClipboard>,
-    heads: Query<(Entity, &head::HeadRef), With<head::OpenHead>>,
-    mut cmds: Commands,
-) {
-    // Collect heads to process.
-    let heads_to_process: Vec<_> = heads
-        .iter()
-        .map(|(entity, head_ref)| (entity, (**head_ref).clone()))
-        .collect();
-
-    for (entity, head) in heads_to_process {
-        let head_state = gui_state.open_heads.entry(head.clone()).or_default();
-        for cmd in std::mem::take(&mut head_state.scene.cmds) {
-            log::debug!("{cmd:?}");
-            match cmd {
-                gantz_egui::Cmd::EvalEntry(entrypoint) => {
-                    cmds.trigger(EvalEntryEvent {
-                        head: entity,
-                        entrypoint,
-                    });
-                }
-                gantz_egui::Cmd::OpenPath(path) => {
-                    let head_state = gui_state.open_heads.get_mut(&head).unwrap();
-                    head_state.path = path;
-                }
-                gantz_egui::Cmd::OpenHead(target) => {
-                    cmds.trigger(head::OpenEvent(target));
-                }
-                gantz_egui::Cmd::BranchNode { new_name, ca, path } => {
-                    cmds.trigger(BranchNodeEvent {
-                        head: entity,
-                        new_name,
-                        ca,
-                        path,
-                    });
-                }
-                gantz_egui::Cmd::InspectEdge(cmd) => {
-                    cmds.trigger(InspectEdgeEvent { head: entity, cmd });
-                }
-                gantz_egui::Cmd::CreateNode(cmd) => {
-                    cmds.trigger(CreateNodeEvent { head: entity, cmd });
-                }
-                gantz_egui::Cmd::CopyNodes(nodes) => {
-                    cmds.trigger(CopyNodesEvent {
-                        head: entity,
-                        nodes,
-                    });
-                }
-                gantz_egui::Cmd::Paste { text, pos } => {
-                    let text = text.or_else(|| clipboard.get_text());
-                    if let Some(text) = text {
-                        cmds.trigger(PasteEvent {
-                            head: entity,
-                            text,
-                            pos,
-                        });
-                    }
-                }
-                gantz_egui::Cmd::Undo => {
-                    let parent =
-                        gantz_egui::ops::undo(&registry, &mut gui_state.redo_stacks, &head);
-                    if let Some(parent) = parent {
-                        navigate_head(&mut cmds, entity, &head, parent);
-                    }
-                }
-                gantz_egui::Cmd::Redo => {
-                    if let Some(redo_ca) = gantz_egui::ops::redo(&mut gui_state.redo_stacks, &head)
-                    {
-                        navigate_head(&mut cmds, entity, &head, redo_ca);
-                    }
-                }
-                gantz_egui::Cmd::ExportHead => {
-                    cmds.trigger(ExportHeadEvent { head: entity });
-                }
-                gantz_egui::Cmd::ExportAllNamed => {
-                    cmds.trigger(ExportAllNamedEvent);
-                }
-                gantz_egui::Cmd::OpenCommandPalette => {
-                    gui_state.command_palette.toggle();
-                }
-            }
-        }
-    }
-}
-
 /// Update the Gantz GUI and process widget responses.
 ///
 /// This system:
 /// - Shows the Gantz widget in an egui CentralPanel
 /// - Processes GUI responses (head open/close/replace, branch creation, etc.)
+/// - Dispatches dynamic response payloads via [`ResponseDispatchers`]
 /// - Uses TraceCapture for tracing and PerfVm/PerfGui for performance capture
 pub fn update<N>(
     trace_capture: Res<TraceCapture>,
@@ -1173,6 +1139,7 @@ pub fn update<N>(
         ResMut<CompileConfig>,
     ),
     mut demos: ResMut<Demos>,
+    dispatchers: Res<ResponseDispatchers>,
     mut cmds: Commands,
 ) -> Result
 where
@@ -1194,6 +1161,15 @@ where
         .and_then(|e| tab_order.iter().position(|&x| x == e))
         .unwrap_or(0);
 
+    // Map heads to entities for response payload dispatch (after `show`).
+    let head_to_entity: HashMap<ca::Head, Entity> = tab_order
+        .iter()
+        .filter_map(|&e| {
+            let data = heads_query.get(e).ok()?;
+            Some(((**data.core.head_ref).clone(), e))
+        })
+        .collect();
+
     // Create the head access adapter.
     let mut access = HeadAccess::new(&tab_order, &mut heads_query, &mut vms);
 
@@ -1204,7 +1180,7 @@ where
 
     // Build and show the Gantz widget.
     let current_compile_config = compile_config.0;
-    let response = egui::containers::CentralPanel::default()
+    let mut response = egui::containers::CentralPanel::default()
         .frame(egui::Frame::default())
         .show(ctx, |ui| {
             gantz_egui::widget::Gantz::new(&node_reg, &base_names.0)
@@ -1324,6 +1300,18 @@ where
         cmds.insert_resource(ImportTask(task));
     }
 
+    // Dispatch the dynamic response payloads emitted during the GUI pass.
+    // Payload types are registered in `ResponseDispatchers` (see
+    // `RegisterResponseExt`); unregistered payloads are reported.
+    for (head, data) in response.responses.drain() {
+        log::debug!("{data:?}");
+        let entity = head.and_then(|h| head_to_entity.get(&h).copied());
+        match dispatchers.0.get(&data.data_type_id()) {
+            Some(dispatch) => dispatch(entity, data, &mut cmds),
+            None => log::warn!("unhandled response payload: {}", data.data_type_name()),
+        }
+    }
+
     // Record GUI frame time.
     perf_gui.0.record(gui_start.elapsed());
 
@@ -1333,6 +1321,66 @@ where
 // ---------------------------------------------------------------------------
 // Functions
 // ---------------------------------------------------------------------------
+
+/// Downcast a dispatched payload to its concrete type.
+///
+/// Dispatchers are keyed by the payload's `TypeId`, so the downcast cannot
+/// fail for a correctly registered dispatcher.
+fn downcast_payload<T: ResponseData>(data: Box<dyn ResponseData>) -> T {
+    *data
+        .into_any()
+        .downcast::<T>()
+        .expect("dispatcher registered for this payload type")
+}
+
+/// Dispatch a head-scoped payload as a [`ForHead`] event.
+fn dispatch_for_head<T: ResponseData>(
+    entity: Option<Entity>,
+    data: Box<dyn ResponseData>,
+    cmds: &mut Commands,
+) {
+    let Some(head) = entity else {
+        log::error!(
+            "response payload `{}` has no open-head entity",
+            data.data_type_name()
+        );
+        return;
+    };
+    let data = downcast_payload::<T>(data);
+    cmds.trigger(ForHead { head, data });
+}
+
+/// Dispatch a [`gantz_egui::EvalEntry`] payload as an [`EvalEntryEvent`].
+fn dispatch_eval_entry(entity: Option<Entity>, data: Box<dyn ResponseData>, cmds: &mut Commands) {
+    let Some(head) = entity else {
+        log::error!("EvalEntry payload has no open-head entity");
+        return;
+    };
+    let gantz_egui::EvalEntry(entrypoint) = downcast_payload(data);
+    cmds.trigger(EvalEntryEvent { head, entrypoint });
+}
+
+/// Dispatch a [`gantz_egui::OpenHead`] payload as a [`head::OpenEvent`].
+fn dispatch_open_head(_: Option<Entity>, data: Box<dyn ResponseData>, cmds: &mut Commands) {
+    let gantz_egui::OpenHead(target) = downcast_payload(data);
+    cmds.trigger(head::OpenEvent(target));
+}
+
+/// Dispatch a [`gantz_egui::ExportHead`] payload as an [`ExportHeadEvent`].
+fn dispatch_export_head(entity: Option<Entity>, data: Box<dyn ResponseData>, cmds: &mut Commands) {
+    let Some(head) = entity else {
+        log::error!("ExportHead payload has no open-head entity");
+        return;
+    };
+    let gantz_egui::ExportHead = downcast_payload(data);
+    cmds.trigger(ExportHeadEvent { head });
+}
+
+/// Dispatch a [`gantz_egui::ExportAllNamed`] payload as an [`ExportAllNamedEvent`].
+fn dispatch_export_all_named(_: Option<Entity>, data: Box<dyn ResponseData>, cmds: &mut Commands) {
+    let gantz_egui::ExportAllNamed = downcast_payload(data);
+    cmds.trigger(ExportAllNamedEvent);
+}
 
 /// Trigger the appropriate event to move a head to a target commit.
 ///

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -23,7 +23,6 @@ pub use gantz_egui::RegistryRef;
 use std::collections::{HashMap, HashSet};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
-use steel::steel_vm::engine::Engine;
 
 pub mod base;
 pub mod node;
@@ -584,6 +583,7 @@ pub fn on_create_node<N>(
     demos: Res<Demos>,
     mut vms: NonSendMut<head::HeadVms>,
     mut heads: Query<head::OpenHeadData<N>, With<head::OpenHead>>,
+    mut views_query: Query<&mut GraphViews, With<head::OpenHead>>,
 ) where
     N: 'static
         + Node
@@ -597,35 +597,25 @@ pub fn on_create_node<N>(
         log::error!("CreateNode: head not found for entity {:?}", event.head);
         return;
     };
+    let Ok(mut views) = views_query.get_mut(event.head) else {
+        log::error!("CreateNode: views not found for entity {:?}", event.head);
+        return;
+    };
     let Some(vm) = vms.get_mut(&event.head) else {
         log::error!("CreateNode: VM not found for entity {:?}", event.head);
         return;
     };
 
-    let Some(graph) = gantz_egui::widget::graph_scene::index_path_graph_mut(
-        &mut data.working_graph,
-        &event.cmd.path,
-    ) else {
-        log::error!(
-            "CreateNode: could not find graph at path {:?}",
-            event.cmd.path
-        );
-        return;
-    };
-
     let node_reg = registry_ref(&registry, &builtins, &demos);
-    let Some(node) = node_reg.create_node(&event.cmd.node_type) else {
-        log::error!("CreateNode: unknown node type {:?}", event.cmd.node_type);
-        return;
-    };
-
-    let id = graph.add_node(node);
-    let ix = id.index();
-
-    let node_path: Vec<_> = event.cmd.path.iter().copied().chain(Some(ix)).collect();
     let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
-    let reg_ctx = gantz_core::node::RegCtx::new(&get_node, &node_path, vm);
-    graph[id].register(reg_ctx);
+    gantz_egui::ops::create_node(
+        &get_node,
+        |node_type| node_reg.create_node(node_type),
+        &mut data.working_graph,
+        &mut views,
+        vm,
+        event.cmd.clone(),
+    );
 }
 
 /// Handle branch node events.
@@ -648,37 +638,14 @@ pub fn on_branch_node<N>(
         log::error!("BranchNode: head not found for entity {:?}", event.head);
         return;
     };
-
-    let commit_ca = ca::CommitAddr::from(event.ca);
-    let Some(commit) = registry.commits().get(&commit_ca) else {
-        log::error!("BranchNode: commit not found for {:?}", commit_ca);
-        return;
-    };
-    let graph_addr = commit.graph;
-    let new_commit_ca = registry.commit_graph(
+    gantz_egui::ops::branch_node(
+        &mut registry,
         bevy_gantz::reg::timestamp(),
-        Some(commit_ca),
-        graph_addr,
-        || unreachable!("graph already exists in registry"),
+        &mut data.working_graph,
+        event.new_name.clone(),
+        event.ca,
+        &event.path,
     );
-    registry.insert_name(event.new_name.clone(), new_commit_ca);
-
-    // Replace the NamedRef node in the working graph.
-    let (parent_path, node_ix_slice) = event.path.split_at(event.path.len() - 1);
-    let Some(graph) =
-        gantz_egui::widget::graph_scene::index_path_graph_mut(&mut data.working_graph, parent_path)
-    else {
-        log::error!("BranchNode: could not find graph at path {:?}", parent_path);
-        return;
-    };
-    let node_id = gantz_core::node::graph::NodeIx::new(node_ix_slice[0]);
-    let new_ref = gantz_core::node::Ref::new(new_commit_ca.into());
-    let named_ref = gantz_egui::node::NamedRef::new(event.new_name.clone(), new_ref);
-    if let Some(node) = graph.node_weight_mut(node_id) {
-        *node = N::from(named_ref);
-    } else {
-        log::error!("BranchNode: node not found at index {}", node_ix_slice[0]);
-    }
 }
 
 /// Handle inspect edge events.
@@ -713,8 +680,10 @@ pub fn on_inspect_edge<N>(
     };
 
     let node_reg = registry_ref(&registry, &builtins, &demos);
-    inspect_edge(
-        &node_reg,
+    let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
+    gantz_egui::ops::inspect_edge(
+        &get_node,
+        || node_reg.create_node("inspect"),
         &mut data.working_graph,
         &mut views,
         vm,
@@ -730,7 +699,7 @@ pub fn on_inspect_edge<N>(
 pub fn on_copy_nodes<N>(
     trigger: On<CopyNodesEvent>,
     registry: Res<Registry<N>>,
-    gui_state: ResMut<GuiState>,
+    gui_state: Res<GuiState>,
     views: Res<Views>,
     mut clipboard: ResMut<bevy_egui::EguiClipboard>,
     mut heads: Query<
@@ -756,28 +725,16 @@ pub fn on_copy_nodes<N>(
         return;
     };
 
-    let path = head_state.path.clone();
-    let selection = event.nodes.clone();
-    if selection.is_empty() {
-        return;
-    }
-
-    let graph: &mut Graph<N> = &mut *wg;
-    let Some(g) = gantz_egui::widget::graph_scene::index_path_graph_mut(graph, &path) else {
-        log::error!("CopySelection: could not find graph at path {path:?}");
-        return;
-    };
-
-    let layout = gv
-        .get(&path)
-        .map(|v| &v.layout)
-        .cloned()
-        .unwrap_or_default();
-
-    let copied = gantz_egui::export::copy(&registry, &views, g, &selection, &layout);
-    match ron::to_string(&copied) {
-        Ok(text) => clipboard.set_text(&text),
-        Err(e) => log::error!("CopySelection: failed to serialize: {e}"),
+    let text = gantz_egui::ops::copy_nodes(
+        &registry,
+        &views,
+        &mut wg,
+        &gv,
+        &head_state.path,
+        &event.nodes,
+    );
+    if let Some(text) = text {
+        clipboard.set_text(&text);
     }
 }
 
@@ -790,7 +747,7 @@ pub fn on_paste<N>(
     trigger: On<PasteEvent>,
     mut registry: ResMut<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
-    gui_state: ResMut<GuiState>,
+    mut gui_state: ResMut<GuiState>,
     mut views: ResMut<Views>,
     mut demos: ResMut<Demos>,
     mut vms: NonSendMut<head::HeadVms>,
@@ -812,57 +769,32 @@ pub fn on_paste<N>(
         log::error!("PasteSelection: head not found for entity {:?}", event.head);
         return;
     };
-    let Some(head_state) = gui_state.open_heads.get(&**head_ref) else {
+    let Some(head_state) = gui_state.open_heads.get_mut(&**head_ref) else {
         log::error!("PasteSelection: GUI state not found for head");
         return;
     };
 
-    let copied: gantz_egui::export::Copied<N> = match ron::from_str(&event.text) {
-        Ok(c) => c,
-        Err(e) => {
-            log::debug!("Clipboard does not contain a valid gantz payload: {e}");
-            return;
-        }
-    };
-
-    let offset = gantz_egui::resolve_paste_offset(&event.pos, &copied.positions);
-
-    let path = head_state.path.clone();
-    let new_indices = {
-        let graph: &mut Graph<N> = &mut *wg;
-        let Some(g) = gantz_egui::widget::graph_scene::index_path_graph_mut(graph, &path) else {
-            log::error!("PasteSelection: could not find graph at path {path:?}");
-            return;
-        };
-        let view = gv.entry(path).or_default();
-        gantz_egui::export::paste(
-            &mut registry,
-            &mut views,
-            &mut demos,
-            g,
-            &mut view.layout,
-            &copied,
-            offset,
-        )
-    };
+    let pasted = gantz_egui::ops::paste(
+        &mut registry,
+        &mut views,
+        &mut demos,
+        &mut wg,
+        &mut gv,
+        head_state,
+        &event.text,
+        &event.pos,
+    );
 
     // Re-register the full root graph so pasted nodes get their state
     // initialized with the correct nested hashmap structure. Idempotent
     // for existing nodes.
-    if let Some(vm) = vms.get_mut(&event.head) {
-        let node_reg = registry_ref(&registry, &builtins, &demos);
-        let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
-        gantz_core::graph::register(&get_node, &**wg, &[], vm);
+    if pasted {
+        if let Some(vm) = vms.get_mut(&event.head) {
+            let node_reg = registry_ref(&registry, &builtins, &demos);
+            let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
+            gantz_core::graph::register(&get_node, &**wg, &[], vm);
+        }
     }
-
-    // Update selection to the pasted nodes.
-    let head_state = gui_state
-        .into_inner()
-        .open_heads
-        .get_mut(&**head_ref)
-        .unwrap();
-    head_state.scene.interaction.selection.nodes = new_indices.into_iter().collect();
-    head_state.scene.interaction.selection.edges.clear();
 }
 
 /// Handle export head events.
@@ -890,16 +822,14 @@ pub fn on_export_head<N>(
     let node_reg = registry_ref(&registry, &builtins, &demos);
     let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
 
-    let export_registry = gantz_core::reg::export_heads(&get_node, &registry, [head]);
-    let export = gantz_egui::export::export_with(export_registry, &views, &demos);
-
-    let ron_str = match ron::ser::to_string_pretty(&export, ron::ser::PrettyConfig::default()) {
-        Ok(s) => s,
-        Err(e) => {
-            log::error!("ExportHead: failed to serialize: {e}");
-            return;
-        }
-    };
+    let ron_str =
+        match gantz_egui::export::export_heads_ron(&get_node, &registry, &views, &demos, [head]) {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!("ExportHead: failed to serialize: {e}");
+                return;
+            }
+        };
 
     // Derive a default filename from the head.
     let default_name = gantz_egui::export::default_filename(&head);
@@ -948,10 +878,13 @@ pub fn on_export_all_named<N>(
         return;
     }
 
-    let export_registry = gantz_core::reg::export_heads(&get_node, &registry, named_heads.iter());
-    let export = gantz_egui::export::export_with(export_registry, &views, &demos);
-
-    let ron_str = match ron::ser::to_string_pretty(&export, ron::ser::PrettyConfig::default()) {
+    let ron_str = match gantz_egui::export::export_heads_ron(
+        &get_node,
+        &registry,
+        &views,
+        &demos,
+        named_heads.iter(),
+    ) {
         Ok(s) => s,
         Err(e) => {
             log::error!("ExportAllNamed: failed to serialize: {e}");
@@ -991,31 +924,19 @@ pub fn on_import_file<N>(
     N: 'static + Node + Clone + serde::de::DeserializeOwned + Send + Sync,
 {
     let event = trigger.event();
-    let text = match std::str::from_utf8(&event.bytes) {
-        Ok(s) => s,
-        Err(e) => {
-            log::error!("ImportFile: invalid UTF-8: {e}");
-            return;
-        }
-    };
-    let export: gantz_egui::export::Export<Graph<N>> = match ron::from_str(text) {
+    let export = match gantz_egui::export::parse_export::<N>(&event.bytes) {
         Ok(e) => e,
         Err(e) => {
-            log::error!("ImportFile: failed to deserialize: {e}");
+            log::error!("ImportFile: {e}");
             return;
         }
     };
 
-    // Compute root names before merge if we might open a head.
+    // Compute the root name before merge if we might open a head.
     let root_name = if event.open_head {
         let node_reg = registry_ref(&registry, &builtins, &demos);
         let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
-        let roots = gantz_core::reg::root_names(&get_node, &export.registry);
-        if roots.len() == 1 {
-            Some(roots.into_iter().next().unwrap())
-        } else {
-            None
-        }
+        gantz_egui::export::unique_root_name(&get_node, &export)
     } else {
         None
     };
@@ -1201,24 +1122,14 @@ pub fn process_cmds<N: 'static + Send + Sync>(
                     }
                 }
                 gantz_egui::Cmd::Undo => {
-                    let commit_ca = registry.head_commit_ca(&head).copied();
-                    let parent = commit_ca
-                        .and_then(|ca| registry.commits().get(&ca))
-                        .and_then(|c| c.parent);
+                    let parent =
+                        gantz_egui::ops::undo(&registry, &mut gui_state.redo_stacks, &head);
                     if let Some(parent) = parent {
-                        if let Some(ca) = commit_ca {
-                            gui_state
-                                .redo_stacks
-                                .entry(head.clone())
-                                .or_default()
-                                .push(ca);
-                        }
                         navigate_head(&mut cmds, entity, &head, parent);
                     }
                 }
                 gantz_egui::Cmd::Redo => {
-                    if let Some(redo_ca) =
-                        gui_state.redo_stacks.entry(head.clone()).or_default().pop()
+                    if let Some(redo_ca) = gantz_egui::ops::redo(&mut gui_state.redo_stacks, &head)
                     {
                         navigate_head(&mut cmds, entity, &head, redo_ca);
                     }
@@ -1436,69 +1347,4 @@ fn navigate_head(cmds: &mut Commands, entity: Entity, head: &ca::Head, target: c
             target,
         }),
     }
-}
-
-/// Insert an Inspect node on the given edge, replacing the edge with two edges.
-fn inspect_edge<N>(
-    node_reg: &RegistryRef<N>,
-    wg: &mut head::WorkingGraph<N>,
-    gv: &mut GraphViews,
-    vm: &mut Engine,
-    cmd: gantz_egui::InspectEdge,
-) where
-    N: 'static
-        + Node
-        + From<gantz_egui::node::NamedRef>
-        + gantz_egui::widget::graph_scene::ToGraphMut<Node = N>
-        + Send
-        + Sync,
-{
-    let gantz_egui::InspectEdge { path, edge, pos } = cmd;
-
-    let graph: &mut Graph<N> = &mut *wg;
-    let views: &mut gantz_egui::GraphViews = &mut *gv;
-
-    let Some(nested) = gantz_egui::widget::graph_scene::index_path_graph_mut(graph, &path) else {
-        log::error!("InspectEdge: could not find graph at path");
-        return;
-    };
-
-    let Some((src_node, dst_node)) = nested.edge_endpoints(edge) else {
-        log::error!("InspectEdge: edge not found");
-        return;
-    };
-    let edge_weight = *nested.edge_weight(edge).unwrap();
-
-    nested.remove_edge(edge);
-
-    let Some(inspect_node) = node_reg.create_node("inspect") else {
-        log::error!("InspectEdge: could not create inspect node");
-        return;
-    };
-    let inspect_id = nested.add_node(inspect_node);
-
-    let node_path: Vec<_> = path
-        .iter()
-        .copied()
-        .chain(Some(inspect_id.index()))
-        .collect();
-    let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
-    let reg_ctx = gantz_core::node::RegCtx::new(&get_node, &node_path, vm);
-    nested[inspect_id].register(reg_ctx);
-
-    nested.add_edge(
-        src_node,
-        inspect_id,
-        gantz_core::Edge::new(edge_weight.output, gantz_core::node::Input(0)),
-    );
-
-    nested.add_edge(
-        inspect_id,
-        dst_node,
-        gantz_core::Edge::new(gantz_core::node::Output(0), edge_weight.input),
-    );
-
-    let node_id = egui_graph::NodeId::from_u64(inspect_id.index() as u64);
-    let view = views.entry(path).or_default();
-    view.layout.insert(node_id, pos);
 }

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -19,7 +19,7 @@ use gantz_ca as ca;
 use gantz_core::Node;
 use gantz_core::node::graph::Graph;
 pub use gantz_egui::RegistryRef;
-use gantz_egui::{HeadDataMut, ResponseData};
+use gantz_egui::{HeadDataMut, Payload, ResponseData};
 use std::any::TypeId;
 use std::collections::HashMap;
 use std::marker::PhantomData;
@@ -263,7 +263,7 @@ pub struct ResetBaseGraphEvent(pub String);
 ///
 /// The `Option<Entity>` is the open-head entity resolved from the payload's
 /// head tag (`None` for app-level payloads).
-pub type DispatchFn = fn(Option<Entity>, Box<dyn ResponseData>, &mut Commands);
+pub type DispatchFn = fn(Option<Entity>, Payload, &mut Commands);
 
 /// `TypeId`-keyed dispatchers turning the dynamic GUI response payloads into
 /// typed events. Register payload types via [`RegisterResponseExt`].
@@ -1303,12 +1303,12 @@ where
     // Dispatch the dynamic response payloads emitted during the GUI pass.
     // Payload types are registered in `ResponseDispatchers` (see
     // `RegisterResponseExt`); unregistered payloads are reported.
-    for (head, data) in response.responses.drain() {
-        log::debug!("{data:?}");
+    for (head, payload) in response.responses.drain() {
+        log::debug!("{payload:?}");
         let entity = head.and_then(|h| head_to_entity.get(&h).copied());
-        match dispatchers.0.get(&data.data_type_id()) {
-            Some(dispatch) => dispatch(entity, data, &mut cmds),
-            None => log::warn!("unhandled response payload: {}", data.data_type_name()),
+        match dispatchers.0.get(&payload.type_id()) {
+            Some(dispatch) => dispatch(entity, payload, &mut cmds),
+            None => log::warn!("unhandled response payload: {}", payload.type_name()),
         }
     }
 
@@ -1326,9 +1326,8 @@ where
 ///
 /// Dispatchers are keyed by the payload's `TypeId`, so the downcast cannot
 /// fail for a correctly registered dispatcher.
-fn downcast_payload<T: ResponseData>(data: Box<dyn ResponseData>) -> T {
-    *data
-        .into_any()
+fn downcast_payload<T: ResponseData>(payload: Payload) -> T {
+    payload
         .downcast::<T>()
         .expect("dispatcher registered for this payload type")
 }
@@ -1336,49 +1335,49 @@ fn downcast_payload<T: ResponseData>(data: Box<dyn ResponseData>) -> T {
 /// Dispatch a head-scoped payload as a [`ForHead`] event.
 fn dispatch_for_head<T: ResponseData>(
     entity: Option<Entity>,
-    data: Box<dyn ResponseData>,
+    payload: Payload,
     cmds: &mut Commands,
 ) {
     let Some(head) = entity else {
         log::error!(
             "response payload `{}` has no open-head entity",
-            data.data_type_name()
+            payload.type_name()
         );
         return;
     };
-    let data = downcast_payload::<T>(data);
+    let data = downcast_payload::<T>(payload);
     cmds.trigger(ForHead { head, data });
 }
 
 /// Dispatch a [`gantz_egui::EvalEntry`] payload as an [`EvalEntryEvent`].
-fn dispatch_eval_entry(entity: Option<Entity>, data: Box<dyn ResponseData>, cmds: &mut Commands) {
+fn dispatch_eval_entry(entity: Option<Entity>, payload: Payload, cmds: &mut Commands) {
     let Some(head) = entity else {
         log::error!("EvalEntry payload has no open-head entity");
         return;
     };
-    let gantz_egui::EvalEntry(entrypoint) = downcast_payload(data);
+    let gantz_egui::EvalEntry(entrypoint) = downcast_payload(payload);
     cmds.trigger(EvalEntryEvent { head, entrypoint });
 }
 
 /// Dispatch a [`gantz_egui::OpenHead`] payload as a [`head::OpenEvent`].
-fn dispatch_open_head(_: Option<Entity>, data: Box<dyn ResponseData>, cmds: &mut Commands) {
-    let gantz_egui::OpenHead(target) = downcast_payload(data);
+fn dispatch_open_head(_: Option<Entity>, payload: Payload, cmds: &mut Commands) {
+    let gantz_egui::OpenHead(target) = downcast_payload(payload);
     cmds.trigger(head::OpenEvent(target));
 }
 
 /// Dispatch a [`gantz_egui::ExportHead`] payload as an [`ExportHeadEvent`].
-fn dispatch_export_head(entity: Option<Entity>, data: Box<dyn ResponseData>, cmds: &mut Commands) {
+fn dispatch_export_head(entity: Option<Entity>, payload: Payload, cmds: &mut Commands) {
     let Some(head) = entity else {
         log::error!("ExportHead payload has no open-head entity");
         return;
     };
-    let gantz_egui::ExportHead = downcast_payload(data);
+    let gantz_egui::ExportHead = downcast_payload(payload);
     cmds.trigger(ExportHeadEvent { head });
 }
 
 /// Dispatch a [`gantz_egui::ExportAllNamed`] payload as an [`ExportAllNamedEvent`].
-fn dispatch_export_all_named(_: Option<Entity>, data: Box<dyn ResponseData>, cmds: &mut Commands) {
-    let gantz_egui::ExportAllNamed = downcast_payload(data);
+fn dispatch_export_all_named(_: Option<Entity>, payload: Payload, cmds: &mut Commands) {
+    let gantz_egui::ExportAllNamed = downcast_payload(payload);
     cmds.trigger(ExportAllNamedEvent);
 }
 

--- a/crates/gantz/src/main.rs
+++ b/crates/gantz/src/main.rs
@@ -7,7 +7,7 @@ use bevy_gantz::{
     BuiltinNodes, FocusedHead, GantzPlugin, HeadRef, HeadTabOrder, OpenHead, OpenHeadDataReadOnly,
     Registry, WorkingGraph,
     debounced_input::{DebouncedInputEvent, DebouncedInputPlugin},
-    head, reg, timestamp, vm,
+    reg, timestamp,
 };
 use bevy_gantz_egui::{GantzEguiPlugin, GuiState, HeadGuiState, TraceCapture, Views};
 use bevy_pkv::PkvStore;
@@ -44,7 +44,6 @@ fn main() {
                 reg::prune_unused::<Box<dyn node::Node>>
                     .after(setup_resources)
                     .after(setup_open),
-                vm::setup::<Box<dyn node::Node>>.after(reg::prune_unused::<Box<dyn node::Node>>),
             ),
         )
         .add_systems(EguiPrimaryContextPass, load_egui_memory)
@@ -106,7 +105,9 @@ fn setup_open(
         bevy_gantz_egui::storage::load_open(&*storage, &mut *registry, &*views, timestamp());
     let focused_head = bevy_gantz::storage::load_focused_head(&*storage);
 
-    // Spawn entities for each open head.
+    // Spawn entities for each open head. `OpenHead`'s required components
+    // cover the compile outcome; `vm::sync` initializes the VMs on the first
+    // `Update`.
     for (head, graph, head_views) in loaded {
         let is_focused = focused_head.as_ref() == Some(&head);
         let entity = cmds
@@ -115,8 +116,6 @@ fn setup_open(
                 HeadRef(head),
                 WorkingGraph(graph),
                 head_views,
-                head::Module::default(),
-                head::Diagnostics::default(),
                 HeadGuiState::default(),
             ))
             .id();
@@ -170,7 +169,7 @@ fn persist_resources(
         }
     }
 
-    // Save all views (already updated in update_vm).
+    // Save all views (kept up to date by `persist_views`).
     bevy_gantz_egui::storage::save_views(&mut *storage, &*views);
     // Save the gantz GUI state.
     bevy_gantz_egui::storage::save_gui_state(&mut *storage, &gui_state);

--- a/crates/gantz/src/main_update_base.rs
+++ b/crates/gantz/src/main_update_base.rs
@@ -14,7 +14,7 @@ use bevy_gantz::{
     BuiltinNodes, FocusedHead, GantzPlugin, HeadRef, HeadTabOrder, OpenHead, OpenHeadDataReadOnly,
     WorkingGraph,
     debounced_input::{DebouncedInputEvent, DebouncedInputPlugin},
-    head, timestamp, vm,
+    timestamp,
 };
 use bevy_gantz_egui::{GantzEguiPlugin, GuiState, HeadGuiState, TraceCapture, Views};
 use bevy_pkv::PkvStore;
@@ -47,7 +47,6 @@ fn main() {
                 setup_gui_state,
                 bevy_gantz_egui::base::load::<Box<dyn node::Node>>.after(setup_gui_state),
                 setup_open.after(bevy_gantz_egui::base::load::<Box<dyn node::Node>>),
-                vm::setup::<Box<dyn node::Node>>.after(setup_open),
             ),
         )
         .add_systems(EguiPrimaryContextPass, load_egui_memory)
@@ -108,6 +107,8 @@ fn setup_open(
         bevy_gantz_egui::storage::load_open(&*storage, &mut *registry, &*views, timestamp());
     let focused_head = bevy_gantz::storage::load_focused_head(&*storage);
 
+    // `OpenHead`'s required components cover the compile outcome; `vm::sync`
+    // initializes the VMs on the first `Update`.
     for (head, graph, head_views) in loaded {
         let is_focused = focused_head.as_ref() == Some(&head);
         let entity = cmds
@@ -116,8 +117,6 @@ fn setup_open(
                 HeadRef(head),
                 WorkingGraph(graph),
                 head_views,
-                head::Module::default(),
-                head::Diagnostics::default(),
                 HeadGuiState::default(),
             ))
             .id();

--- a/crates/gantz_egui/Cargo.toml
+++ b/crates/gantz_egui/Cargo.toml
@@ -26,6 +26,7 @@ hex.workspace = true
 humantime.workspace = true
 log.workspace = true
 petgraph.workspace = true
+ron.workspace = true
 serde.workspace = true
 steel-core.workspace = true
 sublime_fuzzy.workspace = true
@@ -39,7 +40,6 @@ dyn-clone.workspace = true
 eframe.workspace = true
 pollster.workspace = true
 rfd.workspace = true
-ron.workspace = true
 typetag.workspace = true
 # FIXME: temporarily disabled, see #122.
 # Workaround for https://github.com/emilk/egui/issues/7106

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -243,6 +243,13 @@ impl gantz_egui::widget::graph_scene::ToGraphMut for Box<dyn Node> {
     }
 }
 
+// Required by `gantz_egui::ops::branch_node` to replace branched nodes.
+impl From<gantz_egui::node::NamedRef> for Box<dyn Node> {
+    fn from(named: gantz_egui::node::NamedRef) -> Self {
+        Box::new(named)
+    }
+}
+
 // ----------------------------------------------
 // Graph
 // ----------------------------------------------
@@ -912,135 +919,105 @@ fn process_cmds(ctx: &egui::Context, state: &mut State) {
                     open_head(state, target);
                 }
                 gantz_egui::Cmd::BranchNode { new_name, ca, path } => {
-                    let commit_ca = gantz_ca::CommitAddr::from(ca);
-                    let graph_addr = state.env.registry.commits()[&commit_ca].graph;
-                    let new_commit_ca = state.env.registry.commit_graph(
+                    let (_, graph, _) = &mut state.heads[ix];
+                    gantz_egui::ops::branch_node(
+                        &mut state.env.registry,
                         timestamp(),
-                        Some(commit_ca),
-                        graph_addr,
-                        || unreachable!("graph already exists in registry"),
+                        graph,
+                        new_name,
+                        ca,
+                        &path,
                     );
-                    state
-                        .env
-                        .registry
-                        .insert_name(new_name.clone(), new_commit_ca);
-                    let (_, root_graph, _) = &mut state.heads[ix];
-                    let (parent_path, node_ix_slice) = path.split_at(path.len() - 1);
-                    let Some(graph) = gantz_egui::widget::graph_scene::index_path_graph_mut(
-                        root_graph,
-                        parent_path,
-                    ) else {
-                        log::error!("BranchNode: could not find graph at path {parent_path:?}");
-                        continue;
-                    };
-                    let node_id = gantz_core::node::graph::NodeIx::new(node_ix_slice[0]);
-                    let new_ref = gantz_core::node::Ref::new(new_commit_ca.into());
-                    let named_ref = gantz_egui::node::NamedRef::new(new_name, new_ref);
-                    if let Some(node) = graph.node_weight_mut(node_id) {
-                        *node = Box::new(named_ref);
-                    } else {
-                        log::error!("BranchNode: node not found at index {}", node_ix_slice[0]);
-                    }
                 }
                 gantz_egui::Cmd::InspectEdge(cmd) => {
+                    let env = &state.env;
+                    let get_node = |ca: &gantz_ca::ContentAddr| env.node(ca);
                     let (_, graph, views) = &mut state.heads[ix];
-                    inspect_edge(&state.env, graph, views, &mut state.vms[ix], cmd);
+                    gantz_egui::ops::inspect_edge(
+                        &get_node,
+                        || env.new_node("inspect"),
+                        graph,
+                        views,
+                        &mut state.vms[ix],
+                        cmd,
+                    );
                 }
                 gantz_egui::Cmd::CreateNode(cmd) => {
+                    let env = &state.env;
+                    let get_node = |ca: &gantz_ca::ContentAddr| env.node(ca);
                     let (_, graph, views) = &mut state.heads[ix];
-                    create_node(&state.env, graph, views, &mut state.vms[ix], cmd);
+                    gantz_egui::ops::create_node(
+                        &get_node,
+                        |node_type| env.new_node(node_type),
+                        graph,
+                        views,
+                        &mut state.vms[ix],
+                        cmd,
+                    );
                 }
                 gantz_egui::Cmd::CopyNodes(nodes) => {
-                    copy_nodes(ctx, state, ix, &head, nodes);
+                    let head_state = state.gantz.open_heads.get_mut(&head).unwrap();
+                    let path = head_state.path.clone();
+                    let (_, graph, gv) = &mut state.heads[ix];
+                    let text = gantz_egui::ops::copy_nodes(
+                        &state.env.registry,
+                        &HashMap::new(),
+                        graph,
+                        gv,
+                        &path,
+                        &nodes,
+                    );
+                    if let Some(text) = text {
+                        ctx.copy_text(text);
+                    }
                 }
                 gantz_egui::Cmd::Paste { text, pos } => {
                     // In eframe, Event::Paste provides text directly.
                     let Some(text) = text else { continue };
-                    let copied: gantz_egui::export::Copied<Box<dyn Node>> =
-                        match ron::from_str(&text) {
-                            Ok(c) => c,
-                            Err(e) => {
-                                log::debug!(
-                                    "Clipboard does not contain a valid gantz payload: {e}"
-                                );
-                                continue;
-                            }
-                        };
-                    let offset = gantz_egui::resolve_paste_offset(&pos, &copied.positions);
                     let head_state = state.gantz.open_heads.get_mut(&head).unwrap();
-                    let path = head_state.path.clone();
                     let (_, graph, gv) = &mut state.heads[ix];
-                    let new_indices = {
-                        let Some(g) =
-                            gantz_egui::widget::graph_scene::index_path_graph_mut(graph, &path)
-                        else {
-                            continue;
-                        };
-                        let view = gv.entry(path).or_default();
-                        let mut all_views = std::collections::HashMap::new();
-                        let mut all_demos = std::collections::HashMap::new();
-                        gantz_egui::export::paste(
-                            &mut state.env.registry,
-                            &mut all_views,
-                            &mut all_demos,
-                            g,
-                            &mut view.layout,
-                            &copied,
-                            offset,
-                        )
-                    };
+                    let pasted = gantz_egui::ops::paste(
+                        &mut state.env.registry,
+                        &mut HashMap::new(),
+                        &mut HashMap::new(),
+                        graph,
+                        gv,
+                        head_state,
+                        &text,
+                        &pos,
+                    );
                     // Re-register the full root graph so pasted nodes get
                     // their state initialized. Idempotent for existing nodes.
-                    let vm = &mut state.vms[ix];
-                    let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
-                    gantz_core::graph::register(&get_node, &*graph, &[], vm);
-                    // Update selection to the pasted nodes.
-                    let head_state = state.gantz.open_heads.get_mut(&head).unwrap();
-                    head_state.scene.interaction.selection.nodes =
-                        new_indices.into_iter().collect();
-                    head_state.scene.interaction.selection.edges.clear();
+                    if pasted {
+                        let vm = &mut state.vms[ix];
+                        let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
+                        gantz_core::graph::register(&get_node, &*graph, &[], vm);
+                    }
                 }
                 gantz_egui::Cmd::Undo => {
-                    let commit_ca = state.env.registry.head_commit_ca(&head).copied();
-                    let parent = commit_ca
-                        .and_then(|ca| state.env.registry.commits().get(&ca))
-                        .and_then(|c| c.parent);
+                    let parent = gantz_egui::ops::undo(
+                        &state.env.registry,
+                        &mut state.gantz.redo_stacks,
+                        &head,
+                    );
                     if let Some(parent) = parent {
-                        if let Some(ca) = commit_ca {
-                            state
-                                .gantz
-                                .redo_stacks
-                                .entry(head.clone())
-                                .or_default()
-                                .push(ca);
-                        }
                         navigate_head(ctx, state, &head, parent);
                     }
                 }
                 gantz_egui::Cmd::Redo => {
-                    if let Some(redo_ca) = state
-                        .gantz
-                        .redo_stacks
-                        .entry(head.clone())
-                        .or_default()
-                        .pop()
-                    {
+                    let redo_ca = gantz_egui::ops::redo(&mut state.gantz.redo_stacks, &head);
+                    if let Some(redo_ca) = redo_ca {
                         navigate_head(ctx, state, &head, redo_ca);
                     }
                 }
                 gantz_egui::Cmd::ExportHead => {
                     let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
-                    let export_registry =
-                        gantz_core::reg::export_heads(&get_node, &state.env.registry, [&head]);
-                    let all_views = HashMap::new();
-                    let export = gantz_egui::export::export_with(
-                        export_registry,
-                        &all_views,
+                    let ron_str = match gantz_egui::export::export_heads_ron(
+                        &get_node,
+                        &state.env.registry,
                         &HashMap::new(),
-                    );
-                    let ron_str = match ron::ser::to_string_pretty(
-                        &export,
-                        ron::ser::PrettyConfig::default(),
+                        &HashMap::new(),
+                        [&head],
                     ) {
                         Ok(s) => s,
                         Err(e) => {
@@ -1075,20 +1052,12 @@ fn process_cmds(ctx: &egui::Context, state: &mut State) {
                         log::info!("ExportAllNamed: no named graphs to export");
                         continue;
                     }
-                    let export_registry = gantz_core::reg::export_heads(
+                    let ron_str = match gantz_egui::export::export_heads_ron(
                         &get_node,
                         &state.env.registry,
-                        named_heads.iter(),
-                    );
-                    let all_views = HashMap::new();
-                    let export = gantz_egui::export::export_with(
-                        export_registry,
-                        &all_views,
                         &HashMap::new(),
-                    );
-                    let ron_str = match ron::ser::to_string_pretty(
-                        &export,
-                        ron::ser::PrettyConfig::default(),
+                        &HashMap::new(),
+                        named_heads.iter(),
                     ) {
                         Ok(s) => s,
                         Err(e) => {
@@ -1115,131 +1084,6 @@ fn process_cmds(ctx: &egui::Context, state: &mut State) {
             }
         }
     }
-}
-
-fn copy_nodes(
-    ctx: &egui::Context,
-    state: &mut State,
-    ix: usize,
-    head: &gantz_ca::Head,
-    nodes: std::collections::HashSet<gantz_egui::widget::graph_scene::NodeIndex>,
-) {
-    if nodes.is_empty() {
-        return;
-    }
-    let head_state = state.gantz.open_heads.get_mut(head).unwrap();
-    let path = head_state.path.clone();
-    let (_, graph, gv) = &mut state.heads[ix];
-    let Some(g) = gantz_egui::widget::graph_scene::index_path_graph_mut(graph, &path) else {
-        return;
-    };
-    let layout = gv
-        .get(&path)
-        .map(|v| &v.layout)
-        .cloned()
-        .unwrap_or_default();
-    let all_views = std::collections::HashMap::new();
-    let copied = gantz_egui::export::copy(&state.env.registry, &all_views, g, &nodes, &layout);
-    match ron::to_string(&copied) {
-        Ok(text) => ctx.copy_text(text),
-        Err(e) => log::error!("Failed to serialize copy payload: {e}"),
-    }
-}
-
-fn inspect_edge(
-    env: &Environment,
-    graph: &mut Graph,
-    views: &mut GraphViews,
-    vm: &mut Engine,
-    cmd: gantz_egui::InspectEdge,
-) {
-    let gantz_egui::InspectEdge { path, edge, pos } = cmd;
-
-    // Navigate to the nested graph at the path.
-    let Some(nested) = gantz_egui::widget::graph_scene::index_path_graph_mut(graph, &path) else {
-        log::error!("InspectEdge: could not find graph at path");
-        return;
-    };
-
-    // Get edge endpoints and weight.
-    let Some((src_node, dst_node)) = nested.edge_endpoints(edge) else {
-        log::error!("InspectEdge: edge not found");
-        return;
-    };
-    let edge_weight = *nested.edge_weight(edge).unwrap();
-
-    // Remove the edge.
-    nested.remove_edge(edge);
-
-    // Create a new Inspect node.
-    let Some(inspect_node) = env.new_node("inspect") else {
-        log::error!("InspectEdge: could not create inspect node");
-        return;
-    };
-    let inspect_id = nested.add_node(inspect_node);
-
-    // Determine the node path and register it with the VM.
-    let node_path: Vec<_> = path
-        .iter()
-        .copied()
-        .chain(Some(inspect_id.index()))
-        .collect();
-    let get_node = |ca: &gantz_ca::ContentAddr| env.node(ca);
-    let reg_ctx = gantz_core::node::RegCtx::new(&get_node, &node_path, vm);
-    nested[inspect_id].register(reg_ctx);
-
-    // Add edge: src -> inspect (using original output, input 0).
-    nested.add_edge(
-        src_node,
-        inspect_id,
-        gantz_core::Edge::new(edge_weight.output, gantz_core::node::Input(0)),
-    );
-
-    // Add edge: inspect -> dst (using output 0, original input).
-    nested.add_edge(
-        inspect_id,
-        dst_node,
-        gantz_core::Edge::new(gantz_core::node::Output(0), edge_weight.input),
-    );
-
-    // Position the new node at the click position.
-    let node_id = egui_graph::NodeId::from_u64(inspect_id.index() as u64);
-    let view = views.entry(path).or_default();
-    view.layout.insert(node_id, pos);
-}
-
-fn create_node(
-    env: &Environment,
-    graph: &mut Graph,
-    views: &mut GraphViews,
-    vm: &mut Engine,
-    cmd: gantz_egui::CreateNode,
-) {
-    let gantz_egui::CreateNode { path, node_type } = cmd;
-
-    // Navigate to the nested graph at the path.
-    let Some(nested) = gantz_egui::widget::graph_scene::index_path_graph_mut(graph, &path) else {
-        log::error!("CreateNode: could not find graph at path");
-        return;
-    };
-
-    // Create the new node.
-    let Some(node) = env.new_node(&node_type) else {
-        log::error!("CreateNode: unknown node type: {node_type}");
-        return;
-    };
-    let node_ix = nested.add_node(node);
-
-    // Register the new node with the VM.
-    let node_path: Vec<_> = path.iter().copied().chain(Some(node_ix.index())).collect();
-    let get_node = |ca: &gantz_ca::ContentAddr| env.node(ca);
-    let reg_ctx = gantz_core::node::RegCtx::new(&get_node, &node_path, vm);
-    nested[node_ix].register(reg_ctx);
-
-    // Position the new node at the scene center (or use layout default).
-    let egui_id = egui_graph::NodeId::from_u64(node_ix.index() as u64);
-    let view = views.entry(path).or_default();
-    view.layout.entry(egui_id).or_insert(egui::Pos2::ZERO);
 }
 
 fn gui(ctx: &egui::Context, state: &mut State) {
@@ -1342,39 +1186,25 @@ fn gui(ctx: &egui::Context, state: &mut State) {
 /// Deserializes the export, merges into the registry, and optionally opens
 /// the unique root head.
 fn import_bytes(state: &mut State, bytes: Vec<u8>, open_head: bool) {
-    let text = match std::str::from_utf8(&bytes) {
-        Ok(s) => s,
-        Err(e) => {
-            log::error!("Import: invalid UTF-8: {e}");
-            return;
-        }
-    };
-    let export: gantz_egui::export::Export<Graph> = match ron::from_str(text) {
+    let export = match gantz_egui::export::parse_export::<Box<dyn Node>>(&bytes) {
         Ok(e) => e,
         Err(e) => {
-            log::error!("Import: failed to deserialize: {e}");
+            log::error!("Import: {e}");
             return;
         }
     };
 
     let root_name = if open_head {
         let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
-        let roots = gantz_core::reg::root_names(&get_node, &export.registry);
-        if roots.len() == 1 {
-            Some(roots.into_iter().next().unwrap())
-        } else {
-            None
-        }
+        gantz_egui::export::unique_root_name(&get_node, &export)
     } else {
         None
     };
 
-    let mut all_views = HashMap::new();
-    let mut all_demos = HashMap::new();
     let result = gantz_egui::export::merge_with(
         &mut state.env.registry,
-        &mut all_views,
-        &mut all_demos,
+        &mut HashMap::new(),
+        &mut HashMap::new(),
         export,
     );
     log::info!(

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -509,7 +509,7 @@ impl App {
 
 impl eframe::App for App {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        gui(ctx, &mut self.state);
+        let responses = gui(ctx, &mut self.state);
 
         // Check for changes to each open graph and commit/recompile them.
         // FIXME: Rather than checking changed CA to monitor changes, ideally
@@ -554,8 +554,8 @@ impl eframe::App for App {
             }
         }
 
-        // Process any pending commands generated from the UI.
-        process_cmds(ctx, &mut self.state);
+        // Process any pending response payloads generated from the UI.
+        process_responses(ctx, &mut self.state, responses);
     }
 
     fn save(&mut self, storage: &mut dyn eframe::Storage) {
@@ -881,212 +881,233 @@ fn commit_key(ca: gantz_ca::CommitAddr) -> String {
     format!("{ca}")
 }
 
-// Drain the commands provided by the UI and process them.
-fn process_cmds(ctx: &egui::Context, state: &mut State) {
-    // Collect heads with their indices to process.
-    let heads_to_process: Vec<_> = state
-        .heads
-        .iter()
-        .enumerate()
-        .map(|(ix, (h, _, _))| (ix, h.clone()))
-        .collect();
+/// Resolve a payload's head tag to the head and its index in `state.heads`.
+fn tagged_head(state: &State, head: Option<gantz_ca::Head>) -> Option<(gantz_ca::Head, usize)> {
+    let head = head?;
+    let ix = state.heads.iter().position(|(h, _, _)| *h == head)?;
+    Some((head, ix))
+}
 
-    for (ix, head) in heads_to_process {
-        let head_state = state.gantz.open_heads.entry(head.clone()).or_default();
-        for cmd in std::mem::take(&mut head_state.scene.cmds) {
-            log::debug!("{cmd:?}");
-            match cmd {
-                gantz_egui::Cmd::EvalEntry(ep) => {
-                    let fn_name = gantz_core::compile::entry_fn_name(&ep.id());
-                    let result = state.vms[ix].call_function_by_name_with_args(&fn_name, vec![]);
-                    // Runtime diagnostics reflect the latest evaluation only.
-                    let diags = &mut state.diagnostics[ix];
-                    diags.retain(|d| d.severity != gantz_core::diagnostic::Severity::Runtime);
-                    if let Err(e) = result {
-                        if let Some(compiled) = &state.modules[ix] {
-                            let vm = &state.vms[ix];
-                            diags.push(gantz_core::diagnostic::from_eval_error(&e, vm, compiled));
-                        }
-                        log::error!("{e}");
-                    }
-                }
-                gantz_egui::Cmd::OpenPath(path) => {
-                    // Re-borrow head_state to modify path.
-                    let head_state = state.gantz.open_heads.get_mut(&head).unwrap();
-                    head_state.path = path;
-                }
-                gantz_egui::Cmd::OpenHead(target) => {
-                    open_head(state, target);
-                }
-                gantz_egui::Cmd::BranchNode { new_name, ca, path } => {
-                    let (_, graph, _) = &mut state.heads[ix];
-                    gantz_egui::ops::branch_node(
-                        &mut state.env.registry,
-                        timestamp(),
-                        graph,
-                        new_name,
-                        ca,
-                        &path,
-                    );
-                }
-                gantz_egui::Cmd::InspectEdge(cmd) => {
-                    let env = &state.env;
-                    let get_node = |ca: &gantz_ca::ContentAddr| env.node(ca);
-                    let (_, graph, views) = &mut state.heads[ix];
-                    gantz_egui::ops::inspect_edge(
-                        &get_node,
-                        || env.new_node("inspect"),
-                        graph,
-                        views,
-                        &mut state.vms[ix],
-                        cmd,
-                    );
-                }
-                gantz_egui::Cmd::CreateNode(cmd) => {
-                    let env = &state.env;
-                    let get_node = |ca: &gantz_ca::ContentAddr| env.node(ca);
-                    let (_, graph, views) = &mut state.heads[ix];
-                    gantz_egui::ops::create_node(
-                        &get_node,
-                        |node_type| env.new_node(node_type),
-                        graph,
-                        views,
-                        &mut state.vms[ix],
-                        cmd,
-                    );
-                }
-                gantz_egui::Cmd::CopyNodes(nodes) => {
-                    let head_state = state.gantz.open_heads.get_mut(&head).unwrap();
-                    let path = head_state.path.clone();
-                    let (_, graph, gv) = &mut state.heads[ix];
-                    let text = gantz_egui::ops::copy_nodes(
-                        &state.env.registry,
-                        &HashMap::new(),
-                        graph,
-                        gv,
-                        &path,
-                        &nodes,
-                    );
-                    if let Some(text) = text {
-                        ctx.copy_text(text);
-                    }
-                }
-                gantz_egui::Cmd::Paste { text, pos } => {
-                    // In eframe, Event::Paste provides text directly.
-                    let Some(text) = text else { continue };
-                    let head_state = state.gantz.open_heads.get_mut(&head).unwrap();
-                    let (_, graph, gv) = &mut state.heads[ix];
-                    let pasted = gantz_egui::ops::paste(
-                        &mut state.env.registry,
-                        &mut HashMap::new(),
-                        &mut HashMap::new(),
-                        graph,
-                        gv,
-                        head_state,
-                        &text,
-                        &pos,
-                    );
-                    // Re-register the full root graph so pasted nodes get
-                    // their state initialized. Idempotent for existing nodes.
-                    if pasted {
-                        let vm = &mut state.vms[ix];
-                        let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
-                        gantz_core::graph::register(&get_node, &*graph, &[], vm);
-                    }
-                }
-                gantz_egui::Cmd::Undo => {
-                    let parent = gantz_egui::ops::undo(
-                        &state.env.registry,
-                        &mut state.gantz.redo_stacks,
-                        &head,
-                    );
-                    if let Some(parent) = parent {
-                        navigate_head(ctx, state, &head, parent);
-                    }
-                }
-                gantz_egui::Cmd::Redo => {
-                    let redo_ca = gantz_egui::ops::redo(&mut state.gantz.redo_stacks, &head);
-                    if let Some(redo_ca) = redo_ca {
-                        navigate_head(ctx, state, &head, redo_ca);
-                    }
-                }
-                gantz_egui::Cmd::ExportHead => {
-                    let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
-                    let ron_str = match gantz_egui::export::export_heads_ron(
-                        &get_node,
-                        &state.env.registry,
-                        &HashMap::new(),
-                        &HashMap::new(),
-                        [&head],
-                    ) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            log::error!("ExportHead: failed to serialize: {e}");
-                            continue;
-                        }
-                    };
-                    let default_name = gantz_egui::export::default_filename(&head);
-                    let ext = gantz_egui::export::FILE_EXTENSION;
-                    let dialog = rfd::AsyncFileDialog::new()
-                        .set_title("Export Graph")
-                        .set_file_name(&default_name)
-                        .add_filter("Gantz Export", &[ext]);
-                    if let Some(handle) = pollster::block_on(dialog.save_file()) {
-                        if let Err(e) = pollster::block_on(handle.write(ron_str.as_bytes())) {
-                            log::error!("ExportHead: failed to write: {e}");
-                        } else {
-                            log::info!("Exported graph to {}", handle.file_name());
-                        }
-                    }
-                }
-                gantz_egui::Cmd::ExportAllNamed => {
-                    let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
-                    let named_heads: Vec<gantz_ca::Head> = state
-                        .env
-                        .registry
-                        .names()
-                        .keys()
-                        .map(|name| gantz_ca::Head::Branch(name.clone()))
-                        .collect();
-                    if named_heads.is_empty() {
-                        log::info!("ExportAllNamed: no named graphs to export");
-                        continue;
-                    }
-                    let ron_str = match gantz_egui::export::export_heads_ron(
-                        &get_node,
-                        &state.env.registry,
-                        &HashMap::new(),
-                        &HashMap::new(),
-                        named_heads.iter(),
-                    ) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            log::error!("ExportAllNamed: failed to serialize: {e}");
-                            continue;
-                        }
-                    };
-                    let ext = gantz_egui::export::FILE_EXTENSION;
-                    let dialog = rfd::AsyncFileDialog::new()
-                        .set_title("Export All Named Graphs")
-                        .set_file_name(&format!("gantz.{ext}"))
-                        .add_filter("Gantz Export", &[ext]);
-                    if let Some(handle) = pollster::block_on(dialog.save_file()) {
-                        if let Err(e) = pollster::block_on(handle.write(ron_str.as_bytes())) {
-                            log::error!("ExportAllNamed: failed to write: {e}");
-                        } else {
-                            log::info!("Exported all named graphs to {}", handle.file_name());
-                        }
-                    }
-                }
-                gantz_egui::Cmd::OpenCommandPalette => {
-                    state.gantz.command_palette.toggle();
-                }
+// Drain the response payloads emitted by the UI and process them.
+fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gantz_egui::Responses) {
+    for (head, gantz_egui::EvalEntry(ep)) in responses.take() {
+        let Some((_, ix)) = tagged_head(state, head) else {
+            continue;
+        };
+        let fn_name = gantz_core::compile::entry_fn_name(&ep.id());
+        let result = state.vms[ix].call_function_by_name_with_args(&fn_name, vec![]);
+        // Runtime diagnostics reflect the latest evaluation only.
+        let diags = &mut state.diagnostics[ix];
+        diags.retain(|d| d.severity != gantz_core::diagnostic::Severity::Runtime);
+        if let Err(e) = result {
+            if let Some(compiled) = &state.modules[ix] {
+                let vm = &state.vms[ix];
+                diags.push(gantz_core::diagnostic::from_eval_error(&e, vm, compiled));
+            }
+            log::error!("{e}");
+        }
+    }
+
+    for (_, gantz_egui::OpenHead(target)) in responses.take() {
+        open_head(state, target);
+    }
+
+    for (head, branch) in responses.take::<gantz_egui::BranchNode>() {
+        let Some((_, ix)) = tagged_head(state, head) else {
+            continue;
+        };
+        let gantz_egui::BranchNode { new_name, ca, path } = branch;
+        let (_, graph, _) = &mut state.heads[ix];
+        gantz_egui::ops::branch_node(
+            &mut state.env.registry,
+            timestamp(),
+            graph,
+            new_name,
+            ca,
+            &path,
+        );
+    }
+
+    for (head, inspect) in responses.take::<gantz_egui::InspectEdge>() {
+        let Some((_, ix)) = tagged_head(state, head) else {
+            continue;
+        };
+        let env = &state.env;
+        let get_node = |ca: &gantz_ca::ContentAddr| env.node(ca);
+        let (_, graph, views) = &mut state.heads[ix];
+        gantz_egui::ops::inspect_edge(
+            &get_node,
+            || env.new_node("inspect"),
+            graph,
+            views,
+            &mut state.vms[ix],
+            inspect,
+        );
+    }
+
+    for (head, create) in responses.take::<gantz_egui::CreateNode>() {
+        let Some((_, ix)) = tagged_head(state, head) else {
+            continue;
+        };
+        let env = &state.env;
+        let get_node = |ca: &gantz_ca::ContentAddr| env.node(ca);
+        let (_, graph, views) = &mut state.heads[ix];
+        gantz_egui::ops::create_node(
+            &get_node,
+            |node_type| env.new_node(node_type),
+            graph,
+            views,
+            &mut state.vms[ix],
+            create,
+        );
+    }
+
+    for (head, gantz_egui::CopyNodes(nodes)) in responses.take() {
+        let Some((head, ix)) = tagged_head(state, head) else {
+            continue;
+        };
+        let head_state = state.gantz.open_heads.entry(head).or_default();
+        let path = head_state.path.clone();
+        let (_, graph, gv) = &mut state.heads[ix];
+        let text = gantz_egui::ops::copy_nodes(
+            &state.env.registry,
+            &HashMap::new(),
+            graph,
+            gv,
+            &path,
+            &nodes,
+        );
+        if let Some(text) = text {
+            ctx.copy_text(text);
+        }
+    }
+
+    for (head, gantz_egui::Paste { text, pos }) in responses.take() {
+        let Some((head, ix)) = tagged_head(state, head) else {
+            continue;
+        };
+        // In eframe, Event::Paste provides text directly.
+        let Some(text) = text else { continue };
+        let head_state = state.gantz.open_heads.entry(head).or_default();
+        let (_, graph, gv) = &mut state.heads[ix];
+        let pasted = gantz_egui::ops::paste(
+            &mut state.env.registry,
+            &mut HashMap::new(),
+            &mut HashMap::new(),
+            graph,
+            gv,
+            head_state,
+            &text,
+            &pos,
+        );
+        // Re-register the full root graph so pasted nodes get their state
+        // initialized. Idempotent for existing nodes.
+        if pasted {
+            let vm = &mut state.vms[ix];
+            let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
+            gantz_core::graph::register(&get_node, &*graph, &[], vm);
+        }
+    }
+
+    for (head, gantz_egui::Undo) in responses.take() {
+        let Some((head, _)) = tagged_head(state, head) else {
+            continue;
+        };
+        let parent =
+            gantz_egui::ops::undo(&state.env.registry, &mut state.gantz.redo_stacks, &head);
+        if let Some(parent) = parent {
+            navigate_head(ctx, state, &head, parent);
+        }
+    }
+
+    for (head, gantz_egui::Redo) in responses.take() {
+        let Some((head, _)) = tagged_head(state, head) else {
+            continue;
+        };
+        let redo_ca = gantz_egui::ops::redo(&mut state.gantz.redo_stacks, &head);
+        if let Some(redo_ca) = redo_ca {
+            navigate_head(ctx, state, &head, redo_ca);
+        }
+    }
+
+    for (head, gantz_egui::ExportHead) in responses.take() {
+        let Some(head) = head else { continue };
+        let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
+        let ron_str = match gantz_egui::export::export_heads_ron(
+            &get_node,
+            &state.env.registry,
+            &HashMap::new(),
+            &HashMap::new(),
+            [&head],
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!("ExportHead: failed to serialize: {e}");
+                continue;
+            }
+        };
+        let default_name = gantz_egui::export::default_filename(&head);
+        let ext = gantz_egui::export::FILE_EXTENSION;
+        let dialog = rfd::AsyncFileDialog::new()
+            .set_title("Export Graph")
+            .set_file_name(&default_name)
+            .add_filter("Gantz Export", &[ext]);
+        if let Some(handle) = pollster::block_on(dialog.save_file()) {
+            if let Err(e) = pollster::block_on(handle.write(ron_str.as_bytes())) {
+                log::error!("ExportHead: failed to write: {e}");
+            } else {
+                log::info!("Exported graph to {}", handle.file_name());
             }
         }
     }
+
+    for (_, gantz_egui::ExportAllNamed) in responses.take() {
+        let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
+        let named_heads: Vec<gantz_ca::Head> = state
+            .env
+            .registry
+            .names()
+            .keys()
+            .map(|name| gantz_ca::Head::Branch(name.clone()))
+            .collect();
+        if named_heads.is_empty() {
+            log::info!("ExportAllNamed: no named graphs to export");
+            continue;
+        }
+        let ron_str = match gantz_egui::export::export_heads_ron(
+            &get_node,
+            &state.env.registry,
+            &HashMap::new(),
+            &HashMap::new(),
+            named_heads.iter(),
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!("ExportAllNamed: failed to serialize: {e}");
+                continue;
+            }
+        };
+        let ext = gantz_egui::export::FILE_EXTENSION;
+        let dialog = rfd::AsyncFileDialog::new()
+            .set_title("Export All Named Graphs")
+            .set_file_name(&format!("gantz.{ext}"))
+            .add_filter("Gantz Export", &[ext]);
+        if let Some(handle) = pollster::block_on(dialog.save_file()) {
+            if let Err(e) = pollster::block_on(handle.write(ron_str.as_bytes())) {
+                log::error!("ExportAllNamed: failed to write: {e}");
+            } else {
+                log::info!("Exported all named graphs to {}", handle.file_name());
+            }
+        }
+    }
+
+    // Any remaining payloads are unhandled - report rather than silently drop.
+    for name in responses.type_names() {
+        log::warn!("unhandled response payload: {name}");
+    }
 }
 
-fn gui(ctx: &egui::Context, state: &mut State) {
+fn gui(ctx: &egui::Context, state: &mut State) -> gantz_egui::Responses {
     let compile_config = state.compile_config;
     let response = egui::containers::CentralPanel::default()
         .frame(egui::Frame::default())
@@ -1179,6 +1200,8 @@ fn gui(ctx: &egui::Context, state: &mut State) {
         state.compile_config = cfg;
         recompile_heads(state);
     }
+
+    response.responses
 }
 
 /// Import a `.gantz` file from raw bytes.

--- a/crates/gantz_egui/src/export.rs
+++ b/crates/gantz_egui/src/export.rs
@@ -6,12 +6,37 @@
 
 use crate::GraphViews;
 use gantz_ca::{CommitAddr, registry::MergeResult};
-use gantz_core::node::{self, graph::Graph};
+use gantz_core::node::{self, GetNode, graph::Graph};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
 /// File extension for gantz export files (without the leading dot).
 pub const FILE_EXTENSION: &str = "gantz";
+
+/// An error produced when parsing the raw bytes of a `.gantz` file.
+#[derive(Debug)]
+pub enum ParseExportError {
+    Utf8(std::str::Utf8Error),
+    Ron(ron::de::SpannedError),
+}
+
+impl std::fmt::Display for ParseExportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Utf8(e) => write!(f, "invalid UTF-8: {e}"),
+            Self::Ron(e) => write!(f, "failed to deserialize: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ParseExportError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Utf8(e) => Some(e),
+            Self::Ron(e) => Some(e),
+        }
+    }
+}
 
 /// A serializable bundle of a registry subset and its associated view state.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -53,6 +78,46 @@ where
         views,
         demos,
     }
+}
+
+/// Parse the raw bytes of a `.gantz` file into an [`Export`].
+pub fn parse_export<N>(bytes: &[u8]) -> Result<Export<Graph<N>>, ParseExportError>
+where
+    N: serde::de::DeserializeOwned,
+{
+    let text = std::str::from_utf8(bytes).map_err(ParseExportError::Utf8)?;
+    ron::from_str(text).map_err(ParseExportError::Ron)
+}
+
+/// The unique root name of an export, if it has exactly one.
+///
+/// `get_node` resolves node lookups outside the export (e.g. builtins).
+pub fn unique_root_name<N>(get_node: GetNode, export: &Export<Graph<N>>) -> Option<String>
+where
+    N: gantz_core::Node,
+{
+    let mut roots = gantz_core::reg::root_names(get_node, &export.registry);
+    (roots.len() == 1).then(|| roots.pop().unwrap())
+}
+
+/// Build and serialize an [`Export`] for the given heads as pretty RON.
+///
+/// Covers both export-head and export-all-named: the export contains the
+/// heads' transitively required commits along with their views and demos.
+/// File IO stays with the caller.
+pub fn export_heads_ron<N>(
+    get_node: GetNode,
+    registry: &gantz_ca::Registry<Graph<N>>,
+    all_views: &HashMap<CommitAddr, GraphViews>,
+    all_demos: &HashMap<CommitAddr, String>,
+    heads: impl IntoIterator<Item = impl std::borrow::Borrow<gantz_ca::Head>>,
+) -> Result<String, ron::Error>
+where
+    N: gantz_core::Node + Clone + serde::Serialize,
+{
+    let export_registry = gantz_core::reg::export_heads(get_node, registry, heads);
+    let export = export_with(export_registry, all_views, all_demos);
+    ron::ser::to_string_pretty(&export, ron::ser::PrettyConfig::default())
 }
 
 /// Merge an [`Export`] into an existing registry, views and demos maps.

--- a/crates/gantz_egui/src/impls/graph.rs
+++ b/crates/gantz_egui/src/impls/graph.rs
@@ -1,4 +1,4 @@
-use crate::{Cmd, NodeCtx, NodeUi, Registry, widget::node_inspector};
+use crate::{NodeCtx, NodeUi, OpenPath, Registry, widget::node_inspector};
 
 impl<N> NodeUi for gantz_core::node::GraphNode<N>
 where
@@ -10,13 +10,13 @@ where
 
     fn ui(
         &mut self,
-        ctx: NodeCtx,
+        mut ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
     ) -> egui_graph::FramedResponse<egui::Response> {
         uictx.framed(|ui, _sockets| {
             let res = ui.add(egui::Label::new("graph").selectable(false));
             if ui.response().double_clicked() {
-                ctx.cmds.push(Cmd::OpenPath(ctx.path().to_vec()));
+                ctx.response(OpenPath(ctx.path().to_vec()));
             }
             res
         })

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -14,11 +14,13 @@ mod impls;
 pub mod node;
 pub mod ops;
 pub mod reg;
+pub mod response;
 pub mod widget;
 
 // Re-export traits that make up the Registry supertrait.
 pub use node::{FnNodeNames, NameRegistry};
 pub use reg::RegistryRef;
+pub use response::{ResponseData, Responses};
 pub use widget::gantz::NodeTypeRegistry;
 pub use widget::graph_select::GraphRegistry;
 
@@ -161,7 +163,7 @@ pub struct NodeCtx<'a> {
     inlets: &'a [node::Id],
     outlets: &'a [node::Id],
     vm: &'a mut Engine,
-    cmds: &'a mut Vec<Cmd>,
+    responses: &'a mut Vec<Box<dyn ResponseData>>,
 }
 
 /// How to position pasted nodes.
@@ -192,53 +194,31 @@ pub fn resolve_paste_offset(pos: &PastePos, copied_positions: &egui_graph::Layou
     }
 }
 
-/// Commands emitted by nodes and widgets, processed after the GUI pass.
-///
-/// All variants must be exhaustively handled in both
-/// `bevy_gantz_egui::process_cmds` and the demo's `process_cmds`
-/// (`gantz_egui/examples/demo.rs`). Adding a new variant without updating
-/// both will produce a compile error.
-#[derive(Debug)]
-pub enum Cmd {
-    /// Evaluate an entrypoint (push or pull).
-    EvalEntry(gantz_core::compile::Entrypoint),
-    /// Navigate the path within the current head's graph hierarchy.
-    OpenPath(Vec<node::Id>),
-    /// Open a head (named or commit) as a new tab.
-    OpenHead(gantz_ca::Head),
-    /// Branch a named node: create a new name with its own commit for the
-    /// given content address, and replace the node with a reference to it.
-    BranchNode {
-        new_name: String,
-        ca: gantz_ca::ContentAddr,
-        /// Path from root to the NamedRef node (last element = node index).
-        path: Vec<crate::node::Id>,
-    },
-    /// Insert an inspect node on the given edge at the given position.
-    InspectEdge(InspectEdge),
-    /// Create a new node of the given type at the current path.
-    CreateNode(CreateNode),
-    /// Copy the given nodes to the clipboard.
-    CopyNodes(std::collections::HashSet<widget::graph_scene::NodeIndex>),
-    /// Paste clipboard contents at the given position.
-    ///
-    /// `text` is `Some` when the integration layer provides clipboard text
-    /// directly (e.g. via `egui::Event::Paste` in eframe). When `None`, the
-    /// command handler is expected to read the system clipboard itself.
-    Paste { text: Option<String>, pos: PastePos },
-    /// Undo the last graph edit (move head to parent commit).
-    Undo,
-    /// Redo a previously undone edit (move head forward).
-    Redo,
-    /// Export the focused head (graph + transitive deps + views) to a `.gantz` file.
-    ExportHead,
-    /// Export all named graphs (with transitive deps + views) to a single `.gantz` file.
-    ExportAllNamed,
-    /// Open the command palette for node creation.
-    OpenCommandPalette,
+// ----------------------------------------------------------------------------
+// Response payloads
+//
+// Typed payloads emitted from within the widget tree via the dynamic
+// [`response::Responses`] channel and returned from `Gantz::show`. With the
+// exception of [`OpenPath`] and [`OpenCommandPalette`] (which `Gantz::show`
+// handles itself), applications drain and handle these after the GUI pass.
+// Unhandled payloads should be reported via [`response::Responses::type_names`].
+// ----------------------------------------------------------------------------
+
+/// Branch a named node: create a new name with its own commit for the given
+/// content address, and replace the node with a reference to it.
+#[derive(Clone, Debug)]
+pub struct BranchNode {
+    pub new_name: String,
+    pub ca: gantz_ca::ContentAddr,
+    /// Path from root to the NamedRef node (last element = node index).
+    pub path: Vec<node::Id>,
 }
 
-/// A command to create a new node.
+/// Copy the given nodes to the clipboard.
+#[derive(Clone, Debug)]
+pub struct CopyNodes(pub std::collections::HashSet<widget::graph_scene::NodeIndex>);
+
+/// Create a new node of the given type at the current path.
 #[derive(Clone, Debug)]
 pub struct CreateNode {
     /// The path within the graph hierarchy where the node should be created.
@@ -247,13 +227,62 @@ pub struct CreateNode {
     pub node_type: String,
 }
 
-/// A command to insert an Inspect node on an edge.
+/// Evaluate an entrypoint (push or pull).
+#[derive(Clone, Debug)]
+pub struct EvalEntry(pub gantz_core::compile::Entrypoint);
+
+/// Export all named graphs (with transitive deps + views) to a single
+/// `.gantz` file. Emitted without an associated head.
+#[derive(Clone, Copy, Debug)]
+pub struct ExportAllNamed;
+
+/// Export the emitting head (graph + transitive deps + views) to a `.gantz`
+/// file.
+#[derive(Clone, Copy, Debug)]
+pub struct ExportHead;
+
+/// Insert an inspect node on the given edge at the given position.
 #[derive(Clone, Debug)]
 pub struct InspectEdge {
     pub path: Vec<node::Id>,
     pub edge: petgraph::graph::EdgeIndex<usize>,
     pub pos: egui::Pos2,
 }
+
+/// Open the command palette for node creation.
+///
+/// Handled by `Gantz::show` itself - applications never see this payload.
+#[derive(Clone, Copy, Debug)]
+pub struct OpenCommandPalette;
+
+/// Open a head (named or commit) as a new tab.
+#[derive(Clone, Debug)]
+pub struct OpenHead(pub gantz_ca::Head);
+
+/// Navigate the path within the emitting head's graph hierarchy.
+///
+/// Handled by `Gantz::show` itself - applications never see this payload.
+#[derive(Clone, Debug)]
+pub struct OpenPath(pub Vec<node::Id>);
+
+/// Paste clipboard contents at the given position.
+///
+/// `text` is `Some` when the integration layer provides clipboard text
+/// directly (e.g. via `egui::Event::Paste` in eframe). When `None`, the
+/// handler is expected to read the system clipboard itself.
+#[derive(Clone, Debug)]
+pub struct Paste {
+    pub text: Option<String>,
+    pub pos: PastePos,
+}
+
+/// Redo a previously undone edit (move head forward).
+#[derive(Clone, Copy, Debug)]
+pub struct Redo;
+
+/// Undo the last graph edit (move head to parent commit).
+#[derive(Clone, Copy, Debug)]
+pub struct Undo;
 
 impl<'a, N> NodeUi for &'a mut N
 where
@@ -330,7 +359,7 @@ impl<'a> NodeCtx<'a> {
         inlets: &'a [node::Id],
         outlets: &'a [node::Id],
         vm: &'a mut Engine,
-        cmds: &'a mut Vec<Cmd>,
+        responses: &'a mut Vec<Box<dyn ResponseData>>,
     ) -> Self {
         Self {
             registry,
@@ -338,8 +367,19 @@ impl<'a> NodeCtx<'a> {
             inlets,
             outlets,
             vm,
-            cmds,
+            responses,
         }
+    }
+
+    /// Emit a response payload for the application to handle after the GUI
+    /// pass.
+    ///
+    /// Payloads may be any of the builtin types (e.g. [`OpenHead`],
+    /// [`EvalEntry`]) or custom types defined alongside the node, allowing
+    /// independently-declared nodes to communicate with application-specific
+    /// handlers.
+    pub fn response<T: ResponseData>(&mut self, data: T) {
+        self.responses.push(Box::new(data));
     }
 
     /// Provide access to the registry.
@@ -384,7 +424,7 @@ impl<'a> NodeCtx<'a> {
     /// was compiled.
     pub fn push_eval(&mut self, n_outputs: u8) {
         let ep = gantz_core::compile::entrypoint::push(self.path.to_vec(), n_outputs);
-        self.cmds.push(Cmd::EvalEntry(ep));
+        self.response(EvalEntry(ep));
     }
 
     /// Queue a call to the generated pull evaluation function for this node.
@@ -394,7 +434,7 @@ impl<'a> NodeCtx<'a> {
     /// was compiled.
     pub fn pull_eval(&mut self, n_inputs: u8) {
         let ep = gantz_core::compile::entrypoint::pull(self.path.to_vec(), n_inputs);
-        self.cmds.push(Cmd::EvalEntry(ep));
+        self.response(EvalEntry(ep));
     }
 
     /// The IDs of the inlets within the current graph.

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -20,7 +20,7 @@ pub mod widget;
 // Re-export traits that make up the Registry supertrait.
 pub use node::{FnNodeNames, NameRegistry};
 pub use reg::RegistryRef;
-pub use response::{ResponseData, Responses};
+pub use response::{Payload, ResponseData, Responses};
 pub use widget::gantz::NodeTypeRegistry;
 pub use widget::graph_select::GraphRegistry;
 
@@ -163,7 +163,7 @@ pub struct NodeCtx<'a> {
     inlets: &'a [node::Id],
     outlets: &'a [node::Id],
     vm: &'a mut Engine,
-    responses: &'a mut Vec<Box<dyn ResponseData>>,
+    responses: &'a mut Vec<Payload>,
 }
 
 /// How to position pasted nodes.
@@ -359,7 +359,7 @@ impl<'a> NodeCtx<'a> {
         inlets: &'a [node::Id],
         outlets: &'a [node::Id],
         vm: &'a mut Engine,
-        responses: &'a mut Vec<Box<dyn ResponseData>>,
+        responses: &'a mut Vec<Payload>,
     ) -> Self {
         Self {
             registry,
@@ -379,7 +379,7 @@ impl<'a> NodeCtx<'a> {
     /// independently-declared nodes to communicate with application-specific
     /// handlers.
     pub fn response<T: ResponseData>(&mut self, data: T) {
-        self.responses.push(Box::new(data));
+        self.responses.push(Payload::new(data));
     }
 
     /// Provide access to the registry.

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -20,7 +20,7 @@ pub mod widget;
 // Re-export traits that make up the Registry supertrait.
 pub use node::{FnNodeNames, NameRegistry};
 pub use reg::RegistryRef;
-pub use response::{Payload, ResponseData, Responses};
+pub use response::{DynResponse, ResponseData, Responses};
 pub use widget::gantz::NodeTypeRegistry;
 pub use widget::graph_select::GraphRegistry;
 
@@ -163,7 +163,7 @@ pub struct NodeCtx<'a> {
     inlets: &'a [node::Id],
     outlets: &'a [node::Id],
     vm: &'a mut Engine,
-    responses: &'a mut Vec<Payload>,
+    responses: &'a mut Vec<DynResponse>,
 }
 
 /// How to position pasted nodes.
@@ -359,7 +359,7 @@ impl<'a> NodeCtx<'a> {
         inlets: &'a [node::Id],
         outlets: &'a [node::Id],
         vm: &'a mut Engine,
-        responses: &'a mut Vec<Payload>,
+        responses: &'a mut Vec<DynResponse>,
     ) -> Self {
         Self {
             registry,
@@ -379,7 +379,7 @@ impl<'a> NodeCtx<'a> {
     /// independently-declared nodes to communicate with application-specific
     /// handlers.
     pub fn response<T: ResponseData>(&mut self, data: T) {
-        self.responses.push(Payload::new(data));
+        self.responses.push(DynResponse::new(data));
     }
 
     /// Provide access to the registry.

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -12,6 +12,7 @@ use steel::{
 pub mod export;
 mod impls;
 pub mod node;
+pub mod ops;
 pub mod reg;
 pub mod widget;
 

--- a/crates/gantz_egui/src/node/named_ref.rs
+++ b/crates/gantz_egui/src/node/named_ref.rs
@@ -1,6 +1,6 @@
 //! A node that references another node by name and content address.
 
-use crate::{Cmd, NodeCtx, NodeUi, widget::node_inspector};
+use crate::{BranchNode, NodeCtx, NodeUi, OpenHead, widget::node_inspector};
 use gantz_ca::CaHash;
 use gantz_core::node::{self, ExprCtx, ExprResult, MetaCtx, Node, RegCtx};
 use serde::{Deserialize, Serialize};
@@ -133,7 +133,7 @@ impl NodeUi for NamedRef {
 
     fn ui(
         &mut self,
-        ctx: NodeCtx,
+        mut ctx: NodeCtx,
         uictx: egui_graph::NodeCtx,
     ) -> egui_graph::FramedResponse<egui::Response> {
         let registry = ctx.registry();
@@ -176,8 +176,7 @@ impl NodeUi for NamedRef {
 
         // Open the node on double-click (handler decides if the node is openable).
         if response.inner.response.double_clicked() {
-            ctx.cmds
-                .push(Cmd::OpenHead(gantz_ca::Head::Branch(self.name.clone())));
+            ctx.response(OpenHead(gantz_ca::Head::Branch(self.name.clone())));
         }
 
         response
@@ -254,7 +253,7 @@ impl NodeUi for NamedRef {
                             let fork_hover = format!("fork a new node at {}", current_short);
                             if ui.button("fork").on_hover_text(fork_hover).clicked() {
                                 let new_name = format!("{}-{}", self.name, current_short);
-                                ctx.cmds.push(Cmd::BranchNode {
+                                ctx.response(BranchNode {
                                     new_name,
                                     ca: self.ref_.content_addr(),
                                     path: ctx.path.to_vec(),

--- a/crates/gantz_egui/src/ops.rs
+++ b/crates/gantz_egui/src/ops.rs
@@ -1,0 +1,278 @@
+//! Shared operations behind the GUI's graph-mutating commands.
+//!
+//! Each fn implements the state change for one [`Cmd`][crate::Cmd] over plain
+//! graph/view/VM/registry types so that frontends (e.g. `bevy_gantz_egui` and
+//! the pure-egui demo) remain thin adapters around identical behaviour.
+//! Frontend-specific effects (clipboard access, file dialogs, head
+//! navigation) stay with the caller.
+
+use crate::widget::gantz::OpenHeadState;
+use crate::widget::graph_scene::{self, NodeIndex, ToGraphMut};
+use crate::{CreateNode, GraphViews, InspectEdge, PastePos, export, node::NamedRef};
+use gantz_ca::CommitAddr;
+use gantz_core::node::{self, GetNode, graph::Graph};
+use std::collections::{HashMap, HashSet};
+use steel::steel_vm::engine::Engine;
+
+/// Branch a named node: create a new commit for the given content address
+/// (original commit as parent), insert the new name pointing at it, and
+/// replace the node at `path` with a [`NamedRef`] referencing the fresh
+/// commit.
+pub fn branch_node<N>(
+    registry: &mut gantz_ca::Registry<Graph<N>>,
+    timestamp: std::time::Duration,
+    graph: &mut Graph<N>,
+    new_name: String,
+    ca: gantz_ca::ContentAddr,
+    path: &[node::Id],
+) where
+    N: From<NamedRef> + ToGraphMut<Node = N>,
+{
+    let commit_ca = CommitAddr::from(ca);
+    let Some(commit) = registry.commits().get(&commit_ca) else {
+        log::error!("BranchNode: commit not found for {commit_ca:?}");
+        return;
+    };
+    let graph_addr = commit.graph;
+    let new_commit_ca = registry.commit_graph(timestamp, Some(commit_ca), graph_addr, || {
+        unreachable!("graph already exists in registry")
+    });
+    registry.insert_name(new_name.clone(), new_commit_ca);
+
+    // Replace the NamedRef node in the working graph.
+    let Some((&node_ix, parent_path)) = path.split_last() else {
+        log::error!("BranchNode: empty node path");
+        return;
+    };
+    let Some(g) = graph_scene::index_path_graph_mut(graph, parent_path) else {
+        log::error!("BranchNode: could not find graph at path {parent_path:?}");
+        return;
+    };
+    let node_id = node::graph::NodeIx::new(node_ix);
+    let new_ref = node::Ref::new(new_commit_ca.into());
+    let named_ref = NamedRef::new(new_name, new_ref);
+    if let Some(node) = g.node_weight_mut(node_id) {
+        *node = N::from(named_ref);
+    } else {
+        log::error!("BranchNode: node not found at index {node_ix}");
+    }
+}
+
+/// Serialize the selection at `path` to a RON clipboard payload.
+///
+/// Returns `None` when the selection is empty, the path is invalid, or
+/// serialization fails (logging the cause). Writing the resulting string to
+/// the clipboard is the caller's responsibility.
+pub fn copy_nodes<N>(
+    registry: &gantz_ca::Registry<Graph<N>>,
+    all_views: &HashMap<CommitAddr, GraphViews>,
+    graph: &mut Graph<N>,
+    head_views: &GraphViews,
+    path: &[node::Id],
+    selection: &HashSet<NodeIndex>,
+) -> Option<String>
+where
+    N: gantz_core::Node + Clone + serde::Serialize + ToGraphMut<Node = N>,
+{
+    if selection.is_empty() {
+        return None;
+    }
+    let Some(g) = graph_scene::index_path_graph_mut(graph, path) else {
+        log::error!("CopyNodes: could not find graph at path {path:?}");
+        return None;
+    };
+    let layout = head_views
+        .get(path)
+        .map(|v| &v.layout)
+        .cloned()
+        .unwrap_or_default();
+    let copied = export::copy(registry, all_views, g, selection, &layout);
+    match ron::to_string(&copied) {
+        Ok(text) => Some(text),
+        Err(e) => {
+            log::error!("CopyNodes: failed to serialize: {e}");
+            None
+        }
+    }
+}
+
+/// Create a node of the given type at `cmd.path`, register it with the VM,
+/// and ensure it has a layout entry.
+///
+/// Returns the index of the new node within the graph at `cmd.path`.
+pub fn create_node<N>(
+    get_node: GetNode,
+    new_node: impl FnOnce(&str) -> Option<N>,
+    graph: &mut Graph<N>,
+    views: &mut GraphViews,
+    vm: &mut Engine,
+    cmd: CreateNode,
+) -> Option<NodeIndex>
+where
+    N: gantz_core::Node + ToGraphMut<Node = N>,
+{
+    let CreateNode { path, node_type } = cmd;
+    let Some(nested) = graph_scene::index_path_graph_mut(graph, &path) else {
+        log::error!("CreateNode: could not find graph at path {path:?}");
+        return None;
+    };
+    let Some(node) = new_node(&node_type) else {
+        log::error!("CreateNode: unknown node type: {node_type}");
+        return None;
+    };
+    let node_ix = nested.add_node(node);
+
+    // Register the new node with the VM.
+    let node_path: Vec<_> = path.iter().copied().chain(Some(node_ix.index())).collect();
+    let reg_ctx = node::RegCtx::new(get_node, &node_path, vm);
+    nested[node_ix].register(reg_ctx);
+
+    // Position the new node at the scene center (or use layout default).
+    let egui_id = egui_graph::NodeId::from_u64(node_ix.index() as u64);
+    let view = views.entry(path).or_default();
+    view.layout.entry(egui_id).or_insert(egui::Pos2::ZERO);
+
+    Some(node_ix)
+}
+
+/// Insert an Inspect node on the given edge, splicing it between the
+/// endpoints and positioning it at `cmd.pos`.
+pub fn inspect_edge<N>(
+    get_node: GetNode,
+    new_inspect: impl FnOnce() -> Option<N>,
+    graph: &mut Graph<N>,
+    views: &mut GraphViews,
+    vm: &mut Engine,
+    cmd: InspectEdge,
+) where
+    N: gantz_core::Node + ToGraphMut<Node = N>,
+{
+    let InspectEdge { path, edge, pos } = cmd;
+
+    // Navigate to the nested graph at the path.
+    let Some(nested) = graph_scene::index_path_graph_mut(graph, &path) else {
+        log::error!("InspectEdge: could not find graph at path {path:?}");
+        return;
+    };
+
+    // Get edge endpoints and weight.
+    let Some((src_node, dst_node)) = nested.edge_endpoints(edge) else {
+        log::error!("InspectEdge: edge not found");
+        return;
+    };
+    let edge_weight = *nested.edge_weight(edge).unwrap();
+
+    // Remove the edge.
+    nested.remove_edge(edge);
+
+    // Create a new Inspect node.
+    let Some(inspect_node) = new_inspect() else {
+        log::error!("InspectEdge: could not create inspect node");
+        return;
+    };
+    let inspect_id = nested.add_node(inspect_node);
+
+    // Determine the node path and register it with the VM.
+    let node_path: Vec<_> = path
+        .iter()
+        .copied()
+        .chain(Some(inspect_id.index()))
+        .collect();
+    let reg_ctx = node::RegCtx::new(get_node, &node_path, vm);
+    nested[inspect_id].register(reg_ctx);
+
+    // Add edge: src -> inspect (using original output, input 0).
+    nested.add_edge(
+        src_node,
+        inspect_id,
+        gantz_core::Edge::new(edge_weight.output, node::Input(0)),
+    );
+
+    // Add edge: inspect -> dst (using output 0, original input).
+    nested.add_edge(
+        inspect_id,
+        dst_node,
+        gantz_core::Edge::new(node::Output(0), edge_weight.input),
+    );
+
+    // Position the new node at the click position.
+    let node_id = egui_graph::NodeId::from_u64(inspect_id.index() as u64);
+    let view = views.entry(path).or_default();
+    view.layout.insert(node_id, pos);
+}
+
+/// Paste a previously-copied clipboard payload into the graph at the head's
+/// current path, and update the selection to the pasted nodes.
+///
+/// Returns `true` if a payload was pasted. The caller is responsible for
+/// re-registering the root graph with the VM afterwards so pasted nodes get
+/// their state initialized.
+pub fn paste<N>(
+    registry: &mut gantz_ca::Registry<Graph<N>>,
+    all_views: &mut HashMap<CommitAddr, GraphViews>,
+    all_demos: &mut HashMap<CommitAddr, String>,
+    graph: &mut Graph<N>,
+    head_views: &mut GraphViews,
+    head_state: &mut OpenHeadState,
+    text: &str,
+    pos: &PastePos,
+) -> bool
+where
+    N: Clone + serde::de::DeserializeOwned + ToGraphMut<Node = N>,
+{
+    let copied: export::Copied<N> = match ron::from_str(text) {
+        Ok(c) => c,
+        Err(e) => {
+            log::debug!("Clipboard does not contain a valid gantz payload: {e}");
+            return false;
+        }
+    };
+    let offset = crate::resolve_paste_offset(pos, &copied.positions);
+
+    let path = head_state.path.clone();
+    let Some(g) = graph_scene::index_path_graph_mut(graph, &path) else {
+        log::error!("Paste: could not find graph at path {path:?}");
+        return false;
+    };
+    let view = head_views.entry(path).or_default();
+    let new_indices = export::paste(
+        registry,
+        all_views,
+        all_demos,
+        g,
+        &mut view.layout,
+        &copied,
+        offset,
+    );
+
+    // Update selection to the pasted nodes.
+    head_state.scene.interaction.selection.nodes = new_indices.into_iter().collect();
+    head_state.scene.interaction.selection.edges.clear();
+    true
+}
+
+/// Undo: push the head's current commit onto its redo stack and return the
+/// parent commit to navigate to.
+///
+/// Returns `None` when the head has no parent commit to return to.
+/// Navigation itself is frontend-specific and stays with the caller.
+pub fn undo<G>(
+    registry: &gantz_ca::Registry<G>,
+    redo_stacks: &mut HashMap<gantz_ca::Head, Vec<CommitAddr>>,
+    head: &gantz_ca::Head,
+) -> Option<CommitAddr> {
+    let commit_ca = registry.head_commit_ca(head).copied()?;
+    let parent = registry.commits().get(&commit_ca)?.parent?;
+    redo_stacks.entry(head.clone()).or_default().push(commit_ca);
+    Some(parent)
+}
+
+/// Redo: pop the most recently undone commit from the head's redo stack.
+///
+/// Navigation itself is frontend-specific and stays with the caller.
+pub fn redo(
+    redo_stacks: &mut HashMap<gantz_ca::Head, Vec<CommitAddr>>,
+    head: &gantz_ca::Head,
+) -> Option<CommitAddr> {
+    redo_stacks.get_mut(head)?.pop()
+}

--- a/crates/gantz_egui/src/ops.rs
+++ b/crates/gantz_egui/src/ops.rs
@@ -1,10 +1,10 @@
-//! Shared operations behind the GUI's graph-mutating commands.
+//! Shared operations behind the GUI's graph-mutating response payloads.
 //!
-//! Each fn implements the state change for one [`Cmd`][crate::Cmd] over plain
-//! graph/view/VM/registry types so that frontends (e.g. `bevy_gantz_egui` and
-//! the pure-egui demo) remain thin adapters around identical behaviour.
-//! Frontend-specific effects (clipboard access, file dialogs, head
-//! navigation) stay with the caller.
+//! Each fn implements the state change for one payload (e.g.
+//! [`CreateNode`][crate::CreateNode]) over plain graph/view/VM/registry types
+//! so that frontends (e.g. `bevy_gantz_egui` and the pure-egui demo) remain
+//! thin adapters around identical behaviour. Frontend-specific effects
+//! (clipboard access, file dialogs, head navigation) stay with the caller.
 
 use crate::widget::gantz::OpenHeadState;
 use crate::widget::graph_scene::{self, NodeIndex, ToGraphMut};

--- a/crates/gantz_egui/src/ops.rs
+++ b/crates/gantz_egui/src/ops.rs
@@ -1,7 +1,7 @@
 //! Shared operations behind the GUI's graph-mutating response payloads.
 //!
 //! Each fn implements the state change for one payload (e.g.
-//! [`CreateNode`][crate::CreateNode]) over plain graph/view/VM/registry types
+//! [`CreateNode`]) over plain graph/view/VM/registry types
 //! so that frontends (e.g. `bevy_gantz_egui` and the pure-egui demo) remain
 //! thin adapters around identical behaviour. Frontend-specific effects
 //! (clipboard access, file dialogs, head navigation) stay with the caller.

--- a/crates/gantz_egui/src/response.rs
+++ b/crates/gantz_egui/src/response.rs
@@ -11,7 +11,7 @@
 //! Payloads are dynamically typed so that nodes defined downstream can emit
 //! their own custom types without this crate knowing about them: the
 //! application drains the payloads it understands via [`Responses::take`]
-//! (or dispatches on [`Payload::type_id`]) and warns on the rest.
+//! (or dispatches on [`DynResponse::type_id`]) and warns on the rest.
 
 use std::any::{Any, TypeId};
 
@@ -32,7 +32,7 @@ pub trait ResponseData: Any + std::fmt::Debug + Send + Sync {
 /// box via method calls would resolve to the *box's* impl and report the
 /// box's `TypeId` rather than the payload's, silently breaking dispatch.
 #[derive(Debug)]
-pub struct Payload {
+pub struct DynResponse {
     type_id: TypeId,
     type_name: &'static str,
     data: Box<dyn ResponseData>,
@@ -44,10 +44,10 @@ pub struct Payload {
 /// app-level emissions like [`ExportAllNamed`][crate::ExportAllNamed]).
 #[derive(Debug, Default)]
 pub struct Responses {
-    entries: Vec<(Option<gantz_ca::Head>, Payload)>,
+    entries: Vec<(Option<gantz_ca::Head>, DynResponse)>,
 }
 
-impl Payload {
+impl DynResponse {
     /// Erase a concrete payload, capturing its type identity.
     pub fn new<T: ResponseData>(data: T) -> Self {
         Self {
@@ -86,14 +86,14 @@ impl Responses {
     /// Emit a payload, tagged with the head whose UI emitted it (`None` for
     /// app-level payloads).
     pub fn push<T: ResponseData>(&mut self, head: Option<gantz_ca::Head>, data: T) {
-        self.entries.push((head, Payload::new(data)));
+        self.entries.push((head, DynResponse::new(data)));
     }
 
     /// Merge payloads emitted by a single head's widgets.
     pub fn extend(
         &mut self,
         head: Option<&gantz_ca::Head>,
-        data: impl IntoIterator<Item = Payload>,
+        data: impl IntoIterator<Item = DynResponse>,
     ) {
         self.entries
             .extend(data.into_iter().map(|d| (head.cloned(), d)));
@@ -114,7 +114,7 @@ impl Responses {
     }
 
     /// Drain all remaining entries in order of emission.
-    pub fn drain(&mut self) -> impl Iterator<Item = (Option<gantz_ca::Head>, Payload)> + '_ {
+    pub fn drain(&mut self) -> impl Iterator<Item = (Option<gantz_ca::Head>, DynResponse)> + '_ {
         self.entries.drain(..)
     }
 
@@ -152,7 +152,7 @@ mod tests {
     /// box itself satisfies the `ResponseData` blanket impl).
     #[test]
     fn payload_identity_is_the_concrete_type() {
-        let p = Payload::new(A(1));
+        let p = DynResponse::new(A(1));
         assert_eq!(p.type_id(), TypeId::of::<A>());
         assert_eq!(p.type_name(), std::any::type_name::<A>());
         assert_eq!(p.downcast::<A>().unwrap(), A(1));
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn downcast_to_wrong_type_returns_the_payload() {
-        let p = Payload::new(A(1));
+        let p = DynResponse::new(A(1));
         let p = p.downcast::<B>().unwrap_err();
         assert_eq!(p.downcast::<A>().unwrap(), A(1));
     }
@@ -183,7 +183,7 @@ mod tests {
     fn extend_tags_payloads_with_the_head() {
         let head = gantz_ca::Head::Branch("main".to_string());
         let mut rs = Responses::default();
-        rs.extend(Some(&head), [Payload::new(A(1))]);
+        rs.extend(Some(&head), [DynResponse::new(A(1))]);
         let mut taken = rs.take::<A>();
         assert_eq!(taken.len(), 1);
         let (tag, a) = taken.pop().unwrap();

--- a/crates/gantz_egui/src/response.rs
+++ b/crates/gantz_egui/src/response.rs
@@ -11,7 +11,7 @@
 //! Payloads are dynamically typed so that nodes defined downstream can emit
 //! their own custom types without this crate knowing about them: the
 //! application drains the payloads it understands via [`Responses::take`]
-//! (or dispatches on [`ResponseData::data_type_id`]) and warns on the rest.
+//! (or dispatches on [`Payload::type_id`]) and warns on the rest.
 
 use std::any::{Any, TypeId};
 
@@ -20,14 +20,22 @@ use std::any::{Any, TypeId};
 /// Blanket-implemented for any eligible type, so emitting a custom payload
 /// requires no trait impl - only `Debug + Send + Sync + 'static`.
 pub trait ResponseData: Any + std::fmt::Debug + Send + Sync {
-    /// The [`TypeId`] of the concrete payload type.
-    fn data_type_id(&self) -> TypeId;
-
-    /// The type name of the concrete payload, for unhandled-payload warnings.
-    fn data_type_name(&self) -> &'static str;
-
     /// Upcast for downcasting to the concrete payload type.
     fn into_any(self: Box<Self>) -> Box<dyn Any>;
+}
+
+/// A type-erased response payload.
+///
+/// The concrete type's identity is captured at construction, where the type
+/// is statically known. This matters because `Box<dyn ResponseData>` itself
+/// satisfies the [`ResponseData`] blanket impl: identity queried through a
+/// box via method calls would resolve to the *box's* impl and report the
+/// box's `TypeId` rather than the payload's, silently breaking dispatch.
+#[derive(Debug)]
+pub struct Payload {
+    type_id: TypeId,
+    type_name: &'static str,
+    data: Box<dyn ResponseData>,
 }
 
 /// Dynamic response data collected during one widget pass.
@@ -36,23 +44,41 @@ pub trait ResponseData: Any + std::fmt::Debug + Send + Sync {
 /// app-level emissions like [`ExportAllNamed`][crate::ExportAllNamed]).
 #[derive(Debug, Default)]
 pub struct Responses {
-    entries: Vec<(Option<gantz_ca::Head>, Box<dyn ResponseData>)>,
+    entries: Vec<(Option<gantz_ca::Head>, Payload)>,
 }
 
-impl<T> ResponseData for T
-where
-    T: Any + std::fmt::Debug + Send + Sync,
-{
-    fn data_type_id(&self) -> TypeId {
-        TypeId::of::<T>()
+impl Payload {
+    /// Erase a concrete payload, capturing its type identity.
+    pub fn new<T: ResponseData>(data: T) -> Self {
+        Self {
+            type_id: TypeId::of::<T>(),
+            type_name: std::any::type_name::<T>(),
+            data: Box::new(data),
+        }
     }
 
-    fn data_type_name(&self) -> &'static str {
-        std::any::type_name::<T>()
+    /// The `TypeId` of the concrete payload type.
+    pub fn type_id(&self) -> TypeId {
+        self.type_id
     }
 
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
+    /// The type name of the concrete payload, for unhandled-payload warnings.
+    pub fn type_name(&self) -> &'static str {
+        self.type_name
+    }
+
+    /// Downcast to the concrete payload type.
+    pub fn downcast<T: ResponseData>(self) -> Result<T, Self> {
+        if self.type_id == TypeId::of::<T>() {
+            let data = self
+                .data
+                .into_any()
+                .downcast::<T>()
+                .expect("`type_id` matches `T`");
+            Ok(*data)
+        } else {
+            Err(self)
+        }
     }
 }
 
@@ -60,14 +86,14 @@ impl Responses {
     /// Emit a payload, tagged with the head whose UI emitted it (`None` for
     /// app-level payloads).
     pub fn push<T: ResponseData>(&mut self, head: Option<gantz_ca::Head>, data: T) {
-        self.entries.push((head, Box::new(data)));
+        self.entries.push((head, Payload::new(data)));
     }
 
-    /// Merge untagged payloads emitted by a single head's widgets.
+    /// Merge payloads emitted by a single head's widgets.
     pub fn extend(
         &mut self,
         head: Option<&gantz_ca::Head>,
-        data: impl IntoIterator<Item = Box<dyn ResponseData>>,
+        data: impl IntoIterator<Item = Payload>,
     ) {
         self.entries
             .extend(data.into_iter().map(|d| (head.cloned(), d)));
@@ -77,15 +103,10 @@ impl Responses {
     pub fn take<T: ResponseData>(&mut self) -> Vec<(Option<gantz_ca::Head>, T)> {
         let mut taken = Vec::new();
         let mut rest = Vec::with_capacity(self.entries.len());
-        for (head, data) in self.entries.drain(..) {
-            if data.data_type_id() == TypeId::of::<T>() {
-                let data = data
-                    .into_any()
-                    .downcast::<T>()
-                    .expect("`data_type_id` matched `T`");
-                taken.push((head, *data));
-            } else {
-                rest.push((head, data));
+        for (head, payload) in self.entries.drain(..) {
+            match payload.downcast::<T>() {
+                Ok(data) => taken.push((head, data)),
+                Err(payload) => rest.push((head, payload)),
             }
         }
         self.entries = rest;
@@ -93,9 +114,7 @@ impl Responses {
     }
 
     /// Drain all remaining entries in order of emission.
-    pub fn drain(
-        &mut self,
-    ) -> impl Iterator<Item = (Option<gantz_ca::Head>, Box<dyn ResponseData>)> + '_ {
+    pub fn drain(&mut self) -> impl Iterator<Item = (Option<gantz_ca::Head>, Payload)> + '_ {
         self.entries.drain(..)
     }
 
@@ -106,6 +125,78 @@ impl Responses {
 
     /// Type names of the remaining entries, for unhandled-payload warnings.
     pub fn type_names(&self) -> impl Iterator<Item = &'static str> + '_ {
-        self.entries.iter().map(|(_, d)| d.data_type_name())
+        self.entries.iter().map(|(_, p)| p.type_name())
+    }
+}
+
+impl<T> ResponseData for T
+where
+    T: Any + std::fmt::Debug + Send + Sync,
+{
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq)]
+    struct A(u32);
+
+    #[derive(Debug, PartialEq)]
+    struct B(&'static str);
+
+    /// Identity must be the concrete payload's, never the erased box's (the
+    /// box itself satisfies the `ResponseData` blanket impl).
+    #[test]
+    fn payload_identity_is_the_concrete_type() {
+        let p = Payload::new(A(1));
+        assert_eq!(p.type_id(), TypeId::of::<A>());
+        assert_eq!(p.type_name(), std::any::type_name::<A>());
+        assert_eq!(p.downcast::<A>().unwrap(), A(1));
+    }
+
+    #[test]
+    fn downcast_to_wrong_type_returns_the_payload() {
+        let p = Payload::new(A(1));
+        let p = p.downcast::<B>().unwrap_err();
+        assert_eq!(p.downcast::<A>().unwrap(), A(1));
+    }
+
+    #[test]
+    fn take_drains_matching_entries_in_order() {
+        let mut rs = Responses::default();
+        rs.push(None, A(1));
+        rs.push(None, B("x"));
+        rs.push(None, A(2));
+        let taken: Vec<_> = rs.take::<A>().into_iter().map(|(_, a)| a).collect();
+        assert_eq!(taken, vec![A(1), A(2)]);
+        let names: Vec<_> = rs.type_names().collect();
+        assert_eq!(names, vec![std::any::type_name::<B>()]);
+        rs.take::<B>();
+        assert!(rs.is_empty());
+    }
+
+    #[test]
+    fn extend_tags_payloads_with_the_head() {
+        let head = gantz_ca::Head::Branch("main".to_string());
+        let mut rs = Responses::default();
+        rs.extend(Some(&head), [Payload::new(A(1))]);
+        let mut taken = rs.take::<A>();
+        assert_eq!(taken.len(), 1);
+        let (tag, a) = taken.pop().unwrap();
+        assert_eq!(tag.as_ref(), Some(&head));
+        assert_eq!(a, A(1));
+    }
+
+    #[test]
+    fn drained_payloads_dispatch_by_concrete_type_id() {
+        let mut rs = Responses::default();
+        rs.push(None, A(1));
+        rs.push(None, B("x"));
+        let ids: Vec<_> = rs.drain().map(|(_, p)| p.type_id()).collect();
+        assert_eq!(ids, vec![TypeId::of::<A>(), TypeId::of::<B>()]);
     }
 }

--- a/crates/gantz_egui/src/response.rs
+++ b/crates/gantz_egui/src/response.rs
@@ -1,0 +1,111 @@
+//! Dynamic, typed response data emitted from within the widget tree.
+//!
+//! Widgets deep within the tree (node UIs via [`NodeCtx`][crate::NodeCtx],
+//! the graph scene's context menus, keyboard shortcuts, etc.) cannot mutate
+//! application state directly. Instead they emit typed payloads (e.g.
+//! [`CreateNode`][crate::CreateNode], [`Paste`][crate::Paste], or any custom
+//! type) that are collected into a [`Responses`] and returned from
+//! [`Gantz::show`][crate::widget::Gantz::show] as part of its response, for
+//! the application to handle after the pass.
+//!
+//! Payloads are dynamically typed so that nodes defined downstream can emit
+//! their own custom types without this crate knowing about them: the
+//! application drains the payloads it understands via [`Responses::take`]
+//! (or dispatches on [`ResponseData::data_type_id`]) and warns on the rest.
+
+use std::any::{Any, TypeId};
+
+/// A dynamic response payload emitted from within the widget tree.
+///
+/// Blanket-implemented for any eligible type, so emitting a custom payload
+/// requires no trait impl - only `Debug + Send + Sync + 'static`.
+pub trait ResponseData: Any + std::fmt::Debug + Send + Sync {
+    /// The [`TypeId`] of the concrete payload type.
+    fn data_type_id(&self) -> TypeId;
+
+    /// The type name of the concrete payload, for unhandled-payload warnings.
+    fn data_type_name(&self) -> &'static str;
+
+    /// Upcast for downcasting to the concrete payload type.
+    fn into_any(self: Box<Self>) -> Box<dyn Any>;
+}
+
+/// Dynamic response data collected during one widget pass.
+///
+/// Entries are tagged with the head whose UI emitted them (`None` for
+/// app-level emissions like [`ExportAllNamed`][crate::ExportAllNamed]).
+#[derive(Debug, Default)]
+pub struct Responses {
+    entries: Vec<(Option<gantz_ca::Head>, Box<dyn ResponseData>)>,
+}
+
+impl<T> ResponseData for T
+where
+    T: Any + std::fmt::Debug + Send + Sync,
+{
+    fn data_type_id(&self) -> TypeId {
+        TypeId::of::<T>()
+    }
+
+    fn data_type_name(&self) -> &'static str {
+        std::any::type_name::<T>()
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+}
+
+impl Responses {
+    /// Emit a payload, tagged with the head whose UI emitted it (`None` for
+    /// app-level payloads).
+    pub fn push<T: ResponseData>(&mut self, head: Option<gantz_ca::Head>, data: T) {
+        self.entries.push((head, Box::new(data)));
+    }
+
+    /// Merge untagged payloads emitted by a single head's widgets.
+    pub fn extend(
+        &mut self,
+        head: Option<&gantz_ca::Head>,
+        data: impl IntoIterator<Item = Box<dyn ResponseData>>,
+    ) {
+        self.entries
+            .extend(data.into_iter().map(|d| (head.cloned(), d)));
+    }
+
+    /// Drain all entries of type `T` in order of emission, leaving the rest.
+    pub fn take<T: ResponseData>(&mut self) -> Vec<(Option<gantz_ca::Head>, T)> {
+        let mut taken = Vec::new();
+        let mut rest = Vec::with_capacity(self.entries.len());
+        for (head, data) in self.entries.drain(..) {
+            if data.data_type_id() == TypeId::of::<T>() {
+                let data = data
+                    .into_any()
+                    .downcast::<T>()
+                    .expect("`data_type_id` matched `T`");
+                taken.push((head, *data));
+            } else {
+                rest.push((head, data));
+            }
+        }
+        self.entries = rest;
+        taken
+    }
+
+    /// Drain all remaining entries in order of emission.
+    pub fn drain(
+        &mut self,
+    ) -> impl Iterator<Item = (Option<gantz_ca::Head>, Box<dyn ResponseData>)> + '_ {
+        self.entries.drain(..)
+    }
+
+    /// Whether any entries remain.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Type names of the remaining entries, for unhandled-payload warnings.
+    pub fn type_names(&self) -> impl Iterator<Item = &'static str> + '_ {
+        self.entries.iter().map(|(_, d)| d.data_type_name())
+    }
+}

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -1,7 +1,7 @@
 use crate::{
     CopyNodes, CreateNode, ExportAllNamed, ExportHead, GraphViews, HeadAccess, NodeCtx, NodeUi,
     OpenCommandPalette, OpenPath, Paste, Redo, Registry, Undo, export,
-    response::{ResponseData, Responses},
+    response::{Payload, Responses},
     widget::{
         self, GraphScene, GraphSceneState,
         graph_scene::{self, ToGraphMut},
@@ -829,7 +829,7 @@ where
                 if let Some(fh) = access.heads().get(*focused_head).cloned() {
                     let immutable = head_immutable(&fh, gantz.base_immutable, base_names);
                     let head_state = state.open_heads.entry(fh.clone()).or_default();
-                    let mut responses: Vec<Box<dyn ResponseData>> = Vec::new();
+                    let mut responses: Vec<Payload> = Vec::new();
                     access.with_head_mut(&fh, |data| {
                         node_inspector(
                             gantz.env,
@@ -1664,7 +1664,7 @@ fn node_inspector<N>(
     vm: &mut Engine,
     head_state: &mut OpenHeadState,
     immutable: bool,
-    responses: &mut Vec<Box<dyn ResponseData>>,
+    responses: &mut Vec<Payload>,
     ui: &mut egui::Ui,
 ) -> egui::InnerResponse<()>
 where

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -1,7 +1,7 @@
 use crate::{
     CopyNodes, CreateNode, ExportAllNamed, ExportHead, GraphViews, HeadAccess, NodeCtx, NodeUi,
     OpenCommandPalette, OpenPath, Paste, Redo, Registry, Undo, export,
-    response::{Payload, Responses},
+    response::{DynResponse, Responses},
     widget::{
         self, GraphScene, GraphSceneState,
         graph_scene::{self, ToGraphMut},
@@ -1542,7 +1542,7 @@ fn path_labels(
     scene_rect: egui::Rect,
     head_state: &mut OpenHeadState,
     ui: &mut egui::Ui,
-) -> Vec<Payload> {
+) -> Vec<DynResponse> {
     let mut responses = Vec::new();
     if head_state.path.is_empty() {
         return responses;
@@ -1567,7 +1567,7 @@ fn path_labels(
                 .show(ui, |ui| {
                     ui.vertical_centered_justified(|ui| {
                         if ui.add(button("R")).on_hover_text("root graph").clicked() {
-                            responses.push(Payload::new(OpenPath(vec![])));
+                            responses.push(DynResponse::new(OpenPath(vec![])));
                             head_state.scene.interaction.selection.clear();
                         }
                     });
@@ -1583,7 +1583,7 @@ fn path_labels(
                                 .clicked()
                             {
                                 if !current_path {
-                                    responses.push(Payload::new(OpenPath(path.to_vec())));
+                                    responses.push(DynResponse::new(OpenPath(path.to_vec())));
                                     head_state.scene.interaction.selection.clear();
                                 }
                             }
@@ -1665,7 +1665,7 @@ fn node_inspector<N>(
     head_state: &mut OpenHeadState,
     immutable: bool,
     ui: &mut egui::Ui,
-) -> egui::InnerResponse<Vec<Payload>>
+) -> egui::InnerResponse<Vec<DynResponse>>
 where
     N: Node + NodeUi + ToGraphMut<Node = N>,
 {

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -1,5 +1,7 @@
 use crate::{
-    Cmd, GraphViews, HeadAccess, NodeCtx, NodeUi, Registry, export,
+    CopyNodes, CreateNode, ExportAllNamed, ExportHead, GraphViews, HeadAccess, NodeCtx, NodeUi,
+    OpenCommandPalette, OpenPath, Paste, Redo, Registry, Undo, export,
+    response::{ResponseData, Responses},
     widget::{
         self, GraphScene, GraphSceneState,
         graph_scene::{self, ToGraphMut},
@@ -29,7 +31,7 @@ pub enum FileDropTarget {
 /// A registry of available node types.
 ///
 /// Provides the list of node type names available for creation.
-/// Actual node creation is handled via [`crate::Cmd::CreateNode`].
+/// Actual node creation is handled via [`crate::CreateNode`].
 pub trait NodeTypeRegistry {
     /// The unique name of each node available.
     fn node_types(&self) -> Vec<&str>;
@@ -179,14 +181,19 @@ where
     Access::Node: Node + NodeUi + ToGraphMut<Node = Access::Node>,
 {
     gantz: &'a mut Gantz<'s>,
-    state: &'s mut GantzState,
-    access: &'s mut Access,
+    state: &'a mut GantzState,
+    access: &'a mut Access,
     focused_head: usize,
-    base_names: &'s gantz_ca::registry::Names,
+    base_names: &'a gantz_ca::registry::Names,
     gantz_response: &'a mut GantzResponse,
 }
 
 /// Response from the top-level gantz widget.
+///
+/// Whole-widget outcomes (focus, tab management, file drops, config) are
+/// plain fields; operations emitted from deeper within the widget tree
+/// (node UIs, context menus, shortcuts) arrive as dynamic payloads in
+/// [`responses`][Self::responses] for the application to drain and handle.
 #[derive(Debug)]
 pub struct GantzResponse {
     /// The focused head index (may have changed due to user interaction).
@@ -204,6 +211,9 @@ pub struct GantzResponse {
     pub reset_base_graph: Option<gantz_ca::Head>,
     /// The global compile config was changed via the Graph Config pane.
     pub compile_config: Option<gantz_core::compile::Config>,
+    /// Dynamic payloads emitted from within the widget tree, tagged with the
+    /// emitting head. See [`crate::response`] for the handling contract.
+    pub responses: Responses,
 }
 
 /// State for editing a tab name via double-click.
@@ -275,14 +285,6 @@ impl GantzResponse {
         self.graph_select
             .as_ref()
             .map(|g| g.import)
-            .unwrap_or(false)
-    }
-
-    /// Indicates the export-all button was clicked.
-    pub fn export_all(&self) -> bool {
-        self.graph_select
-            .as_ref()
-            .map(|g| g.export_all)
             .unwrap_or(false)
     }
 }
@@ -404,6 +406,7 @@ impl<'a> Gantz<'a> {
             demo_changed: None,
             reset_base_graph: None,
             compile_config: None,
+            responses: Responses::default(),
         };
 
         // The context for traversing the tree of tiles.
@@ -424,6 +427,16 @@ impl<'a> Gantz<'a> {
         // Detect .gantz file drops globally (not per-pane, since pointer
         // position may be unavailable during OS file drags on some platforms).
         response.file_drops = collect_gantz_file_drops(ui.ctx());
+
+        // Apply payloads that only affect `GantzState`, so applications never
+        // see them: path navigation and command palette toggling.
+        for (head, OpenPath(path)) in response.responses.take::<OpenPath>() {
+            let Some(head) = head else { continue };
+            state.open_heads.entry(head).or_default().path = path;
+        }
+        for _ in response.responses.take::<OpenCommandPalette>() {
+            state.command_palette.toggle();
+        }
 
         // Persist the tree.
         ui.memory_mut(|m| m.data.insert_persisted(tree_id, Some(tree)));
@@ -597,8 +610,7 @@ where
                         gantz_response.compile_config = Some(cfg);
                     }
                     if res.inner.export {
-                        let head_state = state.open_heads.entry(head).or_default();
-                        head_state.scene.cmds.push(Cmd::ExportHead);
+                        gantz_response.responses.push(Some(head), ExportHead);
                     }
                 }
                 None => {
@@ -645,6 +657,7 @@ where
                     focused_head,
                     closed_heads: &mut gantz_response.closed_heads,
                     new_branch: &mut gantz_response.new_branch,
+                    responses: &mut gantz_response.responses,
                     base_names,
                     base_immutable: gantz.base_immutable,
                 };
@@ -664,7 +677,9 @@ where
                         // Copy is always allowed.
                         if ui.input(|i| i.modifiers.command && i.key_pressed(egui::Key::C)) {
                             let nodes = head_state.scene.interaction.selection.nodes.clone();
-                            head_state.scene.cmds.push(Cmd::CopyNodes(nodes));
+                            gantz_response
+                                .responses
+                                .push(Some(fh.clone()), CopyNodes(nodes));
                         }
                         // New graph: Cmd/Ctrl+N.
                         if ui.input(|i| i.modifiers.command && i.key_pressed(egui::Key::N)) {
@@ -687,10 +702,11 @@ where
                             let ctrl_v = paste_text.is_some()
                                 || ui.input(|i| i.modifiers.command && i.key_pressed(egui::Key::V));
                             if ctrl_v {
-                                head_state.scene.cmds.push(Cmd::Paste {
+                                let paste = Paste {
                                     text: paste_text,
                                     pos: crate::PastePos::Offset(egui::vec2(20.0, 20.0)),
-                                });
+                                };
+                                gantz_response.responses.push(Some(fh.clone()), paste);
                             }
                             // Undo: Cmd/Ctrl+Z (without Shift).
                             if ui.input(|i| {
@@ -698,7 +714,7 @@ where
                                     && !i.modifiers.shift
                                     && i.key_pressed(egui::Key::Z)
                             }) {
-                                head_state.scene.cmds.push(Cmd::Undo);
+                                gantz_response.responses.push(Some(fh.clone()), Undo);
                             }
                             // Redo: Cmd/Ctrl+Shift+Z or Cmd/Ctrl+Y.
                             if ui.input(|i| {
@@ -707,14 +723,21 @@ where
                                     && i.key_pressed(egui::Key::Z))
                                     || (i.modifiers.command && i.key_pressed(egui::Key::Y))
                             }) {
-                                head_state.scene.cmds.push(Cmd::Redo);
+                                gantz_response.responses.push(Some(fh.clone()), Redo);
                             }
                         }
                     }
 
                     // Skip command palette when immutable.
                     if !focused_immutable {
-                        command_palette(gantz.env, head_state, &mut state.command_palette, ui);
+                        command_palette(
+                            gantz.env,
+                            &fh,
+                            head_state,
+                            &mut state.command_palette,
+                            &mut gantz_response.responses,
+                            ui,
+                        );
                     }
                 }
 
@@ -735,10 +758,7 @@ where
                 let res = graph_select(gantz.env, heads, *focused_head, *base_names, ui);
 
                 if res.inner.export_all {
-                    if let Some(fh) = access.heads().get(*focused_head).cloned() {
-                        let head_state = state.open_heads.entry(fh).or_default();
-                        head_state.scene.cmds.push(Cmd::ExportAllNamed);
-                    }
+                    gantz_response.responses.push(None, ExportAllNamed);
                 }
                 match &mut gantz_response.graph_select {
                     Some(gs) => *gs |= res.inner,
@@ -789,8 +809,10 @@ where
                     // Clicking an entry navigates to and selects its node.
                     if let (Some(path), Some(fh)) = (res.inner.clicked_path, focused) {
                         if let Some((&node_id, parent)) = path.split_last() {
-                            let head_state = state.open_heads.entry(fh).or_default();
-                            head_state.scene.cmds.push(Cmd::OpenPath(parent.to_vec()));
+                            let head_state = state.open_heads.entry(fh.clone()).or_default();
+                            gantz_response
+                                .responses
+                                .push(Some(fh), OpenPath(parent.to_vec()));
                             let selection = &mut head_state.scene.interaction.selection;
                             selection.clear();
                             selection.nodes.insert(graph_scene::NodeIndex::new(node_id));
@@ -807,9 +829,19 @@ where
                 if let Some(fh) = access.heads().get(*focused_head).cloned() {
                     let immutable = head_immutable(&fh, gantz.base_immutable, base_names);
                     let head_state = state.open_heads.entry(fh.clone()).or_default();
+                    let mut responses: Vec<Box<dyn ResponseData>> = Vec::new();
                     access.with_head_mut(&fh, |data| {
-                        node_inspector(gantz.env, data.graph, data.vm, head_state, immutable, ui);
+                        node_inspector(
+                            gantz.env,
+                            data.graph,
+                            data.vm,
+                            head_state,
+                            immutable,
+                            &mut responses,
+                            ui,
+                        );
                     });
+                    gantz_response.responses.extend(Some(&fh), responses);
                 }
             }
             Pane::Steel => {
@@ -894,6 +926,8 @@ where
     closed_heads: &'a mut Vec<gantz_ca::Head>,
     /// New branch created from tab double-click: (original_head, new_branch_name).
     new_branch: &'a mut Option<(gantz_ca::Head, String)>,
+    /// Dynamic payloads emitted from within the graph scenes.
+    responses: &'a mut Responses,
     base_names: &'a gantz_ca::registry::Names,
     base_immutable: bool,
 }
@@ -1107,6 +1141,7 @@ where
                 immutable,
                 &diagnostics,
                 data.vm,
+                self.responses,
                 ui,
             )
         });
@@ -1456,6 +1491,7 @@ fn graph_scene<N>(
     immutable: bool,
     diagnostics: &[gantz_core::Diagnostic],
     vm: &mut Engine,
+    responses: &mut Responses,
     ui: &mut egui::Ui,
 ) -> Option<graph_scene::GraphSceneResponse>
 where
@@ -1485,13 +1521,16 @@ where
                     }
                 });
 
-            let response = GraphScene::new(registry, graph, &head_state.path)
+            let mut response = GraphScene::new(registry, graph, &head_state.path)
                 .with_id(id)
                 .auto_layout(auto_layout)
                 .layout_flow(layout_flow)
                 .center_view(center_view)
                 .immutable(immutable)
                 .show(view, &mut head_state.scene, vm, ui);
+
+            // Tag the scene's emissions with this head.
+            responses.extend(Some(head), response.responses.drain(..));
 
             graph_scene::paint_diagnostics(diagnostics, &head_state.path, &response, ui);
 
@@ -1524,7 +1563,7 @@ where
                 .show(ui, |ui| {
                     ui.vertical_centered_justified(|ui| {
                         if ui.add(button("R")).on_hover_text("root graph").clicked() {
-                            head_state.scene.cmds.push(Cmd::OpenPath(vec![]));
+                            responses.push(Some(head.clone()), OpenPath(vec![]));
                             head_state.scene.interaction.selection.clear();
                         }
                     });
@@ -1540,7 +1579,7 @@ where
                                 .clicked()
                             {
                                 if !current_path {
-                                    head_state.scene.cmds.push(Cmd::OpenPath(path.to_vec()));
+                                    responses.push(Some(head.clone()), OpenPath(path.to_vec()));
                                     head_state.scene.interaction.selection.clear();
                                 }
                             }
@@ -1554,8 +1593,10 @@ where
 
 fn command_palette(
     env: &dyn Registry,
-    head_state: &mut OpenHeadState,
+    head: &gantz_ca::Head,
+    head_state: &OpenHeadState,
     cmd_palette: &mut widget::CommandPalette,
+    responses: &mut Responses,
     ui: &mut egui::Ui,
 ) {
     // If space is pressed, toggle command palette visibility.
@@ -1569,15 +1610,13 @@ fn command_palette(
     let types = env.node_types();
     let cmds = types.iter().map(|&k| NodeTyCmd { env, name: k });
 
-    // If a command was emitted, emit a CreateNode command.
+    // If a command was emitted, emit a CreateNode payload.
     if let Some(cmd) = cmd_palette.show(ui.ctx(), cmds) {
-        head_state
-            .scene
-            .cmds
-            .push(crate::Cmd::CreateNode(crate::CreateNode {
-                path: head_state.path.clone(),
-                node_type: cmd.name.to_string(),
-            }));
+        let create = CreateNode {
+            path: head_state.path.clone(),
+            node_type: cmd.name.to_string(),
+        };
+        responses.push(Some(head.clone()), create);
     }
 }
 
@@ -1625,6 +1664,7 @@ fn node_inspector<N>(
     vm: &mut Engine,
     head_state: &mut OpenHeadState,
     immutable: bool,
+    responses: &mut Vec<Box<dyn ResponseData>>,
     ui: &mut egui::Ui,
 ) -> egui::InnerResponse<()>
 where
@@ -1650,14 +1690,8 @@ where
                         let ix = id.index();
                         let path: Vec<_> =
                             head_state.path.iter().copied().chain(Some(ix)).collect();
-                        let ctx = NodeCtx::new(
-                            registry,
-                            &path[..],
-                            &inlets,
-                            &outlets,
-                            vm,
-                            &mut head_state.scene.cmds,
-                        );
+                        let ctx =
+                            NodeCtx::new(registry, &path[..], &inlets, &outlets, vm, responses);
                         let resp = widget::NodeInspector::new(node, ctx, immutable).show(ui);
                         if resp.label_response.clicked() {
                             let sel = &mut head_state.scene.interaction.selection.nodes;

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -730,14 +730,11 @@ where
 
                     // Skip command palette when immutable.
                     if !focused_immutable {
-                        command_palette(
-                            gantz.env,
-                            &fh,
-                            head_state,
-                            &mut state.command_palette,
-                            &mut gantz_response.responses,
-                            ui,
-                        );
+                        let created =
+                            command_palette(gantz.env, head_state, &mut state.command_palette, ui);
+                        if let Some(create) = created {
+                            gantz_response.responses.push(Some(fh), create);
+                        }
                     }
                 }
 
@@ -829,19 +826,13 @@ where
                 if let Some(fh) = access.heads().get(*focused_head).cloned() {
                     let immutable = head_immutable(&fh, gantz.base_immutable, base_names);
                     let head_state = state.open_heads.entry(fh.clone()).or_default();
-                    let mut responses: Vec<Payload> = Vec::new();
-                    access.with_head_mut(&fh, |data| {
-                        node_inspector(
-                            gantz.env,
-                            data.graph,
-                            data.vm,
-                            head_state,
-                            immutable,
-                            &mut responses,
-                            ui,
-                        );
+                    let responses = access.with_head_mut(&fh, |data| {
+                        node_inspector(gantz.env, data.graph, data.vm, head_state, immutable, ui)
+                            .inner
                     });
-                    gantz_response.responses.extend(Some(&fh), responses);
+                    gantz_response
+                        .responses
+                        .extend(Some(&fh), responses.into_iter().flatten());
                 }
             }
             Pane::Steel => {
@@ -1127,6 +1118,9 @@ where
         let layout_flow = head_state.layout_flow;
         let center_view = head_state.center_view;
 
+        // We'll use this for positioning the fixed path labels window.
+        let rect = ui.available_rect_before_wrap();
+
         // Get mutable access to this head's data and render the graph scene.
         let graph_response = self.access.with_head_mut(pane_head, |data| {
             graph_scene(
@@ -1141,17 +1135,22 @@ where
                 immutable,
                 &diagnostics,
                 data.vm,
-                self.responses,
                 ui,
             )
         });
 
-        // Focus this head when clicking on the graph or any of its nodes.
         if let Some(Some(response)) = graph_response {
+            // Focus this head when clicking on the graph or any of its nodes.
             if response.scene.clicked() || response.any_node_interacted() {
                 *self.focused_head = ix;
             }
+            // Tag the scene's emissions with this head.
+            self.responses.extend(Some(&*pane_head), response.responses);
         }
+
+        // Floating path navigation labels.
+        let labels = path_labels(rect, head_state, ui);
+        self.responses.extend(Some(&*pane_head), labels);
 
         egui_tiles::UiResponse::None
     }
@@ -1479,6 +1478,10 @@ fn perf_view(title: &str, capture: &mut widget::PerfCapture, ui: &mut egui::Ui) 
 }
 
 /// Returns the response from the graph scene if it was shown.
+///
+/// Payloads emitted within the scene are returned in
+/// [`GraphSceneResponse::responses`][graph_scene::GraphSceneResponse] for the
+/// caller to tag and merge.
 fn graph_scene<N>(
     registry: &dyn Registry,
     graph: &mut gantz_core::node::graph::Graph<N>,
@@ -1491,62 +1494,63 @@ fn graph_scene<N>(
     immutable: bool,
     diagnostics: &[gantz_core::Diagnostic],
     vm: &mut Engine,
-    responses: &mut Responses,
     ui: &mut egui::Ui,
 ) -> Option<graph_scene::GraphSceneResponse>
 where
     N: Node + NodeUi + graph_scene::ToGraphMut<Node = N>,
 {
-    // We'll use this for positioning the fixed path labels window.
-    let rect = ui.available_rect_before_wrap();
-
     // Show the `GraphScene` for the graph at the current path.
-    let response = match graph_scene::index_path_graph_mut(graph, &head_state.path) {
-        None => {
-            log::error!("path {:?} is not a graph", head_state.path);
-            None
-        }
-        Some(graph) => {
-            // Use both head and path for a unique ID per graph pane.
-            let id = egui::Id::new(head).with(&head_state.path);
-
-            // Get or create the View for this path from external storage.
-            let view = head_views
-                .entry(head_state.path.to_vec())
-                .or_insert_with(|| {
-                    let layout = widget::graph_scene::layout(graph, id, layout_flow, ui.ctx());
-                    egui_graph::View {
-                        scene_rect: egui::Rect::ZERO,
-                        layout,
-                    }
-                });
-
-            let mut response = GraphScene::new(registry, graph, &head_state.path)
-                .with_id(id)
-                .auto_layout(auto_layout)
-                .layout_flow(layout_flow)
-                .center_view(center_view)
-                .immutable(immutable)
-                .show(view, &mut head_state.scene, vm, ui);
-
-            // Tag the scene's emissions with this head.
-            responses.extend(Some(head), response.responses.drain(..));
-
-            graph_scene::paint_diagnostics(diagnostics, &head_state.path, &response, ui);
-
-            Some(response)
-        }
+    let Some(graph) = graph_scene::index_path_graph_mut(graph, &head_state.path) else {
+        log::error!("path {:?} is not a graph", head_state.path);
+        return None;
     };
 
-    // Floating path index labels over the bottom-left corner of the scene.
-    // Only show when viewing a subgraph (non-empty path).
+    // Use both head and path for a unique ID per graph pane.
+    let id = egui::Id::new(head).with(&head_state.path);
+
+    // Get or create the View for this path from external storage.
+    let view = head_views
+        .entry(head_state.path.to_vec())
+        .or_insert_with(|| {
+            let layout = widget::graph_scene::layout(graph, id, layout_flow, ui.ctx());
+            egui_graph::View {
+                scene_rect: egui::Rect::ZERO,
+                layout,
+            }
+        });
+
+    let response = GraphScene::new(registry, graph, &head_state.path)
+        .with_id(id)
+        .auto_layout(auto_layout)
+        .layout_flow(layout_flow)
+        .center_view(center_view)
+        .immutable(immutable)
+        .show(view, &mut head_state.scene, vm, ui);
+
+    graph_scene::paint_diagnostics(diagnostics, &head_state.path, &response, ui);
+
+    Some(response)
+}
+
+/// Floating path index labels over the bottom-left corner of the scene,
+/// shown when viewing a subgraph (non-empty path).
+///
+/// Returns the [`OpenPath`] payloads emitted by clicked labels. Shown even
+/// when the path failed to resolve to a graph - the labels are the recovery
+/// mechanism for navigating back out of an invalid path.
+fn path_labels(
+    scene_rect: egui::Rect,
+    head_state: &mut OpenHeadState,
+    ui: &mut egui::Ui,
+) -> Vec<Payload> {
+    let mut responses = Vec::new();
     if head_state.path.is_empty() {
-        return response;
+        return responses;
     }
     let space = ui.style().interaction.interact_radius * 3.0;
     egui::Window::new("path_label_window")
         .pivot(egui::Align2::LEFT_BOTTOM)
-        .fixed_pos(rect.left_bottom() + egui::vec2(space, -space))
+        .fixed_pos(scene_rect.left_bottom() + egui::vec2(space, -space))
         .title_bar(false)
         .resizable(false)
         .collapsible(false)
@@ -1563,7 +1567,7 @@ where
                 .show(ui, |ui| {
                     ui.vertical_centered_justified(|ui| {
                         if ui.add(button("R")).on_hover_text("root graph").clicked() {
-                            responses.push(Some(head.clone()), OpenPath(vec![]));
+                            responses.push(Payload::new(OpenPath(vec![])));
                             head_state.scene.interaction.selection.clear();
                         }
                     });
@@ -1579,7 +1583,7 @@ where
                                 .clicked()
                             {
                                 if !current_path {
-                                    responses.push(Some(head.clone()), OpenPath(path.to_vec()));
+                                    responses.push(Payload::new(OpenPath(path.to_vec())));
                                     head_state.scene.interaction.selection.clear();
                                 }
                             }
@@ -1587,18 +1591,16 @@ where
                     }
                 })
         });
-
-    response
+    responses
 }
 
+/// Returns a [`CreateNode`] payload when a node type is chosen.
 fn command_palette(
     env: &dyn Registry,
-    head: &gantz_ca::Head,
     head_state: &OpenHeadState,
     cmd_palette: &mut widget::CommandPalette,
-    responses: &mut Responses,
     ui: &mut egui::Ui,
-) {
+) -> Option<CreateNode> {
     // If space is pressed, toggle command palette visibility.
     if !ui.ctx().wants_keyboard_input() {
         if ui.ctx().input(|i| i.key_pressed(egui::Key::Space)) {
@@ -1610,14 +1612,11 @@ fn command_palette(
     let types = env.node_types();
     let cmds = types.iter().map(|&k| NodeTyCmd { env, name: k });
 
-    // If a command was emitted, emit a CreateNode payload.
-    if let Some(cmd) = cmd_palette.show(ui.ctx(), cmds) {
-        let create = CreateNode {
-            path: head_state.path.clone(),
-            node_type: cmd.name.to_string(),
-        };
-        responses.push(Some(head.clone()), create);
-    }
+    // The chosen node type becomes a `CreateNode` payload.
+    cmd_palette.show(ui.ctx(), cmds).map(|cmd| CreateNode {
+        path: head_state.path.clone(),
+        node_type: cmd.name.to_string(),
+    })
 }
 
 fn log_view(
@@ -1658,19 +1657,20 @@ fn head_immutable(
     base_immutable && is_base && !is_demo
 }
 
+/// Returns the payloads emitted by node UIs within the inspector.
 fn node_inspector<N>(
     registry: &dyn Registry,
     root: &mut gantz_core::node::graph::Graph<N>,
     vm: &mut Engine,
     head_state: &mut OpenHeadState,
     immutable: bool,
-    responses: &mut Vec<Payload>,
     ui: &mut egui::Ui,
-) -> egui::InnerResponse<()>
+) -> egui::InnerResponse<Vec<Payload>>
 where
     N: Node + NodeUi + ToGraphMut<Node = N>,
 {
     pane_ui(ui, |ui| {
+        let mut responses = Vec::new();
         egui::ScrollArea::vertical()
             .auto_shrink(egui::Vec2b::FALSE)
             .show(ui, |ui| {
@@ -1690,8 +1690,14 @@ where
                         let ix = id.index();
                         let path: Vec<_> =
                             head_state.path.iter().copied().chain(Some(ix)).collect();
-                        let ctx =
-                            NodeCtx::new(registry, &path[..], &inlets, &outlets, vm, responses);
+                        let ctx = NodeCtx::new(
+                            registry,
+                            &path[..],
+                            &inlets,
+                            &outlets,
+                            vm,
+                            &mut responses,
+                        );
                         let resp = widget::NodeInspector::new(node, ctx, immutable).show(ui);
                         if resp.label_response.clicked() {
                             let sel = &mut head_state.scene.interaction.selection.nodes;
@@ -1707,6 +1713,7 @@ where
                     });
                 }
             });
+        responses
     })
 }
 

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -1,4 +1,7 @@
-use crate::{Cmd, NodeUi, PastePos, Registry};
+use crate::{
+    CopyNodes, InspectEdge, NodeUi, OpenCommandPalette, OpenHead, Paste, PastePos, Registry,
+    response::ResponseData,
+};
 use egui::emath::GuiRounding;
 use egui_graph::{self, SocketKind, node::EdgeEvent};
 use gantz_core::{
@@ -18,6 +21,9 @@ pub struct GraphSceneResponse {
     pub scene: egui::Response,
     /// Responses from each node, keyed by node index.
     pub nodes: Vec<(NodeIndex, NodeResponse)>,
+    /// Dynamic payloads emitted within the scene (node UIs, context menus),
+    /// to be handled by the application after the pass.
+    pub responses: Vec<Box<dyn ResponseData>>,
 }
 
 /// An alias for the node response type returned from gantz nodes.
@@ -66,9 +72,6 @@ pub struct GraphScene<'a, N> {
 #[derive(Default, serde::Deserialize, serde::Serialize)]
 pub struct GraphSceneState {
     pub interaction: Interaction,
-    /// Commands queued within the graph scene widget to be handled externally.
-    #[serde(default, skip)]
-    pub cmds: Vec<Cmd>,
 }
 
 #[derive(Default, serde::Deserialize, serde::Serialize)]
@@ -171,6 +174,7 @@ where
             view.layout = layout(&*self.graph, self.id, self.layout_flow, ui.ctx());
         }
         let mut node_responses = Vec::new();
+        let mut responses: Vec<Box<dyn ResponseData>> = Vec::new();
         let selected: HashSet<egui_graph::NodeId> = state
             .interaction
             .selection
@@ -191,12 +195,15 @@ where
                         self.path,
                         nctx,
                         state,
+                        &mut responses,
                         vm,
                         immutable,
                         ui,
                     );
                 })
-                .edges(ui, |ectx, ui| edges(self.graph, self.path, ectx, state, ui));
+                .edges(ui, |ectx, ui| {
+                    edges(self.graph, self.path, ectx, state, &mut responses, ui)
+                });
             });
 
         // Sync selection when egui_graph reports a change.
@@ -217,7 +224,7 @@ where
                 // positioning.
                 let menu_screen_pos = ui.min_rect().left_top();
                 if ui.button("add node").clicked() {
-                    state.cmds.push(Cmd::OpenCommandPalette);
+                    responses.push(Box::new(OpenCommandPalette));
                     ui.close();
                 }
                 if ui.button("paste").clicked() {
@@ -227,7 +234,7 @@ where
                         .map(|t| t * menu_screen_pos)
                         .unwrap_or(menu_screen_pos);
                     let pos = PastePos::GraphPos(graph_pos);
-                    state.cmds.push(Cmd::Paste { text: None, pos });
+                    responses.push(Box::new(Paste { text: None, pos }));
                     ui.close();
                 }
             });
@@ -236,6 +243,7 @@ where
         GraphSceneResponse {
             scene: graph_response.response,
             nodes: node_responses,
+            responses,
         }
     }
 }
@@ -293,6 +301,7 @@ fn nodes<N>(
     path: &[node::Id],
     nctx: &mut egui_graph::NodesCtx,
     state: &mut GraphSceneState,
+    responses: &mut Vec<Box<dyn ResponseData>>,
     vm: &mut Engine,
     immutable: bool,
     ui: &mut egui::Ui,
@@ -306,7 +315,7 @@ where
     let node_ids: Vec<_> = graph.node_identifiers().collect();
     let mut path = path.to_vec();
     let (inlets, outlets) = crate::inlet_outlet_ids(registry, graph);
-    let mut responses = Vec::with_capacity(node_ids.len());
+    let mut node_responses = Vec::with_capacity(node_ids.len());
     let mut nodes_to_delete = Vec::new();
     let mut nodes_to_reset = Vec::new();
     for n_id in node_ids {
@@ -325,7 +334,7 @@ where
 
                 // Create the gantz node context.
                 let node_ctx =
-                    crate::NodeCtx::new(registry, &path, &inlets, &outlets, vm, &mut state.cmds);
+                    crate::NodeCtx::new(registry, &path, &inlets, &outlets, vm, responses);
 
                 // Instantiate the node UI, return its response.
                 let response = node.ui(node_ctx, nui_ctx);
@@ -376,7 +385,7 @@ where
                 HashSet::from([n_id])
             };
             if ui.button("copy").clicked() {
-                state.cmds.push(Cmd::CopyNodes(target.clone()));
+                responses.push(Box::new(CopyNodes(target.clone())));
                 ui.close();
             }
             // Demo graph, if the node has one.
@@ -384,9 +393,7 @@ where
             let demo_btn = ui.add_enabled(demo_name.is_some(), egui::Button::new("demo"));
             if let Some(name) = demo_name {
                 if demo_btn.on_hover_text(format!("opens {name}")).clicked() {
-                    state
-                        .cmds
-                        .push(Cmd::OpenHead(gantz_ca::Head::Branch(name.to_string())));
+                    responses.push(Box::new(OpenHead(gantz_ca::Head::Branch(name.to_string()))));
                     ui.close();
                 }
             } else {
@@ -412,7 +419,7 @@ where
             }
         });
 
-        responses.push((n_id, response));
+        node_responses.push((n_id, response));
     }
 
     // Unified delete: both keyboard and context menu deletes go through here.
@@ -439,7 +446,7 @@ where
         gantz_core::graph::register(&get_node, &*graph, &path, vm);
     }
 
-    responses
+    node_responses
 }
 
 fn edges<N>(
@@ -447,6 +454,7 @@ fn edges<N>(
     path: &[node::Id],
     ectx: &mut egui_graph::EdgesCtx,
     state: &mut GraphSceneState,
+    responses: &mut Vec<Box<dyn ResponseData>>,
     ui: &mut egui::Ui,
 ) {
     // Track whether any edge has a context menu open this frame.
@@ -489,7 +497,7 @@ fn edges<N>(
         response.context_menu(|ui| {
             if ui.button("inspect").clicked() {
                 if let Some(pos) = state.interaction.edge_context_menu_pos.take() {
-                    state.cmds.push(Cmd::InspectEdge(crate::InspectEdge {
+                    responses.push(Box::new(InspectEdge {
                         path: path.to_vec(),
                         edge: e,
                         pos,

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -1,6 +1,6 @@
 use crate::{
     CopyNodes, InspectEdge, NodeUi, OpenCommandPalette, OpenHead, Paste, PastePos, Registry,
-    response::ResponseData,
+    response::Payload,
 };
 use egui::emath::GuiRounding;
 use egui_graph::{self, SocketKind, node::EdgeEvent};
@@ -23,7 +23,7 @@ pub struct GraphSceneResponse {
     pub nodes: Vec<(NodeIndex, NodeResponse)>,
     /// Dynamic payloads emitted within the scene (node UIs, context menus),
     /// to be handled by the application after the pass.
-    pub responses: Vec<Box<dyn ResponseData>>,
+    pub responses: Vec<Payload>,
 }
 
 /// An alias for the node response type returned from gantz nodes.
@@ -174,7 +174,7 @@ where
             view.layout = layout(&*self.graph, self.id, self.layout_flow, ui.ctx());
         }
         let mut node_responses = Vec::new();
-        let mut responses: Vec<Box<dyn ResponseData>> = Vec::new();
+        let mut responses: Vec<Payload> = Vec::new();
         let selected: HashSet<egui_graph::NodeId> = state
             .interaction
             .selection
@@ -224,7 +224,7 @@ where
                 // positioning.
                 let menu_screen_pos = ui.min_rect().left_top();
                 if ui.button("add node").clicked() {
-                    responses.push(Box::new(OpenCommandPalette));
+                    responses.push(Payload::new(OpenCommandPalette));
                     ui.close();
                 }
                 if ui.button("paste").clicked() {
@@ -234,7 +234,7 @@ where
                         .map(|t| t * menu_screen_pos)
                         .unwrap_or(menu_screen_pos);
                     let pos = PastePos::GraphPos(graph_pos);
-                    responses.push(Box::new(Paste { text: None, pos }));
+                    responses.push(Payload::new(Paste { text: None, pos }));
                     ui.close();
                 }
             });
@@ -301,7 +301,7 @@ fn nodes<N>(
     path: &[node::Id],
     nctx: &mut egui_graph::NodesCtx,
     state: &mut GraphSceneState,
-    responses: &mut Vec<Box<dyn ResponseData>>,
+    responses: &mut Vec<Payload>,
     vm: &mut Engine,
     immutable: bool,
     ui: &mut egui::Ui,
@@ -385,7 +385,7 @@ where
                 HashSet::from([n_id])
             };
             if ui.button("copy").clicked() {
-                responses.push(Box::new(CopyNodes(target.clone())));
+                responses.push(Payload::new(CopyNodes(target.clone())));
                 ui.close();
             }
             // Demo graph, if the node has one.
@@ -393,7 +393,9 @@ where
             let demo_btn = ui.add_enabled(demo_name.is_some(), egui::Button::new("demo"));
             if let Some(name) = demo_name {
                 if demo_btn.on_hover_text(format!("opens {name}")).clicked() {
-                    responses.push(Box::new(OpenHead(gantz_ca::Head::Branch(name.to_string()))));
+                    responses.push(Payload::new(OpenHead(gantz_ca::Head::Branch(
+                        name.to_string(),
+                    ))));
                     ui.close();
                 }
             } else {
@@ -454,7 +456,7 @@ fn edges<N>(
     path: &[node::Id],
     ectx: &mut egui_graph::EdgesCtx,
     state: &mut GraphSceneState,
-    responses: &mut Vec<Box<dyn ResponseData>>,
+    responses: &mut Vec<Payload>,
     ui: &mut egui::Ui,
 ) {
     // Track whether any edge has a context menu open this frame.
@@ -497,7 +499,7 @@ fn edges<N>(
         response.context_menu(|ui| {
             if ui.button("inspect").clicked() {
                 if let Some(pos) = state.interaction.edge_context_menu_pos.take() {
-                    responses.push(Box::new(InspectEdge {
+                    responses.push(Payload::new(InspectEdge {
                         path: path.to_vec(),
                         edge: e,
                         pos,

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -1,6 +1,6 @@
 use crate::{
     CopyNodes, InspectEdge, NodeUi, OpenCommandPalette, OpenHead, Paste, PastePos, Registry,
-    response::Payload,
+    response::DynResponse,
 };
 use egui::emath::GuiRounding;
 use egui_graph::{self, SocketKind, node::EdgeEvent};
@@ -23,7 +23,7 @@ pub struct GraphSceneResponse {
     pub nodes: Vec<(NodeIndex, NodeResponse)>,
     /// Dynamic payloads emitted within the scene (node UIs, context menus),
     /// to be handled by the application after the pass.
-    pub responses: Vec<Payload>,
+    pub responses: Vec<DynResponse>,
 }
 
 /// An alias for the node response type returned from gantz nodes.
@@ -174,7 +174,7 @@ where
             view.layout = layout(&*self.graph, self.id, self.layout_flow, ui.ctx());
         }
         let mut node_responses = Vec::new();
-        let mut responses: Vec<Payload> = Vec::new();
+        let mut responses: Vec<DynResponse> = Vec::new();
         let selected: HashSet<egui_graph::NodeId> = state
             .interaction
             .selection
@@ -224,7 +224,7 @@ where
                 // positioning.
                 let menu_screen_pos = ui.min_rect().left_top();
                 if ui.button("add node").clicked() {
-                    responses.push(Payload::new(OpenCommandPalette));
+                    responses.push(DynResponse::new(OpenCommandPalette));
                     ui.close();
                 }
                 if ui.button("paste").clicked() {
@@ -234,7 +234,7 @@ where
                         .map(|t| t * menu_screen_pos)
                         .unwrap_or(menu_screen_pos);
                     let pos = PastePos::GraphPos(graph_pos);
-                    responses.push(Payload::new(Paste { text: None, pos }));
+                    responses.push(DynResponse::new(Paste { text: None, pos }));
                     ui.close();
                 }
             });
@@ -301,7 +301,7 @@ fn nodes<N>(
     path: &[node::Id],
     nctx: &mut egui_graph::NodesCtx,
     state: &mut GraphSceneState,
-    responses: &mut Vec<Payload>,
+    responses: &mut Vec<DynResponse>,
     vm: &mut Engine,
     immutable: bool,
     ui: &mut egui::Ui,
@@ -385,7 +385,7 @@ where
                 HashSet::from([n_id])
             };
             if ui.button("copy").clicked() {
-                responses.push(Payload::new(CopyNodes(target.clone())));
+                responses.push(DynResponse::new(CopyNodes(target.clone())));
                 ui.close();
             }
             // Demo graph, if the node has one.
@@ -393,7 +393,7 @@ where
             let demo_btn = ui.add_enabled(demo_name.is_some(), egui::Button::new("demo"));
             if let Some(name) = demo_name {
                 if demo_btn.on_hover_text(format!("opens {name}")).clicked() {
-                    responses.push(Payload::new(OpenHead(gantz_ca::Head::Branch(
+                    responses.push(DynResponse::new(OpenHead(gantz_ca::Head::Branch(
                         name.to_string(),
                     ))));
                     ui.close();
@@ -456,7 +456,7 @@ fn edges<N>(
     path: &[node::Id],
     ectx: &mut egui_graph::EdgesCtx,
     state: &mut GraphSceneState,
-    responses: &mut Vec<Payload>,
+    responses: &mut Vec<DynResponse>,
     ui: &mut egui::Ui,
 ) {
     // Track whether any edge has a context menu open this frame.
@@ -499,7 +499,7 @@ fn edges<N>(
         response.context_menu(|ui| {
             if ui.button("inspect").clicked() {
                 if let Some(pos) = state.interaction.edge_context_menu_pos.take() {
-                    responses.push(Payload::new(InspectEdge {
+                    responses.push(DynResponse::new(InspectEdge {
                         path: path.to_vec(),
                         edge: e,
                         pos,


### PR DESCRIPTION
# Summary

Reduces the cognitive overhead of event handling across the GUI and bevy crates. Previously: ~350 lines of frontend logic duplicated between `bevy_gantz_egui` and the demo, GUI intents leaving the widget via two channels (a per-head `Cmd` queue persisted in scene state plus the widget response), five bevy event types existing only as 1:1 borrow-rule workarounds, and three separate VM recompile paths (duplicate init observers, CA-polling `vm::update`, and a `run_if`-gated `recompile_all`).

## 1. `gantz_egui::ops` - shared frontend operations (940f363)

The graph-mutating logic behind each GUI operation (`create_node`, `inspect_edge`, `copy_nodes`, `paste`, `branch_node`, `undo`/`redo`, plus export/import helpers in `export`) now lives once in `gantz_egui`, over plain graph/view/VM/registry types. The bevy observers and the demo are thin adapters around identical behaviour.

- Unifies a latent inconsistency: the bevy frontend now inserts a layout entry for newly created nodes (previously demo-only).
- `ron` is promoted from dev-dependency to dependency of `gantz_egui`.

## 2. Dynamic response channel replaces `Cmd` (2a0eb7a + 92b6e6c)

The `Cmd` enum and the per-head command queue are removed. Everything the widget tree emits is now typed response data returned from `Gantz::show`, consistent with egui's response idiom:

- `gantz_egui::response`: `ResponseData` (blanket trait - any `Debug + Send + Sync + 'static` type qualifies) and `Responses` (head-tagged payload collection). Node UIs emit via `NodeCtx::response(..)`.
- `Gantz::show` self-handles payloads that only touch `GantzState` (`OpenPath`, `OpenCommandPalette`) - applications never see them.
- bevy: payloads dispatch through a `TypeId`-keyed `ResponseDispatchers` resource into a generic `ForHead<T>` `EntityEvent`. Nodes declared in independent plugins can emit custom payloads and handle them with `app.register_head_response::<MyPayload>()` + `add_observer(|t: On<ForHead<MyPayload>>, ..| ..)`.
- demo: typed `responses.take::<T>()` drains over the shared ops.

Behaviour changes:

- Payloads are handled the same frame they are emitted (previously deferred to the next frame's `process_cmds`).
- The compile-time exhaustive `Cmd` match is replaced by a runtime "unhandled response payload" warning in both frontends.

The follow-up fix (92b6e6c) captures payload type identity at emission via `response::Payload`: `Box<dyn ResponseData>` itself satisfies the blanket impl, so identity methods called on the box resolved to the box's impl and returned the box's `TypeId`, breaking all dispatch at runtime. Identity is now recorded inside the generic emit fns where the concrete type is statically known, with unit tests guarding the round trip.

## 3. Input-addressed VM sync (f621506)

One `vm::sync` system replaces the three recompile paths with a single declarative rule: recompile iff the inputs to compilation changed. Each head's `CompiledInputs` component memoizes the inputs of the last compile attempt (working-graph content address + `compile::Config`); `sync` compares by value every `Update`, committing diverged working graphs (emitting `CommittedEvent` as before) and rebuilding the VM. There is no dirty flag to set or forget, and the load-bearing `resource_changed.and(not(resource_added))` run condition is gone.

- Init vs in-place recompile is decided by VM presence in `HeadVms`: head replace/branch-move remove the VM (discarding the old graph's node state) and reset the memo, forcing a fresh init; edits and config changes compile in place, preserving node state.
- `OpenHead` now `#[require]`s `Module`, `Diagnostics` and `CompiledInputs`, so spawn paths cannot forget them; `vm::setup` and the app binaries' `Startup` registrations are deleted.
- `vm::sync` runs in the new `VmSet`; `drive_frame_bangs` orders after it.
- The events-vs-messages convention (request/hook observer events vs buffered messages) is documented in the `bevy_gantz` crate docs.

Behaviour changes:

- A head whose initial compile failed now retries on the next input change (previously `vm::update` skipped VM-less heads forever).
- A `frame!` node may skip at most one frame across a head replace (VM init moves from observer flush to the next `Update`).

## Breaking changes

- `gantz_egui::Cmd` removed; variants are standalone payload structs (`CreateNode`, `Paste`, `Undo`, ...). `GraphSceneState.cmds` removed. `GantzResponse` gains `responses`; the dead `export_all()` getter is removed.
- `bevy_gantz_egui`: `process_cmds` and the `CreateNodeEvent`, `InspectEdgeEvent`, `CopyNodesEvent`, `PasteEvent`, `BranchNodeEvent` types are removed in favour of `ForHead<T>` + `RegisterResponseExt`.
- `bevy_gantz::vm`: `setup`, `update`, `recompile_all`, `on_head_opened`, `on_head_changed` are removed in favour of `vm::sync`.