### PR TITLE
feat(gantz): persist native window size between sessions

### DIFF
--- a/crates/gantz/src/main.rs
+++ b/crates/gantz/src/main.rs
@@ -1,6 +1,6 @@
 use bevy::{
     prelude::*,
-    window::{Window, WindowPlugin},
+    window::{PrimaryWindow, Window},
 };
 use bevy_egui::{EguiContexts, EguiPlugin, EguiPrimaryContextPass};
 use bevy_gantz::{
@@ -17,6 +17,7 @@ use storage::Pkv;
 mod builtin;
 mod node;
 mod storage;
+mod window;
 
 fn main() {
     App::new()
@@ -28,7 +29,7 @@ fn main() {
         .insert_resource(BuiltinNodes::<Box<dyn node::Node>>(Box::new(
             Builtins::new(),
         )))
-        .add_plugins(DefaultPlugins.set(log_plugin()).set(window_plugin()))
+        .add_plugins(DefaultPlugins.set(log_plugin()).set(window::plugin()))
         .add_plugins(EguiPlugin::default())
         .add_plugins(DebouncedInputPlugin::new(0.25))
         .insert_resource(Pkv(PkvStore::new("nannou-org", "gantz")))
@@ -36,6 +37,7 @@ fn main() {
             Startup,
             (
                 setup_camera,
+                setup_window,
                 setup_resources,
                 bevy_gantz_egui::base::load::<Box<dyn node::Node>>
                     .after(setup_resources)
@@ -64,24 +66,15 @@ fn log_plugin() -> bevy::log::LogPlugin {
     }
 }
 
-fn window_plugin() -> WindowPlugin {
-    WindowPlugin {
-        primary_window: Some(Window {
-            title: "gantz".into(),
-            name: Some("gantz".into()),
-            fit_canvas_to_parent: true,
-            // NOTE: This vastly improves input-latency on wayland. If you
-            // notice tearing or simialr issues, open an issue so we can try and
-            // select the right `PresentMode` for each system!
-            present_mode: bevy::window::PresentMode::AutoNoVsync,
-            ..default()
-        }),
-        ..default()
-    }
-}
-
 fn setup_camera(mut cmds: Commands) {
     cmds.spawn(Camera2d);
+}
+
+/// Restore the persisted window size (native only; no-op on web).
+fn setup_window(storage: Res<Pkv>, mut windows: Query<&mut Window, With<PrimaryWindow>>) {
+    if let Ok(mut window) = windows.single_mut() {
+        window::apply_saved_size(&*storage, &mut window);
+    }
 }
 
 fn setup_resources(storage: Res<Pkv>, mut cmds: Commands) {
@@ -148,6 +141,7 @@ fn persist_resources(
     tab_order: Res<HeadTabOrder>,
     focused: Res<FocusedHead>,
     heads_query: Query<OpenHeadDataReadOnly<Box<dyn node::Node>>, With<OpenHead>>,
+    primary_window: Query<&Window, With<PrimaryWindow>>,
 ) {
     // Save registry (graphs, commits, names).
     bevy_gantz::storage::save_registry(&mut *storage, &registry);
@@ -176,6 +170,10 @@ fn persist_resources(
     // Save egui memory (widget states).
     if let Ok(ctx) = ctxs.ctx_mut() {
         bevy_gantz_egui::storage::save_egui_memory(&mut *storage, ctx);
+    }
+    // Save the native window size (no-op on web).
+    if let Ok(window) = primary_window.single() {
+        window::save(&mut *storage, window);
     }
 }
 

--- a/crates/gantz/src/window.rs
+++ b/crates/gantz/src/window.rs
@@ -1,0 +1,73 @@
+//! Primary window setup and native window-size persistence.
+//!
+//! On native platforms the window's size is restored on launch and persisted
+//! via the same [`bevy_pkv`]-backed store as the rest of the app state. On web
+//! the window is governed by `fit_canvas_to_parent` (the canvas fills its HTML
+//! container), so persisting a fixed size is meaningless and is disabled.
+
+use bevy::{
+    prelude::*,
+    window::{Window, WindowPlugin},
+};
+use bevy_gantz::storage::{Load, Save};
+#[cfg(not(target_arch = "wasm32"))]
+use serde::{Deserialize, Serialize};
+
+/// The persisted size of the primary window, in logical pixels.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct WindowSize {
+    pub width: f32,
+    pub height: f32,
+}
+
+/// The storage key under which the window size is persisted.
+#[cfg(not(target_arch = "wasm32"))]
+const KEY: &str = "window-size";
+
+/// Build the [`WindowPlugin`] for the primary window.
+pub fn plugin() -> WindowPlugin {
+    WindowPlugin {
+        primary_window: Some(Window {
+            title: "gantz".into(),
+            name: Some("gantz".into()),
+            fit_canvas_to_parent: true,
+            // NOTE: This vastly improves input-latency on wayland. If you
+            // notice tearing or simialr issues, open an issue so we can try and
+            // select the right `PresentMode` for each system!
+            present_mode: bevy::window::PresentMode::AutoNoVsync,
+            ..default()
+        }),
+        ..default()
+    }
+}
+
+/// Apply the persisted window size to `window`, if one was saved.
+///
+/// Called from a `Startup` system. No-op on web, where the window size is not
+/// persisted.
+pub fn apply_saved_size(storage: &impl Load, window: &mut Window) {
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(size) = bevy_gantz::storage::load::<WindowSize>(storage, KEY) {
+        window.resolution.set(size.width, size.height);
+    }
+    #[cfg(target_arch = "wasm32")]
+    let _ = (storage, window);
+}
+
+/// Persist the primary window's logical size to storage.
+///
+/// No-op on web. Also skips the write before the window surface is realized,
+/// when the reported size is still effectively zero.
+pub fn save(storage: &mut impl Save, window: &Window) {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let width = window.resolution.width();
+        let height = window.resolution.height();
+        if width >= 1.0 && height >= 1.0 {
+            bevy_gantz::storage::save(storage, KEY, &WindowSize { width, height });
+        }
+    }
+    #[cfg(target_arch = "wasm32")]
+    let _ = (storage, window);
+}


### PR DESCRIPTION
Restore the window's logical size on launch and persist it between sessions, storing it under a `window-size` key in the same in-world `Pkv` store as the rest of the app state.

A `setup_window` Startup system reads the persisted size from `Res<Pkv>` and applies it to the primary `Window`; `persist_resources` saves the current size alongside the other state on the debounced-input trigger. Window setup moves into a new `window` module (`plugin`, `apply_saved_size`, `save`, `WindowSize`).

Gated to native via `cfg(not(target_arch = "wasm32"))`; web keeps `fit_canvas_to_parent` and does not persist a fixed size.