### PR TITLE
docs(readme): add missing crates to the crates table

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ The following gantz crates are included in this repo.
 |---|---|---|
 | **`gantz_base`** | [![Crates.io](https://img.shields.io/crates/v/gantz_base.svg)](https://crates.io/crates/gantz_base) | Embedded base node export for gantz. |
 | **`gantz_ca`** | [![Crates.io](https://img.shields.io/crates/v/gantz_ca.svg)](https://crates.io/crates/gantz_ca) | The gantz content addressing abstractions. |
+| **`gantz_ca_derive`** | [![Crates.io](https://img.shields.io/crates/v/gantz_ca_derive.svg)](https://crates.io/crates/gantz_ca_derive) | Derive macro for the `CaHash` content-addressing trait. |
 | **`gantz_core`** | [![Crates.io](https://img.shields.io/crates/v/gantz_core.svg)](https://crates.io/crates/gantz_core) | The core node and graph abstractions. |
 | **`gantz_std`** | [![Crates.io](https://img.shields.io/crates/v/gantz_std.svg)](https://crates.io/crates/gantz_std) | A standard library of commonly useful nodes. |
+| **`gantz_format`** | [![Crates.io](https://img.shields.io/crates/v/gantz_format.svg)](https://crates.io/crates/gantz_format) | Human-readable text format for gantz graph registries. |
 | **`gantz_egui`** | [![Crates.io](https://img.shields.io/crates/v/gantz_egui.svg)](https://crates.io/crates/gantz_egui) | UI traits and widgets that make up the gantz GUI. |
 | **`bevy_gantz`** | [![Crates.io](https://img.shields.io/crates/v/bevy_gantz.svg)](https://crates.io/crates/bevy_gantz) | A bevy plugin for gantz. |
 | **`bevy_gantz_egui`** | [![Crates.io](https://img.shields.io/crates/v/bevy_gantz_egui.svg)](https://crates.io/crates/bevy_gantz_egui) | Bevy and egui integration for gantz. |


### PR DESCRIPTION
List `gantz_ca_derive` and `gantz_format` in the Crates table, kept in roughly topological order.