### PR TITLE
chore(deps): update steel-core to 0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anymap3"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5dfbc6d8d2675589ccbe4d0fd61df2419075625f8c1a62325e718e2b0049f9"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3179,15 +3185,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "gantz"
 version = "0.2.2"
 dependencies = [
@@ -3319,6 +3316,16 @@ checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "generic_singleton"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6e923c8e978e57cf63e2e200ca967d1d20f0ea2662b28f6d4e11c44aa6ab16"
+dependencies = [
+ "anymap3",
+ "parking_lot",
 ]
 
 [[package]]
@@ -3684,6 +3691,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_casemap"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ca9983e8bf51223c2f89014fa4eaa9e9b336c47f3af0d000538f86f841fba1"
+dependencies = [
+ "icu_casemap_data",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties",
+ "icu_provider",
+ "potential_utf",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_casemap_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98d4663d0f99b301033a19e0acf94e9d2fa4b107638580165e5a6ccc49ad1450"
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3691,6 +3720,7 @@ checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -3832,10 +3862,11 @@ dependencies = [
 
 [[package]]
 name = "im-lists"
-version = "0.9.1"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b971d2652e5700514cc92ca020dba64c790352af0ff2b9acb7514868a32d6aa"
+checksum = "82158d5d59eff663dbb9d89295eacac296f58bc0473331cea2f45d9d270c5540"
 dependencies = [
+ "generic_singleton",
  "smallvec",
 ]
 
@@ -4680,11 +4711,13 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "5.0.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
+ "rand 0.8.6",
+ "serde",
 ]
 
 [[package]]
@@ -5035,16 +5068,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quickscope"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d47bcfc3e13850589cf9338a02b6dfb5aebb3748a0f93a392e8df91d6193b6b"
-dependencies = [
- "indexmap 1.9.3",
- "smallvec",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5070,6 +5093,16 @@ name = "radsort"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "019b4b213425016d7d84a153c4c73afb0946fbb4840e4eece7ba8848b9d6da22"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core 0.6.4",
+ "serde",
+]
 
 [[package]]
 name = "rand"
@@ -5106,6 +5139,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "rand_core"
@@ -5516,6 +5552,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_vector"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aacfea9afcf271e69d700140dc2a3e2ff44b1092dd0de71fdd4e5c26672a2"
+dependencies = [
+ "allocator-api2",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5684,9 +5729,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "steel-core"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fcd4a04c6b2fc5f695ad37b379ad0e4245a9a12dcd742fe4fe1ad15ddd6546"
+checksum = "b4acadc255e0d56fe71c09c605ebde51e6009b02d86ae610386f26437c4f91f8"
 dependencies = [
  "arc-swap",
  "bigdecimal",
@@ -5695,17 +5740,19 @@ dependencies = [
  "codespan-reporting 0.11.1",
  "compact_str",
  "crossbeam-channel",
+ "crossbeam-queue",
  "crossbeam-utils",
  "env_home",
  "futures-executor",
  "futures-task",
  "futures-util",
- "fxhash",
  "getrandom 0.3.4",
  "glob",
  "httparse",
+ "icu_casemap",
  "im-lists",
  "im-rc",
+ "js-sys",
  "lasso",
  "log",
  "md-5",
@@ -5716,15 +5763,18 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "polling",
- "quickscope",
  "rand 0.9.2",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
+ "shared_vector",
  "smallvec",
  "steel-derive",
  "steel-gen",
  "steel-parser",
+ "steel-quickscope",
  "strsim",
+ "thin-vec",
  "weak-table",
  "which",
  "xdg",
@@ -5732,9 +5782,9 @@ dependencies = [
 
 [[package]]
 name = "steel-derive"
-version = "0.6.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab7d1c6e3ee7b3ba6a4187b545d7dc1fa6e4929f0721a8798cfc3b8c7ed2b23"
+checksum = "7a564df3ca16e0be05e71bdcc3fe52f8b71e47be9c73e7a0bf43840fde591997"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5743,9 +5793,9 @@ dependencies = [
 
 [[package]]
 name = "steel-gen"
-version = "0.3.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deabc06d4f4735677503f593ae185d3f47c0fa8089b7e9a7177e0e0544483d86"
+checksum = "e1a614449ed6cba4138ce2e54943fb403533248da8070dad6ce943f1b14417b8"
 dependencies = [
  "codegen",
  "serde",
@@ -5753,19 +5803,33 @@ dependencies = [
 
 [[package]]
 name = "steel-parser"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf95d03e34e5d34a318a1f3ad7c933628c476776d3dc4fe9accb5b7b6b5a295"
+checksum = "769cea4a36ee603bfde799ab9c1ec1f93a67df30bcf4cd22d069eb8d4155e2b2"
 dependencies = [
  "compact_str",
- "fxhash",
+ "dashmap",
  "lasso",
+ "log",
  "num-bigint",
  "num-rational",
  "num-traits",
  "once_cell",
+ "ordered-float",
  "pretty",
+ "rustc-hash 2.1.1",
  "serde",
+ "smallvec",
+ "thin-vec",
+]
+
+[[package]]
+name = "steel-quickscope"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3b5ab5dbc71b317360a2f5287abc1c91a92ced9a983066e2622a607583bc89e"
+dependencies = [
+ "indexmap 2.12.0",
  "smallvec",
 ]
 
@@ -5888,6 +5952,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6798,14 +6871,11 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "7.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
- "either",
- "env_home",
- "rustix 1.1.2",
- "winsafe",
+ "libc",
 ]
 
 [[package]]
@@ -7249,12 +7319,6 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,8 @@ rfd = "0.15"
 ron = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-steel-core = "0.7"
-steel-derive = "0.6"
+steel-core = "0.8"
+steel-derive = "0.8"
 sublime_fuzzy = "0.7"
 thiserror = "2"
 time = { version = "0.3", features = ["local-offset", "wasm-bindgen"] }

--- a/crates/gantz_core/src/node/expr.rs
+++ b/crates/gantz_core/src/node/expr.rs
@@ -337,6 +337,30 @@ fn test_collect_unique_vars() {
     assert_eq!(vars, vec!["$a", "$?b", "$?c"]);
 }
 
+// A parse or lex error must surface as an `Err`, never be silently accepted.
+// `emit_ast` is the parse gate in both `Expr::new` and `Expr::expr`, so the
+// token reconstruction in `collect_unique_vars`/`interpolate_tokens` - which
+// just copies each token's source, including steel 0.8's fallible `Err` tokens
+// - cannot swallow an error: `emit_ast` re-lexes the result and propagates it.
+#[test]
+fn invalid_expr_source_is_rejected() {
+    // Construction gate (`Expr::new` -> `emit_ast(&src)?`).
+    assert!(Expr::new("(+ $a").is_err(), "unbalanced paren");
+    assert!(
+        Expr::new("\"unterminated").is_err(),
+        "lex error: unterminated string"
+    );
+    assert!(Expr::new("").is_err(), "no expression");
+
+    // Compile gate (`Expr::expr` -> `emit_ast(&new_src)?`). A malformed source
+    // can reach `expr` via deserialization, which doesn't re-validate, so
+    // compilation itself must error rather than emit broken Steel.
+    let bad: Expr = serde_json::from_str(r#"{"src":"(+ 1","outputs":1}"#).unwrap();
+    let outputs = node::Conns::try_from([true]).unwrap();
+    let ctx = node::ExprCtx::new(&|_| None, &[], &[None], &outputs);
+    assert!(bad.expr(ctx).is_err(), "malformed src must fail to compile");
+}
+
 // A no-op node lookup for constructing a `MetaCtx` in tests.
 #[cfg(test)]
 fn no_lookup(_: &gantz_ca::ContentAddr) -> Option<&'static dyn Node> {

--- a/crates/gantz_core/src/node/expr.rs
+++ b/crates/gantz_core/src/node/expr.rs
@@ -167,7 +167,13 @@ pub(crate) fn collect_unique_vars(tts: TokenStream) -> Vec<String> {
     let mut seen = HashSet::new();
     let mut vars = Vec::new();
     for token in tts {
-        let src = token.source();
+        // steel 0.8's `TokenStream` yields `Result`s; read the `source` field
+        // (present on both the clean and the lex-error token) so we still see
+        // every token's text.
+        let src = match &token {
+            Ok(t) => t.source,
+            Err(e) => e.source,
+        };
         if src.starts_with("$") {
             let var_name = src.to_string();
             if seen.insert(var_name.clone()) {
@@ -205,7 +211,12 @@ pub(crate) fn interpolate_tokens(
         .collect();
 
     let tokens = tts.map(|token| {
-        let src = token.source();
+        // See `collect_unique_vars`: 0.8's `TokenStream` yields `Result`s, so
+        // reconstruct from the `source` field of every token.
+        let src = match &token {
+            Ok(t) => t.source,
+            Err(e) => e.source,
+        };
         if src.starts_with("$?") {
             let index = var_to_index.get(src).unwrap();
             match inputs.get(*index).and_then(|o| o.as_ref()) {

--- a/crates/gantz_core/src/vm.rs
+++ b/crates/gantz_core/src/vm.rs
@@ -150,7 +150,7 @@ pub fn steel_err_span(
     };
     steel_err_spans(err)
         .find(in_module)
-        .map(|span| span.range())
+        .map(|span| span.usize_range())
 }
 
 /// The first span attached to a steel error, *without* verifying which
@@ -160,7 +160,7 @@ pub fn steel_err_span(
 /// returned by [`compile`] itself, whose spans can only index the module
 /// just run.
 pub fn steel_err_raw_span(err: &SteelErr) -> Option<std::ops::Range<usize>> {
-    steel_err_spans(err).next().map(|span| span.range())
+    steel_err_spans(err).next().map(|span| span.usize_range())
 }
 
 /// The full path of the node best attributed to a steel error (see

--- a/crates/gantz_core/tests/state.rs
+++ b/crates/gantz_core/tests/state.rs
@@ -233,6 +233,87 @@ fn test_graph_with_counters() {
     assert_eq!([a, b, c], [Counter(1), Counter(2), Counter(3)]);
 }
 
+// Manual regression check for #266: a stateful node must not leak memory per
+// evaluation. Drives one over a *single* persistent `Engine`, sampling RSS, and
+// asserts it stays bounded once warmed up.
+//
+// The leak was a steel 0.7.0 bug: the mutated+captured `graph-state` local
+// (threaded by `compile::emit`) was heap-boxed via an `ALLOC` path whose box
+// is never reclaimed, so every evaluation leaked ~0.8 KB and RSS climbed
+// unbounded (1e6 pushes: 21 -> 718 MB). steel >=0.8 compiles that local to a
+// GC-managed box the collector reclaims, so RSS plateaus (~65 MB, flat).
+//
+// `#[ignore]`d, so it is opt-in rather than part of the default suite, for two
+// reasons: the only available signal is process RSS (`/proc/self/statm`), which
+// is Linux-only and would conflate this graph's footprint with whatever else
+// the shared test process is doing; and it drives ~1e6 VM calls. steel exposes
+// no public per-engine heap/allocation count to measure instead. Run with:
+//   cargo test -p gantz_core --test state -- --ignored --nocapture leak
+#[cfg(target_os = "linux")]
+#[test]
+#[ignore]
+fn stateful_eval_does_not_leak() {
+    fn rss_bytes() -> usize {
+        let statm = std::fs::read_to_string("/proc/self/statm").unwrap();
+        let resident: usize = statm.split_whitespace().nth(1).unwrap().parse().unwrap();
+        resident * 4096
+    }
+
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let counter = g.add_node(Box::new(node_counter()) as Box<_>);
+    g.add_edge(push, counter, Edge::from((0, 0)));
+
+    let ctx = node::MetaCtx::new(&no_lookup);
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Default::default()).unwrap();
+
+    let mut vm = Engine::new_base();
+    vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+    gantz_core::graph::register(&no_lookup, &g, &[], &mut vm);
+    for f in module {
+        vm.run(format!("{f}")).unwrap();
+    }
+
+    let ep = entrypoint::push(vec![push.index()], g[push].n_outputs(ctx) as u8);
+    let fn_name = entry_fn_name(&ep.id());
+
+    // Measure RSS growth over the run *after* a warmup, so the no-leak heap's
+    // initial ramp (~100k pushes) isn't counted. A fixed leak adds ~0.8 KB per
+    // push - tens of MB over the window - so growth beyond `MAX_GROWTH` (well
+    // above any allocator noise) means the leak is back.
+    const PUSHES: usize = 1_000_000;
+    const SAMPLE: usize = 100_000;
+    const WARMUP: usize = 2 * SAMPLE;
+    const MAX_GROWTH: usize = 100 * 1024 * 1024;
+
+    let mut warmup_rss = 0;
+    let mut last_rss = 0;
+    for i in 0..PUSHES {
+        vm.call_function_by_name_with_args(&fn_name, vec![])
+            .unwrap();
+        if i % SAMPLE == 0 {
+            let rss = rss_bytes();
+            eprintln!("push {i:>9}: RSS {:>6} MB", rss / (1024 * 1024));
+            if i == WARMUP {
+                warmup_rss = rss;
+            }
+            last_rss = rss;
+        }
+    }
+    let growth = last_rss.saturating_sub(warmup_rss);
+    eprintln!(
+        "RSS grew {} MB ({} bytes/push) after warmup",
+        growth / (1024 * 1024),
+        growth / (PUSHES - WARMUP),
+    );
+    assert!(
+        growth < MAX_GROWTH,
+        "RSS grew {} MB after warmup - stateful-node leak (#266) is back",
+        growth / (1024 * 1024),
+    );
+}
+
 // Two `Ref`s to the *same* nested graph commit, at different positions in the
 // parent, must keep independent runtime state. State is keyed by the ref's
 // positional path (`graph-fn-{path}` + a per-path state slot), not by the

--- a/crates/gantz_format/src/sexpr.rs
+++ b/crates/gantz_format/src/sexpr.rs
@@ -62,13 +62,15 @@ pub fn as_keyword(e: &ExprKind) -> Option<String> {
 
 /// The source span of a datum.
 pub fn span(e: &ExprKind) -> Option<Span> {
-    e.span()
-        .map(|s| Span::new(s.start as usize, s.end as usize))
+    // steel 0.8's `ExprKind::span` returns a plain `Span`; every datum we read
+    // comes from real source text, so it is always present.
+    let s = e.span();
+    Some(Span::new(s.start as usize, s.end as usize))
 }
 
 /// The verbatim source slice a datum covers within `src`.
 pub fn span_src<'a>(e: &ExprKind, src: &'a str) -> Option<&'a str> {
-    let s = e.span()?;
+    let s = e.span();
     src.get(s.start as usize..s.end as usize)
 }
 


### PR DESCRIPTION
Fixes the per-evaluation memory leak in stateful nodes (#266). On steel 0.7.0 the `graph-state` local threaded through node codegen is both `set!` and captured by a closure, so steel heap-boxes it via an `ALLOC` path whose box is never reclaimed - every stateful evaluation leaks (~0.8-1.4 KB/push), unbounded under a per-frame driver (frame! -> plot, frame! -> inspect). steel
>=0.8 rewrites mutated+captured locals to GC-managed boxes that the collector
reclaims, removing the leak at the source with no gantz codegen change.

Migration to the 0.8.2 API:
- vm: `Span::range()` -> `Span::usize_range()` (span fields are now u32).
- expr: `TokenStream` yields `Result`s; read each token's `source` field.
- sexpr: `ExprKind::span()` now returns a plain `Span`, not `Option`.

Adds an ignored, Linux-only RSS check (stateful_eval_does_not_leak) that drives a stateful node ~1e6 times over one Engine and asserts bounded RSS after warmup. It is opt-in (run with --ignored) because process RSS is the only available signal - steel exposes no per-engine heap/allocation count - and running it inline would conflate this graph's footprint with the rest of the shared test process (0.7.0 climbs 21 -> 718 MB; 0.8.2 stays flat 65 MB).

Closes #266