### PR TITLE
feat: Add a configurable `plot` node to `gantz_egui`

### DIFF
--- a/crates/gantz/src/builtin.rs
+++ b/crates/gantz/src/builtin.rs
@@ -129,6 +129,9 @@ fn primitives() -> Primitives {
     register_primitive(&mut p, "outlet", || {
         Box::new(gantz_core::node::graph::Outlet::default()) as Box<_>
     });
+    register_primitive(&mut p, "plot", || {
+        Box::new(gantz_egui::node::Plot::default()) as Box<_>
+    });
     p
 }
 

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -166,7 +166,7 @@ mod tests {
                     ("show_grid", Datum::Bool(false)),
                     ("show_axes", Datum::Bool(true)),
                     ("interactive", Datum::Bool(true)),
-                    ("margin", Datum::F64(0.25)),
+                    ("margin", Datum::Bool(false)),
                     ("y_min", Datum::F64(1.5)),
                     ("y_max", Datum::Null),
                 ],

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -45,6 +45,8 @@ impl Node for gantz_egui::node::Comment {}
 impl Node for bevy_gantz_egui::node::FrameBang {}
 #[typetag::serde]
 impl Node for gantz_egui::node::Inspect {}
+#[typetag::serde]
+impl Node for gantz_egui::node::Plot {}
 
 impl From<gantz_egui::node::NamedRef> for Box<dyn Node> {
     fn from(named: gantz_egui::node::NamedRef) -> Self {
@@ -142,6 +144,28 @@ mod tests {
                 vec![
                     ("ref_", Datum::Str("0".repeat(64))),
                     ("name", Datum::Str("mul".into())),
+                ],
+            ),
+            node_datum(
+                "Plot",
+                vec![
+                    ("mode", Datum::Str("Signal".into())),
+                    ("style", Datum::Str("Line".into())),
+                    ("capacity", Datum::U64(128)),
+                    ("width", Datum::U64(160)),
+                    ("height", Datum::U64(90)),
+                    (
+                        "color",
+                        Datum::Seq(vec![
+                            Datum::U64(10),
+                            Datum::U64(20),
+                            Datum::U64(30),
+                            Datum::U64(255),
+                        ]),
+                    ),
+                    ("show_grid", Datum::Bool(false)),
+                    ("show_axes", Datum::Bool(true)),
+                    ("interactive", Datum::Bool(true)),
                 ],
             ),
         ];

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -166,6 +166,9 @@ mod tests {
                     ("show_grid", Datum::Bool(false)),
                     ("show_axes", Datum::Bool(true)),
                     ("interactive", Datum::Bool(true)),
+                    ("margin", Datum::F64(0.25)),
+                    ("y_min", Datum::F64(1.5)),
+                    ("y_max", Datum::Null),
                 ],
             ),
         ];

--- a/crates/gantz_core/src/node/state.rs
+++ b/crates/gantz_core/src/node/state.rs
@@ -119,7 +119,14 @@ where
 
     fn register(&self, ctx: node::RegCtx<'_, '_>) {
         let (get_node, path, vm) = ctx.into_parts();
-        S::register(vm);
+        // Register the state type + its fns only once. Steel's `register_value`/
+        // `register_fn` allocate a new global slot and shadow the previous
+        // binding rather than overwriting it, so re-running this on every
+        // recompile (the engine persists across them) would leak. `register_type`
+        // binds the predicate under `S::NAME`, so its presence means `S` is set up.
+        if vm.extract_value(S::NAME).is_err() {
+            S::register(vm);
+        }
         // Only initialize state if not already present.
         if extract_value(vm, path).ok().flatten().is_none() {
             let val = default_node_state_steel_val::<S>();

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -283,6 +283,9 @@ fn primitives() -> Primitives {
     register_primitive(&mut p, "number", || {
         Box::new(gantz_std::Number::default()) as Box<_>
     });
+    register_primitive(&mut p, "plot", || {
+        Box::new(gantz_egui::node::Plot::default()) as Box<_>
+    });
     p
 }
 
@@ -326,6 +329,8 @@ impl Node for gantz_std::Number {}
 impl Node for gantz_egui::node::Inspect {}
 #[typetag::serde]
 impl Node for gantz_egui::node::NamedRef {}
+#[typetag::serde]
+impl Node for gantz_egui::node::Plot {}
 
 #[typetag::serde]
 impl Node for Box<dyn Node> {}

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -383,6 +383,16 @@ pub trait NodeUi {
     ) -> Option<SocketDoc> {
         None
     }
+
+    /// Whether the inspector's default table includes a row showing the node's
+    /// current VM state.
+    ///
+    /// Returns `true` by default. Override to `false` for nodes whose raw state
+    /// is large or unwieldy (e.g. a long buffer) and better summarised in
+    /// [`inspector_ui`](NodeUi::inspector_ui).
+    fn show_state(&self) -> bool {
+        true
+    }
 }
 
 /// A wrapper around a node's path and the VM providing easy access to the
@@ -594,6 +604,10 @@ where
     fn context_menu(&mut self, ctx: &mut NodeCtx, ui: &mut egui::Ui) -> ContextMenuResponse {
         (**self).context_menu(ctx, ui)
     }
+
+    fn show_state(&self) -> bool {
+        (**self).show_state()
+    }
 }
 
 macro_rules! impl_node_ui_for_ptr {
@@ -640,6 +654,10 @@ macro_rules! impl_node_ui_for_ptr {
 
             fn context_menu(&mut self, ctx: &mut NodeCtx, ui: &mut egui::Ui) -> ContextMenuResponse {
                 (**self).context_menu(ctx, ui)
+            }
+
+            fn show_state(&self) -> bool {
+                (**self).show_state()
             }
         }
     };

--- a/crates/gantz_egui/src/node.rs
+++ b/crates/gantz_egui/src/node.rs
@@ -10,8 +10,10 @@ pub use fn_named_ref::{FnNamedRef, FnNodeNames};
 pub use gantz_core::node::{Id, state};
 pub use inspect::Inspect;
 pub use named_ref::{NESTED_SEP, NameRegistry, NamedRef, missing_color, outdated_color};
+pub use plot::{Plot, PlotMode, PlotStyle};
 
 pub mod comment;
 pub mod fn_named_ref;
 pub mod inspect;
 pub mod named_ref;
+pub mod plot;

--- a/crates/gantz_egui/src/node/plot.rs
+++ b/crates/gantz_egui/src/node/plot.rs
@@ -254,13 +254,14 @@ impl NodeUi for Plot {
         let style = uictx.style();
         let interaction = uictx.interaction();
 
-        // A minimal extreme-bg frame, keeping the default rounded corners. The
-        // `margin` toggle controls whether the data is inset by the frame's
-        // regular margin or fills it.
+        // A minimal extreme-bg frame. The `margin` toggle controls whether the
+        // data is inset by the frame's regular margin (with rounded corners) or
+        // fills it edge-to-edge (with square corners, so nothing is clipped).
         let mut frame = egui_graph::node::default_frame(style, interaction);
         frame.fill = style.visuals.extreme_bg_color;
         if !self.margin {
             frame.inner_margin = egui::Margin::ZERO;
+            frame.corner_radius = egui::CornerRadius::ZERO;
         }
 
         let node_egui_id = uictx.egui_id();
@@ -331,39 +332,50 @@ impl NodeUi for Plot {
                         plot = plot.cursor_color(egui::Color32::TRANSPARENT);
                     }
 
-                    plot.show(ui, |plot_ui| {
-                        match plot_style {
-                            PlotStyle::Bars => {
-                                let bars = ys
-                                    .iter()
-                                    .enumerate()
-                                    .map(|(i, &y)| {
-                                        egui_plot::Bar::new(i as f64, y)
-                                            .width(1.0)
-                                            .fill(color)
-                                            .stroke(egui::Stroke::NONE)
-                                    })
-                                    .collect();
-                                plot_ui.bar_chart(
-                                    egui_plot::BarChart::new("", bars).allow_hover(interactive),
-                                );
+                    let plot_resp = plot
+                        .show(ui, |plot_ui| {
+                            match plot_style {
+                                PlotStyle::Bars => {
+                                    let bars = ys
+                                        .iter()
+                                        .enumerate()
+                                        .map(|(i, &y)| {
+                                            egui_plot::Bar::new(i as f64, y)
+                                                .width(1.0)
+                                                .fill(color)
+                                                .stroke(egui::Stroke::NONE)
+                                        })
+                                        .collect();
+                                    plot_ui.bar_chart(
+                                        egui_plot::BarChart::new("", bars).allow_hover(interactive),
+                                    );
+                                }
+                                PlotStyle::Line => {
+                                    let points = egui_plot::PlotPoints::from_ys_f64(&ys);
+                                    plot_ui.line(
+                                        egui_plot::Line::new("", points)
+                                            .color(color)
+                                            .allow_hover(interactive),
+                                    );
+                                }
                             }
-                            PlotStyle::Line => {
-                                let points = egui_plot::PlotPoints::from_ys_f64(&ys);
-                                plot_ui.line(
-                                    egui_plot::Line::new("", points)
-                                        .color(color)
-                                        .allow_hover(interactive),
-                                );
-                            }
-                        }
-                        // Drive the view deterministically from the data + config
-                        // (the plot never pans), so live updates and min/max apply.
-                        let ([xlo, ylo], [xhi, yhi]) = bounds;
-                        plot_ui.set_plot_bounds_x(xlo..=xhi);
-                        plot_ui.set_plot_bounds_y(ylo..=yhi);
-                    })
-                    .response
+                            // Drive the view deterministically from the data +
+                            // config (the plot never pans), so live updates and
+                            // min/max apply.
+                            let ([xlo, ylo], [xhi, yhi]) = bounds;
+                            plot_ui.set_plot_bounds_x(xlo..=xhi);
+                            plot_ui.set_plot_bounds_y(ylo..=yhi);
+                        })
+                        .response;
+
+                    // egui_plot sets a crosshair *mouse cursor* on hover; when not
+                    // interactive, restore the default arrow so the plot reads as a
+                    // static node. (The resize corner sets its own cursor after
+                    // this, so it is unaffected.)
+                    if !interactive && plot_resp.hovered() {
+                        ui.ctx().set_cursor_icon(egui::CursorIcon::Default);
+                    }
+                    plot_resp
                 })
         });
 
@@ -386,8 +398,20 @@ impl NodeUi for Plot {
             });
             row.col(|ui| {
                 ui.horizontal(|ui| {
-                    changed |= radio_option(ui, &mut self.mode, PlotMode::Scope, "scope");
-                    changed |= radio_option(ui, &mut self.mode, PlotMode::Signal, "signal");
+                    changed |= radio_option(
+                        ui,
+                        &mut self.mode,
+                        PlotMode::Scope,
+                        "scope",
+                        "accumulate a scrolling history",
+                    );
+                    changed |= radio_option(
+                        ui,
+                        &mut self.mode,
+                        PlotMode::Signal,
+                        "signal",
+                        "plot the incoming value directly",
+                    );
                 });
             });
         });
@@ -398,8 +422,20 @@ impl NodeUi for Plot {
             });
             row.col(|ui| {
                 ui.horizontal(|ui| {
-                    changed |= radio_option(ui, &mut self.style, PlotStyle::Bars, "bars");
-                    changed |= radio_option(ui, &mut self.style, PlotStyle::Line, "line");
+                    changed |= radio_option(
+                        ui,
+                        &mut self.style,
+                        PlotStyle::Bars,
+                        "bars",
+                        "draw as contiguous bars",
+                    );
+                    changed |= radio_option(
+                        ui,
+                        &mut self.style,
+                        PlotStyle::Line,
+                        "line",
+                        "draw as a connected line",
+                    );
                 });
             });
         });
@@ -428,7 +464,9 @@ impl NodeUi for Plot {
             row.col(|ui| {
                 if ui
                     .checkbox(&mut self.margin, "")
-                    .on_hover_text("inset the data within the node frame's margin")
+                    .on_hover_text(
+                        "inset the data within the node frame's margin (rounded corners)",
+                    )
                     .changed()
                 {
                     changed = true;
@@ -443,11 +481,20 @@ impl NodeUi for Plot {
             row.col(|ui| {
                 ui.horizontal(|ui| {
                     let mut col = resolve_color(self.color, ui);
-                    if ui.color_edit_button_srgba(&mut col).changed() {
+                    if ui
+                        .color_edit_button_srgba(&mut col)
+                        .on_hover_text("the line/bar colour")
+                        .changed()
+                    {
                         self.color = Some([col.r(), col.g(), col.b(), col.a()]);
                         changed = true;
                     }
-                    if self.color.is_some() && ui.button("theme").clicked() {
+                    if self.color.is_some()
+                        && ui
+                            .button("theme")
+                            .on_hover_text("follow the theme's strong text colour")
+                            .clicked()
+                    {
                         self.color = None;
                         changed = true;
                     }
@@ -455,14 +502,16 @@ impl NodeUi for Plot {
             });
         });
 
-        body.row(row_h, |mut row| {
+        // Min and max share a 2-row grid so their checkboxes/dialers stay aligned
+        // and don't shift as a dialer's value width changes.
+        body.row(row_h * 2.0, |mut row| {
             row.col(|ui| {
                 ui.label("range");
             });
             row.col(|ui| {
-                ui.horizontal(|ui| {
-                    changed |= bound_control(ui, "min", &mut self.y_min);
-                    changed |= bound_control(ui, "max", &mut self.y_max);
+                egui::Grid::new("plot_range").num_columns(2).show(ui, |ui| {
+                    changed |= bound_row(ui, "mn", "minimum", &mut self.y_min);
+                    changed |= bound_row(ui, "mx", "maximum", &mut self.y_max);
                 });
             });
         });
@@ -473,8 +522,14 @@ impl NodeUi for Plot {
             });
             row.col(|ui| {
                 ui.horizontal(|ui| {
-                    changed |= ui.checkbox(&mut self.show_grid, "grid").changed();
-                    changed |= ui.checkbox(&mut self.show_axes, "axes").changed();
+                    changed |= ui
+                        .checkbox(&mut self.show_grid, "grid")
+                        .on_hover_text("draw the background grid")
+                        .changed();
+                    changed |= ui
+                        .checkbox(&mut self.show_axes, "axes")
+                        .on_hover_text("draw the axes")
+                        .changed();
                     changed |= ui
                         .checkbox(&mut self.interactive, "interactive")
                         .on_hover_text("show a crosshair and value readout on hover")
@@ -542,10 +597,13 @@ fn radio_option<T: Copy + PartialEq>(
     current: &mut T,
     value: T,
     text: &str,
+    hover: &str,
 ) -> bool {
     let strong = ui.visuals().strong_text_color();
     let mut selected = *current == value;
-    let resp = ui.add(crate::widget::LabelToggle::new(text, &mut selected).selected_color(strong));
+    let resp = ui
+        .add(crate::widget::LabelToggle::new(text, &mut selected).selected_color(strong))
+        .on_hover_text(hover);
     // Clicking an already-selected option is a no-op (it stays selected).
     if resp.changed() && selected {
         *current = value;
@@ -555,24 +613,35 @@ fn radio_option<T: Copy + PartialEq>(
     }
 }
 
-/// A label, an enabling checkbox, and a value dialer for an optional fixed
-/// bound. Returns whether the bound changed.
-fn bound_control(ui: &mut egui::Ui, label: &str, bound: &mut Option<F32>) -> bool {
+/// One grid row for an optional fixed bound: a `label` cell, then a cell with a
+/// tightly-spaced enabling checkbox + value dialer. `kind` names the bound for
+/// hover text. Returns whether the bound changed.
+fn bound_row(ui: &mut egui::Ui, label: &str, kind: &str, bound: &mut Option<F32>) -> bool {
     let mut changed = false;
     ui.label(label);
-    let mut on = bound.is_some();
-    if ui.checkbox(&mut on, "").changed() {
-        *bound = on.then(|| bound.unwrap_or(F32(0.0)));
-        changed = true;
-    }
-    let mut v = bound.map(F32::get).unwrap_or(0.0);
-    if ui
-        .add_enabled(bound.is_some(), egui::DragValue::new(&mut v).speed(0.1))
-        .changed()
-    {
-        *bound = Some(F32(v));
-        changed = true;
-    }
+    ui.horizontal(|ui| {
+        // Tighten the gap between the checkbox and its dialer.
+        ui.spacing_mut().item_spacing.x *= 0.25;
+        let mut on = bound.is_some();
+        if ui
+            .checkbox(&mut on, "")
+            .on_hover_text(format!("clamp the {kind} value"))
+            .changed()
+        {
+            *bound = on.then(|| bound.unwrap_or(F32(0.0)));
+            changed = true;
+        }
+        let mut v = bound.map(F32::get).unwrap_or(0.0);
+        if ui
+            .add_enabled(bound.is_some(), egui::DragValue::new(&mut v).speed(0.1))
+            .on_hover_text(format!("the fixed {kind} value"))
+            .changed()
+        {
+            *bound = Some(F32(v));
+            changed = true;
+        }
+    });
+    ui.end_row();
     changed
 }
 

--- a/crates/gantz_egui/src/node/plot.rs
+++ b/crates/gantz_egui/src/node/plot.rs
@@ -232,9 +232,15 @@ impl gantz_core::Node for Plot {
         let path = ctx.path();
         node::state::init_value_if_absent(ctx.vm(), path, || SteelVal::ListV(Default::default()))
             .unwrap();
-        // Stateless and idempotent: re-registering the same name is a harmless
-        // overwrite shared across all plot nodes.
-        ctx.vm().register_fn("plot-push", plot_push);
+        // Register the shared `plot-push` helper, but only if absent. Steel's
+        // `register_fn` allocates a *new* global slot and shadows the previous
+        // binding rather than overwriting it, so re-registering on every
+        // recompile (the engine persists across them) would leak the old
+        // closure - a slow memory leak as the plot is edited. One binding is
+        // shared by every plot node.
+        if ctx.vm().extract_value("plot-push").is_err() {
+            ctx.vm().register_fn("plot-push", plot_push);
+        }
     }
 }
 
@@ -819,5 +825,25 @@ mod tests {
         // Stored as a lone number; `series` reads it as a single sample.
         let state = node::state::extract_value(&vm, &[p]).unwrap().unwrap();
         assert!(matches!(state, SteelVal::IntV(7)));
+    }
+
+    // Registering the graph again on the same engine (as a recompile does) must
+    // keep `plot-push` working - the registration guard must not skip the first
+    // registration, and must not break on the second. (The guard also prevents a
+    // leaked global binding per recompile.)
+    #[test]
+    fn re_registration_keeps_plot_push_working() {
+        let src = gantz_core::node::expr("5").unwrap().with_push_eval();
+        let plot = Plot {
+            mode: PlotMode::Scope,
+            capacity: 3,
+            ..Default::default()
+        };
+        let (g, s, p) = graph_with(Box::new(src) as Box<dyn Node>, plot);
+        let mut vm = vm_for(&g);
+        // A second registration pass over the same engine.
+        gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+        fire(&mut vm, &g, s, 5);
+        assert_eq!(list_of(&vm, p), vec![5.0, 5.0, 5.0]);
     }
 }

--- a/crates/gantz_egui/src/node/plot.rs
+++ b/crates/gantz_egui/src/node/plot.rs
@@ -1,0 +1,481 @@
+//! A Plot node for visualising numeric values flowing through the graph.
+//!
+//! The node body is intentionally minimal - just a plot - while its appearance
+//! and behaviour are configured through the node inspector and context menu.
+//!
+//! Two modes are supported:
+//! - [`PlotMode::Scope`]: the input is a single number; the node accumulates a
+//!   bounded, scrolling history and plots it like an oscilloscope.
+//! - [`PlotMode::Signal`]: the input is a list of numbers; the node plots the
+//!   whole list directly, replacing it on each evaluation.
+//!
+//! In both modes the node is a pass-through: its output forwards the input
+//! value unchanged (like [`super::Inspect`]), so a value can be observed without
+//! breaking the chain it flows through.
+
+use crate::widget::node_inspector;
+use crate::{NodeCtx, NodeUi, Registry, SocketDoc, SocketKind};
+use gantz_ca::CaHash;
+use gantz_core::node::{self, ExprCtx, ExprResult, MetaCtx, RegCtx};
+use serde::{Deserialize, Serialize};
+use steel::SteelVal;
+use steel::steel_vm::register_fn::RegisterFn;
+
+/// How the plot interprets and accumulates its input.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize, CaHash)]
+pub enum PlotMode {
+    /// The input is a single number; keep a bounded scrolling history.
+    Scope,
+    /// The input is a list of numbers; plot it directly, replacing the prior.
+    Signal,
+}
+
+/// How the series is drawn.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize, CaHash)]
+pub enum PlotStyle {
+    /// Contiguous bars (the default).
+    Bars,
+    /// A connected line.
+    Line,
+}
+
+/// A node that plots the numeric values it receives.
+///
+/// Every field feeds the content address (no `#[cahash(skip)]`), so each
+/// inspector edit is a real, persisted, undoable change rather than transient
+/// view state. The struct is deliberately float-free so `Hash`/`Eq`/`CaHash`
+/// all derive cleanly (`CaHash` has no `f32` impl, and the app's `dyn Node`
+/// requires `Hash`).
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize, CaHash)]
+#[cahash("gantz.plot")]
+pub struct Plot {
+    /// Scope (scalar history) or Signal (plot a list).
+    mode: PlotMode,
+    /// Bars or line.
+    style: PlotStyle,
+    /// The maximum number of samples retained in [`PlotMode::Scope`].
+    capacity: u32,
+    /// Persisted body width (split from a `[u16; 2]` since that is not `CaHash`).
+    width: u16,
+    /// Persisted body height.
+    height: u16,
+    /// Line/bar colour. `None` follows the theme's strong text colour.
+    color: Option<[u8; 4]>,
+    /// Whether to draw the background grid.
+    show_grid: bool,
+    /// Whether to draw the axes.
+    show_axes: bool,
+    /// Whether the embedded plot accepts drag/zoom/scroll. Off by default to
+    /// avoid clashing with the graph's own pan/zoom.
+    interactive: bool,
+}
+
+impl Plot {
+    /// The default body size, `[width, height]`.
+    pub const DEFAULT_SIZE: [u16; 2] = [120, 80];
+    /// The default scope history capacity.
+    pub const DEFAULT_CAPACITY: u32 = 256;
+}
+
+impl Default for Plot {
+    fn default() -> Self {
+        Self {
+            mode: PlotMode::Scope,
+            style: PlotStyle::Bars,
+            capacity: Self::DEFAULT_CAPACITY,
+            width: Self::DEFAULT_SIZE[0],
+            height: Self::DEFAULT_SIZE[1],
+            color: None,
+            show_grid: true,
+            show_axes: true,
+            interactive: false,
+        }
+    }
+}
+
+/// Append `val` to the scope history `state`, dropping oldest entries so the
+/// result holds at most `cap` items. Registered on the VM as `plot-push` and
+/// called from the generated [`PlotMode::Scope`] expression.
+///
+/// `cap` is passed as an argument (not captured) so a single shared `plot-push`
+/// serves every plot node with its own, always-current capacity.
+fn plot_push(state: SteelVal, val: SteelVal, cap: SteelVal) -> SteelVal {
+    let cap = match cap {
+        SteelVal::IntV(n) if n > 0 => n as usize,
+        _ => 0,
+    };
+    // Reuse the existing list, or start fresh if state isn't a list yet.
+    let mut list = match state {
+        SteelVal::ListV(list) => list,
+        _ => Default::default(),
+    };
+    list.push_back(val);
+    while list.len() > cap {
+        list.pop_front();
+    }
+    SteelVal::ListV(list)
+}
+
+/// Read the node's stored series as `f64`s, skipping any non-numeric entries.
+fn series(ctx: &NodeCtx) -> Vec<f64> {
+    match ctx.extract_value() {
+        Ok(Some(SteelVal::ListV(list))) => list.iter().filter_map(steel_num).collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Convert a numeric [`SteelVal`] to `f64`.
+fn steel_num(val: &SteelVal) -> Option<f64> {
+    match val {
+        SteelVal::NumV(f) => Some(*f),
+        SteelVal::IntV(i) => Some(*i as f64),
+        _ => None,
+    }
+}
+
+impl gantz_core::Node for Plot {
+    fn n_inputs(&self, _ctx: MetaCtx) -> usize {
+        1
+    }
+
+    fn n_outputs(&self, _ctx: MetaCtx) -> usize {
+        1
+    }
+
+    fn stateful(&self, _ctx: MetaCtx) -> bool {
+        true
+    }
+
+    fn expr(&self, ctx: ExprCtx<'_, '_>) -> ExprResult {
+        // The node forwards its input unchanged (pass-through) while capturing
+        // the series to plot into `state`.
+        let expr = match ctx.inputs().get(0) {
+            Some(Some(val)) => match self.mode {
+                // Append the incoming number to the bounded history.
+                PlotMode::Scope => format!(
+                    "(begin (if (number? {val}) (set! state (plot-push state {val} {cap})) void) {val})",
+                    cap = self.capacity,
+                ),
+                // Store the incoming list directly.
+                PlotMode::Signal => format!("(begin (set! state {val}) {val})"),
+            },
+            // No input connected: nothing to capture or forward; yield the
+            // stored series (mirrors `inspect`'s unconnected behaviour).
+            _ => "(begin state)".to_string(),
+        };
+        node::parse_expr(&expr)
+    }
+
+    fn register(&self, mut ctx: RegCtx<'_, '_>) {
+        let path = ctx.path();
+        node::state::init_value_if_absent(ctx.vm(), path, || SteelVal::ListV(Default::default()))
+            .unwrap();
+        // Stateless and idempotent: re-registering the same name is a harmless
+        // overwrite shared across all plot nodes.
+        ctx.vm().register_fn("plot-push", plot_push);
+    }
+}
+
+impl NodeUi for Plot {
+    fn name(&self, _: &dyn Registry) -> &str {
+        "plot"
+    }
+
+    fn description(&self) -> Option<&'static str> {
+        Some("Plot incoming values as a scrolling scope or a signal/array")
+    }
+
+    fn ui(
+        &mut self,
+        ctx: NodeCtx,
+        uictx: egui_graph::NodeCtx,
+    ) -> egui_graph::FramedResponse<egui::Response> {
+        let style = uictx.style();
+        let interaction = uictx.interaction();
+
+        // A minimal extreme-bg frame, like `inspect`.
+        let mut frame = egui_graph::node::default_frame(style, interaction);
+        frame.fill = style.visuals.extreme_bg_color;
+
+        let node_egui_id = uictx.egui_id();
+        let resize_id = node_egui_id.with("resize");
+        let plot_id = node_egui_id.with("plot");
+        let min_size = egui::Vec2::splat(style.interaction.interact_radius * 2.0);
+        let default_size = egui::vec2(self.width as f32, self.height as f32);
+
+        // Read the series once, up-front (only borrows `ctx`).
+        let ys = series(&ctx);
+
+        uictx.framed_with(frame, |ui, _sockets| {
+            // Both axes are user-resizable while the node is selected.
+            let resizable = egui::Vec2b::new(interaction.selected, interaction.selected);
+            egui::containers::Resize::default()
+                .id(resize_id)
+                .resizable(resizable)
+                .default_size(default_size)
+                .min_size(min_size)
+                .with_stroke(false)
+                .show(ui, |ui| {
+                    let avail = ui.available_size();
+
+                    // Persist the resized body size. Like every field here it
+                    // is content-addressed, so a resize is a real edit.
+                    self.width = avail.x.max(min_size.x).round() as u16;
+                    self.height = avail.y.max(min_size.y).round() as u16;
+
+                    // Resolve config into locals so no borrow of `self` is held
+                    // across the plot-building closure below.
+                    let plot_style = self.style;
+                    let show_grid = self.show_grid;
+                    let show_axes = self.show_axes;
+                    let interactive = self.interactive;
+                    let color = match self.color {
+                        Some([r, g, b, a]) => egui::Color32::from_rgba_unmultiplied(r, g, b, a),
+                        None => ui.visuals().strong_text_color(),
+                    };
+
+                    let plot = egui_plot::Plot::new(plot_id)
+                        .width(avail.x)
+                        .height(avail.y)
+                        .show_background(false)
+                        .show_axes(egui::Vec2b::new(show_axes, show_axes))
+                        .show_grid(egui::Vec2b::new(show_grid, show_grid))
+                        .allow_drag(interactive)
+                        .allow_zoom(interactive)
+                        .allow_scroll(interactive)
+                        .allow_boxed_zoom(interactive);
+
+                    plot.show(ui, |plot_ui| match plot_style {
+                        PlotStyle::Bars => {
+                            let bars = ys
+                                .iter()
+                                .enumerate()
+                                .map(|(i, &y)| egui_plot::Bar::new(i as f64, y).width(1.0))
+                                .collect();
+                            plot_ui.bar_chart(egui_plot::BarChart::new("", bars).color(color));
+                        }
+                        PlotStyle::Line => {
+                            let points = egui_plot::PlotPoints::from_ys_f64(&ys);
+                            plot_ui.line(egui_plot::Line::new("", points).color(color));
+                        }
+                    })
+                    .response
+                })
+        })
+    }
+
+    fn inspector_rows(&mut self, _ctx: &mut NodeCtx, body: &mut egui_extras::TableBody) {
+        let row_h = node_inspector::table_row_h(body.ui_mut());
+
+        // Mode.
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.add(egui::Label::new("mode").selectable(false))
+                    .on_hover_text("scope: scrolling history of a number; signal: plot a list");
+            });
+            row.col(|ui| {
+                ui.horizontal(|ui| {
+                    ui.selectable_value(&mut self.mode, PlotMode::Scope, "scope");
+                    ui.selectable_value(&mut self.mode, PlotMode::Signal, "signal");
+                });
+            });
+        });
+
+        // Style.
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.add(egui::Label::new("style").selectable(false))
+                    .on_hover_text("how the series is drawn");
+            });
+            row.col(|ui| {
+                ui.horizontal(|ui| {
+                    ui.selectable_value(&mut self.style, PlotStyle::Bars, "bars");
+                    ui.selectable_value(&mut self.style, PlotStyle::Line, "line");
+                });
+            });
+        });
+
+        // Capacity (scope history length).
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.add(egui::Label::new("capacity").selectable(false))
+                    .on_hover_text("max samples retained in scope mode");
+            });
+            row.col(|ui| {
+                let mut n = self.capacity as i32;
+                if ui
+                    .add(egui::DragValue::new(&mut n).range(1..=4096).speed(1.0))
+                    .changed()
+                {
+                    self.capacity = n.clamp(1, 4096) as u32;
+                }
+            });
+        });
+
+        // Colour (with a reset-to-theme button when overridden).
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.add(egui::Label::new("colour").selectable(false))
+                    .on_hover_text("line/bar colour; defaults to the theme");
+            });
+            row.col(|ui| {
+                ui.horizontal(|ui| {
+                    let mut col = match self.color {
+                        Some([r, g, b, a]) => egui::Color32::from_rgba_unmultiplied(r, g, b, a),
+                        None => ui.visuals().strong_text_color(),
+                    };
+                    if ui.color_edit_button_srgba(&mut col).changed() {
+                        self.color = Some([col.r(), col.g(), col.b(), col.a()]);
+                    }
+                    if self.color.is_some() && ui.button("theme").clicked() {
+                        self.color = None;
+                    }
+                });
+            });
+        });
+
+        // Grid / axes / interactive toggles.
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.add(egui::Label::new("display").selectable(false));
+            });
+            row.col(|ui| {
+                ui.horizontal(|ui| {
+                    ui.checkbox(&mut self.show_grid, "grid");
+                    ui.checkbox(&mut self.show_axes, "axes");
+                    ui.checkbox(&mut self.interactive, "interactive")
+                        .on_hover_text("allow drag/zoom inside the node");
+                });
+            });
+        });
+
+        // Size readout.
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.add(egui::Label::new("size").selectable(false));
+            });
+            row.col(|ui| {
+                ui.label(format!("{} x {}", self.width, self.height));
+            });
+        });
+    }
+
+    fn context_menu(&mut self, ctx: &mut NodeCtx, ui: &mut egui::Ui) {
+        if ui
+            .button("clear history")
+            .on_hover_text("empty the plotted series")
+            .clicked()
+        {
+            ctx.update_value(SteelVal::ListV(Default::default())).ok();
+            ui.close();
+        }
+    }
+
+    fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, _ix: usize) -> Option<SocketDoc> {
+        Some(match kind {
+            SocketKind::Input => SocketDoc::ty("number | list").with_description(
+                "scope: a number appended to the history; signal: a list of numbers to plot",
+            ),
+            SocketKind::Output => {
+                SocketDoc::ty("any").with_description("the input value, unchanged")
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gantz_core::node::{Node, WithPushEval};
+    use gantz_core::{
+        Edge, ROOT_STATE,
+        compile::{entry_fn_name, entrypoint, push_pull_entrypoints},
+    };
+    use steel::steel_vm::engine::Engine;
+
+    // A node lookup is unnecessary for these self-contained graphs.
+    fn no_lookup(_: &gantz_ca::ContentAddr) -> Option<&'static dyn Node> {
+        None
+    }
+
+    // Compile `g`, init a base VM with node state, and load the module.
+    fn vm_for(g: &petgraph::graph::DiGraph<Box<dyn Node>, Edge>) -> Engine {
+        let eps = push_pull_entrypoints(&no_lookup, g);
+        let module = gantz_core::compile::module(&no_lookup, g, &eps, &Default::default()).unwrap();
+        let mut vm = Engine::new_base();
+        vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+        gantz_core::graph::register(&no_lookup, g, &[], &mut vm);
+        for f in module {
+            vm.run(format!("{f}")).unwrap();
+        }
+        vm
+    }
+
+    // Fire the push entrypoint of node `ix` `n` times.
+    fn fire(
+        vm: &mut Engine,
+        g: &petgraph::graph::DiGraph<Box<dyn Node>, Edge>,
+        ix: usize,
+        n: usize,
+    ) {
+        let ctx = node::MetaCtx::new(&no_lookup);
+        let ep = entrypoint::push(
+            vec![ix],
+            g[petgraph::graph::NodeIndex::new(ix)].n_outputs(ctx) as u8,
+        );
+        let fn_name = entry_fn_name(&ep.id());
+        for _ in 0..n {
+            vm.call_function_by_name_with_args(&fn_name, vec![])
+                .unwrap();
+        }
+    }
+
+    fn list_of(vm: &Engine, ix: usize) -> Vec<f64> {
+        match node::state::extract_value(vm, &[ix]).unwrap().unwrap() {
+            SteelVal::ListV(list) => list.iter().filter_map(steel_num).collect(),
+            other => panic!("expected list state, got {other:?}"),
+        }
+    }
+
+    // Scope mode appends each pushed number and bounds the history to `capacity`.
+    #[test]
+    fn scope_accumulates_bounded_history() {
+        let mut g = petgraph::graph::DiGraph::new();
+        let src = gantz_core::node::expr("5").unwrap().with_push_eval();
+        let plot = Plot {
+            mode: PlotMode::Scope,
+            capacity: 3,
+            ..Default::default()
+        };
+        let src = g.add_node(Box::new(src) as Box<dyn Node>);
+        let plt = g.add_node(Box::new(plot) as Box<dyn Node>);
+        g.add_edge(src, plt, Edge::from((0, 0)));
+
+        let mut vm = vm_for(&g);
+        // Five pushes, capacity three: history holds the most recent three.
+        fire(&mut vm, &g, src.index(), 5);
+
+        assert_eq!(list_of(&vm, plt.index()), vec![5.0, 5.0, 5.0]);
+    }
+
+    // Signal mode stores the incoming list verbatim, preserving order.
+    #[test]
+    fn signal_stores_list() {
+        let mut g = petgraph::graph::DiGraph::new();
+        let src = gantz_core::node::expr("(list 1 2 3)")
+            .unwrap()
+            .with_push_eval();
+        let plot = Plot {
+            mode: PlotMode::Signal,
+            ..Default::default()
+        };
+        let src = g.add_node(Box::new(src) as Box<dyn Node>);
+        let plt = g.add_node(Box::new(plot) as Box<dyn Node>);
+        g.add_edge(src, plt, Edge::from((0, 0)));
+
+        let mut vm = vm_for(&g);
+        fire(&mut vm, &g, src.index(), 1);
+
+        assert_eq!(list_of(&vm, plt.index()), vec![1.0, 2.0, 3.0]);
+    }
+}

--- a/crates/gantz_egui/src/node/plot.rs
+++ b/crates/gantz_egui/src/node/plot.rs
@@ -4,29 +4,58 @@
 //! and behaviour are configured through the node inspector and context menu.
 //!
 //! Two modes are supported:
-//! - [`PlotMode::Scope`]: the input is a single number; the node accumulates a
-//!   bounded, scrolling history and plots it like an oscilloscope.
-//! - [`PlotMode::Signal`]: the input is a list of numbers; the node plots the
-//!   whole list directly, replacing it on each evaluation.
+//! - [`PlotMode::Scope`]: accumulate a bounded, scrolling history and plot it
+//!   like an oscilloscope. Each pushed number is appended; a pushed list extends
+//!   the history with its elements.
+//! - [`PlotMode::Signal`]: plot the incoming value directly (a list as a series,
+//!   a single number as one bar), replacing it on each evaluation.
 //!
 //! In both modes the node is a pass-through: its output forwards the input
 //! value unchanged (like [`super::Inspect`]), so a value can be observed without
 //! breaking the chain it flows through.
 
-use crate::widget::node_inspector;
-use crate::{NodeCtx, NodeUi, Registry, SocketDoc, SocketKind};
+use crate::{
+    ContextMenuResponse, InspectorUiResponse, NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc,
+    SocketKind,
+};
 use gantz_ca::CaHash;
 use gantz_core::node::{self, ExprCtx, ExprResult, MetaCtx, RegCtx};
 use serde::{Deserialize, Serialize};
 use steel::SteelVal;
 use steel::steel_vm::register_fn::RegisterFn;
 
+/// An `f32` that participates in content addressing and `Hash` via its bit
+/// pattern, letting float-valued config keep [`Plot`]'s derives (the `CaHash`
+/// derive needs every field to be `CaHash`, and the app's `dyn Node` needs
+/// `Hash` - neither is implemented for `f32`).
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct F32(pub f32);
+
+impl F32 {
+    fn get(self) -> f32 {
+        self.0
+    }
+}
+
+impl std::hash::Hash for F32 {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::hash::Hash::hash(&self.0.to_bits(), state);
+    }
+}
+
+impl CaHash for F32 {
+    fn hash(&self, hasher: &mut gantz_ca::Hasher) {
+        CaHash::hash(&self.0.to_bits(), hasher);
+    }
+}
+
 /// How the plot interprets and accumulates its input.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize, CaHash)]
 pub enum PlotMode {
-    /// The input is a single number; keep a bounded scrolling history.
+    /// Accumulate a bounded scrolling history (numbers appended, lists extend).
     Scope,
-    /// The input is a list of numbers; plot it directly, replacing the prior.
+    /// Plot the incoming value directly, replacing the prior.
     Signal,
 }
 
@@ -43,19 +72,17 @@ pub enum PlotStyle {
 ///
 /// Every field feeds the content address (no `#[cahash(skip)]`), so each
 /// inspector edit is a real, persisted, undoable change rather than transient
-/// view state. The struct is deliberately float-free so `Hash`/`Eq`/`CaHash`
-/// all derive cleanly (`CaHash` has no `f32` impl, and the app's `dyn Node`
-/// requires `Hash`).
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize, CaHash)]
+/// view state.
+#[derive(Clone, Debug, Hash, Deserialize, Serialize, CaHash)]
 #[cahash("gantz.plot")]
 pub struct Plot {
-    /// Scope (scalar history) or Signal (plot a list).
+    /// Scope (scalar history) or Signal (plot the value directly).
     mode: PlotMode,
     /// Bars or line.
     style: PlotStyle,
     /// The maximum number of samples retained in [`PlotMode::Scope`].
     capacity: u32,
-    /// Persisted body width (split from a `[u16; 2]` since that is not `CaHash`).
+    /// Persisted body width.
     width: u16,
     /// Persisted body height.
     height: u16,
@@ -65,9 +92,16 @@ pub struct Plot {
     show_grid: bool,
     /// Whether to draw the axes.
     show_axes: bool,
-    /// Whether the embedded plot accepts drag/zoom/scroll. Off by default to
-    /// avoid clashing with the graph's own pan/zoom.
+    /// Whether the embedded plot accepts drag/zoom/scroll. Off by default so the
+    /// node drags and right-clicks like any other (see [`NodeUi::ui`]).
     interactive: bool,
+    /// Fraction of the data range padded on each side; `0` is off (the default),
+    /// letting data fill the frame cleanly.
+    margin: F32,
+    /// A fixed lower bound for the value axis when `Some`.
+    y_min: Option<F32>,
+    /// A fixed upper bound for the value axis when `Some`.
+    y_max: Option<F32>,
 }
 
 impl Plot {
@@ -89,6 +123,9 @@ impl Default for Plot {
             show_grid: true,
             show_axes: true,
             interactive: false,
+            margin: F32(0.0),
+            y_min: None,
+            y_max: None,
         }
     }
 }
@@ -97,8 +134,10 @@ impl Default for Plot {
 /// result holds at most `cap` items. Registered on the VM as `plot-push` and
 /// called from the generated [`PlotMode::Scope`] expression.
 ///
-/// `cap` is passed as an argument (not captured) so a single shared `plot-push`
-/// serves every plot node with its own, always-current capacity.
+/// A numeric `val` is appended; a list `val` extends the history with its
+/// numeric elements; anything else is ignored. `cap` is passed as an argument
+/// (not captured) so a single shared `plot-push` serves every plot node with its
+/// own, always-current capacity.
 fn plot_push(state: SteelVal, val: SteelVal, cap: SteelVal) -> SteelVal {
     let cap = match cap {
         SteelVal::IntV(n) if n > 0 => n as usize,
@@ -109,17 +148,29 @@ fn plot_push(state: SteelVal, val: SteelVal, cap: SteelVal) -> SteelVal {
         SteelVal::ListV(list) => list,
         _ => Default::default(),
     };
-    list.push_back(val);
+    match val {
+        SteelVal::ListV(items) => {
+            for item in items.iter() {
+                if matches!(item, SteelVal::NumV(_) | SteelVal::IntV(_)) {
+                    list.push_back(item.clone());
+                }
+            }
+        }
+        num @ (SteelVal::NumV(_) | SteelVal::IntV(_)) => list.push_back(num),
+        _ => {}
+    }
     while list.len() > cap {
         list.pop_front();
     }
     SteelVal::ListV(list)
 }
 
-/// Read the node's stored series as `f64`s, skipping any non-numeric entries.
+/// Read the node's stored series as `f64`s. A list yields its numeric elements;
+/// a lone number yields a single sample; anything else is empty.
 fn series(ctx: &NodeCtx) -> Vec<f64> {
     match ctx.extract_value() {
         Ok(Some(SteelVal::ListV(list))) => list.iter().filter_map(steel_num).collect(),
+        Ok(Some(ref val)) => steel_num(val).into_iter().collect(),
         _ => Vec::new(),
     }
 }
@@ -130,6 +181,15 @@ fn steel_num(val: &SteelVal) -> Option<f64> {
         SteelVal::NumV(f) => Some(*f),
         SteelVal::IntV(i) => Some(*i as f64),
         _ => None,
+    }
+}
+
+/// Resolve the configured colour, falling back to the theme's strong text
+/// colour when unset.
+fn resolve_color(color: Option<[u8; 4]>, ui: &egui::Ui) -> egui::Color32 {
+    match color {
+        Some([r, g, b, a]) => egui::Color32::from_rgba_unmultiplied(r, g, b, a),
+        None => ui.visuals().strong_text_color(),
     }
 }
 
@@ -151,12 +211,13 @@ impl gantz_core::Node for Plot {
         // the series to plot into `state`.
         let expr = match ctx.inputs().get(0) {
             Some(Some(val)) => match self.mode {
-                // Append the incoming number to the bounded history.
+                // Append the incoming number (or list elements) to the history;
+                // `plot-push` ignores anything non-numeric.
                 PlotMode::Scope => format!(
-                    "(begin (if (number? {val}) (set! state (plot-push state {val} {cap})) void) {val})",
+                    "(begin (set! state (plot-push state {val} {cap})) {val})",
                     cap = self.capacity,
                 ),
-                // Store the incoming list directly.
+                // Store the incoming value directly.
                 PlotMode::Signal => format!("(begin (set! state {val}) {val})"),
             },
             // No input connected: nothing to capture or forward; yield the
@@ -185,17 +246,17 @@ impl NodeUi for Plot {
         Some("Plot incoming values as a scrolling scope or a signal/array")
     }
 
-    fn ui(
-        &mut self,
-        ctx: NodeCtx,
-        uictx: egui_graph::NodeCtx,
-    ) -> egui_graph::FramedResponse<egui::Response> {
+    fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
+        // Set when a settled resize commits a new (CA-affecting) body size.
+        let mut changed = false;
+
         let style = uictx.style();
         let interaction = uictx.interaction();
 
-        // A minimal extreme-bg frame, like `inspect`.
+        // A minimal extreme-bg frame with square corners so data shows cleanly.
         let mut frame = egui_graph::node::default_frame(style, interaction);
         frame.fill = style.visuals.extreme_bg_color;
+        frame.corner_radius = egui::CornerRadius::ZERO;
 
         let node_egui_id = uictx.egui_id();
         let resize_id = node_egui_id.with("resize");
@@ -206,7 +267,18 @@ impl NodeUi for Plot {
         // Read the series once, up-front (only borrows `ctx`).
         let ys = series(&ctx);
 
-        uictx.framed_with(frame, |ui, _sockets| {
+        let framed = uictx.framed_with(frame, |ui, _sockets| {
+            // `Resize` registers its corner under this salt; reading last frame's
+            // response tells us whether it is being actively dragged.
+            let corner_id = resize_id.with("__resize_corner");
+            let resizing = ui
+                .ctx()
+                .read_response(corner_id)
+                .is_some_and(|r| r.dragged());
+            if resizing {
+                ui.ctx().request_repaint();
+            }
+
             // Both axes are user-resizable while the node is selected.
             let resizable = egui::Vec2b::new(interaction.selected, interaction.selected);
             egui::containers::Resize::default()
@@ -218,169 +290,285 @@ impl NodeUi for Plot {
                 .show(ui, |ui| {
                     let avail = ui.available_size();
 
-                    // Persist the resized body size. Like every field here it
-                    // is content-addressed, so a resize is a real edit.
-                    self.width = avail.x.max(min_size.x).round() as u16;
-                    self.height = avail.y.max(min_size.y).round() as u16;
+                    // `size` is part of the content address, so only commit it
+                    // once *settled* - never mid-drag, which would churn a commit
+                    // every frame.
+                    let new_w = avail.x.max(min_size.x).round() as u16;
+                    let new_h = avail.y.max(min_size.y).round() as u16;
+                    if !resizing && (self.width != new_w || self.height != new_h) {
+                        self.width = new_w;
+                        self.height = new_h;
+                        changed = true;
+                    }
 
-                    // Resolve config into locals so no borrow of `self` is held
-                    // across the plot-building closure below.
+                    let color = resolve_color(self.color, ui);
                     let plot_style = self.style;
-                    let show_grid = self.show_grid;
-                    let show_axes = self.show_axes;
                     let interactive = self.interactive;
-                    let color = match self.color {
-                        Some([r, g, b, a]) => egui::Color32::from_rgba_unmultiplied(r, g, b, a),
-                        None => ui.visuals().strong_text_color(),
-                    };
+                    let bounds =
+                        value_bounds(&ys, plot_style, self.margin.get(), self.y_min, self.y_max);
 
-                    let plot = egui_plot::Plot::new(plot_id)
+                    let mut plot = egui_plot::Plot::new(plot_id)
                         .width(avail.x)
                         .height(avail.y)
                         .show_background(false)
-                        .show_axes(egui::Vec2b::new(show_axes, show_axes))
-                        .show_grid(egui::Vec2b::new(show_grid, show_grid))
-                        .allow_drag(interactive)
-                        .allow_zoom(interactive)
-                        .allow_scroll(interactive)
-                        .allow_boxed_zoom(interactive);
+                        .show_axes(egui::Vec2b::new(self.show_axes, self.show_axes))
+                        .show_grid(egui::Vec2b::new(self.show_grid, self.show_grid));
+                    if interactive {
+                        // Free exploration: drag/zoom/scroll, native bounds.
+                        plot = plot
+                            .allow_drag(true)
+                            .allow_zoom(true)
+                            .allow_scroll(true)
+                            .allow_boxed_zoom(true)
+                            .set_margin_fraction(egui::Vec2::splat(self.margin.get()));
+                    } else {
+                        // Purely visual: no crosshair, and `Sense::hover` (no
+                        // click/drag) so the node frame underneath handles drags
+                        // and right-clicks like any other node.
+                        plot = plot
+                            .allow_drag(false)
+                            .allow_zoom(false)
+                            .allow_scroll(false)
+                            .allow_boxed_zoom(false)
+                            .sense(egui::Sense::hover())
+                            .cursor_color(egui::Color32::TRANSPARENT);
+                    }
 
-                    plot.show(ui, |plot_ui| match plot_style {
-                        PlotStyle::Bars => {
-                            let bars = ys
-                                .iter()
-                                .enumerate()
-                                .map(|(i, &y)| egui_plot::Bar::new(i as f64, y).width(1.0))
-                                .collect();
-                            plot_ui.bar_chart(egui_plot::BarChart::new("", bars).color(color));
+                    plot.show(ui, |plot_ui| {
+                        match plot_style {
+                            PlotStyle::Bars => {
+                                let bars = ys
+                                    .iter()
+                                    .enumerate()
+                                    .map(|(i, &y)| {
+                                        egui_plot::Bar::new(i as f64, y)
+                                            .width(1.0)
+                                            .fill(color)
+                                            .stroke(egui::Stroke::NONE)
+                                    })
+                                    .collect();
+                                plot_ui.bar_chart(
+                                    egui_plot::BarChart::new("", bars).allow_hover(interactive),
+                                );
+                            }
+                            PlotStyle::Line => {
+                                let points = egui_plot::PlotPoints::from_ys_f64(&ys);
+                                plot_ui.line(
+                                    egui_plot::Line::new("", points)
+                                        .color(color)
+                                        .allow_hover(interactive),
+                                );
+                            }
                         }
-                        PlotStyle::Line => {
-                            let points = egui_plot::PlotPoints::from_ys_f64(&ys);
-                            plot_ui.line(egui_plot::Line::new("", points).color(color));
+                        // Drive the (non-interactive) view deterministically from
+                        // the data + config so live updates and min/max apply.
+                        if !interactive {
+                            let ([xlo, ylo], [xhi, yhi]) = bounds;
+                            plot_ui.set_plot_bounds_x(xlo..=xhi);
+                            plot_ui.set_plot_bounds_y(ylo..=yhi);
                         }
                     })
                     .response
                 })
-        })
+        });
+
+        let mut resp = NodeUiResponse::new(framed);
+        resp.set_changed(changed);
+        resp
     }
 
-    fn inspector_rows(&mut self, _ctx: &mut NodeCtx, body: &mut egui_extras::TableBody) {
-        let row_h = node_inspector::table_row_h(body.ui_mut());
+    fn inspector_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> InspectorUiResponse {
+        let mut changed = false;
+        ui.separator();
 
-        // Mode.
-        body.row(row_h, |mut row| {
-            row.col(|ui| {
-                ui.add(egui::Label::new("mode").selectable(false))
-                    .on_hover_text("scope: scrolling history of a number; signal: plot a list");
-            });
-            row.col(|ui| {
-                ui.horizontal(|ui| {
-                    ui.selectable_value(&mut self.mode, PlotMode::Scope, "scope");
-                    ui.selectable_value(&mut self.mode, PlotMode::Signal, "signal");
-                });
-            });
+        // State summary: just the sample count (the raw buffer would be huge).
+        ui.horizontal(|ui| {
+            ui.label("data");
+            ui.label(format!("{} samples", series(&ctx).len()));
         });
 
-        // Style.
-        body.row(row_h, |mut row| {
-            row.col(|ui| {
-                ui.add(egui::Label::new("style").selectable(false))
-                    .on_hover_text("how the series is drawn");
-            });
-            row.col(|ui| {
-                ui.horizontal(|ui| {
-                    ui.selectable_value(&mut self.style, PlotStyle::Bars, "bars");
-                    ui.selectable_value(&mut self.style, PlotStyle::Line, "line");
-                });
-            });
+        ui.horizontal(|ui| {
+            ui.label("mode");
+            changed |= ui
+                .selectable_value(&mut self.mode, PlotMode::Scope, "scope")
+                .changed();
+            changed |= ui
+                .selectable_value(&mut self.mode, PlotMode::Signal, "signal")
+                .changed();
         });
 
-        // Capacity (scope history length).
-        body.row(row_h, |mut row| {
-            row.col(|ui| {
-                ui.add(egui::Label::new("capacity").selectable(false))
-                    .on_hover_text("max samples retained in scope mode");
-            });
-            row.col(|ui| {
-                let mut n = self.capacity as i32;
-                if ui
-                    .add(egui::DragValue::new(&mut n).range(1..=4096).speed(1.0))
-                    .changed()
-                {
-                    self.capacity = n.clamp(1, 4096) as u32;
-                }
-            });
+        ui.horizontal(|ui| {
+            ui.label("style");
+            changed |= ui
+                .selectable_value(&mut self.style, PlotStyle::Bars, "bars")
+                .changed();
+            changed |= ui
+                .selectable_value(&mut self.style, PlotStyle::Line, "line")
+                .changed();
         });
 
-        // Colour (with a reset-to-theme button when overridden).
-        body.row(row_h, |mut row| {
-            row.col(|ui| {
-                ui.add(egui::Label::new("colour").selectable(false))
-                    .on_hover_text("line/bar colour; defaults to the theme");
-            });
-            row.col(|ui| {
-                ui.horizontal(|ui| {
-                    let mut col = match self.color {
-                        Some([r, g, b, a]) => egui::Color32::from_rgba_unmultiplied(r, g, b, a),
-                        None => ui.visuals().strong_text_color(),
-                    };
-                    if ui.color_edit_button_srgba(&mut col).changed() {
-                        self.color = Some([col.r(), col.g(), col.b(), col.a()]);
-                    }
-                    if self.color.is_some() && ui.button("theme").clicked() {
-                        self.color = None;
-                    }
-                });
-            });
+        ui.horizontal(|ui| {
+            ui.label("capacity");
+            let mut c = self.capacity as i32;
+            if ui
+                .add(egui::DragValue::new(&mut c).range(1..=4096).speed(1.0))
+                .on_hover_text("max samples retained in scope mode")
+                .changed()
+            {
+                self.capacity = c.clamp(1, 4096) as u32;
+                changed = true;
+            }
         });
 
-        // Grid / axes / interactive toggles.
-        body.row(row_h, |mut row| {
-            row.col(|ui| {
-                ui.add(egui::Label::new("display").selectable(false));
-            });
-            row.col(|ui| {
-                ui.horizontal(|ui| {
-                    ui.checkbox(&mut self.show_grid, "grid");
-                    ui.checkbox(&mut self.show_axes, "axes");
-                    ui.checkbox(&mut self.interactive, "interactive")
-                        .on_hover_text("allow drag/zoom inside the node");
-                });
-            });
+        ui.horizontal(|ui| {
+            ui.label("margin");
+            let mut m = self.margin.get();
+            if ui
+                .add(egui::DragValue::new(&mut m).range(0.0..=1.0).speed(0.005))
+                .on_hover_text("fraction of the data range padded on each side")
+                .changed()
+            {
+                self.margin = F32(m.clamp(0.0, 1.0));
+                changed = true;
+            }
         });
 
-        // Size readout.
-        body.row(row_h, |mut row| {
-            row.col(|ui| {
-                ui.add(egui::Label::new("size").selectable(false));
-            });
-            row.col(|ui| {
-                ui.label(format!("{} x {}", self.width, self.height));
-            });
+        ui.horizontal(|ui| {
+            ui.label("colour");
+            let mut col = resolve_color(self.color, ui);
+            if ui.color_edit_button_srgba(&mut col).changed() {
+                self.color = Some([col.r(), col.g(), col.b(), col.a()]);
+                changed = true;
+            }
+            if self.color.is_some() && ui.button("theme").clicked() {
+                self.color = None;
+                changed = true;
+            }
         });
+
+        // Optional fixed value bounds: an enabling checkbox + a dialer per line.
+        changed |= bound_row(ui, "min", &mut self.y_min);
+        changed |= bound_row(ui, "max", &mut self.y_max);
+
+        ui.horizontal(|ui| {
+            changed |= ui.checkbox(&mut self.show_grid, "grid").changed();
+            changed |= ui.checkbox(&mut self.show_axes, "axes").changed();
+            changed |= ui
+                .checkbox(&mut self.interactive, "interactive")
+                .on_hover_text("allow drag/zoom inside the node")
+                .changed();
+        });
+
+        let mut resp = InspectorUiResponse::default();
+        resp.set_changed(changed);
+        resp
     }
 
-    fn context_menu(&mut self, ctx: &mut NodeCtx, ui: &mut egui::Ui) {
+    fn context_menu(&mut self, ctx: &mut NodeCtx, ui: &mut egui::Ui) -> ContextMenuResponse {
         if ui
             .button("clear history")
             .on_hover_text("empty the plotted series")
             .clicked()
         {
+            // VM runtime state, not content-addressed: do not mark changed.
             ctx.update_value(SteelVal::ListV(Default::default())).ok();
             ui.close();
         }
+        ContextMenuResponse::default()
     }
 
     fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, _ix: usize) -> Option<SocketDoc> {
         Some(match kind {
             SocketKind::Input => SocketDoc::ty("number | list").with_description(
-                "scope: a number appended to the history; signal: a list of numbers to plot",
+                "scope: a number (or list) appended to the history; signal: the value to plot",
             ),
             SocketKind::Output => {
                 SocketDoc::ty("any").with_description("the input value, unchanged")
             }
         })
     }
+
+    fn show_state(&self) -> bool {
+        // The raw history is a long list; the inspector summarises it instead.
+        false
+    }
+}
+
+/// An enabling checkbox plus a value dialer for an optional fixed bound. Returns
+/// whether the bound changed.
+fn bound_row(ui: &mut egui::Ui, label: &str, bound: &mut Option<F32>) -> bool {
+    let mut changed = false;
+    ui.horizontal(|ui| {
+        let mut on = bound.is_some();
+        if ui.checkbox(&mut on, "").changed() {
+            *bound = on.then(|| bound.unwrap_or(F32(0.0)));
+            changed = true;
+        }
+        ui.label(label);
+        let mut v = bound.map(F32::get).unwrap_or(0.0);
+        let resp = ui.add_enabled(bound.is_some(), egui::DragValue::new(&mut v).speed(0.1));
+        if resp.changed() {
+            *bound = Some(F32(v));
+            changed = true;
+        }
+    });
+    changed
+}
+
+/// Compute `([x_min, y_min], [x_max, y_max])` for the non-interactive view from
+/// the data, a margin fraction, and optional fixed value bounds. Bars include
+/// the baseline `0` and span integer x; lines span sample indices.
+fn value_bounds(
+    ys: &[f64],
+    style: PlotStyle,
+    margin: f32,
+    y_min: Option<F32>,
+    y_max: Option<F32>,
+) -> ([f64; 2], [f64; 2]) {
+    let n = ys.len() as f64;
+    let (mut xlo, mut xhi) = match style {
+        PlotStyle::Bars => (-0.5, (n - 0.5).max(0.5)),
+        PlotStyle::Line => (0.0, (n - 1.0).max(1.0)),
+    };
+
+    let (dmin, dmax) = ys
+        .iter()
+        .copied()
+        .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), v| {
+            (lo.min(v), hi.max(v))
+        });
+    let (mut ylo, mut yhi) = if dmin <= dmax {
+        match style {
+            // Bars draw from the baseline, so keep `0` in view.
+            PlotStyle::Bars => (dmin.min(0.0), dmax.max(0.0)),
+            PlotStyle::Line => (dmin, dmax),
+        }
+    } else {
+        (0.0, 1.0)
+    };
+    if (yhi - ylo).abs() < 1e-9 {
+        ylo -= 1.0;
+        yhi += 1.0;
+    }
+
+    // Pad each axis by the margin fraction of its range.
+    let margin = margin as f64;
+    let mx = (xhi - xlo) * margin;
+    let my = (yhi - ylo) * margin;
+    xlo -= mx;
+    xhi += mx;
+    ylo -= my;
+    yhi += my;
+
+    // Fixed overrides are exact (applied after the margin).
+    if let Some(v) = y_min {
+        ylo = v.get() as f64;
+    }
+    if let Some(v) = y_max {
+        yhi = v.get() as f64;
+    }
+
+    ([xlo, ylo], [xhi, yhi])
 }
 
 #[cfg(test)]
@@ -419,10 +607,8 @@ mod tests {
         n: usize,
     ) {
         let ctx = node::MetaCtx::new(&no_lookup);
-        let ep = entrypoint::push(
-            vec![ix],
-            g[petgraph::graph::NodeIndex::new(ix)].n_outputs(ctx) as u8,
-        );
+        let outs = g[petgraph::graph::NodeIndex::new(ix)].n_outputs(ctx) as u8;
+        let ep = entrypoint::push(vec![ix], outs);
         let fn_name = entry_fn_name(&ep.id());
         for _ in 0..n {
             vm.call_function_by_name_with_args(&fn_name, vec![])
@@ -437,31 +623,53 @@ mod tests {
         }
     }
 
+    // Build `src -> plot`, returning the graph and the two node indices.
+    fn graph_with(
+        src: Box<dyn Node>,
+        plot: Plot,
+    ) -> (petgraph::graph::DiGraph<Box<dyn Node>, Edge>, usize, usize) {
+        let mut g = petgraph::graph::DiGraph::new();
+        let s = g.add_node(src);
+        let p = g.add_node(Box::new(plot) as Box<dyn Node>);
+        g.add_edge(s, p, Edge::from((0, 0)));
+        (g, s.index(), p.index())
+    }
+
     // Scope mode appends each pushed number and bounds the history to `capacity`.
     #[test]
     fn scope_accumulates_bounded_history() {
-        let mut g = petgraph::graph::DiGraph::new();
         let src = gantz_core::node::expr("5").unwrap().with_push_eval();
         let plot = Plot {
             mode: PlotMode::Scope,
             capacity: 3,
             ..Default::default()
         };
-        let src = g.add_node(Box::new(src) as Box<dyn Node>);
-        let plt = g.add_node(Box::new(plot) as Box<dyn Node>);
-        g.add_edge(src, plt, Edge::from((0, 0)));
-
+        let (g, s, p) = graph_with(Box::new(src) as Box<dyn Node>, plot);
         let mut vm = vm_for(&g);
-        // Five pushes, capacity three: history holds the most recent three.
-        fire(&mut vm, &g, src.index(), 5);
+        fire(&mut vm, &g, s, 5);
+        assert_eq!(list_of(&vm, p), vec![5.0, 5.0, 5.0]);
+    }
 
-        assert_eq!(list_of(&vm, plt.index()), vec![5.0, 5.0, 5.0]);
+    // Scope mode extends the history with a pushed list's elements.
+    #[test]
+    fn scope_extends_with_list() {
+        let src = gantz_core::node::expr("(list 1 2 3)")
+            .unwrap()
+            .with_push_eval();
+        let plot = Plot {
+            mode: PlotMode::Scope,
+            capacity: 10,
+            ..Default::default()
+        };
+        let (g, s, p) = graph_with(Box::new(src) as Box<dyn Node>, plot);
+        let mut vm = vm_for(&g);
+        fire(&mut vm, &g, s, 2);
+        assert_eq!(list_of(&vm, p), vec![1.0, 2.0, 3.0, 1.0, 2.0, 3.0]);
     }
 
     // Signal mode stores the incoming list verbatim, preserving order.
     #[test]
     fn signal_stores_list() {
-        let mut g = petgraph::graph::DiGraph::new();
         let src = gantz_core::node::expr("(list 1 2 3)")
             .unwrap()
             .with_push_eval();
@@ -469,13 +677,25 @@ mod tests {
             mode: PlotMode::Signal,
             ..Default::default()
         };
-        let src = g.add_node(Box::new(src) as Box<dyn Node>);
-        let plt = g.add_node(Box::new(plot) as Box<dyn Node>);
-        g.add_edge(src, plt, Edge::from((0, 0)));
-
+        let (g, s, p) = graph_with(Box::new(src) as Box<dyn Node>, plot);
         let mut vm = vm_for(&g);
-        fire(&mut vm, &g, src.index(), 1);
+        fire(&mut vm, &g, s, 1);
+        assert_eq!(list_of(&vm, p), vec![1.0, 2.0, 3.0]);
+    }
 
-        assert_eq!(list_of(&vm, plt.index()), vec![1.0, 2.0, 3.0]);
+    // Signal mode also accepts a single number (drawn as one bar).
+    #[test]
+    fn signal_stores_scalar() {
+        let src = gantz_core::node::expr("7").unwrap().with_push_eval();
+        let plot = Plot {
+            mode: PlotMode::Signal,
+            ..Default::default()
+        };
+        let (g, s, p) = graph_with(Box::new(src) as Box<dyn Node>, plot);
+        let mut vm = vm_for(&g);
+        fire(&mut vm, &g, s, 1);
+        // Stored as a lone number; `series` reads it as a single sample.
+        let state = node::state::extract_value(&vm, &[p]).unwrap().unwrap();
+        assert!(matches!(state, SteelVal::IntV(7)));
     }
 }

--- a/crates/gantz_egui/src/node/plot.rs
+++ b/crates/gantz_egui/src/node/plot.rs
@@ -14,9 +14,10 @@
 //! value unchanged (like [`super::Inspect`]), so a value can be observed without
 //! breaking the chain it flows through.
 
+use crate::widget::node_inspector;
 use crate::{
-    ContextMenuResponse, InspectorUiResponse, NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc,
-    SocketKind,
+    ContextMenuResponse, InspectorRowsResponse, InspectorUiResponse, NodeCtx, NodeUi,
+    NodeUiResponse, Registry, SocketDoc, SocketKind,
 };
 use gantz_ca::CaHash;
 use gantz_core::node::{self, ExprCtx, ExprResult, MetaCtx, RegCtx};
@@ -92,12 +93,12 @@ pub struct Plot {
     show_grid: bool,
     /// Whether to draw the axes.
     show_axes: bool,
-    /// Whether the embedded plot accepts drag/zoom/scroll. Off by default so the
-    /// node drags and right-clicks like any other (see [`NodeUi::ui`]).
+    /// When on, hovering shows a crosshair and the value beneath it. The plot
+    /// never pans or zooms regardless - the node drags and right-clicks as usual.
     interactive: bool,
-    /// Fraction of the data range padded on each side; `0` is off (the default),
-    /// letting data fill the frame cleanly.
-    margin: F32,
+    /// When on, the plot is inset within the node frame's regular margin; when
+    /// off the data fills the frame.
+    margin: bool,
     /// A fixed lower bound for the value axis when `Some`.
     y_min: Option<F32>,
     /// A fixed upper bound for the value axis when `Some`.
@@ -120,10 +121,10 @@ impl Default for Plot {
             width: Self::DEFAULT_SIZE[0],
             height: Self::DEFAULT_SIZE[1],
             color: None,
-            show_grid: true,
-            show_axes: true,
+            show_grid: false,
+            show_axes: false,
             interactive: false,
-            margin: F32(0.0),
+            margin: true,
             y_min: None,
             y_max: None,
         }
@@ -253,10 +254,14 @@ impl NodeUi for Plot {
         let style = uictx.style();
         let interaction = uictx.interaction();
 
-        // A minimal extreme-bg frame with square corners so data shows cleanly.
+        // A minimal extreme-bg frame, keeping the default rounded corners. The
+        // `margin` toggle controls whether the data is inset by the frame's
+        // regular margin or fills it.
         let mut frame = egui_graph::node::default_frame(style, interaction);
         frame.fill = style.visuals.extreme_bg_color;
-        frame.corner_radius = egui::CornerRadius::ZERO;
+        if !self.margin {
+            frame.inner_margin = egui::Margin::ZERO;
+        }
 
         let node_egui_id = uictx.egui_id();
         let resize_id = node_egui_id.with("resize");
@@ -304,34 +309,26 @@ impl NodeUi for Plot {
                     let color = resolve_color(self.color, ui);
                     let plot_style = self.style;
                     let interactive = self.interactive;
-                    let bounds =
-                        value_bounds(&ys, plot_style, self.margin.get(), self.y_min, self.y_max);
+                    let bounds = value_bounds(&ys, plot_style, self.y_min, self.y_max);
 
                     let mut plot = egui_plot::Plot::new(plot_id)
                         .width(avail.x)
                         .height(avail.y)
                         .show_background(false)
                         .show_axes(egui::Vec2b::new(self.show_axes, self.show_axes))
-                        .show_grid(egui::Vec2b::new(self.show_grid, self.show_grid));
-                    if interactive {
-                        // Free exploration: drag/zoom/scroll, native bounds.
-                        plot = plot
-                            .allow_drag(true)
-                            .allow_zoom(true)
-                            .allow_scroll(true)
-                            .allow_boxed_zoom(true)
-                            .set_margin_fraction(egui::Vec2::splat(self.margin.get()));
-                    } else {
-                        // Purely visual: no crosshair, and `Sense::hover` (no
-                        // click/drag) so the node frame underneath handles drags
-                        // and right-clicks like any other node.
-                        plot = plot
-                            .allow_drag(false)
-                            .allow_zoom(false)
-                            .allow_scroll(false)
-                            .allow_boxed_zoom(false)
-                            .sense(egui::Sense::hover())
-                            .cursor_color(egui::Color32::TRANSPARENT);
+                        .show_grid(egui::Vec2b::new(self.show_grid, self.show_grid))
+                        // Pan/zoom are always off. `Sense::hover` lets the node
+                        // frame beneath capture drags and right-clicks, so the
+                        // node moves and its context menu opens as usual.
+                        .allow_drag(false)
+                        .allow_zoom(false)
+                        .allow_scroll(false)
+                        .allow_boxed_zoom(false)
+                        .sense(egui::Sense::hover());
+                    if !interactive {
+                        // Purely visual: hide the crosshair (the value readout is
+                        // also suppressed via `allow_hover(false)` below).
+                        plot = plot.cursor_color(egui::Color32::TRANSPARENT);
                     }
 
                     plot.show(ui, |plot_ui| {
@@ -360,13 +357,11 @@ impl NodeUi for Plot {
                                 );
                             }
                         }
-                        // Drive the (non-interactive) view deterministically from
-                        // the data + config so live updates and min/max apply.
-                        if !interactive {
-                            let ([xlo, ylo], [xhi, yhi]) = bounds;
-                            plot_ui.set_plot_bounds_x(xlo..=xhi);
-                            plot_ui.set_plot_bounds_y(ylo..=yhi);
-                        }
+                        // Drive the view deterministically from the data + config
+                        // (the plot never pans), so live updates and min/max apply.
+                        let ([xlo, ylo], [xhi, yhi]) = bounds;
+                        plot_ui.set_plot_bounds_x(xlo..=xhi);
+                        plot_ui.set_plot_bounds_y(ylo..=yhi);
                     })
                     .response
                 })
@@ -377,91 +372,136 @@ impl NodeUi for Plot {
         resp
     }
 
-    fn inspector_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> InspectorUiResponse {
+    fn inspector_rows(
+        &mut self,
+        _ctx: &mut NodeCtx,
+        body: &mut egui_extras::TableBody,
+    ) -> InspectorRowsResponse {
+        let row_h = node_inspector::table_row_h(body.ui_mut());
         let mut changed = false;
-        ui.separator();
 
-        // State summary: just the sample count (the raw buffer would be huge).
-        ui.horizontal(|ui| {
-            ui.label("data");
-            ui.label(format!("{} samples", series(&ctx).len()));
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("mode");
+            });
+            row.col(|ui| {
+                ui.horizontal(|ui| {
+                    changed |= radio_option(ui, &mut self.mode, PlotMode::Scope, "scope");
+                    changed |= radio_option(ui, &mut self.mode, PlotMode::Signal, "signal");
+                });
+            });
         });
 
-        ui.horizontal(|ui| {
-            ui.label("mode");
-            changed |= ui
-                .selectable_value(&mut self.mode, PlotMode::Scope, "scope")
-                .changed();
-            changed |= ui
-                .selectable_value(&mut self.mode, PlotMode::Signal, "signal")
-                .changed();
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("style");
+            });
+            row.col(|ui| {
+                ui.horizontal(|ui| {
+                    changed |= radio_option(ui, &mut self.style, PlotStyle::Bars, "bars");
+                    changed |= radio_option(ui, &mut self.style, PlotStyle::Line, "line");
+                });
+            });
         });
 
-        ui.horizontal(|ui| {
-            ui.label("style");
-            changed |= ui
-                .selectable_value(&mut self.style, PlotStyle::Bars, "bars")
-                .changed();
-            changed |= ui
-                .selectable_value(&mut self.style, PlotStyle::Line, "line")
-                .changed();
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("capacity");
+            });
+            row.col(|ui| {
+                let mut c = self.capacity as i32;
+                if ui
+                    .add(egui::DragValue::new(&mut c).range(1..=4096).speed(1.0))
+                    .on_hover_text("max samples retained in scope mode")
+                    .changed()
+                {
+                    self.capacity = c.clamp(1, 4096) as u32;
+                    changed = true;
+                }
+            });
         });
 
-        ui.horizontal(|ui| {
-            ui.label("capacity");
-            let mut c = self.capacity as i32;
-            if ui
-                .add(egui::DragValue::new(&mut c).range(1..=4096).speed(1.0))
-                .on_hover_text("max samples retained in scope mode")
-                .changed()
-            {
-                self.capacity = c.clamp(1, 4096) as u32;
-                changed = true;
-            }
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("margin");
+            });
+            row.col(|ui| {
+                if ui
+                    .checkbox(&mut self.margin, "")
+                    .on_hover_text("inset the data within the node frame's margin")
+                    .changed()
+                {
+                    changed = true;
+                }
+            });
         });
 
-        ui.horizontal(|ui| {
-            ui.label("margin");
-            let mut m = self.margin.get();
-            if ui
-                .add(egui::DragValue::new(&mut m).range(0.0..=1.0).speed(0.005))
-                .on_hover_text("fraction of the data range padded on each side")
-                .changed()
-            {
-                self.margin = F32(m.clamp(0.0, 1.0));
-                changed = true;
-            }
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("colour");
+            });
+            row.col(|ui| {
+                ui.horizontal(|ui| {
+                    let mut col = resolve_color(self.color, ui);
+                    if ui.color_edit_button_srgba(&mut col).changed() {
+                        self.color = Some([col.r(), col.g(), col.b(), col.a()]);
+                        changed = true;
+                    }
+                    if self.color.is_some() && ui.button("theme").clicked() {
+                        self.color = None;
+                        changed = true;
+                    }
+                });
+            });
         });
 
-        ui.horizontal(|ui| {
-            ui.label("colour");
-            let mut col = resolve_color(self.color, ui);
-            if ui.color_edit_button_srgba(&mut col).changed() {
-                self.color = Some([col.r(), col.g(), col.b(), col.a()]);
-                changed = true;
-            }
-            if self.color.is_some() && ui.button("theme").clicked() {
-                self.color = None;
-                changed = true;
-            }
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("range");
+            });
+            row.col(|ui| {
+                ui.horizontal(|ui| {
+                    changed |= bound_control(ui, "min", &mut self.y_min);
+                    changed |= bound_control(ui, "max", &mut self.y_max);
+                });
+            });
         });
 
-        // Optional fixed value bounds: an enabling checkbox + a dialer per line.
-        changed |= bound_row(ui, "min", &mut self.y_min);
-        changed |= bound_row(ui, "max", &mut self.y_max);
-
-        ui.horizontal(|ui| {
-            changed |= ui.checkbox(&mut self.show_grid, "grid").changed();
-            changed |= ui.checkbox(&mut self.show_axes, "axes").changed();
-            changed |= ui
-                .checkbox(&mut self.interactive, "interactive")
-                .on_hover_text("allow drag/zoom inside the node")
-                .changed();
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("display");
+            });
+            row.col(|ui| {
+                ui.horizontal(|ui| {
+                    changed |= ui.checkbox(&mut self.show_grid, "grid").changed();
+                    changed |= ui.checkbox(&mut self.show_axes, "axes").changed();
+                    changed |= ui
+                        .checkbox(&mut self.interactive, "interactive")
+                        .on_hover_text("show a crosshair and value readout on hover")
+                        .changed();
+                });
+            });
         });
 
-        let mut resp = InspectorUiResponse::default();
+        let mut resp = InspectorRowsResponse::default();
         resp.set_changed(changed);
         resp
+    }
+
+    fn inspector_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> InspectorUiResponse {
+        // Summarise the (potentially long) history rather than dumping it.
+        ui.separator();
+        let inner = ui
+            .horizontal(|ui| {
+                ui.label("data");
+                ui.label(format!("{} samples", series(&ctx).len()));
+            })
+            .response;
+        InspectorUiResponse {
+            inner: Some(inner),
+            changed: false,
+            payloads: Vec::new(),
+        }
     }
 
     fn context_menu(&mut self, ctx: &mut NodeCtx, ui: &mut egui::Ui) -> ContextMenuResponse {
@@ -479,7 +519,7 @@ impl NodeUi for Plot {
 
     fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, _ix: usize) -> Option<SocketDoc> {
         Some(match kind {
-            SocketKind::Input => SocketDoc::ty("number | list").with_description(
+            SocketKind::Input => SocketDoc::ty("number or list").with_description(
                 "scope: a number (or list) appended to the history; signal: the value to plot",
             ),
             SocketKind::Output => {
@@ -494,39 +534,59 @@ impl NodeUi for Plot {
     }
 }
 
-/// An enabling checkbox plus a value dialer for an optional fixed bound. Returns
-/// whether the bound changed.
-fn bound_row(ui: &mut egui::Ui, label: &str, bound: &mut Option<F32>) -> bool {
+/// Render `text` as a label-styled radio option: dim when unselected, strong
+/// when selected (no fill, like the app's tabs). Returns whether it was just
+/// selected.
+fn radio_option<T: Copy + PartialEq>(
+    ui: &mut egui::Ui,
+    current: &mut T,
+    value: T,
+    text: &str,
+) -> bool {
+    let strong = ui.visuals().strong_text_color();
+    let mut selected = *current == value;
+    let resp = ui.add(crate::widget::LabelToggle::new(text, &mut selected).selected_color(strong));
+    // Clicking an already-selected option is a no-op (it stays selected).
+    if resp.changed() && selected {
+        *current = value;
+        true
+    } else {
+        false
+    }
+}
+
+/// A label, an enabling checkbox, and a value dialer for an optional fixed
+/// bound. Returns whether the bound changed.
+fn bound_control(ui: &mut egui::Ui, label: &str, bound: &mut Option<F32>) -> bool {
     let mut changed = false;
-    ui.horizontal(|ui| {
-        let mut on = bound.is_some();
-        if ui.checkbox(&mut on, "").changed() {
-            *bound = on.then(|| bound.unwrap_or(F32(0.0)));
-            changed = true;
-        }
-        ui.label(label);
-        let mut v = bound.map(F32::get).unwrap_or(0.0);
-        let resp = ui.add_enabled(bound.is_some(), egui::DragValue::new(&mut v).speed(0.1));
-        if resp.changed() {
-            *bound = Some(F32(v));
-            changed = true;
-        }
-    });
+    ui.label(label);
+    let mut on = bound.is_some();
+    if ui.checkbox(&mut on, "").changed() {
+        *bound = on.then(|| bound.unwrap_or(F32(0.0)));
+        changed = true;
+    }
+    let mut v = bound.map(F32::get).unwrap_or(0.0);
+    if ui
+        .add_enabled(bound.is_some(), egui::DragValue::new(&mut v).speed(0.1))
+        .changed()
+    {
+        *bound = Some(F32(v));
+        changed = true;
+    }
     changed
 }
 
-/// Compute `([x_min, y_min], [x_max, y_max])` for the non-interactive view from
-/// the data, a margin fraction, and optional fixed value bounds. Bars include
-/// the baseline `0` and span integer x; lines span sample indices.
+/// Compute `([x_min, y_min], [x_max, y_max])` for the view from the data and
+/// optional fixed value bounds. Bars include the baseline `0` and span integer
+/// x; lines span sample indices. The plot itself adds no margin.
 fn value_bounds(
     ys: &[f64],
     style: PlotStyle,
-    margin: f32,
     y_min: Option<F32>,
     y_max: Option<F32>,
 ) -> ([f64; 2], [f64; 2]) {
     let n = ys.len() as f64;
-    let (mut xlo, mut xhi) = match style {
+    let (xlo, xhi) = match style {
         PlotStyle::Bars => (-0.5, (n - 0.5).max(0.5)),
         PlotStyle::Line => (0.0, (n - 1.0).max(1.0)),
     };
@@ -551,16 +611,7 @@ fn value_bounds(
         yhi += 1.0;
     }
 
-    // Pad each axis by the margin fraction of its range.
-    let margin = margin as f64;
-    let mx = (xhi - xlo) * margin;
-    let my = (yhi - ylo) * margin;
-    xlo -= mx;
-    xhi += mx;
-    ylo -= my;
-    yhi += my;
-
-    // Fixed overrides are exact (applied after the margin).
+    // Fixed overrides are exact.
     if let Some(v) = y_min {
         ylo = v.get() as f64;
     }

--- a/crates/gantz_egui/src/node/plot.rs
+++ b/crates/gantz_egui/src/node/plot.rs
@@ -16,8 +16,8 @@
 
 use crate::widget::node_inspector;
 use crate::{
-    ContextMenuResponse, InspectorRowsResponse, InspectorUiResponse, NodeCtx, NodeUi,
-    NodeUiResponse, Registry, SocketDoc, SocketKind,
+    ContextMenuResponse, InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, Registry,
+    SocketDoc, SocketKind,
 };
 use gantz_ca::CaHash;
 use gantz_core::node::{self, ExprCtx, ExprResult, MetaCtx, RegCtx};
@@ -386,11 +386,23 @@ impl NodeUi for Plot {
 
     fn inspector_rows(
         &mut self,
-        _ctx: &mut NodeCtx,
+        ctx: &mut NodeCtx,
         body: &mut egui_extras::TableBody,
     ) -> InspectorRowsResponse {
         let row_h = node_inspector::table_row_h(body.ui_mut());
         let mut changed = false;
+
+        // A summarised replacement for the (suppressed) default state row - the
+        // raw history would be a huge list.
+        let n_samples = series(ctx).len();
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("state");
+            });
+            row.col(|ui| {
+                ui.label(format!("{n_samples} samples"));
+            });
+        });
 
         body.row(row_h, |mut row| {
             row.col(|ui| {
@@ -502,17 +514,17 @@ impl NodeUi for Plot {
             });
         });
 
-        // `mn` and `mx` are two columns of one grid row, so the `mx` controls
-        // stay put as the `mn` dialer's value width changes (the dialers have a
-        // fixed width).
+        // Min and max are two columns of one grid row (hover text says which is
+        // which), so the max controls stay put as the min dialer's value width
+        // changes (the dialers have a fixed width).
         body.row(row_h, |mut row| {
             row.col(|ui| {
                 ui.label("range");
             });
             row.col(|ui| {
                 egui::Grid::new("plot_range").num_columns(2).show(ui, |ui| {
-                    changed |= bound_col(ui, "mn", "minimum", &mut self.y_min);
-                    changed |= bound_col(ui, "mx", "maximum", &mut self.y_max);
+                    changed |= bound_col(ui, "minimum", &mut self.y_min);
+                    changed |= bound_col(ui, "maximum", &mut self.y_max);
                     ui.end_row();
                 });
             });
@@ -543,22 +555,6 @@ impl NodeUi for Plot {
         let mut resp = InspectorRowsResponse::default();
         resp.set_changed(changed);
         resp
-    }
-
-    fn inspector_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> InspectorUiResponse {
-        // Summarise the (potentially long) history rather than dumping it.
-        ui.separator();
-        let inner = ui
-            .horizontal(|ui| {
-                ui.label("data");
-                ui.label(format!("{} samples", series(&ctx).len()));
-            })
-            .response;
-        InspectorUiResponse {
-            inner: Some(inner),
-            changed: false,
-            payloads: Vec::new(),
-        }
     }
 
     fn context_menu(&mut self, ctx: &mut NodeCtx, ui: &mut egui::Ui) -> ContextMenuResponse {
@@ -615,16 +611,15 @@ fn radio_option<T: Copy + PartialEq>(
     }
 }
 
-/// One grid column for an optional fixed bound: a `label`, a tightly-spaced
-/// enabling checkbox, and a fixed-width value dialer (so the next column doesn't
-/// shift as the value's text width changes). `kind` names the bound for hover
-/// text. Returns whether the bound changed.
-fn bound_col(ui: &mut egui::Ui, label: &str, kind: &str, bound: &mut Option<F32>) -> bool {
+/// One grid column for an optional fixed bound: a tightly-spaced enabling
+/// checkbox and a fixed-width value dialer (so the next column doesn't shift as
+/// the value's text width changes). `kind` names the bound for hover text.
+/// Returns whether the bound changed.
+fn bound_col(ui: &mut egui::Ui, kind: &str, bound: &mut Option<F32>) -> bool {
     let mut changed = false;
     ui.horizontal(|ui| {
         // Tighten the gap between the checkbox and its dialer.
         ui.spacing_mut().item_spacing.x *= 0.25;
-        ui.label(label);
         let mut on = bound.is_some();
         if ui
             .checkbox(&mut on, "")

--- a/crates/gantz_egui/src/node/plot.rs
+++ b/crates/gantz_egui/src/node/plot.rs
@@ -502,16 +502,18 @@ impl NodeUi for Plot {
             });
         });
 
-        // Min and max share a 2-row grid so their checkboxes/dialers stay aligned
-        // and don't shift as a dialer's value width changes.
-        body.row(row_h * 2.0, |mut row| {
+        // `mn` and `mx` are two columns of one grid row, so the `mx` controls
+        // stay put as the `mn` dialer's value width changes (the dialers have a
+        // fixed width).
+        body.row(row_h, |mut row| {
             row.col(|ui| {
                 ui.label("range");
             });
             row.col(|ui| {
                 egui::Grid::new("plot_range").num_columns(2).show(ui, |ui| {
-                    changed |= bound_row(ui, "mn", "minimum", &mut self.y_min);
-                    changed |= bound_row(ui, "mx", "maximum", &mut self.y_max);
+                    changed |= bound_col(ui, "mn", "minimum", &mut self.y_min);
+                    changed |= bound_col(ui, "mx", "maximum", &mut self.y_max);
+                    ui.end_row();
                 });
             });
         });
@@ -613,15 +615,16 @@ fn radio_option<T: Copy + PartialEq>(
     }
 }
 
-/// One grid row for an optional fixed bound: a `label` cell, then a cell with a
-/// tightly-spaced enabling checkbox + value dialer. `kind` names the bound for
-/// hover text. Returns whether the bound changed.
-fn bound_row(ui: &mut egui::Ui, label: &str, kind: &str, bound: &mut Option<F32>) -> bool {
+/// One grid column for an optional fixed bound: a `label`, a tightly-spaced
+/// enabling checkbox, and a fixed-width value dialer (so the next column doesn't
+/// shift as the value's text width changes). `kind` names the bound for hover
+/// text. Returns whether the bound changed.
+fn bound_col(ui: &mut egui::Ui, label: &str, kind: &str, bound: &mut Option<F32>) -> bool {
     let mut changed = false;
-    ui.label(label);
     ui.horizontal(|ui| {
         // Tighten the gap between the checkbox and its dialer.
         ui.spacing_mut().item_spacing.x *= 0.25;
+        ui.label(label);
         let mut on = bound.is_some();
         if ui
             .checkbox(&mut on, "")
@@ -632,8 +635,13 @@ fn bound_row(ui: &mut egui::Ui, label: &str, kind: &str, bound: &mut Option<F32>
             changed = true;
         }
         let mut v = bound.map(F32::get).unwrap_or(0.0);
-        if ui
-            .add_enabled(bound.is_some(), egui::DragValue::new(&mut v).speed(0.1))
+        let size = egui::vec2(44.0, ui.spacing().interact_size.y);
+        let resp = ui
+            .add_enabled_ui(bound.is_some(), |ui| {
+                ui.add_sized(size, egui::DragValue::new(&mut v).speed(0.1))
+            })
+            .inner;
+        if resp
             .on_hover_text(format!("the fixed {kind} value"))
             .changed()
         {
@@ -641,7 +649,6 @@ fn bound_row(ui: &mut egui::Ui, label: &str, kind: &str, bound: &mut Option<F32>
             changed = true;
         }
     });
-    ui.end_row();
     changed
 }
 

--- a/crates/gantz_egui/src/widget/node_inspector.rs
+++ b/crates/gantz_egui/src/widget/node_inspector.rs
@@ -80,7 +80,9 @@ pub fn table(
     let push_eval = !node.push_eval(meta_ctx).is_empty();
     let pull_eval = !node.pull_eval(meta_ctx).is_empty();
     let is_stateful = node.stateful(meta_ctx);
-    let state_value = if is_stateful {
+    // A node may opt out of the default state row (e.g. to summarise a large
+    // buffer in its `inspector_ui` instead).
+    let state_value = if is_stateful && node.show_state() {
         Some(ctx.extract_value())
     } else {
         None

--- a/crates/gantz_std/src/log.rs
+++ b/crates/gantz_std/src/log.rs
@@ -66,11 +66,17 @@ impl gantz_core::Node for Log {
         fn trace(path: SteelVal, val: SteelVal) {
             log_val(log::Level::Trace, &path, &val);
         }
-        ctx.vm().register_fn("log/error", error);
-        ctx.vm().register_fn("log/warn", warn);
-        ctx.vm().register_fn("log/info", info);
-        ctx.vm().register_fn("log/debug", debug);
-        ctx.vm().register_fn("log/trace", trace);
+        // Register the helpers only if absent. Steel's `register_fn` allocates a
+        // new global slot and shadows the previous binding rather than
+        // overwriting it, so re-registering on every recompile (the engine
+        // persists across them) would leak the old closures.
+        if ctx.vm().extract_value("log/info").is_err() {
+            ctx.vm().register_fn("log/error", error);
+            ctx.vm().register_fn("log/warn", warn);
+            ctx.vm().register_fn("log/info", info);
+            ctx.vm().register_fn("log/debug", debug);
+            ctx.vm().register_fn("log/trace", trace);
+        }
     }
 }
 


### PR DESCRIPTION
Adds a gantz_egui-native `plot` node for visualising numeric values flowing through a patch. The node body is a minimal embedded plot. Everything else is configured through the node inspector and right-click context menu.

Branch: `feat/plot-node` → `master`

## What it does

- **Two modes** (inspector toggle):
  - **Scope** - feed a number (or a list); accumulates a bounded, scrolling history and draws it like an oscilloscope.
  - **Signal** - feed a list (or a single number); plots it directly, replacing it each evaluation.
- **Pass-through** (1-in / 1-out): forwards the input unchanged on its output (like `inspect`), so a value can be observed mid-chain without breaking it.
- **Default look:** contiguous bars in the theme's strong-text colour on an `extreme_bg_color` background; switchable to a line.
- **Configurable** via the inspector table: mode, style (bars/line), capacity, colour (with a "theme" reset), a `margin` toggle (inset within the frame's margin, with rounded corners, vs. edge-to-edge with square corners), grid and axes toggles, an optional fixed min/max value range, and an `interactive` toggle. Every control has hover text. The `state` row summarises the buffer as a sample count rather than dumping the whole list.
- **Interaction:** the plot never pans/zooms - it senses hover only, so click-drag moves the node and right-click opens its context menu like any other node. `interactive` just toggles the hover crosshair + value readout (and the crosshair mouse-cursor is suppressed when off).

## Implementation notes

- History is stored in VM node state as a plain Steel list, bounded by a stateless `plot-push` helper (capacity passed as an argument so one shared helper serves every plot node). The no-prelude `Engine::new_base()` constraint is respected - only primitive forms plus the one registered helper.
- Every config field feeds the content address (no `#[cahash(skip)]`), so each inspector edit is a real, persisted, undoable commit. The struct is kept float-free where possible; float-valued config rides a small bit-pattern `F32` wrapper so `Plot` still derives `Hash`/`CaHash`.
- Adopts the post-#264 `NodeUi` response API (`NodeUiResponse` / `InspectorRowsResponse` / `ContextMenuResponse`) and the settled-resize `changed` pattern. Adds one `NodeUi::show_state()` hook (default `true`, forwarded through the `Box`/`&mut` blanket impls) so a node can omit the inspector's default raw-state row.
- Wired into both the `demo` example and the `gantz` app (primitive factories + typetag).

## Included register-leak fixes

Surfaced while testing the plot at frame rate: `register_fn`/`register_value` in Steel allocate a *new* global slot and shadow the previous binding rather than overwriting it, so re-registering on every recompile (the engine persists) leaks the old binding. Guarded behind a presence check in three places:

- `plot`'s `plot-push` helper,
- `gantz_std::Log`'s `log/*` helpers,
- the `State<N, S>` wrapper's state-type + fns.