### PR TITLE
feat: Reliable per-head "changed" signal, i.e. stop re-hashing graphs every frame

### DIFF
--- a/crates/bevy_gantz/src/head.rs
+++ b/crates/bevy_gantz/src/head.rs
@@ -49,6 +49,22 @@ pub struct OpenHead;
 pub struct HeadRef(pub ca::Head);
 
 /// The working copy of the graph associated with this head.
+///
+/// # Invariant: commit before returning
+///
+/// Any system that mutates a head's `WorkingGraph` MUST commit it before the
+/// system returns - either via [`vm::commit_working_graph`](crate::vm::commit_working_graph)
+/// (in-place edits: the GUI pass and graph ops) or by replacing the working
+/// graph with a registry commit's graph and resetting
+/// [`CompiledInputs`](crate::vm::CompiledInputs) (head open/replace/branch-move
+/// and resync already do this). Consequently, *between* systems the working
+/// graph's content address always equals the head's committed graph CA
+/// (`registry.head_commit(head).graph`).
+///
+/// [`vm::sync`](crate::vm::sync) relies on this: it reads the committed CA
+/// directly to decide when to recompile and never re-hashes the working graph
+/// (see #159). [`vm::validate_committed`](crate::vm::validate_committed) is a
+/// default-off debug check that flags any violation of this invariant.
 #[derive(Component)]
 pub struct WorkingGraph<N>(pub gantz_core::node::graph::Graph<N>);
 

--- a/crates/bevy_gantz/src/lib.rs
+++ b/crates/bevy_gantz/src/lib.rs
@@ -37,7 +37,10 @@ pub use head::{
     WorkingGraph,
 };
 pub use reg::{Registry, lookup_node, timestamp};
-pub use vm::{CompileConfig, CompiledInputs, EntrypointFns, EvalEntryComplete, EvalEntryEvent};
+pub use vm::{
+    ChangeTrackingValidation, CompileConfig, CompiledInputs, EntrypointFns, EvalEntryComplete,
+    EvalEntryEvent, commit_working_graph,
+};
 
 /// The system set in which [`vm::sync`] runs (in the `Update` schedule).
 ///
@@ -80,6 +83,7 @@ where
         .init_resource::<HeadTabOrder>()
         .init_resource::<Registry<N>>()
         .init_resource::<vm::CompileConfig>()
+        .init_resource::<vm::ChangeTrackingValidation>()
         .init_non_send::<HeadVms>()
         // Register head event handlers.
         .add_observer(head::on_open::<N>)
@@ -90,8 +94,11 @@ where
         // Register eval entry event handler.
         .add_observer(vm::on_eval_entry)
         // Input-addressed VM synchronisation: (re)compiles whenever a head's
-        // compile inputs (graph content address + config) change.
-        .add_systems(Update, vm::sync::<N>.in_set(VmSet));
+        // compile inputs (committed graph content address + config) change.
+        .add_systems(Update, vm::sync::<N>.in_set(VmSet))
+        // Debug check for the WorkingGraph commit-before-return invariant
+        // (no-op unless `ChangeTrackingValidation` is enabled).
+        .add_systems(Update, vm::validate_committed::<N>.after(VmSet));
     }
 }
 

--- a/crates/bevy_gantz/src/lib.rs
+++ b/crates/bevy_gantz/src/lib.rs
@@ -38,8 +38,8 @@ pub use head::{
 };
 pub use reg::{Registry, lookup_node, timestamp};
 pub use vm::{
-    ChangeTrackingValidation, CompileConfig, CompiledInputs, EntrypointFns, EvalEntryComplete,
-    EvalEntryEvent, commit_working_graph,
+    CompileConfig, CompiledInputs, EntrypointFns, EvalEntryComplete, EvalEntryEvent,
+    ValidateCommitted, commit_working_graph,
 };
 
 /// The system set in which [`vm::sync`] runs (in the `Update` schedule).
@@ -83,7 +83,7 @@ where
         .init_resource::<HeadTabOrder>()
         .init_resource::<Registry<N>>()
         .init_resource::<vm::CompileConfig>()
-        .init_resource::<vm::ChangeTrackingValidation>()
+        .init_resource::<vm::ValidateCommitted>()
         .init_non_send::<HeadVms>()
         // Register head event handlers.
         .add_observer(head::on_open::<N>)
@@ -97,7 +97,7 @@ where
         // compile inputs (committed graph content address + config) change.
         .add_systems(Update, vm::sync::<N>.in_set(VmSet))
         // Debug check for the WorkingGraph commit-before-return invariant
-        // (no-op unless `ChangeTrackingValidation` is enabled).
+        // (no-op unless `ValidateCommitted` is enabled).
         .add_systems(Update, vm::validate_committed::<N>.after(VmSet));
     }
 }

--- a/crates/bevy_gantz/src/vm.rs
+++ b/crates/bevy_gantz/src/vm.rs
@@ -92,11 +92,21 @@ struct Inputs {
 
 /// The inputs of a head's last compile *attempt* (success or failure).
 ///
-/// `None` = never attempted. [`sync`] compares this against the current
-/// inputs to decide when to (re)compile - there is no dirty flag to set or
-/// forget.
+/// `None` = never attempted. [`sync`] compares this against the current inputs
+/// (the head's committed graph CA + config) to decide when to (re)compile -
+/// there is no dirty flag to set or forget.
 #[derive(Component, Default)]
 pub struct CompiledInputs(Option<Inputs>);
+
+/// When `true`, [`validate_committed`] hashes every open head's working graph
+/// each frame and warns if it differs from the head's committed graph CA - i.e.
+/// a system mutated the working graph without committing it, violating the
+/// [`WorkingGraph`](head::WorkingGraph) commit-before-return invariant.
+///
+/// Defaults to `false` (no extra hashing); enable at runtime to debug a
+/// suspected missing commit.
+#[derive(Default, Resource)]
+pub struct ChangeTrackingValidation(pub bool);
 
 /// Event to trigger evaluation of an entrypoint.
 #[derive(Event)]
@@ -195,27 +205,67 @@ pub fn on_eval_entry(
 // Systems
 // ---------------------------------------------------------------------------
 
+/// Commit a head's working graph to the registry when it has diverged from the
+/// head's current commit, updating the head and emitting a
+/// [`head::CommittedEvent`]. Returns `true` if a new commit was made.
+///
+/// **Call this from any system that mutates a head's
+/// [`WorkingGraph`](head::WorkingGraph), before the system returns** - it is how
+/// the commit-before-return invariant (see `WorkingGraph`) is upheld, which in
+/// turn lets [`sync`] recompile from the committed address without re-hashing.
+/// This is the single place a working graph is content-addressed.
+pub fn commit_working_graph<N>(
+    registry: &mut Registry<N>,
+    cmds: &mut Commands,
+    entity: Entity,
+    head: &mut ca::Head,
+    graph: &Graph<N>,
+) -> bool
+where
+    N: Clone + ca::CaHash,
+{
+    let graph_ca = ca::graph_addr(graph);
+    let Some(head_commit) = registry.head_commit(head) else {
+        return false;
+    };
+    if head_commit.graph == graph_ca {
+        return false;
+    }
+    let old_head = head.clone();
+    let new_commit_ca = registry.commit_graph_to_head(
+        crate::reg::timestamp(),
+        graph_ca,
+        || crate::clone_graph(graph),
+        head,
+    );
+    log::debug!("Graph changed -> {}", new_commit_ca.display_short());
+    cmds.trigger(head::CommittedEvent {
+        entity,
+        old_head,
+        new_head: head.clone(),
+    });
+    true
+}
+
 /// Keep every open head's VM in sync with the inputs to compilation.
 ///
-/// The inputs are the working graph's content address and the
-/// [`CompileConfig`]; each head's [`CompiledInputs`] memoizes the inputs of
-/// its last compile attempt, and the VM is rebuilt whenever they differ -
-/// there is no dirty flag to set or forget. This single rule covers head
-/// open (and startup spawn), head replace/branch-move, graph edits, and
-/// config changes.
+/// The inputs are the head's *committed* graph content address and the
+/// [`CompileConfig`]; each head's [`CompiledInputs`] memoizes the inputs of its
+/// last compile attempt, and the VM is rebuilt whenever they differ. The
+/// committed CA is read straight from the registry - **no per-frame hashing**
+/// (#159): the [`WorkingGraph`](head::WorkingGraph) commit-before-return
+/// invariant guarantees the working graph already matches it, and every change
+/// is reflected either by a new commit (edits, via [`commit_working_graph`]) or
+/// by a reset `CompiledInputs` (head open/replace/branch-move/resync), so
+/// comparing committed CA + config is sufficient to drive recompiles.
 ///
-/// Whether the rebuild is a fresh `init` or an in-place `compile` is decided
-/// by VM presence in [`head::HeadVms`]: absent means a fresh init (head
+/// Whether the rebuild is a fresh `init` or an in-place `compile` is decided by
+/// VM presence in [`head::HeadVms`]: absent means a fresh init (head
 /// replace/branch-move remove the VM to discard the old graph's node state);
 /// present means an in-place compile, preserving node state (graph edits and
 /// config changes).
-///
-/// When the working graph's address has diverged from the head's commit, the
-/// graph is committed to the registry first and a [`head::CommittedEvent`]
-/// is emitted for UI state updates (handled by `GantzEguiPlugin` if present).
 pub fn sync<N>(
-    mut cmds: Commands,
-    mut registry: ResMut<Registry<N>>,
+    registry: Res<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
     ep_fns: Res<EntrypointFns<N>>,
     config: Res<CompileConfig>,
@@ -225,38 +275,17 @@ pub fn sync<N>(
     N: 'static + Node + Clone + ca::CaHash + Send + Sync,
 {
     for mut data in heads_query.iter_mut() {
-        let graph: &Graph<N> = &*data.working_graph;
+        // The committed graph CA - the working graph already matches it (the
+        // `WorkingGraph` invariant), so there is nothing to hash here.
+        let Some(graph_ca) = registry.head_commit(&data.head_ref.0).map(|c| c.graph) else {
+            continue;
+        };
         let inputs = Inputs {
-            graph: ca::graph_addr(graph),
+            graph: graph_ca,
             config: config.0,
         };
         if data.compiled_inputs.0 == Some(inputs) {
             continue;
-        }
-
-        // Commit when the working copy has diverged from the head's commit.
-        let head: &mut ca::Head = &mut *data.head_ref;
-        if let Some(head_commit) = registry.head_commit(head) {
-            if head_commit.graph != inputs.graph {
-                let old_head = head.clone();
-                let old_commit_ca = registry.head_commit_ca(head).copied().unwrap();
-                let new_commit_ca = registry.commit_graph_to_head(
-                    crate::reg::timestamp(),
-                    inputs.graph,
-                    || crate::clone_graph(graph),
-                    head,
-                );
-                log::debug!(
-                    "Graph changed: {} -> {}",
-                    old_commit_ca.display_short(),
-                    new_commit_ca.display_short()
-                );
-                cmds.trigger(head::CommittedEvent {
-                    entity: data.entity,
-                    old_head,
-                    new_head: head.clone(),
-                });
-            }
         }
 
         // Rebuild the VM. On an in-place compile error the VM is kept (its
@@ -264,6 +293,7 @@ pub fn sync<N>(
         // module/diagnostics components; a failed init leaves no VM, so eval
         // systems (e.g. `drive_frame_bangs`, `on_eval_entry`) skip the head
         // rather than driving a stale graph.
+        let graph: &Graph<N> = &*data.working_graph;
         let get_node = |ca: &ca::ContentAddr| lookup_node(&registry, &**builtins, ca);
         let entrypoints = collect_entrypoints(&ep_fns, &get_node, graph);
         let result = match vms.get_mut(&data.entity) {
@@ -280,5 +310,38 @@ pub fn sync<N>(
         *data.module = module;
         *data.diagnostics = diagnostics;
         data.compiled_inputs.0 = Some(inputs);
+    }
+}
+
+/// Debug check for the [`WorkingGraph`](head::WorkingGraph) commit-before-return
+/// invariant.
+///
+/// When [`ChangeTrackingValidation`] is enabled, hash every open head's working
+/// graph and warn if it differs from the head's committed graph CA - i.e. a
+/// system mutated the working graph without committing it. A no-op (no hashing)
+/// when disabled, which is the default.
+pub fn validate_committed<N>(
+    validate: Res<ChangeTrackingValidation>,
+    registry: Res<Registry<N>>,
+    heads: Query<head::OpenHeadDataReadOnly<N>, With<head::OpenHead>>,
+) where
+    N: 'static + ca::CaHash + Send + Sync,
+{
+    if !validate.0 {
+        return;
+    }
+    for data in heads.iter() {
+        let working = ca::graph_addr(&data.working_graph.0);
+        let committed = registry.head_commit(&data.head_ref.0).map(|c| c.graph);
+        if committed != Some(working) {
+            log::warn!(
+                "WorkingGraph invariant violated: head {:?} working graph ({}) does \
+                 not match its committed graph ({:?}) - a system mutated it without \
+                 committing (see `commit_working_graph`)",
+                data.entity,
+                working.display_short(),
+                committed.map(|c| c.display_short().to_string()),
+            );
+        }
     }
 }

--- a/crates/bevy_gantz/src/vm.rs
+++ b/crates/bevy_gantz/src/vm.rs
@@ -106,7 +106,7 @@ pub struct CompiledInputs(Option<Inputs>);
 /// Defaults to `false` (no extra hashing); enable at runtime to debug a
 /// suspected missing commit.
 #[derive(Default, Resource)]
-pub struct ChangeTrackingValidation(pub bool);
+pub struct ValidateCommitted(pub bool);
 
 /// Event to trigger evaluation of an entrypoint.
 #[derive(Event)]
@@ -316,12 +316,12 @@ pub fn sync<N>(
 /// Debug check for the [`WorkingGraph`](head::WorkingGraph) commit-before-return
 /// invariant.
 ///
-/// When [`ChangeTrackingValidation`] is enabled, hash every open head's working
+/// When [`ValidateCommitted`] is enabled, hash every open head's working
 /// graph and warn if it differs from the head's committed graph CA - i.e. a
 /// system mutated the working graph without committing it. A no-op (no hashing)
 /// when disabled, which is the default.
 pub fn validate_committed<N>(
-    validate: Res<ChangeTrackingValidation>,
+    validate: Res<ValidateCommitted>,
     registry: Res<Registry<N>>,
     heads: Query<head::OpenHeadDataReadOnly<N>, With<head::OpenHead>>,
 ) where

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -1399,7 +1399,7 @@ pub fn update<N>(
         Res<BaseNames>,
         Res<BaseImmutable>,
         ResMut<CompileConfig>,
-        ResMut<bevy_gantz::ChangeTrackingValidation>,
+        ResMut<bevy_gantz::ValidateCommitted>,
     ),
     mut demos: ResMut<Demos>,
     dispatchers: Res<ResponseDispatchers>,

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -99,7 +99,9 @@ where
 
         // Builtin GUI response payload dispatchers. Head-scoped payloads
         // arrive at the observers below as `ForHead<T>` events; the rest map
-        // onto existing event types via custom dispatch fns.
+        // onto existing event types via custom dispatch fns. Observers that edit
+        // a head's working graph commit it before returning (see the
+        // `WorkingGraph` invariant), so no dispatch-side handling is needed.
         app.register_head_response::<gantz_egui::BranchNode>()
             .register_head_response::<gantz_egui::CopyNodes>()
             .register_head_response::<gantz_egui::CreateNode>()
@@ -703,16 +705,19 @@ fn refresh_moved_heads<N>(
 /// Handle create node payloads.
 pub fn on_create_node<N>(
     trigger: On<ForHead<gantz_egui::CreateNode>>,
-    registry: Res<Registry<N>>,
+    mut registry: ResMut<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
     demos: Res<Demos>,
     mut gui_state: ResMut<GuiState>,
     mut vms: NonSendMut<head::HeadVms>,
+    mut cmds: Commands,
     mut heads: Query<head::OpenHeadData<N>, With<head::OpenHead>>,
     mut views_query: Query<&mut GraphView, With<head::OpenHead>>,
 ) where
     N: 'static
         + Node
+        + Clone
+        + ca::CaHash
         + From<gantz_egui::node::NamedRef>
         + gantz_egui::sync::AsNamedRef
         + Send
@@ -753,6 +758,14 @@ pub fn on_create_node<N>(
         vm,
         event.data.clone(),
     );
+    // Uphold the `WorkingGraph` invariant: commit the in-place edit.
+    bevy_gantz::commit_working_graph(
+        &mut registry,
+        &mut cmds,
+        event.head,
+        &mut data.head_ref.0,
+        &data.working_graph.0,
+    );
 }
 
 /// Handle branch node payloads.
@@ -762,9 +775,10 @@ pub fn on_create_node<N>(
 pub fn on_branch_node<N>(
     trigger: On<ForHead<gantz_egui::BranchNode>>,
     mut registry: ResMut<Registry<N>>,
+    mut cmds: Commands,
     mut heads: Query<head::OpenHeadData<N>, With<head::OpenHead>>,
 ) where
-    N: 'static + From<gantz_egui::node::NamedRef> + Send + Sync,
+    N: 'static + Clone + ca::CaHash + From<gantz_egui::node::NamedRef> + Send + Sync,
 {
     let event = trigger.event();
     let Ok(mut data) = heads.get_mut(event.head) else {
@@ -779,6 +793,14 @@ pub fn on_branch_node<N>(
         event.data.ca,
         &event.data.path,
     );
+    // Uphold the `WorkingGraph` invariant: commit the in-place edit.
+    bevy_gantz::commit_working_graph(
+        &mut registry,
+        &mut cmds,
+        event.head,
+        &mut data.head_ref.0,
+        &data.working_graph.0,
+    );
 }
 
 /// Handle create nested graph payloads.
@@ -790,10 +812,11 @@ pub fn on_create_nested_graph<N>(
     trigger: On<ForHead<gantz_egui::CreateNestedGraph>>,
     mut registry: ResMut<Registry<N>>,
     mut gui_state: ResMut<GuiState>,
+    mut cmds: Commands,
     mut heads: Query<head::OpenHeadData<N>, With<head::OpenHead>>,
     mut views_query: Query<&mut GraphView, With<head::OpenHead>>,
 ) where
-    N: 'static + Node + From<gantz_egui::node::NamedRef> + ca::CaHash + Send + Sync,
+    N: 'static + Node + Clone + From<gantz_egui::node::NamedRef> + ca::CaHash + Send + Sync,
 {
     let event = trigger.event();
     let Ok(mut data) = heads.get_mut(event.head) else {
@@ -827,19 +850,28 @@ pub fn on_create_nested_graph<N>(
         event.data.pos,
         &parent,
     );
+    // Uphold the `WorkingGraph` invariant: commit the in-place edit.
+    bevy_gantz::commit_working_graph(
+        &mut registry,
+        &mut cmds,
+        event.head,
+        &mut data.head_ref.0,
+        &data.working_graph.0,
+    );
 }
 
 /// Handle inspect edge payloads.
 pub fn on_inspect_edge<N>(
     trigger: On<ForHead<gantz_egui::InspectEdge>>,
-    registry: Res<Registry<N>>,
+    mut registry: ResMut<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
     demos: Res<Demos>,
     mut vms: NonSendMut<head::HeadVms>,
+    mut cmds: Commands,
     mut heads: Query<head::OpenHeadData<N>, With<head::OpenHead>>,
     mut views_query: Query<&mut GraphView, With<head::OpenHead>>,
 ) where
-    N: 'static + Node + From<gantz_egui::node::NamedRef> + Send + Sync,
+    N: 'static + Node + Clone + ca::CaHash + From<gantz_egui::node::NamedRef> + Send + Sync,
 {
     let event = trigger.event();
     let Ok(mut data) = heads.get_mut(event.head) else {
@@ -864,6 +896,14 @@ pub fn on_inspect_edge<N>(
         &mut views,
         vm,
         event.data.clone(),
+    );
+    // Uphold the `WorkingGraph` invariant: commit the in-place edit.
+    bevy_gantz::commit_working_graph(
+        &mut registry,
+        &mut cmds,
+        event.head,
+        &mut data.head_ref.0,
+        &data.working_graph.0,
     );
 }
 
@@ -915,8 +955,13 @@ pub fn on_paste<N>(
     mut demos: ResMut<Demos>,
     mut vms: NonSendMut<head::HeadVms>,
     mut clipboard: ResMut<bevy_egui::EguiClipboard>,
+    mut cmds: Commands,
     mut heads: Query<
-        (&head::HeadRef, &mut head::WorkingGraph<N>, &mut GraphView),
+        (
+            &mut head::HeadRef,
+            &mut head::WorkingGraph<N>,
+            &mut GraphView,
+        ),
         With<head::OpenHead>,
     >,
 ) where
@@ -934,7 +979,7 @@ pub fn on_paste<N>(
     let Some(text) = event.data.text.clone().or_else(|| clipboard.get_text()) else {
         return;
     };
-    let Ok((head_ref, mut wg, mut gv)) = heads.get_mut(event.head) else {
+    let Ok((mut head_ref, mut wg, mut gv)) = heads.get_mut(event.head) else {
         log::error!("PasteSelection: head not found for entity {:?}", event.head);
         return;
     };
@@ -969,6 +1014,9 @@ pub fn on_paste<N>(
             gantz_core::graph::register(&get_node, &**wg, &[], vm);
         }
     }
+
+    // Uphold the `WorkingGraph` invariant: commit the in-place edit.
+    bevy_gantz::commit_working_graph(&mut registry, &mut cmds, event.head, &mut head_ref.0, &wg.0);
 }
 
 /// Handle undo payloads: move the head back to its parent commit.
@@ -1347,10 +1395,11 @@ pub fn update<N>(
     mut focused: ResMut<head::FocusedHead>,
     mut heads_query: Query<OpenHeadViews<N>, With<head::OpenHead>>,
     import_task: Option<Res<ImportTask>>,
-    (base_names, base_immutable, mut compile_config): (
+    (base_names, base_immutable, mut compile_config, mut change_validation): (
         Res<BaseNames>,
         Res<BaseImmutable>,
         ResMut<CompileConfig>,
+        ResMut<bevy_gantz::ChangeTrackingValidation>,
     ),
     mut demos: ResMut<Demos>,
     dispatchers: Res<ResponseDispatchers>,
@@ -1359,6 +1408,7 @@ pub fn update<N>(
 where
     N: 'static
         + Node
+        + Clone
         + gantz_ca::CaHash
         + gantz_egui::NodeUi
         + gantz_egui::sync::AsNamedRef
@@ -1394,6 +1444,7 @@ where
 
     // Build and show the Gantz widget.
     let current_compile_config = compile_config.0;
+    let current_validate_change_tracking = change_validation.0;
     let panel_id = egui::Id::new((ctx.viewport_id(), "central_panel"));
     let mut panel_ui = egui::Ui::new(
         ctx.clone(),
@@ -1411,6 +1462,7 @@ where
                 .base_immutable(base_immutable.0)
                 .demos(&demos.0)
                 .compile_config(current_compile_config)
+                .validate_change_tracking(current_validate_change_tracking)
                 .trace_capture(trace_capture.0.clone(), level)
                 .perf_captures(&mut perf_vm.0, &mut perf_gui.0)
                 .show(&mut *gui_state, focused_ix, &mut access, ui)
@@ -1524,6 +1576,11 @@ where
         }
     }
 
+    // Toggle change-tracking validation (a debugging aid; see `vm::sync`).
+    if let Some(enabled) = response.validate_change_tracking {
+        change_validation.0 = enabled;
+    }
+
     // Handle import button - open a file dialog (only if none already in flight).
     if response.import() && import_task.is_none() {
         let ext = gantz_egui::export::FILE_EXTENSION;
@@ -1535,6 +1592,27 @@ where
             Some(handle.read().await)
         });
         cmds.insert_resource(ImportTask(task));
+    }
+
+    // Commit each head whose graph the GUI edited in place this pass (node UI
+    // edits + structural scene edits) before returning, upholding the
+    // `WorkingGraph` invariant so `vm::sync` recompiles it from the committed
+    // address without re-hashing every open graph (#159). Graph ops applied via
+    // response observers commit themselves.
+    for head in &response.changed_heads {
+        let Some(&entity) = head_to_entity.get(head) else {
+            continue;
+        };
+        let Ok(mut data) = heads_query.get_mut(entity) else {
+            continue;
+        };
+        bevy_gantz::commit_working_graph(
+            &mut registry,
+            &mut cmds,
+            entity,
+            &mut data.core.head_ref.0,
+            &data.core.working_graph.0,
+        );
     }
 
     // Dispatch the dynamic response payloads emitted during the GUI pass.

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -291,8 +291,9 @@ pub struct ResponseDispatchers(pub HashMap<TypeId, DispatchFn>);
 /// App extension for registering GUI response payload handlers.
 ///
 /// This is how nodes declared in independent plugins receive custom payloads
-/// emitted from their UI (via [`gantz_egui::NodeCtx::response`]): register
-/// the payload type here and add an observer for [`ForHead<T>`]:
+/// emitted from their UI (via the `emit` helper on the node's returned
+/// [`gantz_egui::NodeUiResponse`] and friends): register the payload type here
+/// and add an observer for [`ForHead<T>`]:
 ///
 /// ```ignore
 /// app.register_head_response::<MyPayload>()

--- a/crates/bevy_gantz_egui/src/node/frame_bang.rs
+++ b/crates/bevy_gantz_egui/src/node/frame_bang.rs
@@ -52,8 +52,10 @@ impl gantz_egui::NodeUi for FrameBang {
         &mut self,
         _ctx: gantz_egui::NodeCtx,
         uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response> {
-        uictx.framed(|ui, _sockets| ui.add(egui::Label::new("frame!").selectable(false)))
+    ) -> gantz_egui::NodeUiResponse {
+        let framed =
+            uictx.framed(|ui, _sockets| ui.add(egui::Label::new("frame!").selectable(false)));
+        gantz_egui::NodeUiResponse::new(framed)
     }
 
     fn socket_doc(

--- a/crates/gantz_ca/src/ca.rs
+++ b/crates/gantz_ca/src/ca.rs
@@ -70,7 +70,7 @@ impl str::FromStr for ContentAddr {
 }
 
 /// Hash some type implementing [`CaHash`].
-pub fn content_addr<T: CaHash>(t: &T) -> ContentAddr {
+pub fn content_addr<T: CaHash + ?Sized>(t: &T) -> ContentAddr {
     let mut hasher = Hasher::new();
     t.hash(&mut hasher);
     ContentAddr(hasher.finalize().into())

--- a/crates/gantz_ca/src/hash.rs
+++ b/crates/gantz_ca/src/hash.rs
@@ -75,9 +75,14 @@ impl CaHash for bool {
     }
 }
 
-impl<const N: usize> CaHash for [u8; N] {
+impl<T: CaHash, const N: usize> CaHash for [T; N] {
     fn hash(&self, hasher: &mut Hasher) {
-        hasher.update(&self[..]);
+        // No length prefix: the element count is fixed by the type. For `[u8;
+        // N]` this streams the same bytes as a single bulk update, so existing
+        // content addresses are unchanged.
+        for elem in self {
+            elem.hash(hasher);
+        }
     }
 }
 
@@ -166,5 +171,27 @@ impl<T: CaHash> CaHash for std::collections::BTreeSet<T> {
 impl CaHash for crate::ContentAddr {
     fn hash(&self, hasher: &mut Hasher) {
         self.0.hash(hasher);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::content_addr;
+
+    /// The generalized `[T; N]` impl must stream `[u8; N]` byte-for-byte the
+    /// same as the slice impl, so promoting it doesn't shift existing content
+    /// addresses.
+    #[test]
+    fn u8_array_matches_slice() {
+        let arr: [u8; 3] = [1, 2, 3];
+        let slice: &[u8] = &arr[..];
+        assert_eq!(content_addr(&arr), content_addr(slice));
+    }
+
+    /// Non-`u8` arrays now hash element-wise and are order-sensitive.
+    #[test]
+    fn u16_array_is_element_and_order_sensitive() {
+        assert_ne!(content_addr(&[1u16, 2]), content_addr(&[2u16, 1]));
+        assert_eq!(content_addr(&[1u16, 2]), content_addr(&[1u16, 2]));
     }
 }

--- a/crates/gantz_egui/src/impls/apply.rs
+++ b/crates/gantz_egui/src/impls/apply.rs
@@ -1,4 +1,4 @@
-use crate::{NodeCtx, NodeUi, Registry, SocketDoc, SocketKind};
+use crate::{NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind};
 
 impl NodeUi for gantz_core::node::Apply {
     fn name(&self, _: &dyn Registry) -> &str {
@@ -9,12 +9,10 @@ impl NodeUi for gantz_core::node::Apply {
         Some("Apply a function to arguments")
     }
 
-    fn ui(
-        &mut self,
-        _ctx: NodeCtx,
-        uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response> {
-        uictx.framed(|ui, _sockets| ui.add(egui::Label::new("apply").selectable(false)))
+    fn ui(&mut self, _ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
+        let framed =
+            uictx.framed(|ui, _sockets| ui.add(egui::Label::new("apply").selectable(false)));
+        NodeUiResponse::new(framed)
     }
 
     fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, ix: usize) -> Option<SocketDoc> {

--- a/crates/gantz_egui/src/impls/bang.rs
+++ b/crates/gantz_egui/src/impls/bang.rs
@@ -1,4 +1,4 @@
-use crate::{NodeCtx, NodeUi, Registry, SocketDoc, SocketKind};
+use crate::{NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind};
 
 impl NodeUi for gantz_std::Bang {
     fn name(&self, _: &dyn Registry) -> &str {
@@ -9,18 +9,20 @@ impl NodeUi for gantz_std::Bang {
         Some("Trigger downstream evaluation")
     }
 
-    fn ui(
-        &mut self,
-        mut ctx: NodeCtx,
-        uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response> {
-        uictx.framed(|ui, _sockets| {
+    fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
+        // A bang only triggers downstream evaluation; it never edits the
+        // node's content address, so we queue an eval but never mark `changed`.
+        let mut clicked = false;
+        let framed = uictx.framed(|ui, _sockets| {
             let res = ui.add(egui::Button::new(" ! "));
-            if res.clicked() {
-                ctx.push_eval(1);
-            }
+            clicked = res.clicked();
             res
-        })
+        });
+        let mut resp = NodeUiResponse::new(framed);
+        if clicked {
+            resp.push_eval(ctx.path(), 1);
+        }
+        resp
     }
 
     fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, _ix: usize) -> Option<SocketDoc> {

--- a/crates/gantz_egui/src/impls/branch.rs
+++ b/crates/gantz_egui/src/impls/branch.rs
@@ -1,4 +1,6 @@
-use crate::{NodeCtx, NodeUi, Registry, SocketDoc, SocketKind};
+use crate::{
+    InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind,
+};
 
 /// A widget used to allow for editing and parsing a branch expression.
 pub struct BranchEdit<'a> {
@@ -88,18 +90,26 @@ impl NodeUi for gantz_core::node::Branch {
         Some("Route to an output arm by predicate")
     }
 
-    fn ui(
-        &mut self,
-        ctx: NodeCtx,
-        uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response> {
-        uictx.framed(|ui, _sockets| {
+    fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
+        // `src` (and the branch conns) are part of the content address. Detect a
+        // real edit by hashing before and after: a keystroke that fails to parse
+        // changes the buffer but not the node, so must not mark `changed`.
+        let before = branch_hash(self);
+        let framed = uictx.framed(|ui, _sockets| {
             let id = egui::Id::new("BranchEdit").with(ctx.path());
             ui.add(BranchEdit::new(self, id))
-        })
+        });
+        let mut resp = NodeUiResponse::new(framed);
+        resp.set_changed(branch_hash(self) != before);
+        resp
     }
 
-    fn inspector_rows(&mut self, _ctx: &mut NodeCtx, body: &mut egui_extras::TableBody) {
+    fn inspector_rows(
+        &mut self,
+        _ctx: &mut NodeCtx,
+        body: &mut egui_extras::TableBody,
+    ) -> InspectorRowsResponse {
+        let mut resp = InspectorRowsResponse::default();
         let row_h = crate::widget::node_inspector::table_row_h(body.ui_mut());
 
         // Outputs count.
@@ -118,6 +128,7 @@ impl NodeUi for gantz_core::node::Branch {
                     self.set_outputs(n.clamp(1, 16) as u8);
                     // Ensure all branches still have at least 2 entries.
                     ensure_min_branches(self);
+                    resp.mark_changed();
                 }
             });
         });
@@ -136,6 +147,7 @@ impl NodeUi for gantz_core::node::Branch {
                     .changed()
                 {
                     resize_branches(self, n.clamp(1, 16) as usize);
+                    resp.mark_changed();
                 }
             });
         });
@@ -179,7 +191,9 @@ impl NodeUi for gantz_core::node::Branch {
 
         if changed {
             self.set_branch_conns(branches);
+            resp.mark_changed();
         }
+        resp
     }
 
     fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, ix: usize) -> Option<SocketDoc> {

--- a/crates/gantz_egui/src/impls/delay.rs
+++ b/crates/gantz_egui/src/impls/delay.rs
@@ -1,4 +1,4 @@
-use crate::{NodeCtx, NodeUi, Registry, SocketDoc, SocketKind};
+use crate::{NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind};
 
 impl NodeUi for gantz_core::node::Delay {
     fn name(&self, _: &dyn Registry) -> &str {
@@ -9,12 +9,10 @@ impl NodeUi for gantz_core::node::Delay {
         Some("Output the previous evaluation's value")
     }
 
-    fn ui(
-        &mut self,
-        _ctx: NodeCtx,
-        uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response> {
-        uictx.framed(|ui, _sockets| ui.add(egui::Label::new("delay").selectable(false)))
+    fn ui(&mut self, _ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
+        let framed =
+            uictx.framed(|ui, _sockets| ui.add(egui::Label::new("delay").selectable(false)));
+        NodeUiResponse::new(framed)
     }
 
     fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, _ix: usize) -> Option<SocketDoc> {

--- a/crates/gantz_egui/src/impls/expr.rs
+++ b/crates/gantz_egui/src/impls/expr.rs
@@ -1,4 +1,6 @@
-use crate::{NodeCtx, NodeUi, Registry, SocketDoc, SocketKind};
+use crate::{
+    InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind,
+};
 
 /// A widget used to allow for editing and parsing a steel expression.
 pub struct ExprEdit<'a> {
@@ -88,18 +90,26 @@ impl NodeUi for gantz_core::node::Expr {
         Some("Evaluate a Steel expression")
     }
 
-    fn ui(
-        &mut self,
-        ctx: NodeCtx,
-        uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response> {
-        uictx.framed(|ui, _sockets| {
+    fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
+        // `src` is part of the content address. Detect a real edit by hashing
+        // the node before and after the editor: a keystroke that fails to parse
+        // changes the buffer but not the node, and so must not mark `changed`.
+        let before = expr_hash(self);
+        let framed = uictx.framed(|ui, _sockets| {
             let id = egui::Id::new("ExprEdit").with(ctx.path());
             ui.add(ExprEdit::new(self, id))
-        })
+        });
+        let mut resp = NodeUiResponse::new(framed);
+        resp.set_changed(expr_hash(self) != before);
+        resp
     }
 
-    fn inspector_rows(&mut self, _ctx: &mut NodeCtx, body: &mut egui_extras::TableBody) {
+    fn inspector_rows(
+        &mut self,
+        _ctx: &mut NodeCtx,
+        body: &mut egui_extras::TableBody,
+    ) -> InspectorRowsResponse {
+        let mut resp = InspectorRowsResponse::default();
         let row_h = crate::widget::node_inspector::table_row_h(body.ui_mut());
         body.row(row_h, |mut row| {
             row.col(|ui| {
@@ -112,9 +122,11 @@ impl NodeUi for gantz_core::node::Expr {
                     .changed()
                 {
                     self.set_outputs(n.clamp(1, 16) as u8);
+                    resp.mark_changed();
                 }
             });
         });
+        resp
     }
 
     fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, ix: usize) -> Option<SocketDoc> {

--- a/crates/gantz_egui/src/impls/identity.rs
+++ b/crates/gantz_egui/src/impls/identity.rs
@@ -1,4 +1,4 @@
-use crate::{NodeCtx, NodeUi, Registry, SocketDoc, SocketKind};
+use crate::{NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind};
 
 impl NodeUi for gantz_core::node::Identity {
     fn name(&self, _: &dyn Registry) -> &str {
@@ -9,14 +9,11 @@ impl NodeUi for gantz_core::node::Identity {
         Some("Pass a value through unchanged")
     }
 
-    fn ui(
-        &mut self,
-        _ctx: NodeCtx,
-        uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response> {
-        uictx.framed(|ui, _sockets| {
+    fn ui(&mut self, _ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
+        let framed = uictx.framed(|ui, _sockets| {
             ui.add(egui::Label::new(gantz_core::node::IDENTITY_NAME).selectable(false))
-        })
+        });
+        NodeUiResponse::new(framed)
     }
 
     fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, _ix: usize) -> Option<SocketDoc> {

--- a/crates/gantz_egui/src/impls/inlet.rs
+++ b/crates/gantz_egui/src/impls/inlet.rs
@@ -1,4 +1,7 @@
-use crate::{NodeCtx, NodeUi, Registry, SocketDoc, SocketKind, widget::node_inspector};
+use crate::{
+    InspectorRowsResponse, InspectorUiResponse, NodeCtx, NodeUi, NodeUiResponse, Registry,
+    SocketDoc, SocketKind, widget::node_inspector,
+};
 use gantz_core::node;
 
 impl NodeUi for gantz_core::node::graph::Inlet {
@@ -10,20 +13,21 @@ impl NodeUi for gantz_core::node::graph::Inlet {
         Some("A graph input")
     }
 
-    fn ui(
-        &mut self,
-        ctx: NodeCtx,
-        uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response> {
-        uictx.framed(|ui, _sockets| {
+    fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
+        let framed = uictx.framed(|ui, _sockets| {
             let name = self.name(ctx.registry());
             let ix = inlet_ix(ctx.path(), ctx.inlets());
             let text = format!("{}[{}]", name, ix);
             ui.add(egui::Label::new(text).selectable(false))
-        })
+        });
+        NodeUiResponse::new(framed)
     }
 
-    fn inspector_rows(&mut self, ctx: &mut NodeCtx, body: &mut egui_extras::TableBody) {
+    fn inspector_rows(
+        &mut self,
+        ctx: &mut NodeCtx,
+        body: &mut egui_extras::TableBody,
+    ) -> InspectorRowsResponse {
         let row_h = node_inspector::table_row_h(body.ui_mut());
         body.row(row_h, |mut row| {
             row.col(|ui| {
@@ -34,16 +38,18 @@ impl NodeUi for gantz_core::node::graph::Inlet {
                 ui.label(format!("{ix}"));
             });
         });
+        InspectorRowsResponse::default()
     }
 
-    fn inspector_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> Option<egui::Response> {
+    fn inspector_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> InspectorUiResponse {
         ui.separator();
-        Some(node_inspector::socket_doc_editor(
-            ui,
-            ctx.path(),
-            &mut self.ty,
-            &mut self.description,
-        ))
+        let (resp, changed) =
+            node_inspector::socket_doc_editor(ui, ctx.path(), &mut self.ty, &mut self.description);
+        InspectorUiResponse {
+            inner: Some(resp),
+            changed,
+            payloads: Vec::new(),
+        }
     }
 
     fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, _ix: usize) -> Option<SocketDoc> {

--- a/crates/gantz_egui/src/impls/log.rs
+++ b/crates/gantz_egui/src/impls/log.rs
@@ -1,4 +1,7 @@
-use crate::{NodeCtx, NodeUi, OpenLogs, Registry, SocketDoc, SocketKind};
+use crate::{
+    ContextMenuResponse, InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, OpenLogs,
+    Registry, SocketDoc, SocketKind,
+};
 
 impl NodeUi for gantz_std::log::Log {
     fn name(&self, _: &dyn Registry) -> &str {
@@ -21,18 +24,20 @@ impl NodeUi for gantz_std::log::Log {
         })
     }
 
-    fn ui(
-        &mut self,
-        _ctx: NodeCtx,
-        uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response> {
-        uictx.framed(|ui, _sockets| {
+    fn ui(&mut self, _ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
+        let framed = uictx.framed(|ui, _sockets| {
             let level = format!("{:?}", self.level).to_lowercase();
             ui.add(egui::Label::new(&level).selectable(false))
-        })
+        });
+        NodeUiResponse::new(framed)
     }
 
-    fn inspector_rows(&mut self, ctx: &mut NodeCtx, body: &mut egui_extras::TableBody) {
+    fn inspector_rows(
+        &mut self,
+        _ctx: &mut NodeCtx,
+        body: &mut egui_extras::TableBody,
+    ) -> InspectorRowsResponse {
+        let mut resp = InspectorRowsResponse::default();
         let row_h = crate::widget::node_inspector::table_row_h(body.ui_mut());
         body.row(row_h, |mut row| {
             row.col(|ui| {
@@ -44,10 +49,11 @@ impl NodeUi for gantz_std::log::Log {
                     .on_hover_text("show the logs pane")
                     .clicked()
                 {
-                    ctx.response(OpenLogs);
+                    resp.emit(OpenLogs);
                 }
             });
         });
+        resp
     }
 
     fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, _ix: usize) -> Option<SocketDoc> {
@@ -59,14 +65,16 @@ impl NodeUi for gantz_std::log::Log {
         }
     }
 
-    fn context_menu(&mut self, ctx: &mut NodeCtx, ui: &mut egui::Ui) {
+    fn context_menu(&mut self, _ctx: &mut NodeCtx, ui: &mut egui::Ui) -> ContextMenuResponse {
+        let mut resp = ContextMenuResponse::default();
         if ui
             .button("open logs")
             .on_hover_text("show the logs pane")
             .clicked()
         {
-            ctx.response(OpenLogs);
+            resp.emit(OpenLogs);
             ui.close();
         }
+        resp
     }
 }

--- a/crates/gantz_egui/src/impls/number.rs
+++ b/crates/gantz_egui/src/impls/number.rs
@@ -1,4 +1,4 @@
-use crate::{NodeCtx, NodeUi, Registry, SocketDoc, SocketKind};
+use crate::{NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind};
 use steel::SteelVal;
 
 impl NodeUi for gantz_std::number::Number {
@@ -10,12 +10,12 @@ impl NodeUi for gantz_std::number::Number {
         Some("A numeric value")
     }
 
-    fn ui(
-        &mut self,
-        mut ctx: NodeCtx,
-        uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response> {
-        uictx.framed(|ui, _sockets| {
+    fn ui(&mut self, mut ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
+        // The numeric value lives in VM runtime state, not the node weight, so
+        // editing it does NOT change the graph's content address - we only
+        // queue an evaluation, never mark `changed`.
+        let mut do_eval = false;
+        let framed = uictx.framed(|ui, _sockets| {
             let mut val = ctx.extract_value().unwrap().unwrap();
             let res = match val {
                 SteelVal::NumV(ref mut f) => ui.add(egui::DragValue::new(f)),
@@ -24,10 +24,15 @@ impl NodeUi for gantz_std::number::Number {
             };
             if res.changed() {
                 ctx.update_value(val).unwrap();
-                ctx.push_eval(1);
+                do_eval = true;
             }
             res
-        })
+        });
+        let mut resp = NodeUiResponse::new(framed);
+        if do_eval {
+            resp.push_eval(ctx.path(), 1);
+        }
+        resp
     }
 
     fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, _ix: usize) -> Option<SocketDoc> {

--- a/crates/gantz_egui/src/impls/outlet.rs
+++ b/crates/gantz_egui/src/impls/outlet.rs
@@ -1,4 +1,7 @@
-use crate::{NodeCtx, NodeUi, Registry, SocketDoc, SocketKind, widget::node_inspector};
+use crate::{
+    InspectorRowsResponse, InspectorUiResponse, NodeCtx, NodeUi, NodeUiResponse, Registry,
+    SocketDoc, SocketKind, widget::node_inspector,
+};
 use gantz_core::node;
 
 impl NodeUi for gantz_core::node::graph::Outlet {
@@ -10,20 +13,21 @@ impl NodeUi for gantz_core::node::graph::Outlet {
         Some("A graph output")
     }
 
-    fn ui(
-        &mut self,
-        ctx: NodeCtx,
-        uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response> {
-        uictx.framed(|ui, _sockets| {
+    fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
+        let framed = uictx.framed(|ui, _sockets| {
             let name = self.name(ctx.registry());
             let ix = outlet_ix(ctx.path(), ctx.outlets());
             let text = format!("{}[{}]", name, ix);
             ui.add(egui::Label::new(text).selectable(false))
-        })
+        });
+        NodeUiResponse::new(framed)
     }
 
-    fn inspector_rows(&mut self, ctx: &mut NodeCtx, body: &mut egui_extras::TableBody) {
+    fn inspector_rows(
+        &mut self,
+        ctx: &mut NodeCtx,
+        body: &mut egui_extras::TableBody,
+    ) -> InspectorRowsResponse {
         let row_h = node_inspector::table_row_h(body.ui_mut());
         body.row(row_h, |mut row| {
             row.col(|ui| {
@@ -34,16 +38,18 @@ impl NodeUi for gantz_core::node::graph::Outlet {
                 ui.label(format!("{ix}"));
             });
         });
+        InspectorRowsResponse::default()
     }
 
-    fn inspector_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> Option<egui::Response> {
+    fn inspector_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> InspectorUiResponse {
         ui.separator();
-        Some(node_inspector::socket_doc_editor(
-            ui,
-            ctx.path(),
-            &mut self.ty,
-            &mut self.description,
-        ))
+        let (resp, changed) =
+            node_inspector::socket_doc_editor(ui, ctx.path(), &mut self.ty, &mut self.description);
+        InspectorUiResponse {
+            inner: Some(resp),
+            changed,
+            payloads: Vec::new(),
+        }
     }
 
     fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, _ix: usize) -> Option<SocketDoc> {

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -266,7 +266,139 @@ pub struct HeadDataMut<'a, N> {
     pub vm: &'a mut Engine,
 }
 
+/// The response from [`NodeUi::ui`].
+///
+/// Bundles the node body's framed egui response with whether the node mutated
+/// its content-addressed (CA) state this frame and any payloads it emitted for
+/// the application to handle. See the [`NodeUi`] docs for the `changed`
+/// contract.
+pub struct NodeUiResponse {
+    /// The framed egui response for the node body.
+    pub framed: egui_graph::FramedResponse<egui::Response>,
+    /// Whether the node mutated CA-affecting state this frame.
+    pub changed: bool,
+    /// Payloads emitted by the node for the application to handle after the
+    /// GUI pass.
+    pub payloads: Vec<DynResponse>,
+}
+
+impl NodeUiResponse {
+    /// A response wrapping `framed`, initially unchanged and with no payloads.
+    pub fn new(framed: egui_graph::FramedResponse<egui::Response>) -> Self {
+        Self {
+            framed,
+            changed: false,
+            payloads: Vec::new(),
+        }
+    }
+}
+
+/// The response from [`NodeUi::inspector_rows`].
+#[derive(Debug, Default)]
+pub struct InspectorRowsResponse {
+    /// Whether the node mutated CA-affecting state this frame.
+    pub changed: bool,
+    /// Payloads emitted by the node for the application to handle.
+    pub payloads: Vec<DynResponse>,
+}
+
+/// The response from [`NodeUi::inspector_ui`].
+#[derive(Debug, Default)]
+pub struct InspectorUiResponse {
+    /// The egui response for the extra inspector UI, if any.
+    pub inner: Option<egui::Response>,
+    /// Whether the node mutated CA-affecting state this frame.
+    pub changed: bool,
+    /// Payloads emitted by the node for the application to handle.
+    pub payloads: Vec<DynResponse>,
+}
+
+/// The response from [`NodeUi::context_menu`].
+#[derive(Debug, Default)]
+pub struct ContextMenuResponse {
+    /// Whether the node mutated CA-affecting state this frame.
+    pub changed: bool,
+    /// Payloads emitted by the node for the application to handle.
+    pub payloads: Vec<DynResponse>,
+}
+
+/// Implement the shared `changed`/payload builder helpers on each node
+/// response type. These replace the old `NodeCtx::response` side-channel: a
+/// node records CA-affecting edits and emitted payloads on its returned
+/// response.
+macro_rules! impl_node_response_emit {
+    ($($Ty:ty),* $(,)?) => {$(
+        impl $Ty {
+            /// Mark that the node mutated CA-affecting state this frame.
+            pub fn mark_changed(&mut self) {
+                self.changed = true;
+            }
+
+            /// OR `changed` into the existing flag.
+            pub fn set_changed(&mut self, changed: bool) {
+                self.changed |= changed;
+            }
+
+            /// Emit a payload for the application to handle after the GUI pass.
+            pub fn emit<T: ResponseData>(&mut self, data: T) {
+                self.payloads.push(DynResponse::new(data));
+            }
+
+            /// Queue a call to the generated push evaluation fn for the node at
+            /// `path` (typically [`NodeCtx::path`]).
+            ///
+            /// Only successful if the node's [`gantz_core::Node::push_eval`]
+            /// returned `Some` at the last compile. Does not imply `changed`:
+            /// an eval is a runtime trigger, not an edit to the graph's
+            /// identity.
+            pub fn push_eval(&mut self, path: &[node::Id], n_outputs: u8) {
+                let ep = gantz_core::compile::entrypoint::push(path.to_vec(), n_outputs);
+                self.emit(EvalEntry(ep));
+            }
+
+            /// Queue a call to the generated pull evaluation fn for the node at
+            /// `path` (typically [`NodeCtx::path`]).
+            ///
+            /// See [`push_eval`](Self::push_eval) for the caveats.
+            pub fn pull_eval(&mut self, path: &[node::Id], n_inputs: u8) {
+                let ep = gantz_core::compile::entrypoint::pull(path.to_vec(), n_inputs);
+                self.emit(EvalEntry(ep));
+            }
+        }
+    )*};
+}
+
+impl_node_response_emit!(
+    NodeUiResponse,
+    InspectorRowsResponse,
+    InspectorUiResponse,
+    ContextMenuResponse,
+);
+
 /// A trait providing an egui `Ui` implementation for gantz nodes.
+///
+/// # Reporting changes
+///
+/// The graph the node lives in is content-addressed: its identity (and thus
+/// the need to re-commit and recompile) is derived from a hash of every node's
+/// CA-relevant state. To let the application detect edits without re-hashing
+/// the whole graph every frame, each method returns a response with a
+/// `changed` flag.
+///
+/// **A node MUST mark its response [`changed`](NodeUiResponse::mark_changed)
+/// whenever it mutates state that contributes to its content address (its
+/// `CaHash`), at the moment that state is actually written.** For
+/// buffered/debounced edits (e.g. a text field flushed on focus loss) mark
+/// `changed` at the *flush*, not on the keystroke - the node weight only
+/// changes at the flush. Silent mutations (e.g. auto-syncing a reference to a
+/// newer commit) must mark `changed` too, even though no widget was touched.
+///
+/// State that does NOT affect the content address must NOT mark `changed`:
+/// `#[cahash(skip)]` fields, values written to VM runtime state via
+/// [`NodeCtx::update_value`], node layout/position, and evaluation triggers
+/// queued via [`push_eval`](NodeUiResponse::push_eval). A missed `changed`
+/// leaves the committed graph stale (a correctness bug); a spurious `changed`
+/// only costs a redundant hash, so when in doubt, mark it.
 pub trait NodeUi {
     /// The name used to present the node within the inspector.
     fn name(&self, _registry: &dyn Registry) -> &str;
@@ -276,34 +408,44 @@ pub trait NodeUi {
     /// The node's path into the state tree and the VM are provided to allow for
     /// access to the node's state. The egui_graph node context is provided to
     /// allow customizing the frame and other node display properties.
-    fn ui(
-        &mut self,
-        ctx: NodeCtx,
-        uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response>;
+    ///
+    /// Returns a [`NodeUiResponse`] wrapping the framed egui response; mark it
+    /// [`changed`](NodeUiResponse::mark_changed) on CA-affecting edits and
+    /// [`emit`](NodeUiResponse::emit) any payloads (see the trait docs).
+    fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse;
 
     /// Optionally add additional rows to the node's inspector UI.
     ///
     /// By default, only the node's path and its current state within the VM are
     /// shown. Adding to the given `body` by providing an implementation of this
-    /// method will append extra rows.
-    fn inspector_rows(&mut self, _ctx: &mut NodeCtx, _body: &mut egui_extras::TableBody) {}
+    /// method will append extra rows. Mark the returned response
+    /// [`changed`](InspectorRowsResponse::mark_changed) on CA-affecting edits.
+    fn inspector_rows(
+        &mut self,
+        _ctx: &mut NodeCtx,
+        _body: &mut egui_extras::TableBody,
+    ) -> InspectorRowsResponse {
+        InspectorRowsResponse::default()
+    }
 
     /// Extra UI for the node to be presented within the node inspector
     /// following the default table.
     ///
     /// See [`NodeUi::inspector_rows`] for how to simply append rows to the
     /// table.
-    fn inspector_ui(&mut self, _ctx: NodeCtx, _ui: &mut egui::Ui) -> Option<egui::Response> {
-        None
+    fn inspector_ui(&mut self, _ctx: NodeCtx, _ui: &mut egui::Ui) -> InspectorUiResponse {
+        InspectorUiResponse::default()
     }
 
     /// Add node-specific items to the node's right-click context menu.
     ///
-    /// Called after the built-in items (copy, reset, delete, ...). Emit
-    /// responses for the application (or `Gantz::show`) to handle via
-    /// [`NodeCtx::response`].
-    fn context_menu(&mut self, _ctx: &mut NodeCtx, _ui: &mut egui::Ui) {}
+    /// Called after the built-in items (copy, reset, delete, ...). Mark the
+    /// returned response [`changed`](ContextMenuResponse::mark_changed) on
+    /// CA-affecting edits and [`emit`](ContextMenuResponse::emit) any payloads
+    /// for the application (or `Gantz::show`) to handle.
+    fn context_menu(&mut self, _ctx: &mut NodeCtx, _ui: &mut egui::Ui) -> ContextMenuResponse {
+        ContextMenuResponse::default()
+    }
 
     /// The layout direction of the node's inputs to outputs.
     fn flow(&self, _registry: &dyn Registry) -> egui::Direction {
@@ -351,13 +493,16 @@ pub trait NodeUi {
 
 /// A wrapper around a node's path and the VM providing easy access to the
 /// node's state.
+///
+/// Node UI methods report edits and emit payloads via their returned response
+/// types (see [`NodeUi`]); `NodeCtx` itself only provides read/write access to
+/// the node's surroundings (registry, path, VM state).
 pub struct NodeCtx<'a> {
     registry: &'a dyn Registry,
     path: &'a [node::Id],
     inlets: &'a [node::Id],
     outlets: &'a [node::Id],
     vm: &'a mut Engine,
-    responses: &'a mut Vec<DynResponse>,
 }
 
 /// How to position pasted nodes.
@@ -515,19 +660,19 @@ where
         (**self).description()
     }
 
-    fn ui(
-        &mut self,
-        ctx: NodeCtx,
-        uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response> {
+    fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
         (**self).ui(ctx, uictx)
     }
 
-    fn inspector_rows(&mut self, ctx: &mut NodeCtx, body: &mut egui_extras::TableBody) {
+    fn inspector_rows(
+        &mut self,
+        ctx: &mut NodeCtx,
+        body: &mut egui_extras::TableBody,
+    ) -> InspectorRowsResponse {
         (**self).inspector_rows(ctx, body)
     }
 
-    fn inspector_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> Option<egui::Response> {
+    fn inspector_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> InspectorUiResponse {
         (**self).inspector_ui(ctx, ui)
     }
 
@@ -552,7 +697,7 @@ where
         (**self).socket_doc(registry, kind, ix)
     }
 
-    fn context_menu(&mut self, ctx: &mut NodeCtx, ui: &mut egui::Ui) {
+    fn context_menu(&mut self, ctx: &mut NodeCtx, ui: &mut egui::Ui) -> ContextMenuResponse {
         (**self).context_menu(ctx, ui)
     }
 }
@@ -571,15 +716,15 @@ macro_rules! impl_node_ui_for_ptr {
                 (**self).description()
             }
 
-            fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> egui_graph::FramedResponse<egui::Response> {
+            fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
                 (**self).ui(ctx, uictx)
             }
 
-            fn inspector_rows(&mut self, ctx: &mut NodeCtx, body: &mut egui_extras::TableBody) {
+            fn inspector_rows(&mut self, ctx: &mut NodeCtx, body: &mut egui_extras::TableBody) -> InspectorRowsResponse {
                 (**self).inspector_rows(ctx, body)
             }
 
-            fn inspector_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> Option<egui::Response> {
+            fn inspector_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> InspectorUiResponse {
                 (**self).inspector_ui(ctx, ui)
             }
 
@@ -599,7 +744,7 @@ macro_rules! impl_node_ui_for_ptr {
                 (**self).socket_doc(registry, kind, ix)
             }
 
-            fn context_menu(&mut self, ctx: &mut NodeCtx, ui: &mut egui::Ui) {
+            fn context_menu(&mut self, ctx: &mut NodeCtx, ui: &mut egui::Ui) -> ContextMenuResponse {
                 (**self).context_menu(ctx, ui)
             }
         }
@@ -615,7 +760,6 @@ impl<'a> NodeCtx<'a> {
         inlets: &'a [node::Id],
         outlets: &'a [node::Id],
         vm: &'a mut Engine,
-        responses: &'a mut Vec<DynResponse>,
     ) -> Self {
         Self {
             registry,
@@ -623,19 +767,7 @@ impl<'a> NodeCtx<'a> {
             inlets,
             outlets,
             vm,
-            responses,
         }
-    }
-
-    /// Emit a response payload for the application to handle after the GUI
-    /// pass.
-    ///
-    /// Payloads may be any of the builtin types (e.g. [`OpenHead`],
-    /// [`EvalEntry`]) or custom types defined alongside the node, allowing
-    /// independently-declared nodes to communicate with application-specific
-    /// handlers.
-    pub fn response<T: ResponseData>(&mut self, data: T) {
-        self.responses.push(DynResponse::new(data));
     }
 
     /// Provide access to the registry.
@@ -671,26 +803,6 @@ impl<'a> NodeCtx<'a> {
     /// Register the given value as the node's new state.
     pub fn update<T: IntoSteelVal>(&mut self, val: T) -> Result<(), SteelErr> {
         node::state::update(self.vm, self.path, val)
-    }
-
-    /// Queue a call to the generated push evaluation function for this node.
-    ///
-    /// This will only be successful if the underlying node's
-    /// [`gantz_core::Node::push_eval`] fn returned `Some` last time the graph
-    /// was compiled.
-    pub fn push_eval(&mut self, n_outputs: u8) {
-        let ep = gantz_core::compile::entrypoint::push(self.path.to_vec(), n_outputs);
-        self.response(EvalEntry(ep));
-    }
-
-    /// Queue a call to the generated pull evaluation function for this node.
-    ///
-    /// This will only be successful if the underlying node's
-    /// [`gantz_core::Node::pull_eval`] fn returned `Some` last time the graph
-    /// was compiled.
-    pub fn pull_eval(&mut self, n_inputs: u8) {
-        let ep = gantz_core::compile::entrypoint::pull(self.path.to_vec(), n_inputs);
-        self.response(EvalEntry(ep));
     }
 
     /// The IDs of the inlets within the current graph.

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -24,7 +24,10 @@ pub mod widget;
 pub use egui_graph::SocketKind;
 pub use node::{FnNodeNames, NameRegistry};
 pub use reg::RegistryRef;
-pub use response::{DynResponse, ResponseData, Responses};
+pub use response::{
+    ContextMenuResponse, DynResponse, InspectorRowsResponse, InspectorUiResponse, NodeUiResponse,
+    ResponseData, Responses,
+};
 pub use widget::gantz::NodeTypeRegistry;
 pub use widget::graph_select::GraphRegistry;
 
@@ -265,115 +268,6 @@ pub struct HeadDataMut<'a, N> {
     pub view: &'a mut egui_graph::View,
     pub vm: &'a mut Engine,
 }
-
-/// The response from [`NodeUi::ui`].
-///
-/// Bundles the node body's framed egui response with whether the node mutated
-/// its content-addressed (CA) state this frame and any payloads it emitted for
-/// the application to handle. See the [`NodeUi`] docs for the `changed`
-/// contract.
-pub struct NodeUiResponse {
-    /// The framed egui response for the node body.
-    pub framed: egui_graph::FramedResponse<egui::Response>,
-    /// Whether the node mutated CA-affecting state this frame.
-    pub changed: bool,
-    /// Payloads emitted by the node for the application to handle after the
-    /// GUI pass.
-    pub payloads: Vec<DynResponse>,
-}
-
-impl NodeUiResponse {
-    /// A response wrapping `framed`, initially unchanged and with no payloads.
-    pub fn new(framed: egui_graph::FramedResponse<egui::Response>) -> Self {
-        Self {
-            framed,
-            changed: false,
-            payloads: Vec::new(),
-        }
-    }
-}
-
-/// The response from [`NodeUi::inspector_rows`].
-#[derive(Debug, Default)]
-pub struct InspectorRowsResponse {
-    /// Whether the node mutated CA-affecting state this frame.
-    pub changed: bool,
-    /// Payloads emitted by the node for the application to handle.
-    pub payloads: Vec<DynResponse>,
-}
-
-/// The response from [`NodeUi::inspector_ui`].
-#[derive(Debug, Default)]
-pub struct InspectorUiResponse {
-    /// The egui response for the extra inspector UI, if any.
-    pub inner: Option<egui::Response>,
-    /// Whether the node mutated CA-affecting state this frame.
-    pub changed: bool,
-    /// Payloads emitted by the node for the application to handle.
-    pub payloads: Vec<DynResponse>,
-}
-
-/// The response from [`NodeUi::context_menu`].
-#[derive(Debug, Default)]
-pub struct ContextMenuResponse {
-    /// Whether the node mutated CA-affecting state this frame.
-    pub changed: bool,
-    /// Payloads emitted by the node for the application to handle.
-    pub payloads: Vec<DynResponse>,
-}
-
-/// Implement the shared `changed`/payload builder helpers on each node
-/// response type. These replace the old `NodeCtx::response` side-channel: a
-/// node records CA-affecting edits and emitted payloads on its returned
-/// response.
-macro_rules! impl_node_response_emit {
-    ($($Ty:ty),* $(,)?) => {$(
-        impl $Ty {
-            /// Mark that the node mutated CA-affecting state this frame.
-            pub fn mark_changed(&mut self) {
-                self.changed = true;
-            }
-
-            /// OR `changed` into the existing flag.
-            pub fn set_changed(&mut self, changed: bool) {
-                self.changed |= changed;
-            }
-
-            /// Emit a payload for the application to handle after the GUI pass.
-            pub fn emit<T: ResponseData>(&mut self, data: T) {
-                self.payloads.push(DynResponse::new(data));
-            }
-
-            /// Queue a call to the generated push evaluation fn for the node at
-            /// `path` (typically [`NodeCtx::path`]).
-            ///
-            /// Only successful if the node's [`gantz_core::Node::push_eval`]
-            /// returned `Some` at the last compile. Does not imply `changed`:
-            /// an eval is a runtime trigger, not an edit to the graph's
-            /// identity.
-            pub fn push_eval(&mut self, path: &[node::Id], n_outputs: u8) {
-                let ep = gantz_core::compile::entrypoint::push(path.to_vec(), n_outputs);
-                self.emit(EvalEntry(ep));
-            }
-
-            /// Queue a call to the generated pull evaluation fn for the node at
-            /// `path` (typically [`NodeCtx::path`]).
-            ///
-            /// See [`push_eval`](Self::push_eval) for the caveats.
-            pub fn pull_eval(&mut self, path: &[node::Id], n_inputs: u8) {
-                let ep = gantz_core::compile::entrypoint::pull(path.to_vec(), n_inputs);
-                self.emit(EvalEntry(ep));
-            }
-        }
-    )*};
-}
-
-impl_node_response_emit!(
-    NodeUiResponse,
-    InspectorRowsResponse,
-    InspectorUiResponse,
-    ContextMenuResponse,
-);
 
 /// A trait providing an egui `Ui` implementation for gantz nodes.
 ///

--- a/crates/gantz_egui/src/node/comment.rs
+++ b/crates/gantz_egui/src/node/comment.rs
@@ -1,7 +1,7 @@
 //! A Comment node for documenting patches.
 
 use crate::widget::node_inspector;
-use crate::{NodeCtx, NodeUi};
+use crate::{InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse};
 use gantz_ca::CaHash;
 use gantz_core::node::{self, ExprCtx, ExprResult, MetaCtx};
 use serde::{Deserialize, Serialize};
@@ -26,11 +26,14 @@ fn text_hash(text: &str) -> u64 {
 }
 
 /// A transparent comment node for documenting graphs.
+///
+/// Both `text` and `size` are part of the content address: editing the note or
+/// resizing it are genuine edits that produce a new commit (and ride the export
+/// pipeline), so a resize is undoable just like a text edit.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize, CaHash)]
 #[cahash("gantz.comment")]
 pub struct Comment {
     text: String,
-    #[cahash(skip)]
     size: [u16; 2],
 }
 
@@ -77,11 +80,10 @@ impl NodeUi for Comment {
         Some("A free-floating text note")
     }
 
-    fn ui(
-        &mut self,
-        _ctx: NodeCtx,
-        uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response> {
+    fn ui(&mut self, _ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
+        // Set when a CA-affecting edit settles this frame: a flushed text change
+        // or a settled resize (see the writes inside the closure below).
+        let mut changed = false;
         // Get interaction state
         let interaction = uictx.interaction();
         let style = uictx.style();
@@ -112,7 +114,7 @@ impl NodeUi for Comment {
         let resize_id = node_egui_id.with("resize");
         let min_resize = egui::Vec2::splat(style.interaction.interact_radius);
         let default_size = egui::vec2(self.size[0] as f32, self.size[1] as f32);
-        let response = uictx.framed_with(frame, |ui, _sockets| {
+        let framed = uictx.framed_with(frame, |ui, _sockets| {
             // `Resize` registers its corner interaction under this salt (egui
             // 0.34.x internal, see `containers/resize.rs`). Reading the previous
             // frame's response tells us whether the corner is being dragged.
@@ -193,6 +195,8 @@ impl NodeUi for Comment {
                     let should_flush = response.lost_focus() || timed_out || mouse_active;
 
                     if should_flush {
+                        // A flush that alters the stored text is a CA edit.
+                        changed |= self.text != state.text;
                         self.text = state.text.clone();
                         state.text_hash = text_hash(&self.text);
                     }
@@ -211,19 +215,32 @@ impl NodeUi for Comment {
                     // Persist the editing state.
                     ui.memory_mut(|m| m.data.insert_temp(text_id, state));
 
-                    // Record the fitted size: the dragged width and the content
-                    // height the box auto-fits to. `size` is skipped from the
-                    // cahash, so this only feeds serialization and the next load.
-                    self.size = [width as u16, ui.min_rect().height() as u16];
+                    // The fitted size: the dragged width and the content height
+                    // the box auto-fits to. `size` is part of the content
+                    // address, so only commit it once *settled* - never while
+                    // the corner is actively dragged (which would churn a new
+                    // commit every frame of the drag). On release the height
+                    // snaps back to fit, giving a single settled value.
+                    let new_size = [width as u16, ui.min_rect().height() as u16];
+                    if !resizing && self.size != new_size {
+                        self.size = new_size;
+                        changed = true;
+                    }
 
                     response
                 })
         });
 
-        response
+        let mut resp = NodeUiResponse::new(framed);
+        resp.set_changed(changed);
+        resp
     }
 
-    fn inspector_rows(&mut self, _ctx: &mut NodeCtx, body: &mut egui_extras::TableBody) {
+    fn inspector_rows(
+        &mut self,
+        _ctx: &mut NodeCtx,
+        body: &mut egui_extras::TableBody,
+    ) -> InspectorRowsResponse {
         let row_h = node_inspector::table_row_h(body.ui_mut());
         body.row(row_h, |mut row| {
             row.col(|ui| {
@@ -233,5 +250,47 @@ impl NodeUi for Comment {
                 ui.label(format!("{:?}", self.size));
             });
         });
+        InspectorRowsResponse::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Comment;
+    use gantz_ca::content_addr;
+
+    /// `size` is now part of the content address, so a resize is a genuine edit
+    /// (this is what lets the `changed` signal at a settled resize map to a real
+    /// commit). Identical fields still produce an identical address.
+    #[test]
+    fn size_is_part_of_content_address() {
+        let a = Comment {
+            text: "hi".into(),
+            size: [100, 40],
+        };
+        let b = Comment {
+            text: "hi".into(),
+            size: [200, 40],
+        };
+        let c = Comment {
+            text: "hi".into(),
+            size: [100, 40],
+        };
+        assert_ne!(content_addr(&a), content_addr(&b));
+        assert_eq!(content_addr(&a), content_addr(&c));
+    }
+
+    /// Text remains part of the content address.
+    #[test]
+    fn text_is_part_of_content_address() {
+        let a = Comment {
+            text: "hi".into(),
+            size: [100, 40],
+        };
+        let b = Comment {
+            text: "bye".into(),
+            size: [100, 40],
+        };
+        assert_ne!(content_addr(&a), content_addr(&b));
     }
 }

--- a/crates/gantz_egui/src/node/fn_named_ref.rs
+++ b/crates/gantz_egui/src/node/fn_named_ref.rs
@@ -1,7 +1,10 @@
 //! `Fn<NamedRef>` type alias and NodeUi implementation.
 
 use super::{NameRegistry, NamedRef, missing_color, outdated_color};
-use crate::{NodeCtx, NodeUi, Registry, SocketDoc, SocketKind, widget::node_inspector};
+use crate::{
+    InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind,
+    widget::node_inspector,
+};
 
 /// A function node wrapping a named reference.
 pub type FnNamedRef = gantz_core::node::Fn<NamedRef>;
@@ -18,11 +21,7 @@ impl NodeUi for FnNamedRef {
         "fn"
     }
 
-    fn ui(
-        &mut self,
-        ctx: NodeCtx,
-        uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response> {
+    fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
         let registry = ctx.registry();
         let ref_ca = self.0.content_addr();
 
@@ -33,10 +32,13 @@ impl NodeUi for FnNamedRef {
         let current_ca = registry.name_ca(self.0.name());
         let is_outdated = !is_missing && current_ca.map(|ca| ca != ref_ca).unwrap_or(false);
 
-        // Auto-sync if enabled and outdated (skip if missing).
+        // Auto-sync if enabled and outdated (skip if missing). A silent
+        // mutation that changes the node's CA.
+        let mut changed = false;
         if self.0.sync && is_outdated {
             if let Some(ca) = current_ca {
                 self.0.set_ref(gantz_core::node::Ref::new(ca));
+                changed = true;
             }
         }
 
@@ -49,7 +51,7 @@ impl NodeUi for FnNamedRef {
                 .map(|ca| ca != ref_ca)
                 .unwrap_or(false);
 
-        uictx.framed(|ui, _sockets| {
+        let framed = uictx.framed(|ui, _sockets| {
             ui.horizontal(|ui| {
                 let fn_res = ui.add(egui::Label::new("λ").selectable(false));
                 let name_text = if is_missing {
@@ -63,10 +65,18 @@ impl NodeUi for FnNamedRef {
                 fn_res.union(name_res)
             })
             .inner
-        })
+        });
+        let mut resp = NodeUiResponse::new(framed);
+        resp.set_changed(changed);
+        resp
     }
 
-    fn inspector_rows(&mut self, ctx: &mut NodeCtx, body: &mut egui_extras::TableBody) {
+    fn inspector_rows(
+        &mut self,
+        ctx: &mut NodeCtx,
+        body: &mut egui_extras::TableBody,
+    ) -> InspectorRowsResponse {
+        let mut resp = InspectorRowsResponse::default();
         let row_h = node_inspector::table_row_h(body.ui_mut());
 
         // ComboBox to select which node to reference.
@@ -86,6 +96,7 @@ impl NodeUi for FnNamedRef {
                                 if let Some(ca) = registry.name_ca(name) {
                                     self.0 =
                                         NamedRef::new(name.clone(), gantz_core::node::Ref::new(ca));
+                                    resp.mark_changed();
                                 }
                             }
                         }
@@ -94,7 +105,10 @@ impl NodeUi for FnNamedRef {
         });
 
         // Delegate to NamedRef's inspector rows for CA and update button.
-        self.0.inspector_rows(ctx, body);
+        let inner = self.0.inspector_rows(ctx, body);
+        resp.set_changed(inner.changed);
+        resp.payloads.extend(inner.payloads);
+        resp
     }
 
     fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, _ix: usize) -> Option<SocketDoc> {

--- a/crates/gantz_egui/src/node/inspect.rs
+++ b/crates/gantz_egui/src/node/inspect.rs
@@ -1,6 +1,6 @@
 //! An Inspect node for viewing SteelVals flowing through the graph.
 
-use crate::{NodeCtx, NodeUi, Registry, SocketDoc, SocketKind};
+use crate::{NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind};
 use gantz_ca::CaHash;
 use gantz_core::node::{self, ExprCtx, ExprResult, MetaCtx, RegCtx};
 use serde::{Deserialize, Serialize};
@@ -42,21 +42,18 @@ impl NodeUi for Inspect {
         "inspect"
     }
 
-    fn ui(
-        &mut self,
-        ctx: NodeCtx,
-        uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response> {
+    fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
         let mut frame = egui_graph::node::default_frame(uictx.style(), uictx.interaction());
         frame.fill = uictx.style().visuals.extreme_bg_color;
-        uictx.framed_with(frame, |ui, _sockets| {
+        let framed = uictx.framed_with(frame, |ui, _sockets| {
             let text = match ctx.extract_value() {
                 Ok(Some(val)) => format!("{:?}", val),
                 Ok(None) => "∅".to_string(),
                 Err(_) => "ERR".to_string(),
             };
             ui.add(egui::Label::new(&text).selectable(false))
-        })
+        });
+        NodeUiResponse::new(framed)
     }
 
     fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, _ix: usize) -> Option<SocketDoc> {

--- a/crates/gantz_egui/src/node/named_ref.rs
+++ b/crates/gantz_egui/src/node/named_ref.rs
@@ -1,7 +1,8 @@
 //! A node that references another node by name and content address.
 
 use crate::{
-    BranchNode, NodeCtx, NodeUi, OpenHead, ReplaceHead, SocketDoc, widget::node_inspector,
+    BranchNode, ContextMenuResponse, InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse,
+    OpenHead, ReplaceHead, SocketDoc, widget::node_inspector,
 };
 use gantz_ca::CaHash;
 use gantz_core::node::{self, ExprCtx, ExprResult, MetaCtx, Node, RegCtx};
@@ -207,20 +208,22 @@ impl NodeUi for NamedRef {
         registry.socket_doc(&self.ref_.content_addr(), kind, ix)
     }
 
-    fn ui(
-        &mut self,
-        mut ctx: NodeCtx,
-        uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response> {
+    fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
         let registry = ctx.registry();
+        let mut changed = false;
 
         // Nested graphs always sync so parents follow their children's edits.
-        if self.is_nested() {
+        // Flipping the (CA-relevant) `sync` flag on is a genuine edit.
+        if self.is_nested() && !self.sync {
             self.sync = true;
+            changed = true;
         }
 
-        // Auto-sync if enabled and the name points at a newer commit.
-        self.resync(|name| registry.name_ca(name));
+        // Auto-sync if enabled and the name points at a newer commit. This is a
+        // silent mutation (no widget touched) that still changes the node's CA.
+        if self.resync(|name| registry.name_ca(name)) {
+            changed = true;
+        }
 
         // Recalculate after potential sync.
         let ref_ca = self.ref_.content_addr();
@@ -232,7 +235,7 @@ impl NodeUi for NamedRef {
                 .unwrap_or(false);
 
         // Regular frame, error color if missing, warning color if outdated.
-        let response = uictx.framed(|ui, _sockets| {
+        let framed = uictx.framed(|ui, _sockets| {
             let name_text = if is_missing {
                 egui::RichText::new(&self.name).color(missing_color())
             } else if is_outdated {
@@ -243,26 +246,35 @@ impl NodeUi for NamedRef {
             ui.add(egui::Label::new(name_text).selectable(false))
         });
 
+        let mut resp = NodeUiResponse::new(framed);
+        resp.set_changed(changed);
+
         // Enter the referenced graph on double-click. A nested graph is entered
         // *in place* (the focused tab navigates to it; the breadcrumb returns to
         // the parent); a reference to a root graph opens as a new tab. Either
         // way, the scene's "open in new tab" context-menu action (see
         // `nav_head`) opens it as a separate tab.
-        if response.inner.response.double_clicked() {
+        if resp.framed.inner.response.double_clicked() {
             let head = gantz_ca::Head::Branch(self.name.clone());
             if self.is_nested() {
-                ctx.response(ReplaceHead(head));
+                resp.emit(ReplaceHead(head));
             } else {
-                ctx.response(OpenHead(head));
+                resp.emit(OpenHead(head));
             }
         }
 
-        response
+        resp
     }
 
-    fn inspector_rows(&mut self, ctx: &mut NodeCtx, body: &mut egui_extras::TableBody) {
+    fn inspector_rows(
+        &mut self,
+        ctx: &mut NodeCtx,
+        body: &mut egui_extras::TableBody,
+    ) -> InspectorRowsResponse {
+        let mut resp = InspectorRowsResponse::default();
         let row_h = node_inspector::table_row_h(body.ui_mut());
         let registry = ctx.registry();
+        let path = ctx.path().to_vec();
 
         // Whether the referenced CA exists in the registry.
         let is_missing = !registry.node_exists(&self.ref_.content_addr());
@@ -280,8 +292,9 @@ impl NodeUi for NamedRef {
 
         // Sync toggle row. Forced on (and disabled) for nested graphs.
         let nested = self.is_nested();
-        if nested {
+        if nested && !self.sync {
             self.sync = true;
+            resp.mark_changed();
         }
         body.row(row_h, |mut row| {
             row.col(|ui| {
@@ -294,9 +307,12 @@ impl NodeUi for NamedRef {
                             "sync is always on for nested graphs so the parent \
                              follows the child's edits",
                         );
-                } else {
-                    ui.checkbox(&mut self.sync, "")
-                        .on_hover_text("automatically update to the latest commit");
+                } else if ui
+                    .checkbox(&mut self.sync, "")
+                    .on_hover_text("automatically update to the latest commit")
+                    .changed()
+                {
+                    resp.mark_changed();
                 }
             });
         });
@@ -322,20 +338,36 @@ impl NodeUi for NamedRef {
                     ui.horizontal(|ui| {
                         let warn_text = egui::RichText::new("outdated").color(outdated_color());
                         ui.label(warn_text);
-                        sync_fork_buttons(self, ctx, ui, latest_ca);
+                        match sync_fork_buttons(self, &path, ui, latest_ca) {
+                            SyncForkAction::Synced => resp.mark_changed(),
+                            SyncForkAction::Forked(branch) => resp.emit(branch),
+                            SyncForkAction::None => {}
+                        }
                     });
                 });
             });
         }
+        resp
     }
 
-    fn context_menu(&mut self, ctx: &mut NodeCtx, ui: &mut egui::Ui) {
+    fn context_menu(&mut self, ctx: &mut NodeCtx, ui: &mut egui::Ui) -> ContextMenuResponse {
+        let mut resp = ContextMenuResponse::default();
         // Offer sync/fork on the node itself when the reference is outdated.
         if let Some(latest_ca) = outdated_latest(self, ctx.registry()) {
-            if sync_fork_buttons(self, ctx, ui, latest_ca) {
-                ui.close();
+            let path = ctx.path().to_vec();
+            match sync_fork_buttons(self, &path, ui, latest_ca) {
+                SyncForkAction::Synced => {
+                    resp.mark_changed();
+                    ui.close();
+                }
+                SyncForkAction::Forked(branch) => {
+                    resp.emit(branch);
+                    ui.close();
+                }
+                SyncForkAction::None => {}
             }
         }
+        resp
     }
 }
 
@@ -359,35 +391,45 @@ fn outdated_latest(
     }
 }
 
-/// Render the `sync` and `fork` buttons for an outdated reference, returning
-/// `true` if either was clicked. `sync` repoints the reference at `latest`;
-/// `fork` emits a [`BranchNode`] pinning a fresh name at the current (outdated)
-/// commit. Shared by the inspector and the node context menu.
+/// The outcome of [`sync_fork_buttons`], applied to the caller's response.
+enum SyncForkAction {
+    /// Neither button was clicked.
+    None,
+    /// `sync` was clicked: the reference was repointed (a CA-affecting edit).
+    Synced,
+    /// `fork` was clicked: emit this [`BranchNode`] payload.
+    Forked(BranchNode),
+}
+
+/// Render the `sync` and `fork` buttons for an outdated reference. `sync`
+/// repoints the reference at `latest` (mutating `named`); `fork` produces a
+/// [`BranchNode`] pinning a fresh name at the current (outdated) commit. Shared
+/// by the inspector and the node context menu, which apply the returned
+/// [`SyncForkAction`] to their own response (`changed` / emitted payload).
 fn sync_fork_buttons(
     named: &mut NamedRef,
-    ctx: &mut NodeCtx,
+    path: &[node::Id],
     ui: &mut egui::Ui,
     latest: gantz_ca::ContentAddr,
-) -> bool {
+) -> SyncForkAction {
     let current_short = named.ref_.content_addr().display_short().to_string();
     let latest_short = latest.display_short().to_string();
 
     let sync_hover = format!("sync reference from {current_short} to {latest_short}");
     if ui.button("sync").on_hover_text(sync_hover).clicked() {
         named.ref_ = gantz_core::node::Ref::new(latest);
-        return true;
+        return SyncForkAction::Synced;
     }
 
     let fork_hover = format!("fork a new node at {current_short}");
     if ui.button("fork").on_hover_text(fork_hover).clicked() {
         let new_name = format!("{}-{}", named.name, current_short);
-        ctx.response(BranchNode {
+        return SyncForkAction::Forked(BranchNode {
             new_name,
             ca: named.ref_.content_addr(),
-            path: ctx.path.to_vec(),
+            path: path.to_vec(),
         });
-        return true;
     }
 
-    false
+    SyncForkAction::None
 }

--- a/crates/gantz_egui/src/response.rs
+++ b/crates/gantz_egui/src/response.rs
@@ -138,6 +138,123 @@ where
     }
 }
 
+// ----------------------------------------------------------------------------
+// `NodeUi` method response types
+//
+// Each [`NodeUi`][crate::NodeUi] method returns one of these: the egui part of
+// the interaction, whether the node mutated CA-affecting state, and any
+// payloads emitted (collected here rather than via a `NodeCtx` side-channel).
+// ----------------------------------------------------------------------------
+
+/// The response from [`NodeUi::ui`][crate::NodeUi::ui].
+///
+/// Bundles the node body's framed egui response with whether the node mutated
+/// its content-addressed (CA) state this frame and any payloads it emitted for
+/// the application to handle. See the [`NodeUi`][crate::NodeUi] docs for the
+/// `changed` contract.
+pub struct NodeUiResponse {
+    /// The framed egui response for the node body.
+    pub framed: egui_graph::FramedResponse<egui::Response>,
+    /// Whether the node mutated CA-affecting state this frame.
+    pub changed: bool,
+    /// Payloads emitted by the node for the application to handle after the
+    /// GUI pass.
+    pub payloads: Vec<DynResponse>,
+}
+
+impl NodeUiResponse {
+    /// A response wrapping `framed`, initially unchanged and with no payloads.
+    pub fn new(framed: egui_graph::FramedResponse<egui::Response>) -> Self {
+        Self {
+            framed,
+            changed: false,
+            payloads: Vec::new(),
+        }
+    }
+}
+
+/// The response from [`NodeUi::inspector_rows`][crate::NodeUi::inspector_rows].
+#[derive(Debug, Default)]
+pub struct InspectorRowsResponse {
+    /// Whether the node mutated CA-affecting state this frame.
+    pub changed: bool,
+    /// Payloads emitted by the node for the application to handle.
+    pub payloads: Vec<DynResponse>,
+}
+
+/// The response from [`NodeUi::inspector_ui`][crate::NodeUi::inspector_ui].
+#[derive(Debug, Default)]
+pub struct InspectorUiResponse {
+    /// The egui response for the extra inspector UI, if any.
+    pub inner: Option<egui::Response>,
+    /// Whether the node mutated CA-affecting state this frame.
+    pub changed: bool,
+    /// Payloads emitted by the node for the application to handle.
+    pub payloads: Vec<DynResponse>,
+}
+
+/// The response from [`NodeUi::context_menu`][crate::NodeUi::context_menu].
+#[derive(Debug, Default)]
+pub struct ContextMenuResponse {
+    /// Whether the node mutated CA-affecting state this frame.
+    pub changed: bool,
+    /// Payloads emitted by the node for the application to handle.
+    pub payloads: Vec<DynResponse>,
+}
+
+/// Implement the shared `changed`/payload builder helpers on each node
+/// response type. These replace the old `NodeCtx::response` side-channel: a
+/// node records CA-affecting edits and emitted payloads on its returned
+/// response.
+macro_rules! impl_node_response_emit {
+    ($($Ty:ty),* $(,)?) => {$(
+        impl $Ty {
+            /// Mark that the node mutated CA-affecting state this frame.
+            pub fn mark_changed(&mut self) {
+                self.changed = true;
+            }
+
+            /// OR `changed` into the existing flag.
+            pub fn set_changed(&mut self, changed: bool) {
+                self.changed |= changed;
+            }
+
+            /// Emit a payload for the application to handle after the GUI pass.
+            pub fn emit<T: ResponseData>(&mut self, data: T) {
+                self.payloads.push(DynResponse::new(data));
+            }
+
+            /// Queue a call to the generated push evaluation fn for the node at
+            /// `path` (typically [`NodeCtx::path`][crate::NodeCtx::path]).
+            ///
+            /// Only successful if the node's [`gantz_core::Node::push_eval`]
+            /// returned `Some` at the last compile. Does not imply `changed`:
+            /// an eval is a runtime trigger, not an edit to the graph's
+            /// identity.
+            pub fn push_eval(&mut self, path: &[gantz_core::node::Id], n_outputs: u8) {
+                let ep = gantz_core::compile::entrypoint::push(path.to_vec(), n_outputs);
+                self.emit(crate::EvalEntry(ep));
+            }
+
+            /// Queue a call to the generated pull evaluation fn for the node at
+            /// `path` (typically [`NodeCtx::path`][crate::NodeCtx::path]).
+            ///
+            /// See [`push_eval`](Self::push_eval) for the caveats.
+            pub fn pull_eval(&mut self, path: &[gantz_core::node::Id], n_inputs: u8) {
+                let ep = gantz_core::compile::entrypoint::pull(path.to_vec(), n_inputs);
+                self.emit(crate::EvalEntry(ep));
+            }
+        }
+    )*};
+}
+
+impl_node_response_emit!(
+    NodeUiResponse,
+    InspectorRowsResponse,
+    InspectorUiResponse,
+    ContextMenuResponse,
+);
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -61,6 +61,7 @@ pub struct Gantz<'a> {
     perf_gui: Option<&'a mut widget::PerfCapture>,
     base_immutable: bool,
     compile_config: Option<gantz_core::compile::Config>,
+    validate_change_tracking: Option<bool>,
 }
 
 enum LogSource {
@@ -290,6 +291,8 @@ pub struct GantzResponse {
     pub reset_all_demos: bool,
     /// The global compile config was changed via the Graph Config pane.
     pub compile_config: Option<gantz_core::compile::Config>,
+    /// The change-tracking validation toggle was changed (its new value).
+    pub validate_change_tracking: Option<bool>,
     /// Heads whose graph had a CA-affecting edit this frame (from a node UI, an
     /// inspector edit, or a structural scene edit). Lets the application
     /// commit/recompile only the changed heads instead of re-hashing every open
@@ -410,6 +413,7 @@ impl<'a> Gantz<'a> {
             perf_gui: None,
             base_immutable: true,
             compile_config: None,
+            validate_change_tracking: None,
         }
     }
 
@@ -424,6 +428,14 @@ impl<'a> Gantz<'a> {
     /// heads, and a change is reported via [`GantzResponse::compile_config`].
     pub fn compile_config(mut self, config: gantz_core::compile::Config) -> Self {
         self.compile_config = Some(config);
+        self
+    }
+
+    /// Provide the current change-tracking validation state so the Settings >
+    /// Global pane shows its toggle. A change is reported via
+    /// [`GantzResponse::validate_change_tracking`].
+    pub fn validate_change_tracking(mut self, enabled: bool) -> Self {
+        self.validate_change_tracking = Some(enabled);
         self
     }
 
@@ -525,6 +537,7 @@ impl<'a> Gantz<'a> {
             reset_base_graph: None,
             reset_all_demos: false,
             compile_config: None,
+            validate_change_tracking: None,
             changed_heads: Vec::new(),
             responses: Responses::default(),
         };
@@ -1137,16 +1150,21 @@ where
             }
             Pane::Settings => {
                 let compile_config = gantz.compile_config;
+                let validate_change_tracking = gantz.validate_change_tracking;
                 let res = pane_ui(ui, |ui| {
                     widget::settings(
                         &mut state.view_toggles,
                         compile_config,
+                        validate_change_tracking,
                         &mut state.layout_config,
                         ui,
                     )
                 });
                 if let Some(cfg) = res.inner.compile_config {
                     gantz_response.compile_config = Some(cfg);
+                }
+                if let Some(v) = res.inner.validate_change_tracking {
+                    gantz_response.validate_change_tracking = Some(v);
                 }
                 if res.inner.reset_all_demos {
                     gantz_response.reset_all_demos = true;

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -290,6 +290,11 @@ pub struct GantzResponse {
     pub reset_all_demos: bool,
     /// The global compile config was changed via the Graph Config pane.
     pub compile_config: Option<gantz_core::compile::Config>,
+    /// Heads whose graph had a CA-affecting edit this frame (from a node UI, an
+    /// inspector edit, or a structural scene edit). Lets the application
+    /// commit/recompile only the changed heads instead of re-hashing every open
+    /// graph each frame. May contain duplicates; treat membership as a set.
+    pub changed_heads: Vec<gantz_ca::Head>,
     /// Dynamic payloads emitted from within the widget tree, tagged with the
     /// emitting head. See [`crate::response`] for the handling contract.
     pub responses: Responses,
@@ -520,6 +525,7 @@ impl<'a> Gantz<'a> {
             reset_base_graph: None,
             reset_all_demos: false,
             compile_config: None,
+            changed_heads: Vec::new(),
             responses: Responses::default(),
         };
 
@@ -859,6 +865,7 @@ where
                     closed_heads: &mut gantz_response.closed_heads,
                     new_branch: &mut gantz_response.new_branch,
                     responses: &mut gantz_response.responses,
+                    changed_heads: &mut gantz_response.changed_heads,
                     base_names,
                     base_immutable: gantz.base_immutable,
                 };
@@ -1053,13 +1060,16 @@ where
                 if let Some(fh) = access.heads().get(*focused_head).cloned() {
                     let immutable = head_immutable(&fh, gantz.base_immutable, base_names);
                     let head_state = state.open_heads.entry(fh.clone()).or_default();
-                    let responses = access.with_head_mut(&fh, |data| {
+                    let result = access.with_head_mut(&fh, |data| {
                         node_inspector(gantz.env, data.graph, data.vm, head_state, immutable, ui)
                             .inner
                     });
-                    gantz_response
-                        .responses
-                        .extend(Some(&fh), responses.into_iter().flatten());
+                    if let Some((changed, payloads)) = result {
+                        if changed {
+                            gantz_response.changed_heads.push(fh.clone());
+                        }
+                        gantz_response.responses.extend(Some(&fh), payloads);
+                    }
                 }
             }
             Pane::Steel => {
@@ -1166,6 +1176,8 @@ where
     new_branch: &'a mut Option<(gantz_ca::Head, String)>,
     /// Dynamic payloads emitted from within the graph scenes.
     responses: &'a mut Responses,
+    /// Heads whose graph had a CA-affecting edit this frame.
+    changed_heads: &'a mut Vec<gantz_ca::Head>,
     base_names: &'a gantz_ca::registry::Names,
     base_immutable: bool,
 }
@@ -1393,6 +1405,10 @@ where
             // Focus this head when clicking on the graph or any of its nodes.
             if response.scene.clicked() || response.any_node_interacted() {
                 *self.focused_head = ix;
+            }
+            // Record a CA-affecting edit so the app can commit just this head.
+            if response.changed {
+                self.changed_heads.push(pane_head.clone());
             }
             // Tag the scene's emissions with this head.
             self.responses.extend(Some(&*pane_head), response.responses);
@@ -2191,7 +2207,8 @@ fn head_immutable(
     base_immutable && is_base && !is_demo
 }
 
-/// Returns the payloads emitted by node UIs within the inspector.
+/// Returns whether any inspected node had a CA-affecting edit, together with
+/// the payloads emitted by node UIs within the inspector.
 fn node_inspector<N>(
     registry: &dyn Registry,
     root: &mut gantz_core::node::graph::Graph<N>,
@@ -2199,12 +2216,13 @@ fn node_inspector<N>(
     head_state: &mut OpenHeadState,
     immutable: bool,
     ui: &mut egui::Ui,
-) -> egui::InnerResponse<Vec<DynResponse>>
+) -> egui::InnerResponse<(bool, Vec<DynResponse>)>
 where
     N: Node + NodeUi,
 {
     pane_ui(ui, |ui| {
         let mut responses = Vec::new();
+        let mut changed = false;
         egui::ScrollArea::vertical()
             .auto_shrink(egui::Vec2b::FALSE)
             .show(ui, |ui| {
@@ -2223,15 +2241,10 @@ where
                         };
                         let ix = id.index();
                         let path = [ix];
-                        let ctx = NodeCtx::new(
-                            registry,
-                            &path[..],
-                            &inlets,
-                            &outlets,
-                            vm,
-                            &mut responses,
-                        );
+                        let ctx = NodeCtx::new(registry, &path[..], &inlets, &outlets, vm);
                         let resp = widget::NodeInspector::new(node, ctx, immutable).show(ui);
+                        changed |= resp.changed;
+                        responses.extend(resp.payloads);
                         if resp.label_response.clicked() {
                             let sel = &mut head_state.scene.interaction.selection.nodes;
                             if ui.input(|i| i.modifiers.command) {
@@ -2246,7 +2259,7 @@ where
                     });
                 }
             });
-        responses
+        (changed, responses)
     })
 }
 

--- a/crates/gantz_egui/src/widget/global_config.rs
+++ b/crates/gantz_egui/src/widget/global_config.rs
@@ -11,6 +11,8 @@ use super::gantz::LayoutConfig;
 pub struct GlobalConfigResponse {
     /// The global compile config was changed via the compile toggles.
     pub compile_config: Option<gantz_core::compile::Config>,
+    /// The change-tracking validation toggle was changed (its new value).
+    pub validate_change_tracking: Option<bool>,
     /// The "Reset all demos" button was clicked.
     pub reset_all_demos: bool,
 }
@@ -18,16 +20,22 @@ pub struct GlobalConfigResponse {
 /// Render the global configuration controls.
 ///
 /// `compile_config` is the current global config; when `Some` the compile
-/// toggles are shown. `layout_config` holds the global auto-layout parameters
-/// (mutated in place). The config applies to all open heads.
+/// toggles are shown. `validate_change_tracking` is the current state of the
+/// change-tracking validation toggle; when `Some` the toggle is shown.
+/// `layout_config` holds the global auto-layout parameters (mutated in place).
+/// The config applies to all open heads.
 pub fn global_config(
     compile_config: Option<gantz_core::compile::Config>,
+    validate_change_tracking: Option<bool>,
     layout_config: &mut LayoutConfig,
     ui: &mut egui::Ui,
 ) -> GlobalConfigResponse {
     let mut changed_config = None;
-    if let Some(mut cfg) = compile_config {
+    let mut changed_validate = None;
+    if compile_config.is_some() || validate_change_tracking.is_some() {
         ui.label("Compile:");
+    }
+    if let Some(mut cfg) = compile_config {
         let mut changed = false;
         changed |= ui
             .checkbox(&mut cfg.validate_ir, "Validate IR")
@@ -50,6 +58,22 @@ pub fn global_config(
         if changed {
             changed_config = Some(cfg);
         }
+    }
+    if let Some(mut v) = validate_change_tracking {
+        if ui
+            .checkbox(&mut v, "Validate change tracking")
+            .on_hover_text(
+                "Re-hash every open graph each frame and warn if one changed \
+                 without being reported - a way to catch a missed `changed` \
+                 signal. A debugging aid only; leave off in normal use as it \
+                 reinstates the per-frame hashing this avoids.",
+            )
+            .changed()
+        {
+            changed_validate = Some(v);
+        }
+    }
+    if compile_config.is_some() || validate_change_tracking.is_some() {
         ui.separator();
     }
 
@@ -101,6 +125,7 @@ pub fn global_config(
 
     GlobalConfigResponse {
         compile_config: changed_config,
+        validate_change_tracking: changed_validate,
         reset_all_demos,
     }
 }

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -21,6 +21,11 @@ pub struct GraphSceneResponse {
     pub scene: egui::Response,
     /// Responses from each node, keyed by node index.
     pub nodes: Vec<(NodeIndex, NodeResponse)>,
+    /// Whether anything CA-affecting changed about the graph this frame: a node
+    /// reported a change (see [`NodeUi`]), or the scene itself edited the graph
+    /// structure (added/removed an edge, deleted a node). Lets the application
+    /// detect edits without re-hashing the whole graph each frame.
+    pub changed: bool,
     /// Dynamic payloads emitted within the scene (node UIs, context menus),
     /// to be handled by the application after the pass.
     pub responses: Vec<DynResponse>,
@@ -186,6 +191,8 @@ where
         }
         let mut node_responses = Vec::new();
         let mut responses: Vec<DynResponse> = Vec::new();
+        // Set if a node or the scene makes a CA-affecting edit this pass.
+        let mut changed = false;
         let selected: HashSet<egui_graph::NodeId> = state
             .interaction
             .selection
@@ -206,13 +213,14 @@ where
                         nctx,
                         state,
                         &mut responses,
+                        &mut changed,
                         vm,
                         immutable,
                         ui,
                     );
                 })
                 .edges(ui, |ectx, ui| {
-                    edges(self.graph, ectx, state, &mut responses, ui)
+                    edges(self.graph, ectx, state, &mut responses, &mut changed, ui)
                 });
             });
 
@@ -300,6 +308,7 @@ where
         GraphSceneResponse {
             scene: graph_response.response,
             nodes: node_responses,
+            changed,
             responses,
         }
     }
@@ -462,6 +471,7 @@ fn nodes<N>(
     nctx: &mut egui_graph::NodesCtx,
     state: &mut GraphSceneState,
     responses: &mut Vec<DynResponse>,
+    changed: &mut bool,
     vm: &mut Engine,
     immutable: bool,
     ui: &mut egui::Ui,
@@ -493,9 +503,11 @@ where
                 // A node at this (root) level has the single-element state path
                 // `[n_ix]`.
                 let node_path = [n_ix];
-                let node_ctx =
-                    crate::NodeCtx::new(registry, &node_path, &inlets, &outlets, vm, responses);
-                node.ui(node_ctx, nui_ctx)
+                let node_ctx = crate::NodeCtx::new(registry, &node_path, &inlets, &outlets, vm);
+                let r = node.ui(node_ctx, nui_ctx);
+                *changed |= r.changed;
+                responses.extend(r.payloads);
+                r.framed
             });
 
         // Attach on-hover docs to each socket. Each node describes its own
@@ -530,6 +542,7 @@ where
                             // Check that this edge doesn't already exist.
                             if !graph.edges(a).any(|e| e.target() == b && *e.weight() == w) {
                                 graph.add_edge(a, b, w);
+                                *changed = true;
                             }
                         }
                     }
@@ -614,9 +627,10 @@ where
             }
             // Node-specific items (e.g. the log node's "open logs").
             let node_path = [n_ix];
-            let mut node_ctx =
-                crate::NodeCtx::new(registry, &node_path, &inlets, &outlets, vm, responses);
-            graph[n_id].context_menu(&mut node_ctx, ui);
+            let mut node_ctx = crate::NodeCtx::new(registry, &node_path, &inlets, &outlets, vm);
+            let cm = graph[n_id].context_menu(&mut node_ctx, ui);
+            *changed |= cm.changed;
+            responses.extend(cm.payloads);
         });
 
         node_responses.push((n_id, response));
@@ -628,6 +642,7 @@ where
             let _ = gantz_core::node::state::remove_value(vm, &[n_id.index()]);
             graph.remove_node(n_id);
             state.interaction.selection.nodes.remove(&n_id);
+            *changed = true;
         }
     }
 
@@ -676,6 +691,7 @@ fn edges<N>(
     ectx: &mut egui_graph::EdgesCtx,
     state: &mut GraphSceneState,
     responses: &mut Vec<DynResponse>,
+    changed: &mut bool,
     ui: &mut egui::Ui,
 ) {
     // Track whether any edge has a context menu open this frame.
@@ -695,6 +711,7 @@ fn edges<N>(
         if response.deleted() {
             graph.remove_edge(e);
             state.interaction.selection.edges.remove(&e);
+            *changed = true;
         } else if response.changed() {
             if selected {
                 state.interaction.selection.edges.insert(e);

--- a/crates/gantz_egui/src/widget/node_inspector.rs
+++ b/crates/gantz_egui/src/widget/node_inspector.rs
@@ -1,4 +1,4 @@
-use crate::{NodeCtx, NodeUi};
+use crate::{InspectorRowsResponse, NodeCtx, NodeUi, response::DynResponse};
 use egui::scroll_area::ScrollAreaOutput;
 use egui_extras::{Column, TableBuilder};
 use gantz_core::node::{self, MetaCtx, Node};
@@ -15,6 +15,11 @@ pub struct NodeInspectorResponse {
     pub scroll_area_output: ScrollAreaOutput<()>,
     pub node_response: Option<egui::Response>,
     pub label_response: egui::Response,
+    /// Whether the inspector made a CA-affecting edit to the node this frame
+    /// (from its rows or its extra UI). See [`NodeUi`].
+    pub changed: bool,
+    /// Payloads emitted from the inspector UI, for the application to handle.
+    pub payloads: Vec<DynResponse>,
 }
 
 impl<'a, N> NodeInspector<'a, N>
@@ -35,15 +40,19 @@ where
             mut ctx,
             immutable,
         } = self;
-        let (scroll_area_output, label_response) = table(node, &mut ctx, immutable, ui);
+        let (scroll_area_output, label_response, rows) = table(node, &mut ctx, immutable, ui);
         if immutable {
             ui.disable();
         }
-        let node_response = node.inspector_ui(ctx, ui);
+        let extra = node.inspector_ui(ctx, ui);
+        let mut payloads = rows.payloads;
+        payloads.extend(extra.payloads);
         NodeInspectorResponse {
             scroll_area_output,
-            node_response,
+            node_response: extra.inner,
             label_response,
+            changed: rows.changed || extra.changed,
+            payloads,
         }
     }
 }
@@ -57,7 +66,7 @@ pub fn table(
     ctx: &mut NodeCtx,
     immutable: bool,
     ui: &mut egui::Ui,
-) -> (ScrollAreaOutput<()>, egui::Response) {
+) -> (ScrollAreaOutput<()>, egui::Response, InspectorRowsResponse) {
     // Extract info we need upfront before the closure borrows ctx.
     let registry = ctx.registry();
     let get_node = |ca: &gantz_ca::ContentAddr| registry.node(ca);
@@ -84,6 +93,7 @@ pub fn table(
     );
     ui.add_space(ui.spacing().item_spacing.y);
     let row_h = table_row_h(ui);
+    let mut rows_resp = InspectorRowsResponse::default();
     let scroll_area_output = TableBuilder::new(ui)
         .vscroll(false)
         .column(Column::auto().at_least(50.0).resizable(true))
@@ -147,9 +157,9 @@ pub fn table(
             if immutable {
                 body.ui_mut().disable();
             }
-            node.inspector_rows(ctx, &mut body);
+            rows_resp = node.inspector_rows(ctx, &mut body);
         });
-    (scroll_area_output, label_response)
+    (scroll_area_output, label_response, rows_resp)
 }
 
 /// Format the node's path string.
@@ -181,13 +191,15 @@ struct SocketDocEditState {
 /// (and trimming trailing whitespace) on every keystroke, and means the node -
 /// and thus the working graph - only changes on commit, so editing produces a
 /// single graph edit rather than one per keystroke. `id_salt` scopes the edit
-/// state to the node. Returns the combined field response.
+/// state to the node. Returns the combined field response together with whether
+/// a commit actually changed `ty`/`description` (so the caller can report the
+/// CA-affecting edit), `true` only on the flush frame that writes a new value.
 pub(crate) fn socket_doc_editor(
     ui: &mut egui::Ui,
     id_salt: impl std::hash::Hash,
     ty: &mut String,
     description: &mut String,
-) -> egui::Response {
+) -> (egui::Response, bool) {
     let id = egui::Id::new("socket-doc-editor").with(&id_salt);
     let mut st: SocketDocEditState = ui.memory(|m| m.data.get_temp(id)).unwrap_or_default();
 
@@ -229,8 +241,12 @@ pub(crate) fn socket_doc_editor(
 
     let resp = ty_resp.union(desc_resp);
 
+    let mut changed = false;
     if commit {
         let new = (st.ty.trim().to_string(), st.desc.trim().to_string());
+        // Only a commit that actually alters the stored fields is a CA-affecting
+        // edit; committing unchanged text (e.g. a bare focus loss) is not.
+        changed = new.0 != *ty || new.1 != *description;
         *ty = new.0.clone();
         *description = new.1.clone();
         // Keep the seed in sync with what we just wrote back so the trimmed
@@ -241,5 +257,5 @@ pub(crate) fn socket_doc_editor(
     }
 
     ui.memory_mut(|m| m.data.insert_temp(id, st));
-    resp
+    (resp, changed)
 }

--- a/crates/gantz_egui/src/widget/settings.rs
+++ b/crates/gantz_egui/src/widget/settings.rs
@@ -17,6 +17,8 @@ enum SettingsTab {
 pub struct SettingsResponse {
     /// The global compile config was changed (Global subtab).
     pub compile_config: Option<gantz_core::compile::Config>,
+    /// The change-tracking validation toggle was changed (Global subtab).
+    pub validate_change_tracking: Option<bool>,
     /// The "Reset all demos" button was clicked (Global subtab).
     pub reset_all_demos: bool,
     /// The "reset all" layout button was clicked (Panes subtab).
@@ -27,6 +29,7 @@ pub struct SettingsResponse {
 pub fn settings(
     view: &mut ViewToggles,
     compile_config: Option<gantz_core::compile::Config>,
+    validate_change_tracking: Option<bool>,
     layout_config: &mut LayoutConfig,
     ui: &mut egui::Ui,
 ) -> SettingsResponse {
@@ -85,8 +88,10 @@ pub fn settings(
             ui.weak("Style configuration coming soon.");
         }
         SettingsTab::Global => {
-            let g = super::global_config(compile_config, layout_config, ui);
+            let g =
+                super::global_config(compile_config, validate_change_tracking, layout_config, ui);
             res.compile_config = g.compile_config;
+            res.validate_change_tracking = g.validate_change_tracking;
             res.reset_all_demos = g.reset_all_demos;
         }
     }


### PR DESCRIPTION
## Summary

Previously the bevy app re-hashed every open head's working graph every frame (`ca::graph_addr`) just to detect edits. That hash is redundant: the registry already knows each head's committed graph CA. This PR makes node UIs report changes explicitly and commits edits at their source, so `vm::sync` reads the committed CA and never re-hashes.

Closes #159. Completes the reliable-`changed` follow-up from #62 (the custom response types it asked for already exist).

## What changed

**`gantz_egui` - `NodeUi` returns changed-aware responses**
- `NodeUi::{ui, inspector_rows, inspector_ui, context_menu}` now return typed responses (`NodeUiResponse`, `InspectorRowsResponse`, `InspectorUiResponse`, `ContextMenuResponse`) carrying a `changed` flag + any emitted payloads. The `NodeCtx::response` side-channel (and `push_eval`/`pull_eval`) is removed; emission is via builder helpers on the responses.
- Each impl marks `changed` only at content-address-affecting weight writes (buffered edits like comment text / socket docs signal at *flush*, not keystroke; silent resyncs signal too; Number/eval do not).
- Per-node `changed` aggregates into `GraphSceneResponse.changed` and up to `GantzResponse.changed_heads`.
- `Comment.size` is now part of its content address, so resizes are real, undoable edits (the write is gated to a settled, non-dragging frame).

**`bevy_gantz` - commit at edit sites; `vm::sync` reads committed CA**
- New invariant (documented on `WorkingGraph`): any system that mutates a head's working graph commits it before returning, so between systems the working graph's CA always equals the head's committed CA.
- `vm::commit_working_graph` is the one place a working graph is hashed (commit + head update + `CommittedEvent`, no-op if unchanged). Called by the GUI pass (for `changed_heads`) and the in-place graph ops.
- `vm::sync` is now a plain recompile-on-input-change poller keyed off the committed CA + config - no per-frame hashing, no commit, no dirty marker.
- A default-off `ValidateCommitted` toggle (Settings → Global) runs `vm::validate_committed`, which warns if any working graph diverges from its committed CA - i.e. a missed commit (invariant violation).

The eframe demo keeps its existing graph_addr commit loop.

## Notes

- `gantz_ca`: generalised `CaHash` from `[u8; N]` to `[T; N]` (byte-identical for `[u8; N]`, so no content-address shifts) and relaxed `content_addr` to `?Sized`.