### PR TITLE
Small `gantz_egui` fixes and tweaks - #248 #249 #260

### DIFF
--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -207,9 +207,11 @@ pub struct GuiState(pub gantz_egui::widget::GantzState);
 #[derive(Resource, Default)]
 pub struct Views(pub HashMap<ca::CommitAddr, egui_graph::View>);
 
-/// Demo graph associations: maps a commit to its associated `demo-*` graph name.
+/// Demo graph associations: maps a graph *name* to its associated `demo-*`
+/// graph name. Keyed by name (not commit) so the association survives edits,
+/// which mint a new commit but keep the name.
 #[derive(Resource, Default)]
-pub struct Demos(pub HashMap<ca::CommitAddr, String>);
+pub struct Demos(pub HashMap<String, String>);
 
 /// Names of base nodes baked into the binary.
 ///
@@ -473,7 +475,7 @@ impl DerefMut for Views {
 }
 
 impl Deref for Demos {
-    type Target = HashMap<ca::CommitAddr, String>;
+    type Target = HashMap<String, String>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -1478,16 +1480,15 @@ where
         });
     }
 
-    // Handle demo graph association change.
-    if let Some((head, demo_val)) = &response.demo_changed {
-        if let Some(commit_ca) = registry.head_commit_ca(head).copied() {
-            match demo_val {
-                Some(name) => {
-                    demos.insert(commit_ca, name.clone());
-                }
-                None => {
-                    demos.remove(&commit_ca);
-                }
+    // Handle demo graph association change. Keyed by the head's branch name so
+    // the association survives later edits (which mint a new commit).
+    if let Some((ca::Head::Branch(graph_name), demo_val)) = &response.demo_changed {
+        match demo_val {
+            Some(demo) => {
+                demos.insert(graph_name.clone(), demo.clone());
+            }
+            None => {
+                demos.remove(graph_name);
             }
         }
     }

--- a/crates/gantz_egui/src/export.rs
+++ b/crates/gantz_egui/src/export.rs
@@ -44,32 +44,35 @@ pub struct Export<G> {
     pub registry: gantz_ca::Registry<G>,
     #[serde(default, serialize_with = "gantz_ca::serde_sorted::serialize_map")]
     pub views: HashMap<CommitAddr, egui_graph::View>,
-    /// Maps commits to their associated demo graph name (a `demo-*` name).
+    /// Maps a graph *name* to its associated demo graph name (a `demo-*` name).
+    ///
+    /// Keyed by name (rather than commit) so the association survives an edit:
+    /// editing a graph mints a new commit but keeps the name.
     #[serde(default)]
-    pub demos: HashMap<CommitAddr, String>,
+    pub demos: HashMap<String, String>,
 }
 
-/// Produce an [`Export`] by filtering views and demos to commits present in
-/// the registry.
+/// Produce an [`Export`] by filtering views to commits, and demos to names,
+/// present in the registry.
 pub fn export_with<G>(
     registry: gantz_ca::Registry<G>,
     all_views: &HashMap<CommitAddr, egui_graph::View>,
-    all_demos: &HashMap<CommitAddr, String>,
+    all_demos: &HashMap<String, String>,
 ) -> Export<G>
 where
     G: Clone,
 {
     let commits = registry.commits();
-    let filter = |ca: &&CommitAddr| commits.contains_key(ca);
     let views = all_views
         .iter()
-        .filter(|(ca, _)| filter(ca))
+        .filter(|(ca, _)| commits.contains_key(ca))
         .map(|(&ca, v)| (ca, v.clone()))
         .collect();
+    let names = registry.names();
     let demos = all_demos
         .iter()
-        .filter(|(ca, _)| filter(ca))
-        .map(|(&ca, v)| (ca, v.clone()))
+        .filter(|(name, _)| names.contains_key(name.as_str()))
+        .map(|(name, demo)| (name.clone(), demo.clone()))
         .collect();
     Export {
         registry,
@@ -138,7 +141,7 @@ pub fn export_heads_sexpr<N>(
     get_node: GetNode,
     registry: &gantz_ca::Registry<Graph<N>>,
     all_views: &HashMap<CommitAddr, egui_graph::View>,
-    all_demos: &HashMap<CommitAddr, String>,
+    all_demos: &HashMap<String, String>,
     heads: impl IntoIterator<Item = impl std::borrow::Borrow<gantz_ca::Head>>,
 ) -> Result<String, crate::format::FormatError>
 where
@@ -157,7 +160,7 @@ pub fn export_heads_sexpr_named<N>(
     get_node: GetNode,
     registry: &gantz_ca::Registry<Graph<N>>,
     all_views: &HashMap<CommitAddr, egui_graph::View>,
-    all_demos: &HashMap<CommitAddr, String>,
+    all_demos: &HashMap<String, String>,
     heads: impl IntoIterator<Item = impl std::borrow::Borrow<gantz_ca::Head>>,
 ) -> Result<String, crate::format::FormatError>
 where
@@ -175,15 +178,15 @@ where
 pub fn merge_with<G>(
     registry: &mut gantz_ca::Registry<G>,
     views: &mut HashMap<CommitAddr, egui_graph::View>,
-    demos: &mut HashMap<CommitAddr, String>,
+    demos: &mut HashMap<String, String>,
     export: Export<G>,
 ) -> MergeResult {
     let result = registry.merge(export.registry);
     for (ca, v) in export.views {
         views.entry(ca).or_insert(v);
     }
-    for (ca, d) in export.demos {
-        demos.entry(ca).or_insert(d);
+    for (name, d) in export.demos {
+        demos.entry(name).or_insert(d);
     }
     result
 }
@@ -334,7 +337,7 @@ where
 pub fn paste<N>(
     registry: &mut gantz_ca::Registry<Graph<N>>,
     views: &mut HashMap<CommitAddr, egui_graph::View>,
-    demos: &mut HashMap<CommitAddr, String>,
+    demos: &mut HashMap<String, String>,
     target_graph: &mut Graph<N>,
     target_layout: &mut egui_graph::Layout,
     copied: &Copied<N>,
@@ -508,6 +511,29 @@ mod tests {
         let export = export_with(registry, &all_views, &HashMap::new());
         assert!(export.views.contains_key(&ca));
         assert!(!export.views.contains_key(&cb));
+    }
+
+    #[test]
+    fn export_with_filters_demos() {
+        let ga = graph_addr(1);
+        let ca = commit_addr_raw(10);
+        let commit = Commit::new(Duration::from_secs(1), None, ga);
+        let registry = gantz_ca::Registry::new(
+            HashMap::from([(ga, "g".to_string())]),
+            HashMap::from([(ca, commit)]),
+            BTreeMap::from([("alpha".to_string(), ca)]),
+        );
+        let all_demos = HashMap::from([
+            ("alpha".to_string(), "demo-alpha".to_string()),
+            // `beta` is not a name in the registry, so it is dropped.
+            ("beta".to_string(), "demo-beta".to_string()),
+        ]);
+        let export = export_with(registry, &HashMap::new(), &all_demos);
+        assert_eq!(
+            export.demos.get("alpha").map(String::as_str),
+            Some("demo-alpha")
+        );
+        assert!(!export.demos.contains_key("beta"));
     }
 
     #[test]

--- a/crates/gantz_egui/src/format.rs
+++ b/crates/gantz_egui/src/format.rs
@@ -8,7 +8,7 @@
 //! existing `crate::format::{from_str, to_string}` call sites are unchanged.
 
 use crate::export::Export;
-use gantz_ca::{CaHash, CommitAddr, Registry, Timestamp};
+use gantz_ca::{CaHash, CommitAddr, Timestamp};
 use gantz_core::node::graph::Graph;
 use gantz_format::sexpr;
 use gantz_format::{Addr, Form, GraphLabels, Loaded};
@@ -28,7 +28,7 @@ where
 {
     let loaded = gantz_format::from_str::<N>(text, now)?;
     let mut views: HashMap<CommitAddr, egui_graph::View> = HashMap::new();
-    let mut demos: HashMap<CommitAddr, String> = HashMap::new();
+    let mut demos: HashMap<String, String> = HashMap::new();
     for form in &loaded.extra {
         match form.head.as_str() {
             "layout" => apply_layout(form, &loaded, &mut views),
@@ -64,13 +64,11 @@ where
         }
     }
 
-    // `(demo <name> ...)` per commit that has a demo.
+    // `(demo <name> ...)` per named graph that has a demo, in name order.
     let mut demos: Vec<_> = export.demos.iter().collect();
-    demos.sort_by_key(|(ca, _)| **ca);
-    for (commit_ca, demo) in demos {
-        if let Some(name) = name_for_commit(&export.registry, commit_ca) {
-            sections.push(format!("(demo {} {})", name, sexpr::quote(demo)));
-        }
+    demos.sort_by(|a, b| a.0.cmp(b.0));
+    for (name, demo) in demos {
+        sections.push(format!("(demo {} {})", name, sexpr::quote(demo)));
     }
 
     let mut result = sections.join("\n\n");
@@ -104,8 +102,8 @@ where
     }
 
     // `(demo <name> ...)` per named graph that has a demo, in name order.
-    for (name, commit_ca) in export.registry.names() {
-        if let Some(demo) = export.demos.get(commit_ca) {
+    for (name, _commit_ca) in export.registry.names() {
+        if let Some(demo) = export.demos.get(name) {
             sections.push(format!("(demo {} {})", name, sexpr::quote(demo)));
         }
     }
@@ -215,7 +213,7 @@ fn layout_text(labels: &GraphLabels, view: &egui_graph::View, bare_id: bool) -> 
 
 // -- demos -------------------------------------------------------------------
 
-fn apply_demo<N>(form: &Form, loaded: &Loaded<N>, demos: &mut HashMap<CommitAddr, String>) {
+fn apply_demo<N>(form: &Form, loaded: &Loaded<N>, demos: &mut HashMap<String, String>) {
     let src = &form.raw;
     let Ok(forms) = sexpr::read(src) else { return };
     let Some(args) = forms.first().and_then(sexpr::list_args) else {
@@ -228,8 +226,9 @@ fn apply_demo<N>(form: &Form, loaded: &Loaded<N>, demos: &mut HashMap<CommitAddr
     ) else {
         return;
     };
-    if let Some(&commit) = loaded.names.get(&name) {
-        demos.insert(commit, demo);
+    // Only retain demos for names this document's registry actually defines.
+    if loaded.names.contains_key(&name) {
+        demos.insert(name, demo);
     }
 }
 
@@ -240,13 +239,4 @@ fn addr_of(e: &sexpr::ExprKind) -> Option<Addr> {
     sexpr::as_string(e)
         .map(Addr::Concrete)
         .or_else(|| sexpr::as_symbol(e).map(Addr::Label))
-}
-
-/// The first registry name pointing at `commit`, if any.
-fn name_for_commit<N>(registry: &Registry<Graph<N>>, commit: &CommitAddr) -> Option<String> {
-    registry
-        .names()
-        .iter()
-        .find(|(_, ca)| *ca == commit)
-        .map(|(name, _)| name.clone())
 }

--- a/crates/gantz_egui/src/impls/expr.rs
+++ b/crates/gantz_egui/src/impls/expr.rs
@@ -66,7 +66,9 @@ impl<'a> egui::Widget for ExprEdit<'a> {
         );
         if response.changed() {
             if let Ok(new_expr) = gantz_core::node::expr(&state.code) {
-                *expr = new_expr;
+                // Preserve the user-set output count across text edits; only the
+                // source (and thus the `$var` inputs) should follow the edit.
+                *expr = new_expr.with_outputs(expr.outputs());
             }
         }
 

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -69,9 +69,9 @@ pub trait Registry: NameRegistry + FnNodeNames + NodeTypeRegistry + GraphRegistr
         false
     }
 
-    /// Get the demo graph name for a node at the given content address.
-    fn demo_graph(&self, ca: &gantz_ca::ContentAddr) -> Option<&str> {
-        let _ = ca;
+    /// Get the demo graph name associated with the graph of the given name.
+    fn demo_graph(&self, name: &str) -> Option<&str> {
+        let _ = name;
         None
     }
 

--- a/crates/gantz_egui/src/node/named_ref.rs
+++ b/crates/gantz_egui/src/node/named_ref.rs
@@ -263,14 +263,9 @@ impl NodeUi for NamedRef {
     fn inspector_rows(&mut self, ctx: &mut NodeCtx, body: &mut egui_extras::TableBody) {
         let row_h = node_inspector::table_row_h(body.ui_mut());
         let registry = ctx.registry();
-        let ref_ca = self.ref_.content_addr();
 
-        // Check if the referenced CA exists in registry.
-        let is_missing = !registry.node_exists(&ref_ca);
-
-        // Check if outdated (name points to different CA).
-        let current_ca = registry.name_ca(&self.name);
-        let is_outdated = !is_missing && current_ca.map(|ca| ca != ref_ca).unwrap_or(false);
+        // Whether the referenced CA exists in the registry.
+        let is_missing = !registry.node_exists(&self.ref_.content_addr());
 
         // CA row.
         body.row(row_h, |mut row| {
@@ -317,42 +312,82 @@ impl NodeUi for NamedRef {
                     ui.label(err_text);
                 });
             });
-        // Status row for outdated CA - only shown when sync is disabled.
-        } else if !self.sync && is_outdated {
-            if let Some(latest_ca) = current_ca {
-                let current_short = self.ref_.content_addr().display_short().to_string();
-                let latest_short = latest_ca.display_short().to_string();
-
-                body.row(row_h, |mut row| {
-                    row.col(|ui| {
-                        ui.label("status");
-                    });
-                    row.col(|ui| {
-                        ui.horizontal(|ui| {
-                            let warn_text = egui::RichText::new("outdated").color(outdated_color());
-                            ui.label(warn_text);
-
-                            let sync_hover = format!(
-                                "sync reference from {} to {}",
-                                current_short, latest_short
-                            );
-                            if ui.button("sync").on_hover_text(sync_hover).clicked() {
-                                self.ref_ = gantz_core::node::Ref::new(latest_ca);
-                            }
-
-                            let fork_hover = format!("fork a new node at {}", current_short);
-                            if ui.button("fork").on_hover_text(fork_hover).clicked() {
-                                let new_name = format!("{}-{}", self.name, current_short);
-                                ctx.response(BranchNode {
-                                    new_name,
-                                    ca: self.ref_.content_addr(),
-                                    path: ctx.path.to_vec(),
-                                });
-                            }
-                        });
+        // Status row for an outdated reference - sync/fork to resolve it.
+        } else if let Some(latest_ca) = outdated_latest(self, registry) {
+            body.row(row_h, |mut row| {
+                row.col(|ui| {
+                    ui.label("status");
+                });
+                row.col(|ui| {
+                    ui.horizontal(|ui| {
+                        let warn_text = egui::RichText::new("outdated").color(outdated_color());
+                        ui.label(warn_text);
+                        sync_fork_buttons(self, ctx, ui, latest_ca);
                     });
                 });
+            });
+        }
+    }
+
+    fn context_menu(&mut self, ctx: &mut NodeCtx, ui: &mut egui::Ui) {
+        // Offer sync/fork on the node itself when the reference is outdated.
+        if let Some(latest_ca) = outdated_latest(self, ctx.registry()) {
+            if sync_fork_buttons(self, ctx, ui, latest_ca) {
+                ui.close();
             }
         }
     }
+}
+
+/// The name's current commit CA when this reference is *outdated*: it exists,
+/// auto-sync is off, and the name now points at a different commit. `None`
+/// otherwise (missing, synced, or already up to date).
+fn outdated_latest(
+    named: &NamedRef,
+    registry: &dyn crate::Registry,
+) -> Option<gantz_ca::ContentAddr> {
+    if named.sync {
+        return None;
+    }
+    let ref_ca = named.ref_.content_addr();
+    if !registry.node_exists(&ref_ca) {
+        return None;
+    }
+    match registry.name_ca(&named.name) {
+        Some(latest) if latest != ref_ca => Some(latest),
+        _ => None,
+    }
+}
+
+/// Render the `sync` and `fork` buttons for an outdated reference, returning
+/// `true` if either was clicked. `sync` repoints the reference at `latest`;
+/// `fork` emits a [`BranchNode`] pinning a fresh name at the current (outdated)
+/// commit. Shared by the inspector and the node context menu.
+fn sync_fork_buttons(
+    named: &mut NamedRef,
+    ctx: &mut NodeCtx,
+    ui: &mut egui::Ui,
+    latest: gantz_ca::ContentAddr,
+) -> bool {
+    let current_short = named.ref_.content_addr().display_short().to_string();
+    let latest_short = latest.display_short().to_string();
+
+    let sync_hover = format!("sync reference from {current_short} to {latest_short}");
+    if ui.button("sync").on_hover_text(sync_hover).clicked() {
+        named.ref_ = gantz_core::node::Ref::new(latest);
+        return true;
+    }
+
+    let fork_hover = format!("fork a new node at {current_short}");
+    if ui.button("fork").on_hover_text(fork_hover).clicked() {
+        let new_name = format!("{}-{}", named.name, current_short);
+        ctx.response(BranchNode {
+            new_name,
+            ca: named.ref_.content_addr(),
+            path: ctx.path.to_vec(),
+        });
+        return true;
+    }
+
+    false
 }

--- a/crates/gantz_egui/src/node/named_ref.rs
+++ b/crates/gantz_egui/src/node/named_ref.rs
@@ -190,7 +190,7 @@ impl NodeUi for NamedRef {
     }
 
     fn demo_graph<'a>(&self, registry: &'a dyn crate::Registry) -> Option<&'a str> {
-        registry.demo_graph(&self.ref_.content_addr())
+        registry.demo_graph(&self.name)
     }
 
     fn nav_head(&self, _registry: &dyn crate::Registry) -> Option<gantz_ca::Head> {

--- a/crates/gantz_egui/src/ops.rs
+++ b/crates/gantz_egui/src/ops.rs
@@ -259,7 +259,7 @@ pub fn paste<N>(
     registry: &mut gantz_ca::Registry<Graph<N>>,
     editing: Option<&str>,
     all_views: &mut HashMap<CommitAddr, egui_graph::View>,
-    all_demos: &mut HashMap<CommitAddr, String>,
+    all_demos: &mut HashMap<String, String>,
     graph: &mut Graph<N>,
     head_view: &mut egui_graph::View,
     head_state: &mut OpenHeadState,

--- a/crates/gantz_egui/src/reg.rs
+++ b/crates/gantz_egui/src/reg.rs
@@ -23,7 +23,7 @@ use std::collections::{BTreeMap, HashMap};
 pub struct RegistryRef<'a, N: 'static + Send + Sync> {
     ca_registry: &'a ca::Registry<Graph<N>>,
     builtins: &'a dyn Builtins<Node = N>,
-    demos: &'a HashMap<ca::CommitAddr, String>,
+    demos: &'a HashMap<String, String>,
 }
 
 impl<'a, N: 'static + Send + Sync> RegistryRef<'a, N> {
@@ -31,7 +31,7 @@ impl<'a, N: 'static + Send + Sync> RegistryRef<'a, N> {
     pub fn new(
         ca_registry: &'a ca::Registry<Graph<N>>,
         builtins: &'a dyn Builtins<Node = N>,
-        demos: &'a HashMap<ca::CommitAddr, String>,
+        demos: &'a HashMap<String, String>,
     ) -> Self {
         Self {
             ca_registry,
@@ -173,17 +173,13 @@ impl<N: 'static + Node + crate::NodeUi + crate::sync::AsNamedRef + Send + Sync> 
         crate::cycle::would_cycle(self.ca_registry, target, editing)
     }
 
-    fn demo_graph(&self, ca: &ca::ContentAddr) -> Option<&str> {
-        // Check demos map (commit-level associations from Export).
-        let commit_ca = ca::CommitAddr::from(*ca);
-        if let Some(name) = self.demos.get(&commit_ca) {
-            return Some(name.as_str());
-        }
-        // Check builtins.
-        if let Some(builtin_name) = self.builtins.name(ca) {
-            return self.builtins.demo_graph(builtin_name);
-        }
-        None
+    fn demo_graph(&self, name: &str) -> Option<&str> {
+        // User-graph associations (from Export) are keyed by name; builtins
+        // expose their own demo by builtin name.
+        self.demos
+            .get(name)
+            .map(String::as_str)
+            .or_else(|| self.builtins.demo_graph(name))
     }
 
     fn socket_doc(

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -55,7 +55,7 @@ pub trait NodeTypeRegistry {
 pub struct Gantz<'a> {
     env: &'a dyn Registry,
     base_names: &'a gantz_ca::registry::Names,
-    demos: Option<&'a HashMap<gantz_ca::CommitAddr, String>>,
+    demos: Option<&'a HashMap<String, String>>,
     log_source: Option<LogSource>,
     perf_vm: Option<&'a mut widget::PerfCapture>,
     perf_gui: Option<&'a mut widget::PerfCapture>,
@@ -409,7 +409,7 @@ impl<'a> Gantz<'a> {
     }
 
     /// Provide demo graph associations for the config dropdown.
-    pub fn demos(mut self, demos: &'a HashMap<gantz_ca::CommitAddr, String>) -> Self {
+    pub fn demos(mut self, demos: &'a HashMap<String, String>) -> Self {
         self.demos = Some(demos);
         self
     }
@@ -777,10 +777,9 @@ where
 
                     // Look up the current demo association for this head.
                     let current_demo = match &head {
-                        gantz_ca::Head::Branch(name) => names
-                            .get(name)
-                            .and_then(|ca| gantz.demos.and_then(|d| d.get(ca)))
-                            .map(|s| s.as_str()),
+                        gantz_ca::Head::Branch(name) => {
+                            gantz.demos.and_then(|d| d.get(name)).map(|s| s.as_str())
+                        }
                         _ => None,
                     };
 
@@ -1959,7 +1958,7 @@ fn graph_select(
     heads: &[gantz_ca::Head],
     focused_head: usize,
     base_names: &gantz_ca::registry::Names,
-    demos: Option<&HashMap<gantz_ca::CommitAddr, String>>,
+    demos: Option<&HashMap<String, String>>,
     ui: &mut egui::Ui,
 ) -> egui::InnerResponse<widget::graph_select::GraphSelectResponse> {
     pane_ui(ui, |ui| {

--- a/crates/gantz_egui/src/widget/graph_select.rs
+++ b/crates/gantz_egui/src/widget/graph_select.rs
@@ -13,8 +13,8 @@ pub struct GraphSelect<'a> {
     heads: &'a [gantz_ca::Head],
     focused_head: Option<usize>,
     base_names: &'a gantz_ca::registry::Names,
-    /// Demo associations (commit -> demo name), for the row context menu.
-    demos: Option<&'a HashMap<gantz_ca::CommitAddr, String>>,
+    /// Demo associations (graph name -> demo name), for the row context menu.
+    demos: Option<&'a HashMap<String, String>>,
 }
 
 #[derive(Clone)]
@@ -119,7 +119,7 @@ impl<'a> GraphSelect<'a> {
 
     /// Provide demo associations so a graph's row context menu can offer to
     /// open its associated demo.
-    pub fn demos(mut self, demos: Option<&'a HashMap<gantz_ca::CommitAddr, String>>) -> Self {
+    pub fn demos(mut self, demos: Option<&'a HashMap<String, String>>) -> Self {
         self.demos = demos;
         self
     }
@@ -218,7 +218,7 @@ impl<'a> GraphSelect<'a> {
                         // Deletable iff the row offers an `×` (named, non-base).
                         let deletable = res.delete.is_some();
                         // The associated demo to offer, if any.
-                        let demo = demos.and_then(|d| d.get(ca)).cloned();
+                        let demo = demos.and_then(|d| d.get(name)).cloned();
                         res.row.context_menu(|ui| {
                             if ui.button("open").clicked() {
                                 response.replaced = Some(head.clone());


### PR DESCRIPTION
## `Expr` outputs reset to 1 on text edit

Editing an `Expr` node's text rebuilt it via `node::expr` (`Expr::new`, which hardcodes `outputs: 1`), discarding a user-set output count. The change handler now carries the count over with `new_expr.with_outputs(expr.outputs())`, mirroring how `Branch` preserves its `branch_conns` across edits.

Closes #248

## editing a graph reverts its associated demo to `None`

Demo associations were keyed by `CommitAddr`. Editing a graph mints a new commit, so the association (still on the old commit) was orphaned and the demo reverted to none.

Re-keyed the demos map by graph **name** - the stable identity that survives edits - across the `Export` format, `RegistryRef`, the `Registry::demo_graph` trait, the graph-select/graph-config widgets, and the bevy `Demos` resource + `demo_changed` handler. The on-disk `(demo <name> ...)` form was already name-based, so the format read/write paths simplify (no commit<->name resolution). `base.gantz` has no demos section, so there's no data migration. Adds an `export_with_filters_demos` test.

Closes #249

## sync/fork on the `NamedRef` context menu

`sync`/`fork` only existed in the Node Inspector. They now also appear on the node's right-click context menu, shown only when the reference is outdated. The outdated check and the button rendering are extracted into shared free fns (`outdated_latest`, `sync_fork_buttons`) used by both the inspector and the new `NodeUi::context_menu` impl.

Closes #260 