### PR TITLE
feat(palette): place new nodes under the pointer and select them

### DIFF
--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -703,6 +703,7 @@ pub fn on_create_node<N>(
     registry: Res<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
     demos: Res<Demos>,
+    mut gui_state: ResMut<GuiState>,
     mut vms: NonSendMut<head::HeadVms>,
     mut heads: Query<head::OpenHeadData<N>, With<head::OpenHead>>,
     mut views_query: Query<&mut GraphView, With<head::OpenHead>>,
@@ -731,6 +732,10 @@ pub fn on_create_node<N>(
         log::error!("CreateNode: VM not found for entity {:?}", event.head);
         return;
     };
+    let Some(head_state) = gui_state.open_heads.get_mut(&**data.head_ref) else {
+        log::error!("CreateNode: GUI state not found for head");
+        return;
+    };
 
     let node_reg = registry_ref(&registry, &builtins, &demos);
     let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
@@ -741,6 +746,7 @@ pub fn on_create_node<N>(
         |node_type| node_reg.create_node(node_type),
         &mut data.working_graph,
         &mut views,
+        head_state,
         vm,
         event.data.clone(),
     );
@@ -780,6 +786,7 @@ pub fn on_branch_node<N>(
 pub fn on_create_nested_graph<N>(
     trigger: On<ForHead<gantz_egui::CreateNestedGraph>>,
     mut registry: ResMut<Registry<N>>,
+    mut gui_state: ResMut<GuiState>,
     mut heads: Query<head::OpenHeadData<N>, With<head::OpenHead>>,
     mut views_query: Query<&mut GraphView, With<head::OpenHead>>,
 ) where
@@ -804,11 +811,17 @@ pub fn on_create_nested_graph<N>(
         );
         return;
     };
+    let Some(head_state) = gui_state.open_heads.get_mut(&**data.head_ref) else {
+        log::error!("CreateNestedGraph: GUI state not found for head");
+        return;
+    };
     gantz_egui::ops::create_nested_graph(
         &mut registry,
         bevy_gantz::reg::timestamp(),
         &mut data.working_graph,
         &mut views,
+        head_state,
+        event.data.pos,
         &parent,
     );
 }

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -993,10 +993,11 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
         let Some((head, ix)) = tagged_head(state, head) else {
             continue;
         };
-        let editing = match head {
-            gantz_ca::Head::Branch(name) => Some(name),
+        let editing = match &head {
+            gantz_ca::Head::Branch(name) => Some(name.clone()),
             gantz_ca::Head::Commit(_) => None,
         };
+        let head_state = state.gantz.open_heads.entry(head).or_default();
         let env = &state.env;
         let get_node = |ca: &gantz_ca::ContentAddr| env.node(ca);
         let (_, graph, view) = &mut state.heads[ix];
@@ -1007,12 +1008,13 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
             |node_type| env.new_node(node_type),
             graph,
             view,
+            head_state,
             &mut state.vms[ix],
             create,
         );
     }
 
-    for (head, _) in responses.take::<gantz_egui::CreateNestedGraph>() {
+    for (head, create) in responses.take::<gantz_egui::CreateNestedGraph>() {
         let Some((head, ix)) = tagged_head(state, head) else {
             continue;
         };
@@ -1020,12 +1022,19 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
             log::warn!("CreateNestedGraph: name the graph before adding a nested graph");
             continue;
         };
+        let head_state = state
+            .gantz
+            .open_heads
+            .entry(gantz_ca::Head::Branch(parent.clone()))
+            .or_default();
         let (_, graph, view) = &mut state.heads[ix];
         gantz_egui::ops::create_nested_graph(
             &mut state.env.registry,
             timestamp(),
             graph,
             view,
+            head_state,
+            create.pos,
             &parent,
         );
     }

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -318,6 +318,9 @@ pub struct CopyNodes(pub std::collections::HashSet<widget::graph_scene::NodeInde
 pub struct CreateNode {
     /// The type name of the node to create.
     pub node_type: String,
+    /// Where to place the new node, in graph coordinates. When `None`, the node
+    /// is placed at the center of the current view.
+    pub pos: Option<egui::Pos2>,
 }
 
 /// Create a new nested graph in the emitting head's graph.
@@ -327,7 +330,11 @@ pub struct CreateNode {
 /// [`node::NamedRef`] to it. Behaves like creating any
 /// other node, but is registry-aware.
 #[derive(Clone, Copy, Debug)]
-pub struct CreateNestedGraph;
+pub struct CreateNestedGraph {
+    /// Where to place the new node, in graph coordinates. When `None`, the node
+    /// is placed at the center of the current view.
+    pub pos: Option<egui::Pos2>,
+}
 
 /// Evaluate an entrypoint (push or pull).
 #[derive(Clone, Debug)]

--- a/crates/gantz_egui/src/ops.rs
+++ b/crates/gantz_egui/src/ops.rs
@@ -96,13 +96,14 @@ pub fn create_node<N>(
     new_node: impl FnOnce(&str) -> Option<N>,
     graph: &mut Graph<N>,
     view: &mut egui_graph::View,
+    head_state: &mut OpenHeadState,
     vm: &mut Engine,
     cmd: CreateNode,
 ) -> Option<NodeIndex>
 where
     N: gantz_core::Node + crate::sync::AsNamedRef,
 {
-    let CreateNode { node_type } = cmd;
+    let CreateNode { node_type, pos } = cmd;
     // Refuse references that would form a cycle back to the editing graph; with
     // sync on such a cycle recommits endlessly (see `crate::cycle`). A nameless
     // (detached commit) head can't be the target of a name-based cycle.
@@ -121,9 +122,18 @@ where
     let reg_ctx = node::RegCtx::new(get_node, &node_path, vm);
     graph[node_ix].register(reg_ctx);
 
-    // Position the new node at the scene center (or use layout default).
+    // Position the new node under the pointer, falling back to the center of the
+    // current view. `insert` (not `entry`) so a reused stable-graph index can't
+    // inherit a removed node's stale position.
+    let pos = pos.unwrap_or_else(|| view.scene_rect.center());
     let egui_id = egui_graph::NodeId::from_u64(node_ix.index() as u64);
-    view.layout.entry(egui_id).or_insert(egui::Pos2::ZERO);
+    view.layout.insert(egui_id, pos);
+
+    // Make the new node the sole selection (clearing the previous one).
+    let sel = &mut head_state.scene.interaction.selection;
+    sel.nodes.clear();
+    sel.edges.clear();
+    sel.nodes.insert(node_ix);
 
     Some(node_ix)
 }
@@ -139,6 +149,8 @@ pub fn create_nested_graph<N>(
     timestamp: std::time::Duration,
     graph: &mut Graph<N>,
     view: &mut egui_graph::View,
+    head_state: &mut OpenHeadState,
+    pos: Option<egui::Pos2>,
     parent: &str,
 ) -> Option<NodeIndex>
 where
@@ -166,9 +178,18 @@ where
     let named_ref = NamedRef::with_sync(name, node::Ref::new(commit_ca.into()));
     let node_ix = graph.add_node(N::from(named_ref));
 
-    // Position the new node at the scene center (or use layout default).
+    // Position the new node under the pointer, falling back to the center of the
+    // current view. `insert` (not `entry`) so a reused stable-graph index can't
+    // inherit a removed node's stale position.
+    let pos = pos.unwrap_or_else(|| view.scene_rect.center());
     let egui_id = egui_graph::NodeId::from_u64(node_ix.index() as u64);
-    view.layout.entry(egui_id).or_insert(egui::Pos2::ZERO);
+    view.layout.insert(egui_id, pos);
+
+    // Make the new node the sole selection (clearing the previous one).
+    let sel = &mut head_state.scene.interaction.selection;
+    sel.nodes.clear();
+    sel.edges.clear();
+    sel.nodes.insert(node_ix);
 
     Some(node_ix)
 }

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -869,13 +869,19 @@ where
                             gantz_ca::Head::Branch(name) => Some(name.as_str()),
                             _ => None,
                         };
+                        // The pointer position over the focused head's scene
+                        // (graph coords) recorded this frame; new nodes are placed
+                        // here. `Copy`, so no borrow is held across the call.
+                        let pointer_pos = head_state.scene.interaction.last_pointer_pos;
                         let created =
                             command_palette(gantz.env, editing, &mut state.command_palette, ui);
                         match created {
-                            Some(PaletteChoice::Node(create)) => {
+                            Some(PaletteChoice::Node(mut create)) => {
+                                create.pos = pointer_pos;
                                 gantz_response.responses.push(Some(fh), create);
                             }
-                            Some(PaletteChoice::NestedGraph(create)) => {
+                            Some(PaletteChoice::NestedGraph(mut create)) => {
+                                create.pos = pointer_pos;
                                 gantz_response.responses.push(Some(fh), create);
                             }
                             None => {}
@@ -2062,11 +2068,14 @@ fn command_palette(
     // The chosen node type becomes a creation payload. The reserved
     // `NESTED_GRAPH_TYPE` routes to the registry-aware nested-graph op.
     cmd_palette.show(ui.ctx(), cmds).map(|cmd| {
+        // The placement position is filled in by the caller, which has access to
+        // the focused head's last pointer position.
         if cmd.name == NESTED_GRAPH_TYPE {
-            PaletteChoice::NestedGraph(CreateNestedGraph)
+            PaletteChoice::NestedGraph(CreateNestedGraph { pos: None })
         } else {
             PaletteChoice::Node(CreateNode {
                 node_type: cmd.name.to_string(),
+                pos: None,
             })
         }
     })

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -76,6 +76,11 @@ pub struct Interaction {
     /// Position where an edge context menu was opened (in graph coordinates).
     #[serde(default, skip)]
     pub edge_context_menu_pos: Option<egui::Pos2>,
+    /// Latest pointer position over the scene, in graph coordinates. Updated
+    /// each frame the scene is hovered; used to place palette-created nodes
+    /// under the pointer.
+    #[serde(default, skip)]
+    pub last_pointer_pos: Option<egui::Pos2>,
 }
 
 #[derive(Default, serde::Deserialize, serde::Serialize)]
@@ -212,6 +217,20 @@ where
                 .into_iter()
                 .map(|id| NodeIndex::new(id.value() as usize))
                 .collect();
+        }
+
+        // Track the latest pointer position over the scene (in graph space) so a
+        // node added via the command palette lands under the pointer. While the
+        // palette window covers the scene, `contains_pointer` is false, so this
+        // retains the pre-open position.
+        if graph_response.response.contains_pointer() {
+            let layer_id = graph_response.response.layer_id;
+            let ptr = ui
+                .ctx()
+                .input(|i| i.pointer.interact_pos().or(i.pointer.hover_pos()));
+            if let (Some(ptr), Some(t)) = (ptr, ui.ctx().layer_transform_from_global(layer_id)) {
+                state.interaction.last_pointer_pos = Some(t.mul_pos(ptr));
+            }
         }
 
         // Background context menu: graph actions (when mutable) plus a "panes"


### PR DESCRIPTION
Nodes added via the command palette (Space or the right-click "add node" menu) were inserted at the graph origin (0,0) and left the existing selection untouched, so they often landed off-screen and had to be hunted down and re-selected.

Track the latest graph-space pointer position over each scene (`Interaction::last_pointer_pos`, updated whenever the scene is hovered) and thread it through the `CreateNode`/`CreateNestedGraph` payloads. The `create_node`/`create_nested_graph` ops now place the node at that position (falling back to the current view center) and make it the sole selection, reusing the same pattern as `paste`.