### PR TITLE
feat(layout): one-shot auto-layout & center-view with selection support

### DIFF
--- a/crates/gantz_egui/src/widget.rs
+++ b/crates/gantz_egui/src/widget.rs
@@ -2,7 +2,7 @@
 use time::{OffsetDateTime, UtcOffset, format_description};
 
 pub use command_palette::CommandPalette;
-pub use gantz::{Gantz, GantzState, update_graph_pane_head};
+pub use gantz::{Gantz, GantzState, LayoutConfig, update_graph_pane_head};
 pub use global_config::{GlobalConfigResponse, global_config};
 pub use graph_config::{GraphConfig, GraphConfigResponse};
 pub use graph_scene::{GraphScene, GraphSceneState};

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -85,6 +85,10 @@ pub struct GantzState {
     pub open_heads: OpenHeadStates,
     pub view_toggles: ViewToggles,
     pub command_palette: widget::CommandPalette,
+    /// Global auto-layout parameters (the non-flow `egui_graph` layout params;
+    /// flow stays per-head in [`OpenHeadState::layout_flow`]).
+    #[serde(default)]
+    pub layout_config: LayoutConfig,
     /// Per-head redo stacks for undo/redo support.
     #[serde(default, serialize_with = "gantz_ca::serde_sorted::serialize_map")]
     pub redo_stacks: HashMap<gantz_ca::Head, Vec<gantz_ca::CommitAddr>>,
@@ -114,12 +118,9 @@ pub type OpenHeadStates = HashMap<gantz_ca::Head, OpenHeadState>;
 pub struct OpenHeadState {
     /// State associated with the `GraphScene` widget.
     pub scene: GraphSceneState,
-    #[serde(default)]
-    pub auto_layout: bool,
+    /// The per-head flow direction used when auto-layout is invoked.
     #[serde(default = "default_layout_flow")]
     pub layout_flow: egui::Direction,
-    #[serde(default)]
-    pub center_view: bool,
 }
 
 fn default_layout_flow() -> egui::Direction {
@@ -130,10 +131,66 @@ impl Default for OpenHeadState {
     fn default() -> Self {
         Self {
             scene: GraphSceneState::default(),
-            auto_layout: false,
             layout_flow: GantzState::DEFAULT_DIRECTION,
-            center_view: false,
         }
+    }
+}
+
+/// Global auto-layout parameters, mirroring the non-flow fields of
+/// [`egui_graph::LayoutParams`]. Flow stays per-head (see
+/// [`OpenHeadState::layout_flow`]); these apply to every head's auto-layout.
+#[derive(Clone, Copy, serde::Deserialize, serde::Serialize)]
+pub struct LayoutConfig {
+    /// The gap between adjacent layers along the flow direction.
+    #[serde(default = "default_layer_gap")]
+    pub layer_gap: f32,
+    /// The gap between adjacent nodes within a layer.
+    #[serde(default = "default_node_gap")]
+    pub node_gap: f32,
+    /// The gap between disconnected components of the graph.
+    #[serde(default = "default_component_gap")]
+    pub component_gap: f32,
+    /// Whether the layout accounts for the socket each edge connects to.
+    #[serde(default = "default_socket_aware")]
+    pub socket_aware: bool,
+}
+
+fn default_layer_gap() -> f32 {
+    egui_graph::LayoutParams::DEFAULT_LAYER_GAP
+}
+
+fn default_node_gap() -> f32 {
+    egui_graph::LayoutParams::DEFAULT_NODE_GAP
+}
+
+fn default_component_gap() -> f32 {
+    egui_graph::LayoutParams::DEFAULT_COMPONENT_GAP
+}
+
+fn default_socket_aware() -> bool {
+    true
+}
+
+impl Default for LayoutConfig {
+    fn default() -> Self {
+        Self {
+            layer_gap: default_layer_gap(),
+            node_gap: default_node_gap(),
+            component_gap: default_component_gap(),
+            socket_aware: default_socket_aware(),
+        }
+    }
+}
+
+impl LayoutConfig {
+    /// Build [`egui_graph::LayoutParams`] from these globals plus a per-head
+    /// `flow` direction.
+    pub fn to_params(&self, flow: egui::Direction) -> egui_graph::LayoutParams {
+        egui_graph::LayoutParams::new(flow)
+            .layer_gap(self.layer_gap)
+            .node_gap(self.node_gap)
+            .component_gap(self.component_gap)
+            .socket_aware(self.socket_aware)
     }
 }
 
@@ -533,6 +590,7 @@ impl GantzState {
             open_heads,
             command_palette: widget::CommandPalette::default(),
             view_toggles: ViewToggles::default(),
+            layout_config: LayoutConfig::default(),
             redo_stacks: HashMap::new(),
             sidebar_width: default_sidebar_width(),
             tray_height: default_tray_height(),
@@ -1062,7 +1120,12 @@ where
             Pane::Settings => {
                 let compile_config = gantz.compile_config;
                 let res = pane_ui(ui, |ui| {
-                    widget::settings(&mut state.view_toggles, compile_config, ui)
+                    widget::settings(
+                        &mut state.view_toggles,
+                        compile_config,
+                        &mut state.layout_config,
+                        ui,
+                    )
                 });
                 if let Some(cfg) = res.inner.compile_config {
                     gantz_response.compile_config = Some(cfg);
@@ -1290,10 +1353,10 @@ where
         let immutable = head_immutable(pane_head, self.base_immutable, self.base_names);
         let diagnostics = self.access.diagnostics(pane_head).to_vec();
 
+        // Global layout params (Copy) combined with this head's flow.
+        let layout_config = self.state.layout_config;
         let head_state = self.state.open_heads.entry(pane_head.clone()).or_default();
-        let auto_layout = head_state.auto_layout;
-        let layout_flow = head_state.layout_flow;
-        let center_view = head_state.center_view;
+        let layout_params = layout_config.to_params(head_state.layout_flow);
         // Disjoint borrow of a sibling field of `open_heads` for the graph
         // scene's "Panes" context submenu.
         let view_toggles = &mut self.state.view_toggles;
@@ -1310,9 +1373,7 @@ where
                 head_state,
                 view_toggles,
                 data.view,
-                auto_layout,
-                layout_flow,
-                center_view,
+                layout_params,
                 immutable,
                 &diagnostics,
                 data.vm,
@@ -1930,9 +1991,7 @@ fn graph_scene<N>(
     head_state: &mut OpenHeadState,
     view_toggles: &mut ViewToggles,
     head_view: &mut egui_graph::View,
-    auto_layout: bool,
-    layout_flow: egui::Direction,
-    center_view: bool,
+    layout_params: egui_graph::LayoutParams,
     immutable: bool,
     diagnostics: &[gantz_core::Diagnostic],
     vm: &mut Engine,
@@ -1946,14 +2005,13 @@ where
 
     // Seed the node layout the first time this graph is shown.
     if head_view.layout.is_empty() {
-        head_view.layout = widget::graph_scene::layout(registry, graph, id, layout_flow, ui.ctx());
+        head_view.layout =
+            widget::graph_scene::layout(registry, graph, id, &layout_params, ui.ctx(), None);
     }
 
     let response = GraphScene::new(registry, graph)
         .with_id(id)
-        .auto_layout(auto_layout)
-        .layout_flow(layout_flow)
-        .center_view(center_view)
+        .layout_params(layout_params)
         .immutable(immutable)
         .view_toggles(view_toggles)
         .show(head_view, &mut head_state.scene, vm, ui);

--- a/crates/gantz_egui/src/widget/global_config.rs
+++ b/crates/gantz_egui/src/widget/global_config.rs
@@ -1,7 +1,10 @@
 //! The "Global" sidebar tab: globally relevant configuration.
 //!
 //! Hosts the global compile config toggles (moved here from the per-head Graph
-//! Config pane) and a button to reset all demo graphs to their initial state.
+//! Config pane), the global auto-layout parameters, and a button to reset all
+//! demo graphs to their initial state.
+
+use super::gantz::LayoutConfig;
 
 /// Response from [`global_config`].
 #[derive(Default)]
@@ -15,9 +18,11 @@ pub struct GlobalConfigResponse {
 /// Render the global configuration controls.
 ///
 /// `compile_config` is the current global config; when `Some` the compile
-/// toggles are shown. The config applies to all open heads.
+/// toggles are shown. `layout_config` holds the global auto-layout parameters
+/// (mutated in place). The config applies to all open heads.
 pub fn global_config(
     compile_config: Option<gantz_core::compile::Config>,
+    layout_config: &mut LayoutConfig,
     ui: &mut egui::Ui,
 ) -> GlobalConfigResponse {
     let mut changed_config = None;
@@ -47,6 +52,47 @@ pub fn global_config(
         }
         ui.separator();
     }
+
+    // Auto-layout parameters (the non-flow `egui_graph` layout params; flow is
+    // per-head, in the Graph Config pane). Applied on the next auto-layout.
+    ui.label("Layout:");
+    let gap = |ui: &mut egui::Ui, label: &str, value: &mut f32, hover: &str| {
+        ui.horizontal(|ui| {
+            ui.add(
+                egui::DragValue::new(value)
+                    .speed(0.5)
+                    .range(0.0..=500.0)
+                    .suffix(" px"),
+            )
+            .on_hover_text(hover);
+            ui.label(label);
+        });
+    };
+    gap(
+        ui,
+        "Layer gap",
+        &mut layout_config.layer_gap,
+        "Gap between adjacent layers along the flow direction.",
+    );
+    gap(
+        ui,
+        "Node gap",
+        &mut layout_config.node_gap,
+        "Gap between adjacent nodes within a layer.",
+    );
+    gap(
+        ui,
+        "Component gap",
+        &mut layout_config.component_gap,
+        "Gap between disconnected components of the graph.",
+    );
+    ui.checkbox(&mut layout_config.socket_aware, "Socket-aware")
+        .on_hover_text(
+            "Account for the socket each edge connects to when ordering nodes \
+             and minimising edge crossings. When off, edges anchor at node \
+             centres (classic node-size-only layout).",
+        );
+    ui.separator();
 
     let reset_all_demos = ui
         .button("Reset all demos")

--- a/crates/gantz_egui/src/widget/graph_config.rs
+++ b/crates/gantz_egui/src/widget/graph_config.rs
@@ -5,8 +5,9 @@ use super::head_name_edit::{head_name, head_name_edit};
 
 /// Per-head graph configuration widget.
 ///
-/// Provides a name-editing text field and layout settings
-/// (`auto_layout`, `layout_flow`, `center_view`).
+/// Provides a name-editing text field, one-shot `auto-layout`/`center view`
+/// buttons, and the per-head layout flow direction. The non-flow layout
+/// parameters live globally in `Settings > Global`.
 pub struct GraphConfig<'a> {
     head: &'a gantz_ca::Head,
     head_state: &'a mut OpenHeadState,
@@ -138,12 +139,24 @@ impl<'a> GraphConfig<'a> {
             );
         }
 
-        // Layout config.
-        ui.checkbox(&mut self.head_state.center_view, "Center View");
+        // Layout actions. Auto-layout and center-view are one-shot: they apply
+        // once when clicked (consumed by the graph scene on the next pass), so
+        // arranging nodes by hand is never disturbed.
+        if ui
+            .button("center view")
+            .on_hover_text("center the view over the graph")
+            .clicked()
+        {
+            self.head_state.scene.pending_center_view = true;
+        }
         ui.add_enabled_ui(!self.immutable, |ui| {
-            ui.horizontal(|ui| {
-                ui.checkbox(&mut self.head_state.auto_layout, "Automatic Layout");
-            });
+            if ui
+                .button("auto-layout")
+                .on_hover_text("lay out the selection, or the whole graph when nothing is selected")
+                .clicked()
+            {
+                self.head_state.scene.pending_auto_layout = true;
+            }
             ui.horizontal(|ui| {
                 ui.label("Flow:");
                 ui.radio_value(

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -12,7 +12,7 @@ use petgraph::{
     self,
     visit::{EdgeRef, IntoNodeIdentifiers, NodeIndexable},
 };
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use steel::steel_vm::engine::Engine;
 
 /// Response from the [`GraphScene`] widget.
@@ -52,9 +52,7 @@ pub struct GraphScene<'a, N> {
     registry: &'a dyn Registry,
     graph: &'a mut Graph<N>,
     id: egui::Id,
-    auto_layout: bool,
-    layout_flow: egui::Direction,
-    center_view: bool,
+    layout_params: egui_graph::LayoutParams,
     immutable: bool,
     /// When set, the background context menu gains a "Panes" submenu of
     /// pane-visibility checkboxes.
@@ -66,6 +64,14 @@ pub struct GraphScene<'a, N> {
 #[derive(Default, serde::Deserialize, serde::Serialize)]
 pub struct GraphSceneState {
     pub interaction: Interaction,
+    /// One-shot request to auto-layout, set by a button or context menu and
+    /// consumed by [`GraphScene::show`] on the next pass. Applies to the
+    /// current selection, or the whole graph when nothing is selected.
+    #[serde(default, skip)]
+    pub pending_auto_layout: bool,
+    /// One-shot request to center the view, consumed by [`GraphScene::show`].
+    #[serde(default, skip)]
+    pub pending_center_view: bool,
 }
 
 #[derive(Default, serde::Deserialize, serde::Serialize)]
@@ -100,9 +106,7 @@ where
             registry,
             graph,
             id: egui::Id::new("gantz-graph-scene"),
-            auto_layout: false,
-            layout_flow: egui::Direction::TopDown,
-            center_view: false,
+            layout_params: egui_graph::LayoutParams::new(egui::Direction::TopDown),
             immutable: false,
             view_toggles: None,
         }
@@ -116,28 +120,12 @@ where
         self
     }
 
-    /// Whether or not to automatically layout the graph using
-    /// [`egui_graph::layout()`].
+    /// The parameters used when auto-layout is invoked (one-shot, via the
+    /// pending request flags on [`GraphSceneState`]).
     ///
-    /// Default: `false`
-    pub fn auto_layout(mut self, auto: bool) -> Self {
-        self.auto_layout = auto;
-        self
-    }
-
-    /// The direction in which the egui_graph autolayout.
-    ///
-    /// Default: [`egui::Direction::TopDown`]
-    pub fn layout_flow(mut self, flow: egui::Direction) -> Self {
-        self.layout_flow = flow;
-        self
-    }
-
-    /// Whether or not to center the view over the graph.
-    ///
-    /// Default: `false`
-    pub fn center_view(mut self, center: bool) -> Self {
-        self.center_view = center;
+    /// Default: [`egui_graph::LayoutParams::new`] with [`egui::Direction::TopDown`].
+    pub fn layout_params(mut self, params: egui_graph::LayoutParams) -> Self {
+        self.layout_params = params;
         self
     }
 
@@ -170,13 +158,30 @@ where
         vm: &mut Engine,
         ui: &mut egui::Ui,
     ) -> GraphSceneResponse {
-        if self.auto_layout {
-            view.layout = layout(
+        // Consume one-shot layout/center requests (set by buttons and context
+        // menus). A request raised during this pass (e.g. by a context menu)
+        // is applied on the next pass.
+        let do_layout = std::mem::take(&mut state.pending_auto_layout);
+        let do_center = std::mem::take(&mut state.pending_center_view);
+        if do_layout {
+            // Lay out the selection, or the whole graph when nothing is
+            // selected. The whole-graph case centers at the origin; a subset is
+            // aligned to its prior bounding-box centre.
+            let target: HashSet<NodeIndex> = if state.interaction.selection.nodes.is_empty() {
+                self.graph.node_indices().collect()
+            } else {
+                state.interaction.selection.nodes.clone()
+            };
+            let whole = state.interaction.selection.nodes.is_empty();
+            apply_auto_layout(
                 self.registry,
                 &*self.graph,
                 self.id,
-                self.layout_flow,
+                &self.layout_params,
                 ui.ctx(),
+                view,
+                &target,
+                whole,
             );
         }
         let mut node_responses = Vec::new();
@@ -189,7 +194,7 @@ where
             .map(|ix| egui_graph::NodeId::from_u64(ix.index() as u64))
             .collect();
         let graph_response = egui_graph::Graph::from_id(self.id)
-            .center_view(self.center_view)
+            .center_view(do_center)
             .selected_nodes(selected)
             .immutable(self.immutable)
             .show(view, ui, |ui, show| {
@@ -238,6 +243,7 @@ where
         let immutable = self.immutable;
         let view_toggles = self.view_toggles;
         let mut reset_layout = false;
+        let mut request_layout = false;
         if !immutable || view_toggles.is_some() {
             let layer_id = graph_response.response.layer_id;
             graph_response.response.context_menu(|ui| {
@@ -261,6 +267,16 @@ where
                         responses.push(DynResponse::new(Paste { text: None, pos }));
                         ui.close();
                     }
+                    if ui
+                        .button("auto-layout")
+                        .on_hover_text(
+                            "lay out the selection, or the whole graph when nothing is selected",
+                        )
+                        .clicked()
+                    {
+                        request_layout = true;
+                        ui.close();
+                    }
                 }
                 if let Some(view) = view_toggles {
                     ui.menu_button("panes", |ui| {
@@ -273,6 +289,9 @@ where
                     });
                 }
             });
+        }
+        if request_layout {
+            state.pending_auto_layout = true;
         }
         if reset_layout {
             responses.push(DynResponse::new(ResetTilesLayout));
@@ -293,21 +312,26 @@ impl Selection {
     }
 }
 
-/// Produce the layout for the given graph.
+/// Produce the layout for the given graph (or a `subset` of its nodes).
 ///
 /// The `graph_id` is used to scope node IDs so that nodes with the same index
-/// in different graphs don't share egui memory state.
+/// in different graphs don't share egui memory state. When `subset` is `Some`,
+/// only those nodes and the edges between them are laid out. The result's
+/// bounding box is centred on the origin (see [`apply_auto_layout`] for
+/// selection-relative placement).
 pub fn layout<N>(
     registry: &dyn Registry,
     graph: &Graph<N>,
     graph_id: egui::Id,
-    flow: egui::Direction,
+    params: &egui_graph::LayoutParams,
     ctx: &egui::Context,
+    subset: Option<&HashSet<NodeIndex>>,
 ) -> egui_graph::Layout
 where
     N: Node,
 {
-    if graph.node_count() == 0 {
+    let included = |n: NodeIndex| subset.is_none_or(|s| s.contains(&n));
+    if !graph.node_indices().any(included) {
         return Default::default();
     }
     // Describe each node's sockets (count + padding) and each edge's actual
@@ -320,6 +344,7 @@ where
         let node_sizes = gmem.node_sizes();
         graph
             .node_indices()
+            .filter(|&n| included(n))
             .map(|n| {
                 let node_id = egui_graph::NodeId::from_u64(n.index() as u64);
                 let size = node_sizes
@@ -338,6 +363,9 @@ where
     let nodes = nodes_vec.into_iter();
     let edges = graph.edge_indices().filter_map(|e| {
         let (a, b) = graph.edge_endpoints(e)?;
+        if !included(a) || !included(b) {
+            return None;
+        }
         let edge = graph.edge_weight(e)?;
         Some((
             (
@@ -350,7 +378,82 @@ where
             ),
         ))
     });
-    egui_graph::layout(nodes, edges, flow)
+    egui_graph::layout(nodes, edges, params.clone())
+}
+
+/// Apply a one-shot auto-layout to `view`, laying out `target` and merging the
+/// result back into `view.layout`.
+///
+/// When `whole` (the target is the entire graph), the result is used as-is -
+/// centred on the origin. Otherwise the result's bounding box is translated to
+/// match the centre of `target`'s current bounding box, so a selection lays out
+/// in place rather than snapping toward the origin. Nodes outside `target` are
+/// left untouched.
+pub fn apply_auto_layout<N>(
+    registry: &dyn Registry,
+    graph: &Graph<N>,
+    graph_id: egui::Id,
+    params: &egui_graph::LayoutParams,
+    ctx: &egui::Context,
+    view: &mut egui_graph::View,
+    target: &HashSet<NodeIndex>,
+    whole: bool,
+) where
+    N: Node,
+{
+    let new = layout(registry, graph, graph_id, params, ctx, Some(target));
+    if whole {
+        view.layout = new;
+        return;
+    }
+    // Sizes of the target nodes, so bounding boxes use full node rects.
+    let sizes: HashMap<egui_graph::NodeId, egui::Vec2> =
+        egui_graph::with_graph_memory(ctx, graph_id, |gmem| {
+            let node_sizes = gmem.node_sizes();
+            target
+                .iter()
+                .map(|ix| {
+                    let id = egui_graph::NodeId::from_u64(ix.index() as u64);
+                    let size = node_sizes
+                        .get(&id)
+                        .copied()
+                        .unwrap_or_else(|| [200.0, 50.0].into());
+                    (id, size)
+                })
+                .collect()
+        });
+    let shift = match (
+        bbox_centre(target, &view.layout, &sizes),
+        bbox_centre(target, &new, &sizes),
+    ) {
+        (Some(orig), Some(next)) => orig - next,
+        _ => egui::Vec2::ZERO,
+    };
+    for (id, pos) in new {
+        view.layout.insert(id, pos + shift);
+    }
+}
+
+/// The centre of the bounding box of `target`'s nodes in `layout`, using full
+/// node rects (top-left position + size). Returns `None` when no target node
+/// has a position in `layout`.
+fn bbox_centre(
+    target: &HashSet<NodeIndex>,
+    layout: &egui_graph::Layout,
+    sizes: &HashMap<egui_graph::NodeId, egui::Vec2>,
+) -> Option<egui::Pos2> {
+    let mut bb: Option<egui::Rect> = None;
+    for ix in target {
+        let id = egui_graph::NodeId::from_u64(ix.index() as u64);
+        let Some(&tl) = layout.get(&id) else { continue };
+        let size = sizes
+            .get(&id)
+            .copied()
+            .unwrap_or_else(|| [200.0, 50.0].into());
+        let rect = egui::Rect::from_min_size(tl, size);
+        bb = Some(bb.map_or(rect, |b| b.union(rect)));
+    }
+    bb.map(|b| b.center())
 }
 
 fn nodes<N>(
@@ -374,6 +477,7 @@ where
     let mut node_responses = Vec::with_capacity(node_ids.len());
     let mut nodes_to_delete = Vec::new();
     let mut nodes_to_reset = Vec::new();
+    let mut request_layout = false;
     for n_id in node_ids {
         let n_ix = graph.to_index(n_id);
         let node = &mut graph[n_id];
@@ -449,6 +553,9 @@ where
             } else {
                 HashSet::from([n_id])
             };
+            // Whether the action target is a multi-node selection (this node is
+            // part of a selection of >1). Captured before `target` may be moved.
+            let multi = target.len() > 1;
             if ui.button("copy").clicked() {
                 responses.push(DynResponse::new(CopyNodes(target.clone())));
                 ui.close();
@@ -494,6 +601,16 @@ where
                     nodes_to_delete.extend(target);
                     ui.close();
                 }
+                // Auto-layout the selection (only meaningful for >1 node).
+                if multi
+                    && ui
+                        .button("auto-layout")
+                        .on_hover_text("lay out the selected nodes")
+                        .clicked()
+                {
+                    request_layout = true;
+                    ui.close();
+                }
             }
             // Node-specific items (e.g. the log node's "open logs").
             let node_path = [n_ix];
@@ -523,6 +640,11 @@ where
             }
         }
         gantz_core::graph::register(&get_node, &*graph, &[], vm);
+    }
+
+    // A node-menu "auto-layout" click is applied on the next pass by `show`.
+    if request_layout {
+        state.pending_auto_layout = true;
     }
 
     node_responses

--- a/crates/gantz_egui/src/widget/settings.rs
+++ b/crates/gantz_egui/src/widget/settings.rs
@@ -1,7 +1,7 @@
 //! The "Settings" sidebar tab: globally-relevant configuration grouped into
 //! Panes / Style / Global subtabs.
 
-use super::gantz::ViewToggles;
+use super::gantz::{LayoutConfig, ViewToggles};
 
 /// Which settings subtab is selected. Persisted only within a session.
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
@@ -27,6 +27,7 @@ pub struct SettingsResponse {
 pub fn settings(
     view: &mut ViewToggles,
     compile_config: Option<gantz_core::compile::Config>,
+    layout_config: &mut LayoutConfig,
     ui: &mut egui::Ui,
 ) -> SettingsResponse {
     let id = ui.id().with("settings_subtab");
@@ -84,7 +85,7 @@ pub fn settings(
             ui.weak("Style configuration coming soon.");
         }
         SettingsTab::Global => {
-            let g = super::global_config(compile_config, ui);
+            let g = super::global_config(compile_config, layout_config, ui);
             res.compile_config = g.compile_config;
             res.reset_all_demos = g.reset_all_demos;
         }


### PR DESCRIPTION
Closes #256 

Replace the persistent "Automatic Layout"/"Center View" per-head toggles (which re-ran every frame and fought manual node placement) with one-shot actions:

- Graph Config pane: "auto-layout"/"center view" buttons (flow radios kept).
- Graph-scene background context menu: "auto-layout" (mutable graphs).
- Node context menu: "auto-layout" when the right-clicked node is part of a multi-node selection.

Auto-layout applies to the selected nodes, or the whole graph when nothing is selected. A selection is laid out in place: the result's bounding box is aligned to the selection's prior centre instead of snapping toward the origin; the whole-graph case centres at the origin. Requests are routed through transient pending_auto_layout/pending_center_view flags on GraphSceneState and applied during the egui pass (where node sizes are available), so the existing settled-layout path records them in undo history.

Expose the non-flow egui_graph layout params (layer/node/component gaps, socket-aware) globally in Settings > Global via a new LayoutConfig on GantzState; flow stays per-head in OpenHeadState::layout_flow.