### PR TITLE
fix(command-palette): keep palette open when interacting with scrollbar

### DIFF
--- a/crates/gantz_egui/src/widget/command_palette.rs
+++ b/crates/gantz_egui/src/widget/command_palette.rs
@@ -17,24 +17,6 @@ pub trait Command: Copy + Sized {
     }
 }
 
-/// The egui responses from the command palette's content widgets.
-struct ContentResponses {
-    /// The query text input.
-    text_input: egui::Response,
-    /// Union of all alternative item responses, if any were shown.
-    items: Option<egui::Response>,
-}
-
-impl ContentResponses {
-    /// Fold all content responses into a single combined response.
-    fn combined(&self) -> egui::Response {
-        match &self.items {
-            Some(items) => self.text_input.union(items.clone()),
-            None => self.text_input.clone(),
-        }
-    }
-}
-
 #[derive(Default, serde::Deserialize, serde::Serialize)]
 pub struct CommandPalette {
     visible: bool,
@@ -87,28 +69,21 @@ impl CommandPalette {
                 .inner
             });
 
-        // Close on click outside the palette.
+        // Close on a click outside the palette. `clicked_elsewhere` tests the
+        // window's rect geometrically, so interacting with inner widgets (the
+        // text field, list items, scrollbar) never reads as an outside click.
         if let Some(ref resp) = window_response {
-            if let Some((_, content)) = &resp.inner {
-                let combined = resp.response.union(content.combined());
-                let interacted = combined.hovered() || combined.is_pointer_button_down_on();
-                if egui_ctx.input(|i| i.pointer.any_pressed()) && !interacted {
-                    self.visible = false;
-                    self.query.clear();
-                    return None;
-                }
+            if resp.response.clicked_elsewhere() {
+                self.visible = false;
+                self.query.clear();
+                return None;
             }
         }
 
-        let (selected, _) = window_response?.inner?;
-        selected
+        window_response?.inner?
     }
 
-    fn window_content_ui<T: Command>(
-        &mut self,
-        ui: &mut egui::Ui,
-        commands: &[T],
-    ) -> (Option<T>, ContentResponses) {
+    fn window_content_ui<T: Command>(&mut self, ui: &mut egui::Ui, commands: &[T]) -> Option<T> {
         // Check _before_ we add the `TextEdit`, so it doesn't steal it.
         let enter_pressed = ui.input_mut(|i| i.consume_key(Default::default(), Key::Enter));
 
@@ -124,23 +99,18 @@ impl CommandPalette {
             scroll_to_selected_alternative = true;
         }
 
-        let (selected_command, items_response) = egui::ScrollArea::vertical()
+        let selected_command = egui::ScrollArea::vertical()
             .auto_shrink([false, true])
             .show(ui, |ui| {
                 self.alternatives_ui(ui, commands, enter_pressed, scroll_to_selected_alternative)
             })
             .inner;
 
-        let content_responses = ContentResponses {
-            text_input: text_response,
-            items: items_response,
-        };
-
         if selected_command.is_some() {
             *self = Self::new();
         }
 
-        (selected_command, content_responses)
+        selected_command
     }
 
     fn alternatives_ui<T: Command>(
@@ -149,7 +119,7 @@ impl CommandPalette {
         commands: &[T],
         enter_pressed: bool,
         mut scroll_to_selected_alternative: bool,
-    ) -> (Option<T>, Option<egui::Response>) {
+    ) -> Option<T> {
         scroll_to_selected_alternative |= ui.input(|i| i.key_pressed(Key::ArrowUp));
         scroll_to_selected_alternative |= ui.input(|i| i.key_pressed(Key::ArrowDown));
 
@@ -160,7 +130,6 @@ impl CommandPalette {
 
         let mut num_alternatives: usize = 0;
         let mut selected_command = None;
-        let mut items_response: Option<egui::Response> = None;
 
         let matches = commands_that_match(&query, commands);
 
@@ -181,12 +150,6 @@ impl CommandPalette {
 
             let selected = i == self.selected_alternative;
             let style = ui.style().interact_selectable(&response, selected);
-
-            // Collect for hover merging (response not used after this point).
-            items_response = Some(match items_response.take() {
-                Some(prev) => prev.union(response),
-                None => response,
-            });
 
             if selected {
                 ui.painter()
@@ -245,7 +208,7 @@ impl CommandPalette {
             .selected_alternative
             .clamp(0, num_alternatives.saturating_sub(1));
 
-        (selected_command, items_response)
+        selected_command
     }
 }
 


### PR DESCRIPTION
Closing on "press outside" used a union of the window, text-field and list-item responses and tested `hovered()`/`is_pointer_button_down_on()`. Those are topmost-widget signals, so the `ScrollArea`'s scrollbar stole the interaction; a scrollbar press read as an outside click and closed the palette.

Replace the bespoke union with egui's `clicked_elsewhere()`, which tests the window rect geometrically via `contains_pointer()` and is never stolen by child widgets. Drop the now-unused `ContentResponses` plumbing.