### PR TITLE
`number` dialer node config

### DIFF
--- a/crates/gantz_egui/src/impls/number.rs
+++ b/crates/gantz_egui/src/impls/number.rs
@@ -82,30 +82,27 @@ impl NodeUi for Number {
         let mut changed = false;
         let mut bounds_changed = false;
 
-        // Min and max share a `range` row. An inner grid with fixed-width
-        // dialers keeps the `max` group's position fixed regardless of the
-        // `min` value's width.
+        // Min and max are two columns of one `range` row (hover text says which
+        // is which), sharing the inspector's `bound_col` helper with the plot
+        // node. Fixed-width dialers keep the max column put as the min value's
+        // width changes.
         body.row(row_h, |mut row| {
             row.col(|ui| {
-                ui.label("range").on_hover_text(
-                    "optional min/max bounds; every value is clamped into this range \
-                     (input-socket values included)",
-                );
+                ui.label("range");
             });
             row.col(|ui| {
-                egui::Grid::new(ui.id().with("range"))
-                    .num_columns(4)
-                    .spacing([6.0, 4.0])
+                egui::Grid::new("number_range")
+                    .num_columns(2)
                     .show(ui, |ui| {
-                        let (new_min, min_changed) = bound_cells(ui, "mn", "minimum", self.min());
-                        if min_changed {
-                            self.set_min(new_min);
+                        let mut min = self.min();
+                        if crate::widget::node_inspector::bound_col(ui, "minimum", &mut min) {
+                            self.set_min(min);
                             changed = true;
                             bounds_changed = true;
                         }
-                        let (new_max, max_changed) = bound_cells(ui, "mx", "maximum", self.max());
-                        if max_changed {
-                            self.set_max(new_max);
+                        let mut max = self.max();
+                        if crate::widget::node_inspector::bound_col(ui, "maximum", &mut max) {
+                            self.set_max(max);
                             changed = true;
                             bounds_changed = true;
                         }
@@ -187,50 +184,6 @@ impl NodeUi for Number {
             }
         })
     }
-}
-
-/// Fixed dialer width (px) so a bound's position does not shift with its value.
-const BOUND_DIAL_W: f32 = 48.0;
-
-/// Render one bound as a `label` grid cell followed by a `<checkbox> <dialer>`
-/// grid cell. `hover` expands the abbreviated label.
-///
-/// The dialer is always shown but disabled while the checkbox is off, and is
-/// given a fixed width so the next grid column stays put. The checkbox and
-/// dialer are packed tightly. Returns the (possibly updated) bound and whether
-/// it changed this frame.
-fn bound_cells(
-    ui: &mut egui::Ui,
-    label: &str,
-    hover: &str,
-    value: Option<f64>,
-) -> (Option<f64>, bool) {
-    ui.label(label).on_hover_text(hover);
-    let mut value = value;
-    let changed = ui
-        .horizontal(|ui| {
-            ui.spacing_mut().item_spacing.x *= 0.25;
-            let mut changed = false;
-            let mut enabled = value.is_some();
-            if ui.checkbox(&mut enabled, "").changed() {
-                value = enabled.then(|| value.unwrap_or(0.0));
-                changed = true;
-            }
-            let mut v = value.unwrap_or(0.0);
-            let res = ui
-                .add_enabled_ui(enabled, |ui| {
-                    let size = [BOUND_DIAL_W, ui.spacing().interact_size.y];
-                    ui.add_sized(size, egui::DragValue::new(&mut v).speed(0.1))
-                })
-                .inner;
-            if res.changed() {
-                value = Some(v);
-                changed = true;
-            }
-            changed
-        })
-        .inner;
-    (value, changed)
 }
 
 /// Keep `max >= min` and re-clamp the stored value into the new bounds so the

--- a/crates/gantz_egui/src/impls/number.rs
+++ b/crates/gantz_egui/src/impls/number.rs
@@ -1,7 +1,11 @@
-use crate::{NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind};
+use crate::{
+    ContextMenuResponse, InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, Registry,
+    SocketDoc, SocketKind,
+};
+use gantz_std::number::Number;
 use steel::SteelVal;
 
-impl NodeUi for gantz_std::number::Number {
+impl NodeUi for Number {
     fn name(&self, _: &dyn Registry) -> &str {
         "number"
     }
@@ -12,25 +16,166 @@ impl NodeUi for gantz_std::number::Number {
 
     fn ui(&mut self, mut ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
         // The numeric value lives in VM runtime state, not the node weight, so
-        // editing it does NOT change the graph's content address - we only
-        // queue an evaluation, never mark `changed`.
+        // editing the dialer does NOT change the graph's content address - we
+        // only queue an evaluation (when enabled), never mark `changed`.
+        let frame = egui_graph::node::default_frame(uictx.style(), uictx.interaction());
+        let frame_fill = frame.fill;
+        let push = self.push_eval_on_edit();
+        let (min, max, precision) = (self.min(), self.max(), self.precision());
         let mut do_eval = false;
-        let framed = uictx.framed(|ui, _sockets| {
+        let framed = uictx.framed_with(frame, |ui, _sockets| {
+            // When push-eval is disabled, flatten the dialer so it merges with
+            // the node frame - a cue that editing won't fire downstream.
+            if !push {
+                let widgets = &mut ui.visuals_mut().widgets;
+                widgets.inactive.weak_bg_fill = frame_fill;
+                widgets.inactive.bg_fill = frame_fill;
+            }
             let mut val = ctx.extract_value().unwrap().unwrap();
             let res = match val {
-                SteelVal::NumV(ref mut f) => ui.add(egui::DragValue::new(f)),
-                SteelVal::IntV(ref mut i) => ui.add(egui::DragValue::new(i)),
+                SteelVal::NumV(ref mut f) => {
+                    let mut dv = egui::DragValue::new(f);
+                    if min.is_some() || max.is_some() {
+                        dv = dv
+                            .range(min.unwrap_or(f64::NEG_INFINITY)..=max.unwrap_or(f64::INFINITY));
+                    }
+                    if let Some(p) = precision {
+                        dv = dv.max_decimals(p as usize);
+                    }
+                    ui.add(dv)
+                }
+                SteelVal::IntV(ref mut i) => {
+                    let mut dv = egui::DragValue::new(i);
+                    if min.is_some() || max.is_some() {
+                        let lo = min.map_or(isize::MIN, |m| m as isize);
+                        let hi = max.map_or(isize::MAX, |m| m as isize);
+                        dv = dv.range(lo..=hi);
+                    }
+                    ui.add(dv)
+                }
                 _ => ui.add(egui::Label::new("ERR")),
             };
             if res.changed() {
                 ctx.update_value(val).unwrap();
-                do_eval = true;
+                if push {
+                    do_eval = true;
+                }
             }
             res
         });
         let mut resp = NodeUiResponse::new(framed);
         if do_eval {
             resp.push_eval(ctx.path(), 1);
+        }
+        resp
+    }
+
+    fn inspector_rows(
+        &mut self,
+        ctx: &mut NodeCtx,
+        body: &mut egui_extras::TableBody,
+    ) -> InspectorRowsResponse {
+        let row_h = crate::widget::node_inspector::table_row_h(body.ui_mut());
+        // All four config fields contribute to the content address (so they
+        // persist and are undoable): `changed` tracks any edit; `bounds_changed`
+        // additionally drives a re-clamp of the stored value.
+        let mut changed = false;
+        let mut bounds_changed = false;
+
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("min");
+            });
+            row.col(|ui| {
+                let mut enabled = self.min().is_some();
+                if ui.checkbox(&mut enabled, "").changed() {
+                    self.set_min(enabled.then(|| self.min().unwrap_or(0.0)));
+                    changed = true;
+                    bounds_changed = true;
+                }
+                if let Some(mut m) = self.min() {
+                    if ui.add(egui::DragValue::new(&mut m).speed(0.1)).changed() {
+                        self.set_min(Some(m));
+                        changed = true;
+                        bounds_changed = true;
+                    }
+                }
+            });
+        });
+
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("max");
+            });
+            row.col(|ui| {
+                let mut enabled = self.max().is_some();
+                if ui.checkbox(&mut enabled, "").changed() {
+                    self.set_max(enabled.then(|| self.max().unwrap_or(0.0)));
+                    changed = true;
+                    bounds_changed = true;
+                }
+                if let Some(mut m) = self.max() {
+                    if ui.add(egui::DragValue::new(&mut m).speed(0.1)).changed() {
+                        self.set_max(Some(m));
+                        changed = true;
+                        bounds_changed = true;
+                    }
+                }
+            });
+        });
+
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("precision");
+            });
+            row.col(|ui| {
+                let mut enabled = self.precision().is_some();
+                if ui.checkbox(&mut enabled, "").changed() {
+                    self.set_precision(enabled.then(|| self.precision().unwrap_or(2)));
+                    changed = true;
+                }
+                if let Some(p) = self.precision() {
+                    let mut n = p as i32;
+                    if ui
+                        .add(egui::DragValue::new(&mut n).range(0..=10).speed(0.1))
+                        .changed()
+                    {
+                        self.set_precision(Some(n.clamp(0, 10) as u8));
+                        changed = true;
+                    }
+                }
+            });
+        });
+
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("push-eval on edit");
+            });
+            row.col(|ui| {
+                let mut push = self.push_eval_on_edit();
+                if ui.checkbox(&mut push, "").changed() {
+                    self.set_push_eval_on_edit(push);
+                    changed = true;
+                }
+            });
+        });
+
+        let mut resp = InspectorRowsResponse::default();
+        if changed {
+            resp.mark_changed();
+        }
+        if bounds_changed {
+            reclamp_stored(self, ctx, &mut resp);
+        }
+        resp
+    }
+
+    fn context_menu(&mut self, _ctx: &mut NodeCtx, ui: &mut egui::Ui) -> ContextMenuResponse {
+        let mut resp = ContextMenuResponse::default();
+        let mut push = self.push_eval_on_edit();
+        if ui.checkbox(&mut push, "push-eval on edit").changed() {
+            self.set_push_eval_on_edit(push);
+            resp.mark_changed();
         }
         resp
     }
@@ -43,5 +188,46 @@ impl NodeUi for gantz_std::number::Number {
                 SocketDoc::ty("number").with_description("the current stored value")
             }
         })
+    }
+}
+
+/// Keep `max >= min` and re-clamp the stored value into the new bounds so the
+/// displayed value, the stored state and the output stay consistent. Queues an
+/// evaluation on `resp` when the value moved (and push-eval is enabled).
+fn reclamp_stored(num: &mut Number, ctx: &mut NodeCtx, resp: &mut InspectorRowsResponse) {
+    if let (Some(lo), Some(hi)) = (num.min(), num.max()) {
+        if hi < lo {
+            num.set_max(Some(lo));
+        }
+    }
+    if let Ok(Some(val)) = ctx.extract_value() {
+        if let Some(clamped) = clamp_value(num, &val) {
+            ctx.update_value(clamped).unwrap();
+            if num.push_eval_on_edit() {
+                resp.push_eval(ctx.path(), 1);
+            }
+        }
+    }
+}
+
+/// The value clamped into `num`'s bounds, or `None` if it is already in range.
+fn clamp_value(num: &Number, val: &SteelVal) -> Option<SteelVal> {
+    match val {
+        SteelVal::NumV(f) => {
+            let c = num.clamp(*f);
+            (c != *f).then_some(SteelVal::NumV(c))
+        }
+        SteelVal::IntV(i) => {
+            let c = num.clamp(*i as f64);
+            (c != *i as f64).then(|| {
+                // Keep an integer when the clamp lands on a whole number.
+                if c.fract() == 0.0 {
+                    SteelVal::IntV(c as isize)
+                } else {
+                    SteelVal::NumV(c)
+                }
+            })
+        }
+        _ => None,
     }
 }

--- a/crates/gantz_egui/src/impls/number.rs
+++ b/crates/gantz_egui/src/impls/number.rs
@@ -82,74 +82,72 @@ impl NodeUi for Number {
         let mut changed = false;
         let mut bounds_changed = false;
 
+        // Min and max share a `range` row. An inner grid with fixed-width
+        // dialers keeps the `max` group's position fixed regardless of the
+        // `min` value's width.
         body.row(row_h, |mut row| {
             row.col(|ui| {
-                ui.label("min");
+                ui.label("range").on_hover_text(
+                    "optional min/max bounds; every value is clamped into this range \
+                     (input-socket values included)",
+                );
             });
             row.col(|ui| {
-                let mut enabled = self.min().is_some();
-                if ui.checkbox(&mut enabled, "").changed() {
-                    self.set_min(enabled.then(|| self.min().unwrap_or(0.0)));
-                    changed = true;
-                    bounds_changed = true;
-                }
-                if let Some(mut m) = self.min() {
-                    if ui.add(egui::DragValue::new(&mut m).speed(0.1)).changed() {
-                        self.set_min(Some(m));
-                        changed = true;
-                        bounds_changed = true;
-                    }
-                }
+                egui::Grid::new(ui.id().with("range"))
+                    .num_columns(4)
+                    .spacing([6.0, 4.0])
+                    .show(ui, |ui| {
+                        let (new_min, min_changed) = bound_cells(ui, "mn", "minimum", self.min());
+                        if min_changed {
+                            self.set_min(new_min);
+                            changed = true;
+                            bounds_changed = true;
+                        }
+                        let (new_max, max_changed) = bound_cells(ui, "mx", "maximum", self.max());
+                        if max_changed {
+                            self.set_max(new_max);
+                            changed = true;
+                            bounds_changed = true;
+                        }
+                        ui.end_row();
+                    });
             });
         });
 
         body.row(row_h, |mut row| {
             row.col(|ui| {
-                ui.label("max");
+                ui.label("prec.")
+                    .on_hover_text("precision: decimal places the dialer shows (display only)");
             });
             row.col(|ui| {
-                let mut enabled = self.max().is_some();
-                if ui.checkbox(&mut enabled, "").changed() {
-                    self.set_max(enabled.then(|| self.max().unwrap_or(0.0)));
-                    changed = true;
-                    bounds_changed = true;
-                }
-                if let Some(mut m) = self.max() {
-                    if ui.add(egui::DragValue::new(&mut m).speed(0.1)).changed() {
-                        self.set_max(Some(m));
+                ui.horizontal(|ui| {
+                    let mut enabled = self.precision().is_some();
+                    if ui.checkbox(&mut enabled, "").changed() {
+                        self.set_precision(enabled.then(|| self.precision().unwrap_or(2)));
                         changed = true;
-                        bounds_changed = true;
                     }
-                }
-            });
-        });
-
-        body.row(row_h, |mut row| {
-            row.col(|ui| {
-                ui.label("precision");
-            });
-            row.col(|ui| {
-                let mut enabled = self.precision().is_some();
-                if ui.checkbox(&mut enabled, "").changed() {
-                    self.set_precision(enabled.then(|| self.precision().unwrap_or(2)));
-                    changed = true;
-                }
-                if let Some(p) = self.precision() {
-                    let mut n = p as i32;
+                    let mut n = self.precision().unwrap_or(2) as i32;
                     if ui
-                        .add(egui::DragValue::new(&mut n).range(0..=10).speed(0.1))
+                        .add_enabled(
+                            enabled,
+                            egui::DragValue::new(&mut n).range(0..=10).speed(0.1),
+                        )
                         .changed()
                     {
                         self.set_precision(Some(n.clamp(0, 10) as u8));
                         changed = true;
                     }
-                }
+                });
             });
         });
 
         body.row(row_h, |mut row| {
             row.col(|ui| {
-                ui.label("push-eval on edit");
+                ui.label("push").on_hover_text(
+                    "push-eval on edit: when enabled, editing the dialer fires a push \
+                     evaluation downstream. Values arriving via the input socket are \
+                     always passed through regardless.",
+                );
             });
             row.col(|ui| {
                 let mut push = self.push_eval_on_edit();
@@ -189,6 +187,50 @@ impl NodeUi for Number {
             }
         })
     }
+}
+
+/// Fixed dialer width (px) so a bound's position does not shift with its value.
+const BOUND_DIAL_W: f32 = 48.0;
+
+/// Render one bound as a `label` grid cell followed by a `<checkbox> <dialer>`
+/// grid cell. `hover` expands the abbreviated label.
+///
+/// The dialer is always shown but disabled while the checkbox is off, and is
+/// given a fixed width so the next grid column stays put. The checkbox and
+/// dialer are packed tightly. Returns the (possibly updated) bound and whether
+/// it changed this frame.
+fn bound_cells(
+    ui: &mut egui::Ui,
+    label: &str,
+    hover: &str,
+    value: Option<f64>,
+) -> (Option<f64>, bool) {
+    ui.label(label).on_hover_text(hover);
+    let mut value = value;
+    let changed = ui
+        .horizontal(|ui| {
+            ui.spacing_mut().item_spacing.x *= 0.25;
+            let mut changed = false;
+            let mut enabled = value.is_some();
+            if ui.checkbox(&mut enabled, "").changed() {
+                value = enabled.then(|| value.unwrap_or(0.0));
+                changed = true;
+            }
+            let mut v = value.unwrap_or(0.0);
+            let res = ui
+                .add_enabled_ui(enabled, |ui| {
+                    let size = [BOUND_DIAL_W, ui.spacing().interact_size.y];
+                    ui.add_sized(size, egui::DragValue::new(&mut v).speed(0.1))
+                })
+                .inner;
+            if res.changed() {
+                value = Some(v);
+                changed = true;
+            }
+            changed
+        })
+        .inner;
+    (value, changed)
 }
 
 /// Keep `max >= min` and re-clamp the stored value into the new bounds so the

--- a/crates/gantz_egui/src/impls/number.rs
+++ b/crates/gantz_egui/src/impls/number.rs
@@ -117,24 +117,21 @@ impl NodeUi for Number {
                     .on_hover_text("precision: decimal places the dialer shows (display only)");
             });
             row.col(|ui| {
-                ui.horizontal(|ui| {
-                    let mut enabled = self.precision().is_some();
-                    if ui.checkbox(&mut enabled, "").changed() {
-                        self.set_precision(enabled.then(|| self.precision().unwrap_or(2)));
-                        changed = true;
-                    }
-                    let mut n = self.precision().unwrap_or(2) as i32;
-                    if ui
-                        .add_enabled(
-                            enabled,
-                            egui::DragValue::new(&mut n).range(0..=10).speed(0.1),
-                        )
-                        .changed()
-                    {
-                        self.set_precision(Some(n.clamp(0, 10) as u8));
-                        changed = true;
-                    }
-                });
+                // Same checkbox+dialer widget as the `range` bounds, so the rows
+                // look consistent.
+                let mut on = self.precision().is_some();
+                let mut n = self.precision().unwrap_or(2) as i32;
+                let dialer = egui::DragValue::new(&mut n).range(0..=10).speed(0.1);
+                let resp = ui
+                    .add(
+                        crate::widget::CheckboxEnabled::new(&mut on, dialer)
+                            .width(crate::widget::node_inspector::DIAL_W),
+                    )
+                    .on_hover_text("precision: decimal places the dialer shows (display only)");
+                if resp.changed() {
+                    self.set_precision(on.then(|| n.clamp(0, 10) as u8));
+                    changed = true;
+                }
             });
         });
 

--- a/crates/gantz_egui/src/node/plot.rs
+++ b/crates/gantz_egui/src/node/plot.rs
@@ -529,8 +529,16 @@ impl NodeUi for Plot {
             });
             row.col(|ui| {
                 egui::Grid::new("plot_range").num_columns(2).show(ui, |ui| {
-                    changed |= bound_col(ui, "minimum", &mut self.y_min);
-                    changed |= bound_col(ui, "maximum", &mut self.y_max);
+                    let mut y_min = self.y_min.map(F32::get);
+                    if node_inspector::bound_col(ui, "minimum", &mut y_min) {
+                        self.y_min = y_min.map(F32);
+                        changed = true;
+                    }
+                    let mut y_max = self.y_max.map(F32::get);
+                    if node_inspector::bound_col(ui, "maximum", &mut y_max) {
+                        self.y_max = y_max.map(F32);
+                        changed = true;
+                    }
                     ui.end_row();
                 });
             });
@@ -615,42 +623,6 @@ fn radio_option<T: Copy + PartialEq>(
     } else {
         false
     }
-}
-
-/// One grid column for an optional fixed bound: a tightly-spaced enabling
-/// checkbox and a fixed-width value dialer (so the next column doesn't shift as
-/// the value's text width changes). `kind` names the bound for hover text.
-/// Returns whether the bound changed.
-fn bound_col(ui: &mut egui::Ui, kind: &str, bound: &mut Option<F32>) -> bool {
-    let mut changed = false;
-    ui.horizontal(|ui| {
-        // Tighten the gap between the checkbox and its dialer.
-        ui.spacing_mut().item_spacing.x *= 0.25;
-        let mut on = bound.is_some();
-        if ui
-            .checkbox(&mut on, "")
-            .on_hover_text(format!("clamp the {kind} value"))
-            .changed()
-        {
-            *bound = on.then(|| bound.unwrap_or(F32(0.0)));
-            changed = true;
-        }
-        let mut v = bound.map(F32::get).unwrap_or(0.0);
-        let size = egui::vec2(44.0, ui.spacing().interact_size.y);
-        let resp = ui
-            .add_enabled_ui(bound.is_some(), |ui| {
-                ui.add_sized(size, egui::DragValue::new(&mut v).speed(0.1))
-            })
-            .inner;
-        if resp
-            .on_hover_text(format!("the fixed {kind} value"))
-            .changed()
-        {
-            *bound = Some(F32(v));
-            changed = true;
-        }
-    });
-    changed
 }
 
 /// Compute `([x_min, y_min], [x_max, y_max])` for the view from the data and

--- a/crates/gantz_egui/src/widget.rs
+++ b/crates/gantz_egui/src/widget.rs
@@ -1,6 +1,7 @@
 //! A collection of useful widgets for gantz.
 use time::{OffsetDateTime, UtcOffset, format_description};
 
+pub use checkbox_enabled::CheckboxEnabled;
 pub use command_palette::CommandPalette;
 pub use gantz::{
     AlignConfig, Gantz, GantzState, GridConfig, LayoutConfig, SceneConfig, SnapConfig, SnapMode,
@@ -24,6 +25,7 @@ pub use steel_view::SteelView;
 pub use style_config::style_config;
 pub use tab::{Tab, TabResponse};
 
+pub mod checkbox_enabled;
 pub mod command_palette;
 pub mod gantz;
 pub mod global_config;

--- a/crates/gantz_egui/src/widget/checkbox_enabled.rs
+++ b/crates/gantz_egui/src/widget/checkbox_enabled.rs
@@ -1,0 +1,56 @@
+//! A checkbox that enables/disables an adjacent widget.
+
+/// A checkbox on the left enabling/disabling a widget on the right.
+///
+/// The checkbox is bound to `on`; the wrapped `widget` is shown enabled when
+/// `on` is true and disabled (greyed, non-interactive) when false. The gap
+/// between the two is tightened so the pair reads as one control, and an
+/// optional fixed [`width`][Self::width] keeps a following column aligned as the
+/// widget's content width changes.
+///
+/// The returned [`Response`](egui::Response) is the union of the checkbox and
+/// the inner widget, so `changed()` is true when either the toggle flips or the
+/// inner widget is edited.
+pub struct CheckboxEnabled<'a, W> {
+    on: &'a mut bool,
+    widget: W,
+    width: Option<f32>,
+}
+
+impl<'a, W: egui::Widget> CheckboxEnabled<'a, W> {
+    /// Wrap `widget` with a checkbox bound to `on`.
+    pub fn new(on: &'a mut bool, widget: W) -> Self {
+        Self {
+            on,
+            widget,
+            width: None,
+        }
+    }
+
+    /// Give the wrapped widget a fixed width, so neighbouring widgets stay put
+    /// as its content width changes.
+    pub fn width(mut self, width: f32) -> Self {
+        self.width = Some(width);
+        self
+    }
+}
+
+impl<W: egui::Widget> egui::Widget for CheckboxEnabled<'_, W> {
+    fn ui(self, ui: &mut egui::Ui) -> egui::Response {
+        let Self { on, widget, width } = self;
+        ui.horizontal(|ui| {
+            // Tighten the gap so the checkbox reads as part of its widget.
+            ui.spacing_mut().item_spacing.x *= 0.25;
+            let checkbox = ui.checkbox(on, "");
+            let enabled = *on;
+            let inner = ui
+                .add_enabled_ui(enabled, |ui| match width {
+                    Some(w) => ui.add_sized([w, ui.spacing().interact_size.y], widget),
+                    None => ui.add(widget),
+                })
+                .inner;
+            checkbox.union(inner)
+        })
+        .inner
+    }
+}

--- a/crates/gantz_egui/src/widget/node_inspector.rs
+++ b/crates/gantz_egui/src/widget/node_inspector.rs
@@ -61,6 +61,49 @@ pub fn table_row_h(ui: &egui::Ui) -> f32 {
     ui.text_style_height(&egui::TextStyle::Body) + ui.spacing().item_spacing.y
 }
 
+/// Render an optional numeric bound as a tight `<checkbox> <dialer>` group,
+/// suitable as one column of a `range` grid row.
+///
+/// The dialer is always shown but disabled while the checkbox is off, and has a
+/// fixed width so a following column stays put as the value's width changes.
+/// `kind` names the bound for the hover text (e.g. `"minimum"`). Returns whether
+/// `bound` changed this frame.
+pub fn bound_col<T: egui::emath::Numeric>(
+    ui: &mut egui::Ui,
+    kind: &str,
+    bound: &mut Option<T>,
+) -> bool {
+    let mut changed = false;
+    ui.horizontal(|ui| {
+        // Tighten the gap between the checkbox and its dialer.
+        ui.spacing_mut().item_spacing.x *= 0.25;
+        let mut on = bound.is_some();
+        if ui
+            .checkbox(&mut on, "")
+            .on_hover_text(format!("clamp the {kind} value"))
+            .changed()
+        {
+            *bound = on.then(|| bound.unwrap_or(T::from_f64(0.0)));
+            changed = true;
+        }
+        let mut v = bound.unwrap_or(T::from_f64(0.0));
+        let size = egui::vec2(44.0, ui.spacing().interact_size.y);
+        let resp = ui
+            .add_enabled_ui(bound.is_some(), |ui| {
+                ui.add_sized(size, egui::DragValue::new(&mut v).speed(0.1))
+            })
+            .inner;
+        if resp
+            .on_hover_text(format!("the fixed {kind} value"))
+            .changed()
+        {
+            *bound = Some(v);
+            changed = true;
+        }
+    });
+    changed
+}
+
 pub fn table(
     node: &mut (impl Node + NodeUi),
     ctx: &mut NodeCtx,

--- a/crates/gantz_egui/src/widget/node_inspector.rs
+++ b/crates/gantz_egui/src/widget/node_inspector.rs
@@ -61,47 +61,32 @@ pub fn table_row_h(ui: &egui::Ui) -> f32 {
     ui.text_style_height(&egui::TextStyle::Body) + ui.spacing().item_spacing.y
 }
 
-/// Render an optional numeric bound as a tight `<checkbox> <dialer>` group,
-/// suitable as one column of a `range` grid row.
-///
-/// The dialer is always shown but disabled while the checkbox is off, and has a
-/// fixed width so a following column stays put as the value's width changes.
-/// `kind` names the bound for the hover text (e.g. `"minimum"`). Returns whether
-/// `bound` changed this frame.
+/// The fixed width (px) for the optional-numeric dialers in `range`/`prec.`
+/// inspector rows, so a following column stays put as a value's width changes.
+pub const DIAL_W: f32 = 44.0;
+
+/// Render an optional numeric bound as a tight `<checkbox> <dialer>` group
+/// (a [`CheckboxEnabled`](crate::widget::CheckboxEnabled) dialer), suitable as
+/// one column of a `range` grid row. The dialer is always shown but disabled
+/// while the checkbox is off. `kind` names the bound for the hover text (e.g.
+/// `"minimum"`). Returns whether `bound` changed this frame.
 pub fn bound_col<T: egui::emath::Numeric>(
     ui: &mut egui::Ui,
     kind: &str,
     bound: &mut Option<T>,
 ) -> bool {
-    let mut changed = false;
-    ui.horizontal(|ui| {
-        // Tighten the gap between the checkbox and its dialer.
-        ui.spacing_mut().item_spacing.x *= 0.25;
-        let mut on = bound.is_some();
-        if ui
-            .checkbox(&mut on, "")
-            .on_hover_text(format!("clamp the {kind} value"))
-            .changed()
-        {
-            *bound = on.then(|| bound.unwrap_or(T::from_f64(0.0)));
-            changed = true;
-        }
-        let mut v = bound.unwrap_or(T::from_f64(0.0));
-        let size = egui::vec2(44.0, ui.spacing().interact_size.y);
-        let resp = ui
-            .add_enabled_ui(bound.is_some(), |ui| {
-                ui.add_sized(size, egui::DragValue::new(&mut v).speed(0.1))
-            })
-            .inner;
-        if resp
-            .on_hover_text(format!("the fixed {kind} value"))
-            .changed()
-        {
-            *bound = Some(v);
-            changed = true;
-        }
-    });
-    changed
+    let mut on = bound.is_some();
+    let mut v = bound.unwrap_or(T::from_f64(0.0));
+    let dialer = egui::DragValue::new(&mut v).speed(0.1);
+    let resp = ui
+        .add(crate::widget::CheckboxEnabled::new(&mut on, dialer).width(DIAL_W))
+        .on_hover_text(format!("clamp the {kind} value"));
+    if resp.changed() {
+        // `on == false` -> None; a just-toggled-on bound takes the default `v`.
+        *bound = on.then_some(v);
+        return true;
+    }
+    false
 }
 
 pub fn table(

--- a/crates/gantz_format/src/datum.rs
+++ b/crates/gantz_format/src/datum.rs
@@ -124,6 +124,16 @@ impl Datum {
         }
     }
 
+    /// The value of a float datum, coercing integer datums to `f64`.
+    pub(crate) fn as_f64(&self) -> Option<f64> {
+        match self {
+            Datum::F64(n) => Some(*n),
+            Datum::I64(n) => Some(*n as f64),
+            Datum::U64(n) => Some(*n as f64),
+            _ => None,
+        }
+    }
+
     /// The elements of a sequence datum.
     pub(crate) fn as_seq(&self) -> Option<&[Datum]> {
         match self {

--- a/crates/gantz_format/src/sexpr.rs
+++ b/crates/gantz_format/src/sexpr.rs
@@ -89,6 +89,11 @@ pub fn as_f32(e: &ExprKind, src: &str) -> Option<f32> {
     span_src(e, src)?.parse().ok()
 }
 
+/// A numeric datum parsed as a double (from its verbatim source).
+pub fn as_f64(e: &ExprKind, src: &str) -> Option<f64> {
+    span_src(e, src)?.parse().ok()
+}
+
 /// Quote a string as a Steel string literal.
 pub fn quote(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 2);

--- a/crates/gantz_format/src/sugar.rs
+++ b/crates/gantz_format/src/sugar.rs
@@ -151,7 +151,7 @@ impl Sugar for DefaultSugar {
             "expr" => expr_spec(args, src)?,
             "branch" => branch_spec(args, src)?,
             "comment" => comment_spec(args, src)?,
-            "number" => node_datum("Number", vec![]),
+            "number" => number_spec(args, src)?,
             "log" => log_spec(args, src)?,
             _ => return Ok(None),
         };
@@ -175,6 +175,7 @@ impl Sugar for DefaultSugar {
             "Expr" => Some(write_expr(node)),
             "Branch" => Some(write_branch(node)),
             "Comment" => Some(write_comment(node)),
+            "Number" => Some(write_number(node)),
             "Log" => Some(write_log(node)),
             other => keyword_for_tag(other).map(str::to_string),
         }
@@ -281,6 +282,25 @@ fn comment_spec(args: &[ExprKind], src: &str) -> Result<Datum, FormatError> {
     ))
 }
 
+/// Read a `(number [#:min m] [#:max m] [#:precision n] [#:no-push-eval])` form.
+/// Only the non-default fields are emitted, so a bare `number` stays bare.
+fn number_spec(args: &[ExprKind], src: &str) -> Result<Datum, FormatError> {
+    let mut fields = Vec::new();
+    if let Some(min) = keyword_f64(args, "min", src)? {
+        fields.push(("min", Datum::F64(min)));
+    }
+    if let Some(max) = keyword_f64(args, "max", src)? {
+        fields.push(("max", Datum::F64(max)));
+    }
+    if let Some(precision) = keyword_int(args, "precision", src)? {
+        fields.push(("precision", Datum::U64(precision.max(0) as u64)));
+    }
+    if has_flag(args, "no-push-eval") {
+        fields.push(("push_eval_on_edit", Datum::Bool(false)));
+    }
+    Ok(node_datum("Number", fields))
+}
+
 fn log_spec(args: &[ExprKind], src: &str) -> Result<Datum, FormatError> {
     let level = match args.first().and_then(as_symbol) {
         Some(s) => log_level(&s, &args[0], src)?,
@@ -340,6 +360,36 @@ fn write_comment(node: &Datum) -> String {
     format!("(comment {} {w} {h})", quote(text))
 }
 
+/// Write a `Number` as a bare `number` when all config is default, else as
+/// `(number #:min m #:max m #:precision n #:no-push-eval)` with only the
+/// non-default fields.
+fn write_number(node: &Datum) -> String {
+    let min = node.get("min").and_then(Datum::as_f64);
+    let max = node.get("max").and_then(Datum::as_f64);
+    let precision = node.get("precision").and_then(Datum::as_i64);
+    let push = node
+        .get("push_eval_on_edit")
+        .and_then(Datum::as_bool)
+        .unwrap_or(true);
+    if min.is_none() && max.is_none() && precision.is_none() && push {
+        return "number".to_string();
+    }
+    let mut parts = Vec::new();
+    if let Some(min) = min {
+        parts.push(format!("#:min {min}"));
+    }
+    if let Some(max) = max {
+        parts.push(format!("#:max {max}"));
+    }
+    if let Some(precision) = precision {
+        parts.push(format!("#:precision {precision}"));
+    }
+    if !push {
+        parts.push("#:no-push-eval".to_string());
+    }
+    format!("(number {})", parts.join(" "))
+}
+
 fn write_log(node: &Datum) -> String {
     match node.get("level").and_then(Datum::as_str) {
         Some(level) if !level.eq_ignore_ascii_case("info") => {
@@ -375,6 +425,37 @@ fn keyword_int(args: &[ExprKind], key: &str, src: &str) -> Result<Option<i64>, F
         }
     }
     Ok(None)
+}
+
+fn float_at(e: &ExprKind, src: &str) -> Result<f64, FormatError> {
+    sexpr::as_f64(e, src)
+        .ok_or_else(|| err_at(e, src, ErrorKind::Malformed("expected a number".into())))
+}
+
+/// Find a `#:<key>` keyword in `args` and return the following float value.
+fn keyword_f64(args: &[ExprKind], key: &str, src: &str) -> Result<Option<f64>, FormatError> {
+    for (i, a) in args.iter().enumerate() {
+        if as_keyword(a).as_deref() == Some(key) {
+            let val = args
+                .get(i + 1)
+                .map(|v| float_at(v, src))
+                .transpose()?
+                .ok_or_else(|| {
+                    err_at(
+                        a,
+                        src,
+                        ErrorKind::Malformed(format!("#:{key} requires a number")),
+                    )
+                })?;
+            return Ok(Some(val));
+        }
+    }
+    Ok(None)
+}
+
+/// Whether a bare `#:<key>` flag keyword is present in `args`.
+fn has_flag(args: &[ExprKind], key: &str) -> bool {
+    args.iter().any(|a| as_keyword(a).as_deref() == Some(key))
 }
 
 /// Map a log-level symbol to the `log::Level` serde representation.
@@ -529,5 +610,55 @@ mod tests {
         // A bare (undocumented) inlet still writes as the bare keyword.
         let bare = s.read_bare("inlet").expect("bare inlet");
         assert_eq!(s.write_spec("Inlet", &bare).as_deref(), Some("inlet"));
+    }
+
+    #[test]
+    fn number_config_round_trips() {
+        let s = DefaultSugar;
+
+        // A bare (default) number stays bare, whether read as a keyword or spec.
+        let bare = s.read_bare("number").expect("bare number");
+        assert_eq!(s.write_spec("Number", &bare).as_deref(), Some("number"));
+        let empty = read_spec(&s, "(number)").expect("empty spec");
+        assert_eq!(s.write_spec("Number", &empty).as_deref(), Some("number"));
+
+        // Min/max bounds.
+        let mm = read_spec(&s, "(number #:min 0 #:max 100)").expect("min/max");
+        assert_eq!(mm.get("min").and_then(Datum::as_f64), Some(0.0));
+        assert_eq!(mm.get("max").and_then(Datum::as_f64), Some(100.0));
+        assert_eq!(
+            s.write_spec("Number", &mm).as_deref(),
+            Some("(number #:min 0 #:max 100)"),
+        );
+
+        // Display precision.
+        let p = read_spec(&s, "(number #:precision 2)").expect("precision");
+        assert_eq!(p.get("precision").and_then(Datum::as_i64), Some(2));
+        assert_eq!(
+            s.write_spec("Number", &p).as_deref(),
+            Some("(number #:precision 2)"),
+        );
+
+        // Disabled push-eval.
+        let np = read_spec(&s, "(number #:no-push-eval)").expect("no push-eval");
+        assert_eq!(
+            np.get("push_eval_on_edit").and_then(Datum::as_bool),
+            Some(false)
+        );
+        assert_eq!(
+            s.write_spec("Number", &np).as_deref(),
+            Some("(number #:no-push-eval)"),
+        );
+
+        // Everything at once round-trips in canonical order.
+        let all = read_spec(
+            &s,
+            "(number #:min -1.5 #:max 1.5 #:precision 3 #:no-push-eval)",
+        )
+        .expect("all");
+        assert_eq!(
+            s.write_spec("Number", &all).as_deref(),
+            Some("(number #:min -1.5 #:max 1.5 #:precision 3 #:no-push-eval)"),
+        );
     }
 }

--- a/crates/gantz_std/src/number.rs
+++ b/crates/gantz_std/src/number.rs
@@ -2,11 +2,125 @@ use gantz_ca::CaHash;
 use gantz_core::node::{EvalConf, ExprCtx, ExprResult, MetaCtx, RegCtx};
 use gantz_core::steel::SteelVal;
 use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
 
 /// A number stored in state. Can be updated via the first input.
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Deserialize, Serialize, CaHash)]
-#[cahash("gantz.number")]
-pub struct Number;
+///
+/// Optional configuration:
+/// - `min`/`max` clamp every value (including input-socket values) and so are
+///   part of the content address.
+/// - `precision` controls how many decimals the dialer shows/edits (display
+///   only) and `push_eval_on_edit` toggles whether editing fires downstream.
+///   Both are UI-only and deliberately excluded from the content address.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Number {
+    #[serde(default)]
+    min: Option<f64>,
+    #[serde(default)]
+    max: Option<f64>,
+    #[serde(default)]
+    precision: Option<u8>,
+    #[serde(default = "default_push_eval")]
+    push_eval_on_edit: bool,
+}
+
+impl Number {
+    /// The lower bound the value is clamped to, if any.
+    pub fn min(&self) -> Option<f64> {
+        self.min
+    }
+
+    /// The upper bound the value is clamped to, if any.
+    pub fn max(&self) -> Option<f64> {
+        self.max
+    }
+
+    /// The number of decimal places the dialer shows/edits, if configured.
+    pub fn precision(&self) -> Option<u8> {
+        self.precision
+    }
+
+    /// Whether editing the dialer fires a push-eval downstream.
+    pub fn push_eval_on_edit(&self) -> bool {
+        self.push_eval_on_edit
+    }
+
+    /// Set the lower bound (content-address affecting).
+    pub fn set_min(&mut self, min: Option<f64>) {
+        self.min = min;
+    }
+
+    /// Set the upper bound (content-address affecting).
+    pub fn set_max(&mut self, max: Option<f64>) {
+        self.max = max;
+    }
+
+    /// Set the dialer display precision (UI-only).
+    pub fn set_precision(&mut self, precision: Option<u8>) {
+        self.precision = precision;
+    }
+
+    /// Set whether editing the dialer fires downstream (UI-only).
+    pub fn set_push_eval_on_edit(&mut self, push_eval_on_edit: bool) {
+        self.push_eval_on_edit = push_eval_on_edit;
+    }
+
+    /// Clamp `v` to the configured `min`/`max` bounds.
+    pub fn clamp(&self, v: f64) -> f64 {
+        let v = self.min.map_or(v, |lo| v.max(lo));
+        self.max.map_or(v, |hi| v.min(hi))
+    }
+}
+
+impl Default for Number {
+    fn default() -> Self {
+        Number {
+            min: None,
+            max: None,
+            precision: None,
+            push_eval_on_edit: true,
+        }
+    }
+}
+
+impl PartialEq for Number {
+    fn eq(&self, other: &Self) -> bool {
+        self.min.map(f64::to_bits) == other.min.map(f64::to_bits)
+            && self.max.map(f64::to_bits) == other.max.map(f64::to_bits)
+            && self.precision == other.precision
+            && self.push_eval_on_edit == other.push_eval_on_edit
+    }
+}
+
+impl Eq for Number {}
+
+impl Hash for Number {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Fully qualified to disambiguate from `gantz_ca::CaHash::hash`.
+        Hash::hash(&self.min.map(f64::to_bits), state);
+        Hash::hash(&self.max.map(f64::to_bits), state);
+        Hash::hash(&self.precision, state);
+        Hash::hash(&self.push_eval_on_edit, state);
+    }
+}
+
+impl CaHash for Number {
+    fn hash(&self, hasher: &mut gantz_ca::Hasher) {
+        hasher.update("gantz.number".as_bytes());
+        // Only the semantic bounds contribute to the content address. With no
+        // bounds this matches the old unit-struct hash byte-for-byte, so
+        // existing `number` nodes keep their address. `precision` and
+        // `push_eval_on_edit` are UI-only and intentionally excluded.
+        if let Some(min) = self.min {
+            hasher.update(b"min");
+            CaHash::hash(&min.to_bits(), hasher);
+        }
+        if let Some(max) = self.max {
+            hasher.update(b"max");
+            CaHash::hash(&max.to_bits(), hasher);
+        }
+    }
+}
 
 impl gantz_core::Node for Number {
     fn n_inputs(&self, _ctx: MetaCtx) -> usize {
@@ -23,10 +137,11 @@ impl gantz_core::Node for Number {
 
     fn expr(&self, ctx: ExprCtx<'_, '_>) -> ExprResult {
         let expr = match ctx.inputs().get(0) {
-            // If an input value was provided, use it to update state and
-            // forward that value.
+            // If an input value was provided, clamp it, use it to update state
+            // and forward that value.
             Some(Some(val)) => {
-                format!("(begin (if (number? {val}) (set! state {val}) void) state)")
+                let stored = clamp_steel(val, self.min, self.max);
+                format!("(begin (if (number? {val}) (set! state {stored}) void) state)")
             }
             // If no input value was provided, forward the value in state.
             _ => "(begin state)".to_string(),
@@ -40,7 +155,69 @@ impl gantz_core::Node for Number {
 
     fn register(&self, mut ctx: RegCtx<'_, '_>) {
         let path = ctx.path();
-        gantz_core::node::state::init_value_if_absent(ctx.vm(), path, || SteelVal::NumV(0.0))
+        let init = self.clamp(0.0);
+        gantz_core::node::state::init_value_if_absent(ctx.vm(), path, || SteelVal::NumV(init))
             .unwrap()
+    }
+}
+
+fn default_push_eval() -> bool {
+    true
+}
+
+/// Build a Steel expression that clamps `val` to the given bounds.
+///
+/// `min`/`max` are unavailable in `Engine::new_base`, so this emits primitive
+/// `if`s. `val` is bound once with `let` to avoid evaluating it twice.
+fn clamp_steel(val: &str, min: Option<f64>, max: Option<f64>) -> String {
+    match (min, max) {
+        (None, None) => val.to_string(),
+        (Some(lo), None) => format!("(let ((v {val})) (if (< v {lo:?}) {lo:?} v))"),
+        (None, Some(hi)) => format!("(let ((v {val})) (if (> v {hi:?}) {hi:?} v))"),
+        (Some(lo), Some(hi)) => {
+            format!("(let ((v {val})) (if (< v {lo:?}) {lo:?} (if (> v {hi:?}) {hi:?} v)))")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamp_bounds() {
+        let n = Number {
+            min: Some(0.0),
+            max: Some(10.0),
+            precision: None,
+            push_eval_on_edit: true,
+        };
+        assert_eq!(n.clamp(-5.0), 0.0);
+        assert_eq!(n.clamp(5.0), 5.0);
+        assert_eq!(n.clamp(15.0), 10.0);
+
+        let lo = Number {
+            min: Some(3.0),
+            ..Number::default()
+        };
+        assert_eq!(lo.clamp(1.0), 3.0);
+        assert_eq!(lo.clamp(100.0), 100.0);
+    }
+
+    #[test]
+    fn clamp_steel_forms() {
+        assert_eq!(clamp_steel("x", None, None), "x");
+        assert_eq!(
+            clamp_steel("x", Some(0.0), None),
+            "(let ((v x)) (if (< v 0.0) 0.0 v))",
+        );
+        assert_eq!(
+            clamp_steel("x", None, Some(10.0)),
+            "(let ((v x)) (if (> v 10.0) 10.0 v))",
+        );
+        assert_eq!(
+            clamp_steel("x", Some(0.0), Some(10.0)),
+            "(let ((v x)) (if (< v 0.0) 0.0 (if (> v 10.0) 10.0 v)))",
+        );
     }
 }

--- a/crates/gantz_std/src/number.rs
+++ b/crates/gantz_std/src/number.rs
@@ -7,11 +7,15 @@ use std::hash::{Hash, Hasher};
 /// A number stored in state. Can be updated via the first input.
 ///
 /// Optional configuration:
-/// - `min`/`max` clamp every value (including input-socket values) and so are
-///   part of the content address.
+/// - `min`/`max` clamp every value (including input-socket values).
 /// - `precision` controls how many decimals the dialer shows/edits (display
-///   only) and `push_eval_on_edit` toggles whether editing fires downstream.
-///   Both are UI-only and deliberately excluded from the content address.
+///   only).
+/// - `push_eval_on_edit` toggles whether editing the dialer fires downstream.
+///
+/// Each field is folded into the content address only when non-default (see
+/// [`CaHash`]): a plain `number` keeps the original address, while any
+/// configured field becomes part of the node's identity so it persists and is
+/// undoable under the commit-on-change model.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Number {
     #[serde(default)]
@@ -107,10 +111,11 @@ impl Hash for Number {
 impl CaHash for Number {
     fn hash(&self, hasher: &mut gantz_ca::Hasher) {
         hasher.update("gantz.number".as_bytes());
-        // Only the semantic bounds contribute to the content address. With no
-        // bounds this matches the old unit-struct hash byte-for-byte, so
-        // existing `number` nodes keep their address. `precision` and
-        // `push_eval_on_edit` are UI-only and intentionally excluded.
+        // Each config field is folded in only when non-default, so a plain
+        // `number` hashes to just the tag - byte-for-byte the old unit-struct
+        // address, keeping existing `number` nodes stable. Configuring any field
+        // gives the node a new address, which is how the commit-on-change model
+        // persists it (the working graph is only saved when it commits).
         if let Some(min) = self.min {
             hasher.update(b"min");
             CaHash::hash(&min.to_bits(), hasher);
@@ -118,6 +123,13 @@ impl CaHash for Number {
         if let Some(max) = self.max {
             hasher.update(b"max");
             CaHash::hash(&max.to_bits(), hasher);
+        }
+        if let Some(precision) = self.precision {
+            hasher.update(b"precision");
+            CaHash::hash(&precision, hasher);
+        }
+        if !self.push_eval_on_edit {
+            hasher.update(b"no-push-eval");
         }
     }
 }

--- a/crates/gantz_std/tests/number.rs
+++ b/crates/gantz_std/tests/number.rs
@@ -1,0 +1,83 @@
+//! Tests for the number node's optional min/max bounds: a bounded `Number`
+//! clamps every value it stores, including a value pushed into its input.
+
+use gantz_core::{
+    Edge, Node,
+    compile::{EvalKind, entry_fn_name, push_pull_entrypoints},
+    node::{self, WithPushEval},
+};
+use gantz_std::number::Number;
+use std::fmt::Debug;
+
+trait DebugNode: Debug + Node {}
+impl<T> DebugNode for T where T: Debug + Node {}
+
+// A no-op node lookup function for tests that don't need it.
+fn no_lookup(_: &gantz_ca::ContentAddr) -> Option<&'static dyn Node> {
+    None
+}
+
+fn bounded(min: Option<f64>, max: Option<f64>) -> Number {
+    let mut n = Number::default();
+    n.set_min(min);
+    n.set_max(max);
+    n
+}
+
+// Push `value` into a `Number` configured with `min`/`max`, then assert against
+// the value it forwards downstream via `check` (an expression that panics if its
+// assertion fails). A successful fire proves the bounds were applied.
+fn assert_forwards(value: &str, min: Option<f64>, max: Option<f64>, check: &str) {
+    let mut g = petgraph::graph::DiGraph::new();
+    let push =
+        g.add_node(Box::new(node::expr(value).unwrap().with_push_eval()) as Box<dyn DebugNode>);
+    let num = g.add_node(Box::new(bounded(min, max)) as Box<_>);
+    let check = g.add_node(Box::new(node::expr(check).unwrap()) as Box<_>);
+    g.add_edge(push, num, Edge::from((0, 0)));
+    g.add_edge(num, check, Edge::from((0, 0)));
+
+    let config = gantz_core::compile::Config::default();
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let (mut vm, _compiled) = gantz_core::vm::init(&no_lookup, &g, &eps, &config)
+        .unwrap_or_else(|e| panic!("init: {}", gantz_core::vm::error_chain(&e)));
+
+    let ep = eps
+        .iter()
+        .find(|ep| {
+            ep.0.iter()
+                .any(|s| s.kind == EvalKind::Push && s.path == [push.index()])
+        })
+        .expect("push entrypoint");
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep.id()), vec![])
+        .expect("firing the number errored");
+}
+
+#[test]
+fn clamps_above_max() {
+    assert_forwards("150", Some(0.0), Some(100.0), "(assert! (= $n 100))");
+}
+
+#[test]
+fn clamps_below_min() {
+    assert_forwards("-50", Some(0.0), Some(100.0), "(assert! (= $n 0))");
+}
+
+#[test]
+fn passes_value_in_range() {
+    assert_forwards("42", Some(0.0), Some(100.0), "(assert! (= $n 42))");
+}
+
+#[test]
+fn lower_bound_only() {
+    assert_forwards("-3", Some(0.0), None, "(assert! (= $n 0))");
+}
+
+#[test]
+fn upper_bound_only() {
+    assert_forwards("500", None, Some(10.0), "(assert! (= $n 10))");
+}
+
+#[test]
+fn unbounded_passes_through() {
+    assert_forwards("999", None, None, "(assert! (= $n 999))");
+}


### PR DESCRIPTION
Adds optional configuration to the `number` node - useful for `base.gantz` demos.

## What's new

- **Min/max bounds** - a *semantic* clamp: every value is clamped into the range, including values arriving via the input socket (baked into the node's emitted Steel, not just the dialer widget).
- **Precision** - how many decimal places the dialer shows/edits (display only).
- **Push-eval-on-edit toggle** (default on) - when off, dialing a value stores it without firing downstream ("set without firing"); the dialer background flattens to the node frame as a visual cue.

Controls live in the node inspector (a shared `range` row, plus `prec.`/`push` rows with hover docs), with a quick push-eval toggle in the node context menu.

## Notes

- **Persistence:** under the commit-on-change model, only content-addressed state is saved, so the config fields participate in the `CaHash` *conditionally* - a plain `number` hashes to its original address (existing graphs unchanged), while any configured field gives the node a new, undoable address (like `Comment`'s `size`).
- **Text format:** sugars as `(number #:min m #:max m #:precision n #:no-push-eval)`, staying bare `number` when all-default.
- **Reuse:** the inspector `range` row shares a generic `node_inspector::bound_col` with the plot node.

## Testing

- New runtime tests fire values through a bounded node (clamp above/below/in-range, single-sided bounds, unbounded passthrough) and a `.gantz` sugar round-trip test.
- `base_graphs_all_compile` confirms unbounded `number` nodes keep their address.
- All cargo CI gates pass (`check`/`test` x3 feature configs/`fmt`/`doc`, `-D warnings`).