### PR TITLE
feat(expr): always expose at least one (trigger) input

### DIFF
--- a/crates/gantz_core/src/node/expr.rs
+++ b/crates/gantz_core/src/node/expr.rs
@@ -19,6 +19,14 @@ use thiserror::Error;
 /// Variables are identified by unique names - if the same `$var` appears
 /// multiple times in the expression, it refers to the same inlet.
 ///
+/// ## Trigger input
+///
+/// An expression always has at least one input. When it contains no `$vars`
+/// (e.g. `(list 1 2 3)`), it still exposes a single *trigger* input whose value
+/// is ignored; a push into it simply forces the expression to evaluate. This
+/// makes it easy to author constant values that fire on demand without a dummy
+/// `$bang` variable.
+///
 /// ## Optional inputs
 ///
 /// Variables prefixed with `$?` are treated as optional inputs. When
@@ -219,7 +227,9 @@ pub(crate) fn interpolate_tokens(
 
 impl Node for Expr {
     fn n_inputs(&self, _ctx: node::MetaCtx) -> usize {
-        self.vars.len()
+        // Always expose at least one input. With no `$vars`, the single input
+        // is a trigger whose value is ignored (see the type docs).
+        self.vars.len().max(1)
     }
 
     fn n_outputs(&self, _ctx: node::MetaCtx) -> usize {
@@ -314,6 +324,24 @@ fn test_collect_unique_vars() {
     // Mixed required and optional.
     let vars = vars_from_src("(+ $a $?b $?c)");
     assert_eq!(vars, vec!["$a", "$?b", "$?c"]);
+}
+
+// A no-op node lookup for constructing a `MetaCtx` in tests.
+#[cfg(test)]
+fn no_lookup(_: &gantz_ca::ContentAddr) -> Option<&'static dyn Node> {
+    None
+}
+
+#[test]
+fn test_n_inputs_min_one() {
+    let ctx = || node::MetaCtx::new(&no_lookup);
+    // No `$vars` - still exposes a single trigger input.
+    assert_eq!(Expr::new("(list 1 2 3)").unwrap().n_inputs(ctx()), 1);
+    assert_eq!(Expr::new("42").unwrap().n_inputs(ctx()), 1);
+    // A single var.
+    assert_eq!(Expr::new("$foo").unwrap().n_inputs(ctx()), 1);
+    // Multiple vars are unaffected.
+    assert_eq!(Expr::new("(+ $l $r)").unwrap().n_inputs(ctx()), 2);
 }
 
 #[test]

--- a/crates/gantz_core/tests/graph.rs
+++ b/crates/gantz_core/tests/graph.rs
@@ -115,6 +115,47 @@ fn test_graph_push_eval() {
         .unwrap();
 }
 
+// A `0`-var `expr` exposes a single trigger input whose value is ignored. A push
+// into that input still forces the expression to evaluate. Here two constant
+// exprs are fired via their trigger inputs and compared, proving the
+// connected-but-unreferenced trigger param compiles and the constants propagate.
+#[test]
+fn test_expr_trigger_input() {
+    let mut g = petgraph::graph::DiGraph::new();
+
+    // `left` and `right` have no `$vars`, so each has a single trigger input.
+    let push = node_push();
+    let left = node::expr("(+ 1 2)").unwrap();
+    let right = node::expr("3").unwrap();
+    let assert_eq = node_assert_eq();
+
+    let push = g.add_node(Box::new(push) as Box<dyn DebugNode>);
+    let left = g.add_node(Box::new(left) as Box<_>);
+    let right = g.add_node(Box::new(right) as Box<_>);
+    let assert_eq = g.add_node(Box::new(assert_eq) as Box<_>);
+
+    // The push fires both constants via their trigger inputs.
+    g.add_edge(push, left, Edge::from((0, 0)));
+    g.add_edge(push, right, Edge::from((0, 0)));
+    g.add_edge(left, assert_eq, Edge::from((0, 0)));
+    g.add_edge(right, assert_eq, Edge::from((0, 1)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    for f in module {
+        vm.run(format!("{f}")).unwrap();
+    }
+    let ep = entrypoint::push(vec![push.index()], g[push].n_outputs(ctx) as u8);
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep.id()), vec![])
+        .unwrap();
+}
+
 // A simple test graph that adds two "one"s and checks that it equals "two".
 //
 //    -+-----

--- a/crates/gantz_egui/src/impls/bang.rs
+++ b/crates/gantz_egui/src/impls/bang.rs
@@ -25,7 +25,9 @@ impl NodeUi for gantz_std::Bang {
                 SocketDoc::ty("bang")
                     .with_description("empty list '() emitted to trigger downstream evaluation"),
             ),
-            SocketKind::Input => None,
+            SocketKind::Input => {
+                Some(SocketDoc::ty("trigger").with_description("ignored; emits a bang when pushed"))
+            }
         }
     }
 }

--- a/crates/gantz_egui/src/impls/expr.rs
+++ b/crates/gantz_egui/src/impls/expr.rs
@@ -113,15 +113,21 @@ impl NodeUi for gantz_core::node::Expr {
 
     fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, ix: usize) -> Option<SocketDoc> {
         match kind {
-            SocketKind::Input => {
-                let var = self.vars().get(ix)?;
-                let desc = if var.starts_with("$?") {
-                    "optional input; bound as (Some value) or (None)"
-                } else {
-                    "substituted into the expression"
-                };
-                Some(SocketDoc::ty(var.clone()).with_description(desc))
-            }
+            SocketKind::Input => match self.vars().get(ix) {
+                Some(var) => {
+                    let desc = if var.starts_with("$?") {
+                        "optional input; bound as (Some value) or (None)"
+                    } else {
+                        "substituted into the expression"
+                    };
+                    Some(SocketDoc::ty(var.clone()).with_description(desc))
+                }
+                // The synthetic trigger input present when there are no `$vars`.
+                None => Some(
+                    SocketDoc::ty("trigger")
+                        .with_description("ignored; forces the expression to evaluate"),
+                ),
+            },
             SocketKind::Output if self.outputs() <= 1 => {
                 Some(SocketDoc::ty("any").with_description("expression result"))
             }

--- a/crates/gantz_std/src/bang.rs
+++ b/crates/gantz_std/src/bang.rs
@@ -3,11 +3,20 @@ use gantz_core::node::{EvalConf, ExprCtx, ExprResult, MetaCtx};
 use serde::{Deserialize, Serialize};
 
 /// A simple node for pushing evaluation through the graph.
+///
+/// Exposes a single *trigger* input whose value is ignored: a push into it
+/// emits a bang (`'()`) downstream. This lets a bang be fired from upstream as
+/// well as from its button, normalising any value to a bang.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Deserialize, Serialize, CaHash)]
 #[cahash("gantz.bang")]
 pub struct Bang;
 
 impl gantz_core::Node for Bang {
+    /// A single trigger input whose value is ignored.
+    fn n_inputs(&self, _ctx: MetaCtx) -> usize {
+        1
+    }
+
     fn n_outputs(&self, _ctx: MetaCtx) -> usize {
         1
     }

--- a/crates/gantz_std/tests/bang.rs
+++ b/crates/gantz_std/tests/bang.rs
@@ -1,0 +1,51 @@
+//! Tests for the bang node's trigger input: a `Bang` ignores its input value
+//! and emits a bang (`'()`) downstream when pushed.
+
+use gantz_core::{
+    Edge, Node,
+    compile::{EvalKind, entry_fn_name, push_pull_entrypoints},
+    node::{self, WithPushEval},
+};
+use std::fmt::Debug;
+
+trait DebugNode: Debug + Node {}
+impl<T> DebugNode for T where T: Debug + Node {}
+
+// A no-op node lookup function for tests that don't need it.
+fn no_lookup(_: &gantz_ca::ContentAddr) -> Option<&'static dyn Node> {
+    None
+}
+
+// Firing a value into a bang's trigger input emits `'()` downstream. The
+// downstream `check` asserts it received an empty list, so a successful fire
+// proves the bang ignored its input and emitted a bang.
+#[test]
+fn bang_trigger_input_emits_bang() {
+    let mut g = petgraph::graph::DiGraph::new();
+    let push =
+        g.add_node(Box::new(node::expr("'()").unwrap().with_push_eval()) as Box<dyn DebugNode>);
+    // A constant value, fired by the push via its own trigger input.
+    let val = g.add_node(Box::new(node::expr("42").unwrap()) as Box<_>);
+    // The bang ignores `val`'s output and emits `'()`.
+    let bang = g.add_node(Box::new(gantz_std::Bang::default()) as Box<_>);
+    // Assert the bang emitted an empty list.
+    let check = g.add_node(Box::new(node::expr("(assert! (equal? $b '()))").unwrap()) as Box<_>);
+    g.add_edge(push, val, Edge::from((0, 0)));
+    g.add_edge(val, bang, Edge::from((0, 0)));
+    g.add_edge(bang, check, Edge::from((0, 0)));
+
+    let config = gantz_core::compile::Config::default();
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let (mut vm, _compiled) = gantz_core::vm::init(&no_lookup, &g, &eps, &config)
+        .unwrap_or_else(|e| panic!("init: {}", gantz_core::vm::error_chain(&e)));
+
+    let ep = eps
+        .iter()
+        .find(|ep| {
+            ep.0.iter()
+                .any(|s| s.kind == EvalKind::Push && s.path == [push.index()])
+        })
+        .expect("push entrypoint");
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep.id()), vec![])
+        .expect("firing bang trigger errored");
+}


### PR DESCRIPTION
An `expr` with no `$vars` now exposes a single trigger input whose value is ignored; a push into it forces the expression to evaluate.

This makes it easy to author constant values that fire on demand without a dummy `$bang` variable (e.g. `(list 1 2 3)` in place of `(begin $bang (list 1 2 3))`).

`Exprs` with vars are unchanged - `n_inputs` stays `vars.len()`, and content addresses are unaffected.

`Bang` now also exposes a single trigger input whose value is ignored: a push into it emits a bang `('())` downstream. This lets a bang be fired from upstream as well as from its button, normalising any value to a bang.