### PR TITLE
Include graph layout (node positions) in commit history and in turn, undo/redo history

### DIFF
--- a/crates/bevy_gantz/src/head.rs
+++ b/crates/bevy_gantz/src/head.rs
@@ -128,6 +128,10 @@ pub struct ChangedEvent {
     pub entity: Entity,
     pub old_head: ca::Head,
     pub new_head: ca::Head,
+    /// Whether the new commit shares the previous commit's graph content
+    /// address, i.e. only layout/metadata changed (e.g. a layout undo/redo).
+    /// The VM and its node state are preserved across such a change.
+    pub same_graph: bool,
 }
 
 /// Emitted after a branch has been created from a head.
@@ -344,16 +348,28 @@ pub fn on_replace<N>(
         return;
     };
 
-    // The head now points at a different graph: drop the VM (discarding the
-    // old graph's node state) and reset the compile memo so `vm::sync`
-    // performs a fresh init.
+    // When the new commit shares the old commit's graph content (a layout-only
+    // change, e.g. a layout undo/redo), the graph is byte-identical, so keep the
+    // VM and its node state and leave the compile memo intact (`vm::sync` then
+    // skips recompilation). Only when the graph actually differs do we drop the
+    // VM and reset the memo so `vm::sync` performs a fresh init.
     // Note: HeadGuiState and GraphViews are updated by GantzEguiPlugin observer.
-    vms.remove(&focused_entity);
-    cmds.entity(focused_entity).insert((
-        HeadRef(new_head.clone()),
-        WorkingGraph(graph),
-        crate::vm::CompiledInputs::default(),
-    ));
+    let old_graph = old_head
+        .as_ref()
+        .and_then(|h| registry.head_commit(h).map(|c| c.graph));
+    let new_graph = registry.head_commit(new_head).map(|c| c.graph);
+    let same_graph = matches!((old_graph, new_graph), (Some(a), Some(b)) if a == b);
+    if same_graph {
+        cmds.entity(focused_entity)
+            .insert((HeadRef(new_head.clone()), WorkingGraph(graph)));
+    } else {
+        vms.remove(&focused_entity);
+        cmds.entity(focused_entity).insert((
+            HeadRef(new_head.clone()),
+            WorkingGraph(graph),
+            crate::vm::CompiledInputs::default(),
+        ));
+    }
 
     // Emit hook.
     if let Some(old) = old_head {
@@ -361,6 +377,7 @@ pub fn on_replace<N>(
             entity: focused_entity,
             old_head: old,
             new_head: new_head.clone(),
+            same_graph,
         });
     }
 }
@@ -466,21 +483,32 @@ pub fn on_move_branch<N>(
     N: 'static + Clone + Send + Sync,
 {
     let event = trigger.event();
-    registry.insert_name(event.name.clone(), event.target);
     let head = ca::Head::Branch(event.name.clone());
+    // Capture the current graph before moving the branch pointer so we can
+    // detect a same-graph move (a layout-only undo/redo) below.
+    let old_graph = registry.head_commit(&head).map(|c| c.graph);
+    registry.insert_name(event.name.clone(), event.target);
     let Some(graph) = registry.head_graph(&head).cloned() else {
         log::error!("MoveBranch: graph missing for target commit");
         return;
     };
-    // The head now points at a different graph: drop the VM (discarding the
-    // old graph's node state) and reset the compile memo so `vm::sync`
-    // performs a fresh init.
-    vms.remove(&event.entity);
-    cmds.entity(event.entity)
-        .insert((WorkingGraph(graph), crate::vm::CompiledInputs::default()));
+    // When the target shares the old commit's graph content (a layout-only
+    // change), keep the VM, its node state and the compile memo intact so
+    // `vm::sync` skips recompilation. Otherwise drop the VM and reset the memo
+    // so `vm::sync` performs a fresh init.
+    let new_graph = registry.head_commit(&head).map(|c| c.graph);
+    let same_graph = matches!((old_graph, new_graph), (Some(a), Some(b)) if a == b);
+    if same_graph {
+        cmds.entity(event.entity).insert(WorkingGraph(graph));
+    } else {
+        vms.remove(&event.entity);
+        cmds.entity(event.entity)
+            .insert((WorkingGraph(graph), crate::vm::CompiledInputs::default()));
+    }
     cmds.trigger(ChangedEvent {
         entity: event.entity,
         old_head: head.clone(),
         new_head: head,
+        same_graph,
     });
 }

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -152,7 +152,15 @@ where
                 Update,
                 (
                     node::frame_bang::drive_frame_bangs::<N>.after(bevy_gantz::VmSet),
-                    persist_views::<N>,
+                    persist_camera_and_seed::<N>,
+                    // On layout settle, fork a layout-only commit. Runs after
+                    // `VmSet` (so a graph edit commits first and its baseline is
+                    // already seeded - no spurious layout commit) and after the
+                    // camera/seed pass (so the head's baseline exists).
+                    settle_layout::<N>
+                        .after(bevy_gantz::VmSet)
+                        .after(persist_camera_and_seed::<N>)
+                        .run_if(on_message::<bevy_gantz::debounced_input::DebouncedInputEvent>),
                     poll_import_task,
                 ),
             )
@@ -547,6 +555,7 @@ pub fn on_head_changed<N: 'static + Send + Sync>(
     views: Res<Views>,
     mut gui_state: ResMut<GuiState>,
     mut ctxs: EguiContexts,
+    graph_views: Query<&GraphView>,
     mut cmds: Commands,
 ) {
     let event = trigger.event();
@@ -556,10 +565,19 @@ pub fn on_head_changed<N: 'static + Send + Sync>(
     }
 
     // Load the view for the new head's commit.
-    let head_view = registry
+    let mut head_view = registry
         .head_commit_ca(&event.new_head)
         .and_then(|ca| views.get(ca).cloned())
         .unwrap_or_default();
+
+    // Camera (`scene_rect`) is excluded from undo: on a same-graph navigation
+    // (a layout undo/redo) keep the live camera rather than restoring the target
+    // commit's stored camera.
+    if event.same_graph {
+        if let Ok(current) = graph_views.get(event.entity) {
+            head_view.scene_rect = current.scene_rect;
+        }
+    }
 
     cmds.entity(event.entity)
         .insert(HeadGuiState::default())
@@ -1185,18 +1203,75 @@ where
 // Systems
 // ---------------------------------------------------------------------------
 
-/// Persist views for all open heads to the Views resource.
+/// Keep each open head's camera current and seed its commit's layout baseline.
 ///
-/// This runs every frame to capture layout changes (node dragging, etc.)
-/// that occur without graph topology changes.
-pub fn persist_views<N: 'static + Send + Sync>(
+/// Runs every frame. Unlike a blind per-frame copy, this keeps each commit's
+/// stored `layout` (node positions) *frozen* as an undo baseline: it is written
+/// exactly once - when a commit first has a populated live layout - and is never
+/// overwritten in place. Node-position changes only ever produce a *new* commit
+/// (see [`settle_layout`]). The camera (`scene_rect`) is excluded from undo, so
+/// it tracks the live view in place every frame.
+pub fn persist_camera_and_seed<N: 'static + Send + Sync>(
     registry: Res<Registry<N>>,
     mut views: ResMut<Views>,
     heads: Query<(&head::HeadRef, &GraphView), With<head::OpenHead>>,
 ) {
-    for (head_ref, head_views) in heads.iter() {
-        if let Some(commit_addr) = registry.head_commit_ca(&**head_ref).copied() {
-            views.insert(commit_addr, (**head_views).clone());
+    for (head_ref, head_view) in heads.iter() {
+        let Some(commit_addr) = registry.head_commit_ca(&**head_ref).copied() else {
+            continue;
+        };
+        match views.get_mut(&commit_addr) {
+            // Layout frozen as the undo baseline; only the camera tracks live.
+            Some(view) => view.scene_rect = head_view.scene_rect,
+            // Seed the baseline once the scene has laid the graph out. Guarding
+            // on a non-empty layout avoids capturing an empty pre-layout frame.
+            None if !head_view.layout.is_empty() => {
+                views.insert(commit_addr, (**head_view).clone());
+            }
+            None => {}
+        }
+    }
+}
+
+/// On layout settle ([`DebouncedInputEvent`]), fork a layout-only commit for any
+/// open head whose node positions changed since its frozen baseline view.
+///
+/// Mirrors the graph-commit path's GUI bookkeeping (migrate per-head GUI state,
+/// clear redo, migrate the graph pane) but deliberately does *not* fire
+/// [`head::CommittedEvent`]: the graph content is unchanged, so there is nothing
+/// to resync, and firing it would churn every sync-enabled referrer's history
+/// for a pure layout move. `GraphView` is left untouched - it already holds the
+/// settled layout, which now matches the new commit's seeded baseline.
+///
+/// [`DebouncedInputEvent`]: bevy_gantz::debounced_input::DebouncedInputEvent
+pub fn settle_layout<N>(
+    mut registry: ResMut<Registry<N>>,
+    mut views: ResMut<Views>,
+    mut gui_state: ResMut<GuiState>,
+    mut ctxs: EguiContexts,
+    mut heads: Query<(&mut head::HeadRef, &GraphView), With<head::OpenHead>>,
+) where
+    N: 'static + Send + Sync,
+{
+    for (mut head_ref, head_view) in heads.iter_mut() {
+        let old_head = (**head_ref).clone();
+        let Some(new_commit) = gantz_egui::ops::commit_layout(
+            &mut registry,
+            &views,
+            bevy_gantz::reg::timestamp(),
+            &mut head_ref,
+            head_view,
+        ) else {
+            continue;
+        };
+        // Freeze the new commit's layout baseline this frame, before any
+        // debounce-gated `save_views`/export reads the `Views` resource.
+        views.insert(new_commit, (**head_view).clone());
+        // Clear redo (a new commit invalidates it) and migrate GUI state.
+        let new_head = (**head_ref).clone();
+        gui_state.migrate_head(&old_head, &new_head, true);
+        if let Ok(ctx) = ctxs.ctx_mut() {
+            gantz_egui::widget::update_graph_pane_head(ctx, &old_head, &new_head);
         }
     }
 }

--- a/crates/gantz/src/main.rs
+++ b/crates/gantz/src/main.rs
@@ -51,7 +51,11 @@ fn main() {
         .add_systems(EguiPrimaryContextPass, load_egui_memory)
         .add_systems(
             Update,
-            persist_resources.run_if(on_message::<DebouncedInputEvent>),
+            persist_resources
+                // After `settle_layout` so a layout commit settled this frame
+                // (and its seeded view) is saved in the same pass.
+                .after(bevy_gantz_egui::settle_layout::<Box<dyn node::Node>>)
+                .run_if(on_message::<DebouncedInputEvent>),
         )
         .run();
 }
@@ -163,7 +167,8 @@ fn persist_resources(
         }
     }
 
-    // Save all views (kept up to date by `persist_views`).
+    // Save all views (kept up to date by `persist_camera_and_seed` and
+    // `settle_layout`).
     bevy_gantz_egui::storage::save_views(&mut *storage, &*views);
     // Save the gantz GUI state.
     bevy_gantz_egui::storage::save_gui_state(&mut *storage, &gui_state);

--- a/crates/gantz/src/main_update_base.rs
+++ b/crates/gantz/src/main_update_base.rs
@@ -56,6 +56,9 @@ fn main() {
                 bevy_gantz_egui::base::export_to_file::<Box<dyn node::Node>>,
                 persist_state,
             )
+                // After `settle_layout` so a layout commit settled this frame
+                // (and its seeded view) is exported/saved in the same pass.
+                .after(bevy_gantz_egui::settle_layout::<Box<dyn node::Node>>)
                 .run_if(on_message::<DebouncedInputEvent>),
         )
         .run();

--- a/crates/gantz_egui/src/ops.rs
+++ b/crates/gantz_egui/src/ops.rs
@@ -319,3 +319,39 @@ pub fn redo(
 ) -> Option<CommitAddr> {
     redo_stacks.get_mut(head)?.pop()
 }
+
+/// Commit the current layout as a new commit on the head's *existing* graph
+/// when node positions have changed since the head commit's frozen baseline
+/// view, advancing `head` to the new commit.
+///
+/// The graph content is unchanged, so the new commit reuses the head's
+/// [`gantz_ca::GraphAddr`]: the registry dedups the graph (the `graph` closure
+/// passed to [`gantz_ca::Registry::commit_graph_to_head`] is never called) and
+/// the VM does not need to recompile. Only `layout` (node positions) is
+/// compared; `scene_rect` (camera) is excluded, so camera pan/zoom never
+/// produces a layout commit.
+///
+/// Returns the new commit address when a layout commit was created, else `None`
+/// (no baseline view yet - i.e. the head commit's layout has not been seeded -
+/// or no node-position change). Seeding `views[new]`, clearing the redo stack
+/// and migrating GUI state stay with the caller.
+pub fn commit_layout<G>(
+    registry: &mut gantz_ca::Registry<G>,
+    views: &HashMap<CommitAddr, egui_graph::View>,
+    timestamp: gantz_ca::Timestamp,
+    head: &mut gantz_ca::Head,
+    live: &egui_graph::View,
+) -> Option<CommitAddr> {
+    let head_commit_ca = *registry.head_commit_ca(head)?;
+    let baseline = views.get(&head_commit_ca)?;
+    if baseline.layout == live.layout {
+        return None;
+    }
+    let graph_addr = registry.commits().get(&head_commit_ca)?.graph;
+    Some(registry.commit_graph_to_head(
+        timestamp,
+        graph_addr,
+        || unreachable!("layout commit reuses an existing graph"),
+        head,
+    ))
+}


### PR DESCRIPTION
The main win here is enabling undo/redo of node positioning, rather than just changes to the structure of the graph.

See commit msgs for details.