### PR TITLE
feat(named-ref): guard against reference cycles when adding a `NamedRef`

### DIFF
--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -892,6 +892,7 @@ pub fn on_paste<N>(
         + serde::Serialize
         + serde::de::DeserializeOwned
         + ca::CaHash
+        + gantz_egui::sync::AsNamedRef
         + Send
         + Sync,
 {
@@ -903,6 +904,10 @@ pub fn on_paste<N>(
         log::error!("PasteSelection: head not found for entity {:?}", event.head);
         return;
     };
+    let editing = match &**head_ref {
+        ca::Head::Branch(name) => Some(name.clone()),
+        ca::Head::Commit(_) => None,
+    };
     let Some(head_state) = gui_state.open_heads.get_mut(&**head_ref) else {
         log::error!("PasteSelection: GUI state not found for head");
         return;
@@ -910,6 +915,7 @@ pub fn on_paste<N>(
 
     let pasted = gantz_egui::ops::paste(
         &mut registry,
+        editing.as_deref(),
         &mut views,
         &mut demos,
         &mut wg,

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -79,6 +79,7 @@ where
         + gantz_ca::CaHash
         + From<gantz_egui::node::NamedRef>
         + gantz_egui::sync::AsNamedRefMut
+        + gantz_egui::sync::AsNamedRef
         + gantz_egui::NodeUi
         + node::ToFrameBang
         + serde::Serialize
@@ -688,12 +689,21 @@ pub fn on_create_node<N>(
     mut heads: Query<head::OpenHeadData<N>, With<head::OpenHead>>,
     mut views_query: Query<&mut GraphView, With<head::OpenHead>>,
 ) where
-    N: 'static + Node + From<gantz_egui::node::NamedRef> + Send + Sync,
+    N: 'static
+        + Node
+        + From<gantz_egui::node::NamedRef>
+        + gantz_egui::sync::AsNamedRef
+        + Send
+        + Sync,
 {
     let event = trigger.event();
     let Ok(mut data) = heads.get_mut(event.head) else {
         log::error!("CreateNode: head not found for entity {:?}", event.head);
         return;
+    };
+    let editing = match &**data.head_ref {
+        ca::Head::Branch(name) => Some(name.clone()),
+        ca::Head::Commit(_) => None,
     };
     let Ok(mut views) = views_query.get_mut(event.head) else {
         log::error!("CreateNode: views not found for entity {:?}", event.head);
@@ -707,6 +717,8 @@ pub fn on_create_node<N>(
     let node_reg = registry_ref(&registry, &builtins, &demos);
     let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
     gantz_egui::ops::create_node(
+        node_reg.ca_registry(),
+        editing.as_deref(),
         &get_node,
         |node_type| node_reg.create_node(node_type),
         &mut data.working_graph,
@@ -1248,7 +1260,13 @@ pub fn update<N>(
     mut cmds: Commands,
 ) -> Result
 where
-    N: 'static + Node + gantz_ca::CaHash + gantz_egui::NodeUi + Send + Sync,
+    N: 'static
+        + Node
+        + gantz_ca::CaHash
+        + gantz_egui::NodeUi
+        + gantz_egui::sync::AsNamedRef
+        + Send
+        + Sync,
 {
     let ctx = ctxs.ctx_mut()?;
 

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -60,6 +60,12 @@ impl gantz_egui::sync::AsNamedRefMut for Box<dyn Node> {
     }
 }
 
+impl gantz_egui::sync::AsNamedRef for Box<dyn Node> {
+    fn as_named_ref(&self) -> Option<&gantz_egui::node::NamedRef> {
+        ((&**self) as &dyn Any).downcast_ref::<gantz_egui::node::NamedRef>()
+    }
+}
+
 impl bevy_gantz_egui::node::ToFrameBang for Box<dyn Node> {
     fn to_frame_bang(&self) -> Option<&bevy_gantz_egui::node::FrameBang> {
         let any: &dyn std::any::Any = &**self;

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -153,6 +153,10 @@ impl gantz_egui::Registry for Environment {
             .map(|g| g as &dyn gantz_core::Node)
     }
 
+    fn would_ref_cycle(&self, target: &str, editing: &str) -> bool {
+        gantz_egui::cycle::would_cycle(&self.registry, target, editing)
+    }
+
     fn socket_doc(
         &self,
         ca: &gantz_ca::ContentAddr,
@@ -270,6 +274,12 @@ impl From<gantz_egui::node::NamedRef> for Box<dyn Node> {
 impl gantz_egui::sync::AsNamedRefMut for Box<dyn Node> {
     fn as_named_ref_mut(&mut self) -> Option<&mut gantz_egui::node::NamedRef> {
         ((&mut **self) as &mut dyn Any).downcast_mut::<gantz_egui::node::NamedRef>()
+    }
+}
+
+impl gantz_egui::sync::AsNamedRef for Box<dyn Node> {
+    fn as_named_ref(&self) -> Option<&gantz_egui::node::NamedRef> {
+        ((&**self) as &dyn Any).downcast_ref::<gantz_egui::node::NamedRef>()
     }
 }
 
@@ -976,13 +986,19 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
     }
 
     for (head, create) in responses.take::<gantz_egui::CreateNode>() {
-        let Some((_, ix)) = tagged_head(state, head) else {
+        let Some((head, ix)) = tagged_head(state, head) else {
             continue;
+        };
+        let editing = match head {
+            gantz_ca::Head::Branch(name) => Some(name),
+            gantz_ca::Head::Commit(_) => None,
         };
         let env = &state.env;
         let get_node = |ca: &gantz_ca::ContentAddr| env.node(ca);
         let (_, graph, view) = &mut state.heads[ix];
         gantz_egui::ops::create_node(
+            &state.env.registry,
+            editing.as_deref(),
             &get_node,
             |node_type| env.new_node(node_type),
             graph,

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -1044,10 +1044,15 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
         };
         // In eframe, Event::Paste provides text directly.
         let Some(text) = text else { continue };
+        let editing = match &head {
+            gantz_ca::Head::Branch(name) => Some(name.clone()),
+            gantz_ca::Head::Commit(_) => None,
+        };
         let head_state = state.gantz.open_heads.entry(head).or_default();
         let (_, graph, gv) = &mut state.heads[ix];
         let pasted = gantz_egui::ops::paste(
             &mut state.env.registry,
+            editing.as_deref(),
             &mut HashMap::new(),
             &mut HashMap::new(),
             graph,

--- a/crates/gantz_egui/src/cycle.rs
+++ b/crates/gantz_egui/src/cycle.rs
@@ -1,0 +1,92 @@
+//! Detecting reference cycles among named graphs.
+//!
+//! Adding a [`NamedRef`](crate::node::NamedRef) to the graph it lives in -
+//! directly, or transitively through the referenced graph's own named
+//! references - would form a reference cycle. With `sync` enabled such a cycle
+//! recommits endlessly (a parent chases its own moving commit), so creation is
+//! refused up-front. This is the live-editor counterpart of `gantz_format`'s
+//! load-time `CycleInRefs` check.
+
+use crate::sync::AsNamedRef;
+use gantz_ca::Registry;
+use gantz_core::node::graph::Graph;
+use std::collections::HashSet;
+
+/// Whether inserting a reference to the graph named `target` into the graph
+/// named `editing` would create a reference cycle.
+///
+/// A cycle exists when `editing` is reachable from `target` through named
+/// references at any depth - including the trivial `target == editing`. Names
+/// that resolve to no graph (e.g. builtins) simply contribute no edges.
+pub fn would_cycle<N>(registry: &Registry<Graph<N>>, target: &str, editing: &str) -> bool
+where
+    N: AsNamedRef,
+{
+    let mut stack = vec![target];
+    let mut visited = HashSet::new();
+    while let Some(name) = stack.pop() {
+        if name == editing {
+            return true;
+        }
+        if !visited.insert(name) {
+            continue;
+        }
+        let Some(&commit) = registry.names().get(name) else {
+            continue;
+        };
+        let Some(graph) = registry.commit_graph_ref(&commit) else {
+            continue;
+        };
+        for weight in graph.node_weights() {
+            if let Some(named_ref) = weight.as_named_ref() {
+                stack.push(named_ref.name());
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::NamedRef;
+
+    /// Commit a graph of `NamedRef`s (one per referenced name) under `name`.
+    fn commit_named_refs(registry: &mut Registry<Graph<NamedRef>>, name: &str, refs: &[&str]) {
+        let mut graph = Graph::<NamedRef>::default();
+        for &r in refs {
+            // The referenced content address is irrelevant to the name-based
+            // walk; point each ref at the target name's current commit if known,
+            // else a placeholder derived from an empty graph.
+            let ca: gantz_ca::ContentAddr = registry
+                .names()
+                .get(r)
+                .copied()
+                .map(Into::into)
+                .unwrap_or_else(|| gantz_ca::graph_addr(&Graph::<NamedRef>::default()).into());
+            graph.add_node(NamedRef::new(r.to_string(), gantz_core::node::Ref::new(ca)));
+        }
+        let graph_ca = gantz_ca::graph_addr(&graph);
+        registry.commit_graph_to_name(std::time::Duration::ZERO, graph_ca, || graph, name);
+    }
+
+    #[test]
+    fn detects_cycles_by_name() {
+        let mut registry = Registry::<Graph<NamedRef>>::default();
+        // `a` references `b`; `b` references `a`.
+        commit_named_refs(&mut registry, "b", &[]);
+        commit_named_refs(&mut registry, "a", &["b"]);
+        commit_named_refs(&mut registry, "b", &["a"]);
+        // An unrelated standalone graph.
+        commit_named_refs(&mut registry, "c", &[]);
+
+        // Self-reference.
+        assert!(would_cycle(&registry, "a", "a"));
+        // `b` reaches `a`, so referencing `b` from `a` closes the loop.
+        assert!(would_cycle(&registry, "b", "a"));
+        // `c` references nothing - safe.
+        assert!(!would_cycle(&registry, "c", "a"));
+        // An unknown / builtin name resolves to no graph - safe.
+        assert!(!would_cycle(&registry, "not-a-name", "a"));
+    }
+}

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -9,6 +9,7 @@ use steel::{
     steel_vm::engine::Engine,
 };
 
+pub mod cycle;
 pub mod export;
 pub mod format;
 mod impls;
@@ -56,6 +57,17 @@ pub use widget::graph_select::GraphRegistry;
 pub trait Registry: NameRegistry + FnNodeNames + NodeTypeRegistry + GraphRegistry {
     /// Look up a node by content address.
     fn node(&self, ca: &gantz_ca::ContentAddr) -> Option<&dyn gantz_core::Node>;
+
+    /// Whether referencing the graph named `target` from the graph named
+    /// `editing` would create a reference cycle (see [`cycle::would_cycle`]).
+    ///
+    /// Used by the command palette to hide node types that would form a cycle.
+    /// The default is conservative (never a cycle); the standard [`RegistryRef`]
+    /// implementation walks the registry.
+    fn would_ref_cycle(&self, target: &str, editing: &str) -> bool {
+        let _ = (target, editing);
+        false
+    }
 
     /// Get the demo graph name for a node at the given content address.
     fn demo_graph(&self, ca: &gantz_ca::ContentAddr) -> Option<&str> {

--- a/crates/gantz_egui/src/node/named_ref.rs
+++ b/crates/gantz_egui/src/node/named_ref.rs
@@ -125,6 +125,12 @@ impl NamedRef {
     }
 }
 
+impl crate::sync::AsNamedRef for NamedRef {
+    fn as_named_ref(&self) -> Option<&NamedRef> {
+        Some(self)
+    }
+}
+
 impl Node for NamedRef {
     fn n_inputs(&self, ctx: MetaCtx) -> usize {
         self.ref_.n_inputs(ctx)

--- a/crates/gantz_egui/src/ops.rs
+++ b/crates/gantz_egui/src/ops.rs
@@ -6,6 +6,7 @@
 //! thin adapters around identical behaviour. Frontend-specific effects
 //! (clipboard access, file dialogs, head navigation) stay with the caller.
 
+use crate::sync::AsNamedRef;
 use crate::widget::gantz::OpenHeadState;
 use crate::widget::graph_scene::NodeIndex;
 use crate::{CreateNode, InspectEdge, PastePos, export, node::NamedRef};
@@ -235,6 +236,7 @@ pub fn inspect_edge<N>(
 /// their state initialized.
 pub fn paste<N>(
     registry: &mut gantz_ca::Registry<Graph<N>>,
+    editing: Option<&str>,
     all_views: &mut HashMap<CommitAddr, egui_graph::View>,
     all_demos: &mut HashMap<CommitAddr, String>,
     graph: &mut Graph<N>,
@@ -244,7 +246,7 @@ pub fn paste<N>(
     pos: &PastePos,
 ) -> bool
 where
-    N: Clone + Serialize + DeserializeOwned + CaHash + 'static,
+    N: Clone + Serialize + DeserializeOwned + CaHash + AsNamedRef + 'static,
 {
     let copied: export::Copied<N> = match export::copied_from_str(text) {
         Ok(c) => c,
@@ -253,6 +255,27 @@ where
             return false;
         }
     };
+
+    // Refuse the whole paste if any pasted `NamedRef` would reference the
+    // editing graph (a cycle); with sync on such a cycle recommits endlessly
+    // (see `crate::cycle`). Checked against the live registry before merging, so
+    // a refused paste mutates nothing. A nameless (detached commit) head can't
+    // be a name-based cycle target.
+    if let Some(editing) = editing {
+        if let Some(named) = copied
+            .graph
+            .node_weights()
+            .filter_map(|n| n.as_named_ref())
+            .find(|nr| crate::cycle::would_cycle(registry, nr.name(), editing))
+        {
+            log::warn!(
+                "Paste: '{}' would create a reference cycle in '{editing}'; skipping paste",
+                named.name()
+            );
+            return false;
+        }
+    }
+
     let offset = crate::resolve_paste_offset(pos, &copied.positions);
 
     let new_indices = export::paste(

--- a/crates/gantz_egui/src/ops.rs
+++ b/crates/gantz_egui/src/ops.rs
@@ -89,6 +89,8 @@ where
 ///
 /// Returns the index of the new node.
 pub fn create_node<N>(
+    registry: &gantz_ca::Registry<Graph<N>>,
+    editing: Option<&str>,
     get_node: GetNode,
     new_node: impl FnOnce(&str) -> Option<N>,
     graph: &mut Graph<N>,
@@ -97,9 +99,16 @@ pub fn create_node<N>(
     cmd: CreateNode,
 ) -> Option<NodeIndex>
 where
-    N: gantz_core::Node,
+    N: gantz_core::Node + crate::sync::AsNamedRef,
 {
     let CreateNode { node_type } = cmd;
+    // Refuse references that would form a cycle back to the editing graph; with
+    // sync on such a cycle recommits endlessly (see `crate::cycle`). A nameless
+    // (detached commit) head can't be the target of a name-based cycle.
+    if editing.is_some_and(|editing| crate::cycle::would_cycle(registry, &node_type, editing)) {
+        log::warn!("CreateNode: '{node_type}' would create a reference cycle; skipping");
+        return None;
+    }
     let Some(node) = new_node(&node_type) else {
         log::error!("CreateNode: unknown node type: {node_type}");
         return None;

--- a/crates/gantz_egui/src/reg.rs
+++ b/crates/gantz_egui/src/reg.rs
@@ -161,9 +161,15 @@ impl<N: 'static + Node + Send + Sync> FnNodeNames for RegistryRef<'_, N> {
     }
 }
 
-impl<N: 'static + Node + crate::NodeUi + Send + Sync> Registry for RegistryRef<'_, N> {
+impl<N: 'static + Node + crate::NodeUi + crate::sync::AsNamedRef + Send + Sync> Registry
+    for RegistryRef<'_, N>
+{
     fn node(&self, ca: &ca::ContentAddr) -> Option<&dyn Node> {
         RegistryRef::node(self, ca)
+    }
+
+    fn would_ref_cycle(&self, target: &str, editing: &str) -> bool {
+        crate::cycle::would_cycle(self.ca_registry, target, editing)
     }
 
     fn demo_graph(&self, ca: &ca::ContentAddr) -> Option<&str> {

--- a/crates/gantz_egui/src/sync.rs
+++ b/crates/gantz_egui/src/sync.rs
@@ -23,6 +23,15 @@ pub trait AsNamedRefMut {
     fn as_named_ref_mut(&mut self) -> Option<&mut NamedRef>;
 }
 
+/// Access the [`NamedRef`] within a frontend's node type, if any.
+///
+/// The read-only companion to [`AsNamedRefMut`], used by the reference-cycle
+/// check (`crate::cycle`) to walk a graph's named references without mutating.
+pub trait AsNamedRef {
+    /// A shared reference to the inner [`NamedRef`], if this node is one.
+    fn as_named_ref(&self) -> Option<&NamedRef>;
+}
+
 /// A named graph whose commit moved during [`resync`] or a rename cascade.
 #[derive(Clone, Debug)]
 pub struct Moved {

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -865,7 +865,12 @@ where
 
                     // Skip command palette when immutable.
                     if !focused_immutable {
-                        let created = command_palette(gantz.env, &mut state.command_palette, ui);
+                        let editing = match &fh {
+                            gantz_ca::Head::Branch(name) => Some(name.as_str()),
+                            _ => None,
+                        };
+                        let created =
+                            command_palette(gantz.env, editing, &mut state.command_palette, ui);
                         match created {
                             Some(PaletteChoice::Node(create)) => {
                                 gantz_response.responses.push(Some(fh), create);
@@ -2028,8 +2033,12 @@ enum PaletteChoice {
 }
 
 /// Returns a node-creation payload when a node type is chosen.
+///
+/// `editing` is the focused head's name (when it is a branch), used to hide node
+/// types whose reference would cycle back to the graph being edited.
 fn command_palette(
     env: &dyn Registry,
+    editing: Option<&str>,
     cmd_palette: &mut widget::CommandPalette,
     ui: &mut egui::Ui,
 ) -> Option<PaletteChoice> {
@@ -2040,8 +2049,14 @@ fn command_palette(
         }
     }
 
-    // Map the node types to commands for the command palette.
-    let types = env.node_types();
+    // Map the node types to commands for the command palette, dropping any type
+    // whose reference would form a cycle back to the editing graph. The reserved
+    // nested-graph entry always mints a fresh child, so it is never cyclic.
+    let types: Vec<&str> = env
+        .node_types()
+        .into_iter()
+        .filter(|&k| k == NESTED_GRAPH_TYPE || editing.is_none_or(|e| !env.would_ref_cycle(k, e)))
+        .collect();
     let cmds = types.iter().map(|&k| NodeTyCmd { env, name: k });
 
     // The chosen node type becomes a creation payload. The reserved


### PR DESCRIPTION
Adding a `NamedRef` to a graph that is reachable from the referenced graph (self-reference, or an ancestor at any depth) forms a reference cycle.

With `sync` enabled such a cycle recommits endlessly - each frame the inner ref chases the editing graph's latest commit, changing its address and leaking memory.

Add a name-based reachability check (`cycle::would_cycle`) over the live registry's name DAG, mirroring `gantz_format`'s load-time `CycleInRefs` check.

Enforce it in two layers:

- Authoritative guard in the shared `ops::create_node`, so creation is refused regardless of how it is triggered. `editing` is `Option<&str>`: a detached commit head has no name and cannot be a cycle target, so the
  check is skipped there.
- Command-palette filtering via a new `Registry::would_ref_cycle` probe, so cyclic graph names are never offered. The reserved nested-graph entry is always kept (it mints a fresh child).

Add an immutable `sync::AsNamedRef` trait (companion to `AsNamedRefMut`) so the walk can downcast erased nodes; implement it for `Box<dyn Node>` and `NamedRef`.