### PR TITLE
fix(ci): pass release-plz git token via `GIT_TOKEN`

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,7 +30,8 @@ jobs:
         uses: rust-lang/crates-io-auth-action@v1
       - run: nix develop -c release-plz release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # release-plz reads the git-forge token from GIT_TOKEN.
+          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   # Keep the version-bump + changelog PR up to date on every push to master.
@@ -51,4 +52,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - run: nix develop -c release-plz release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
release-plz's CLI reads the git-forge token from the `GIT_TOKEN` env var (or `--git-token`), not `GITHUB_TOKEN`. Both jobs were setting `GITHUB_TOKEN`, so release-pr failed with "please provide the git token" and release with "git release not configured". Rename the env var to `GIT_TOKEN`.