### PR TITLE
ci: adopt release-plz for automated releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,30 +61,6 @@ jobs:
           name: pr-preview-${{ github.event.pull_request.number }}
           path: artifact/
 
-  cargo-publish:
-    needs: nix
-    permissions:
-      id-token: "write"
-      contents: "read"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@v13
-      - uses: nicknovitski/nix-develop@v1
-      - uses: Swatinem/rust-cache@v2
-      - uses: katyo/publish-crates@v2
-        id: publish-crates
-        with:
-          registry-token: ${{ secrets.CRATESIO_TOKEN }}
-          dry-run: ${{ github.event_name != 'push' }}
-          ignore-unpublished-changes: true
-      - name: List published crates
-        if: ${{ steps.publish-crates.outputs.published != '' }}
-        run: |
-          LIST="${{ join(fromJSON(steps.publish-crates.outputs.published).*.name, ', ') }}"
-          echo "Published crates: $LIST"
-
   deploy-gantz-website:
     needs: nix
     if: github.ref == 'refs/heads/master'

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,54 @@
+name: release-plz
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-plz-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Publish crates + create tags/GitHub releases when a release PR is merged.
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push tags, create releases
+      id-token: write # crates.io trusted publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: Swatinem/rust-cache@v2
+      - id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+      - run: nix develop -c release-plz release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+  # Keep the version-bump + changelog PR up to date on every push to master.
+  release-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: Swatinem/rust-cache@v2
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - run: nix develop -c release-plz release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,9 @@
+[workspace]
+# Per-crate independent versioning (release-plz default): each crate bumps from
+# its own Conventional Commits, with cargo-semver-checks forcing a bump when a
+# breaking API change is detected. A dependent gets a patch bump when an internal
+# dependency it relies on is updated.
+#
+# If strict lockstep is ever wanted (all crates always share one version), add
+# `version_group = "gantz"` to a `[[package]]` entry for every crate.
+semver_check = true

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,11 @@
 {
+  cargo-semver-checks,
   gantz-unwrapped,
   gantz-website,
   lib,
   libGL,
   mkShell,
+  release-plz,
   rustfmt,
   stdenv,
   trunk,
@@ -18,7 +20,14 @@ mkShell {
   ];
   # The rust toolchain comes via `inputsFrom` (gantz-unwrapped) but does not
   # include rustfmt, which `nix develop -c cargo fmt` (and CI) requires.
+  # `release-plz` drives the release process (see .github/workflows/release-plz.yml);
+  # running it from this shell reuses the native build deps that `cargo publish`'s
+  # verify build needs, and lets maintainers preview a release with
+  # `nix develop -c release-plz update`. `cargo-semver-checks` is the binary
+  # release-plz shells out to for `semver_check` (release-plz.toml).
   packages = [
+    cargo-semver-checks
+    release-plz
     rustfmt
   ];
   # FIXME: Remove this, see #122.


### PR DESCRIPTION
Replace the katyo/publish-crates job with release-plz: it opens a release PR that bumps versions and updates changelogs from Conventional Commits, then on merge publishes to crates.io, creates git tags and GitHub releases.

- add release-plz and cargo-semver-checks to the gantz-dev devShell so release-plz runs via `nix develop -c`, reusing the native build deps that `cargo publish`'s verify build needs and the binary its semver check uses
- add release-plz.toml (per-crate independent versioning, semver checks on)
- add .github/workflows/release-plz.yml: a `release` job that publishes via crates.io trusted publishing (OIDC) and a `release-pr` job
- drop the cargo-publish job (katyo/publish-crates) from ci.yml