### PR TITLE
Content-address graphs by canonical node rank

### DIFF
--- a/crates/gantz_ca/src/graph.rs
+++ b/crates/gantz_ca/src/graph.rs
@@ -4,9 +4,7 @@ pub use crate::{
     ContentAddr, content_addr,
     hash::{CaHash, Hasher},
 };
-use petgraph::visit::{
-    Data, EdgeRef, IntoEdgeReferences, IntoNodeReferences, NodeIndexable, NodeRef,
-};
+use petgraph::visit::{Data, EdgeRef, IntoEdgeReferences, IntoNodeReferences, NodeRef};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt, hash::Hash, ops};
 
@@ -47,25 +45,31 @@ impl fmt::Display for GraphAddr {
 
 /// Calculate the content address of a graph.
 ///
-/// Note that some graphs with the same structure may result in different CAs.
-/// This is because indices are (currently) meaningful, as they're provided to
-/// nodes when registering state and generating expressions.
+/// The address depends on graph *structure*, not on the physical node-index
+/// layout: each node is hashed by its canonical rank (its position in
+/// ascending-index order) rather than its raw index. For a hole-free graph the
+/// rank equals the raw index, so addresses are unchanged; vacant slots left by
+/// node removals (`StableGraph` "holes") are compacted away, keeping the address
+/// stable across a `gantz_format` round-trip (which cannot reproduce holes).
+///
+/// Raw indices remain meaningful at *runtime* - they key node state and appear
+/// in generated expressions - but they no longer leak into the address.
 ///
 /// ## Approach
 ///
-/// 1. For each node:
-///     - hash its index (u64, big-endian).
+/// 1. Rank each node by its position in ascending-index order.
+/// 2. For each node (in rank order):
+///     - hash its rank (u64, big-endian).
 ///     - hash the content address of the node.
-/// 2. Collect all edges (src-node-ix, dst-node-ix, src-output, dst-input).
-/// 3. Sort the edges.
-/// 4. For each edge:
-///     - hash the source node index (u64, big-endian).
-///     - hash the target node index (u64, big-endian).
-///     - hash the source node's output (u16, big-endian).
-///     - hash the target node's input (u16, big-endian).
+/// 3. Collect all edges (rank-src, rank-dst, edge-weight).
+/// 4. Sort the edges.
+/// 5. For each edge:
+///     - hash the source node rank (u64, big-endian).
+///     - hash the target node rank (u64, big-endian).
+///     - hash the edge weight (source output + target input).
 pub fn addr<G>(g: G) -> GraphAddr
 where
-    G: Data + IntoEdgeReferences + IntoNodeReferences + NodeIndexable,
+    G: Data + IntoEdgeReferences + IntoNodeReferences,
     G::NodeId: Eq + Hash + Ord,
     G::EdgeWeight: CaHash + Ord,
     G::NodeWeight: CaHash,
@@ -79,7 +83,7 @@ where
 /// addresses are already known.
 pub fn addr_with_nodes<G>(g: G, nodes: &HashMap<G::NodeId, ContentAddr>) -> GraphAddr
 where
-    G: Data + IntoEdgeReferences + IntoNodeReferences + NodeIndexable,
+    G: Data + IntoEdgeReferences + IntoNodeReferences,
     G::NodeId: Hash + Ord,
     G::EdgeWeight: CaHash + Ord,
 {
@@ -91,7 +95,7 @@ where
 /// The implementation of [`addr`] with hasher provided.
 pub fn hash_graph<G>(g: G, hasher: &mut Hasher)
 where
-    G: Data + IntoEdgeReferences + IntoNodeReferences + NodeIndexable,
+    G: Data + IntoEdgeReferences + IntoNodeReferences,
     G::NodeId: Eq + Hash + Ord,
     G::EdgeWeight: CaHash + Ord,
     G::NodeWeight: CaHash,
@@ -103,33 +107,41 @@ where
 /// The implementation of [`addr_with_nodes`] with hasher provided.
 pub fn hash_graph_with_nodes<G>(g: G, nodes: &HashMap<G::NodeId, ContentAddr>, hasher: &mut Hasher)
 where
-    G: Data + IntoEdgeReferences + IntoNodeReferences + NodeIndexable,
+    G: Data + IntoEdgeReferences + IntoNodeReferences,
     G::NodeId: Hash + Ord,
     G::EdgeWeight: CaHash + Ord,
 {
-    const OUT_OF_RANGE: &str = "graph node index exceeds u64::MAX";
+    // Assign each node a canonical rank: its position in ascending-index order
+    // (the order `node_references` yields for a `StableGraph`). For a hole-free
+    // graph the rank equals the raw index, so existing addresses are unchanged;
+    // vacant slots left by node removals are compacted away, making the address
+    // independent of the physical slot layout and stable across a round-trip.
+    let rank: HashMap<G::NodeId, u64> = g
+        .node_references()
+        .enumerate()
+        .map(|(i, n_ref)| (n_ref.id(), i as u64))
+        .collect();
 
-    // Hash all nodes in index order (indices are meaningful).
+    // Hash all nodes in rank order.
     for n_ref in g.node_references() {
         let id = n_ref.id();
         let node_ca = &nodes[&id];
-        let ix: u64 = g.to_index(id).try_into().expect(OUT_OF_RANGE);
-        CaHash::hash(&ix, hasher);
+        CaHash::hash(&rank[&id], hasher);
         CaHash::hash(&**node_ca, hasher);
     }
 
-    // Collect and sort edges by (source, target, edge_data).
-    // Since edge indices don't matter, we can put them in an
-    // edge-index-agnostic deterministic order.
+    // Collect and sort edges by (source rank, target rank, edge weight). Since
+    // edge indices don't matter, we put them in an edge-index-agnostic
+    // deterministic order.
     let mut edges = vec![];
     for e_ref in g.edge_references() {
-        let src: u64 = g.to_index(e_ref.source()).try_into().expect(OUT_OF_RANGE);
-        let dst: u64 = g.to_index(e_ref.target()).try_into().expect(OUT_OF_RANGE);
+        let src = rank[&e_ref.source()];
+        let dst = rank[&e_ref.target()];
         edges.push((src, dst, e_ref));
     }
     edges.sort_by(|(sa, da, ea), (sb, db, eb)| (sa, da, ea.weight()).cmp(&(sb, db, eb.weight())));
 
-    // Hash all edges as (src, dst, src-output, dst-input).
+    // Hash all edges as (src rank, dst rank, edge weight).
     for (src, dst, e_ref) in edges {
         CaHash::hash(&src, hasher);
         CaHash::hash(&dst, hasher);
@@ -140,7 +152,7 @@ where
 /// Hash all the nodes and return a map from node IDs to their content addresses.
 pub fn node_addrs<G>(g: G) -> HashMap<G::NodeId, ContentAddr>
 where
-    G: Data + IntoNodeReferences + NodeIndexable,
+    G: Data + IntoNodeReferences,
     G::NodeId: Eq + std::hash::Hash,
     G::NodeWeight: CaHash,
 {
@@ -151,4 +163,60 @@ where
             (id, ca)
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::addr;
+    use petgraph::{Directed, stable_graph::StableGraph};
+
+    type G = StableGraph<u32, u32, Directed, usize>;
+
+    /// The address must ignore `StableGraph` "holes": an edited graph (whose
+    /// node removals leave vacant index slots) and its compacted form (as
+    /// produced by a `gantz_format` round-trip, which cannot reproduce holes)
+    /// must share an address.
+    #[test]
+    fn addr_is_stable_across_hole_compaction() {
+        // Holey: four nodes wired up, then an interior node removed - leaving a
+        // vacant slot at index 1 and surviving nodes at indices 0, 2, 3.
+        let mut holey = G::default();
+        let h0 = holey.add_node(10);
+        let h1 = holey.add_node(20);
+        let h2 = holey.add_node(30);
+        let h3 = holey.add_node(40);
+        holey.add_edge(h0, h2, 0);
+        holey.add_edge(h2, h3, 1);
+        holey.add_edge(h0, h1, 2); // dropped along with h1
+        holey.remove_node(h1);
+
+        // Compacted: the same surviving structure with contiguous indices.
+        let mut compact = G::default();
+        let c0 = compact.add_node(10);
+        let c1 = compact.add_node(30);
+        let c2 = compact.add_node(40);
+        compact.add_edge(c0, c1, 0);
+        compact.add_edge(c1, c2, 1);
+
+        assert_eq!(addr(&holey), addr(&compact));
+    }
+
+    /// The address is deterministic and remains sensitive to structure (so the
+    /// canonical-rank scheme didn't collapse genuinely distinct graphs).
+    #[test]
+    fn addr_is_deterministic_and_structure_sensitive() {
+        let build = |rev: bool| {
+            let mut g = G::default();
+            let n0 = g.add_node(1);
+            let n1 = g.add_node(2);
+            if rev {
+                g.add_edge(n1, n0, 0);
+            } else {
+                g.add_edge(n0, n1, 0);
+            }
+            g
+        };
+        assert_eq!(addr(&build(false)), addr(&build(false)));
+        assert_ne!(addr(&build(false)), addr(&build(true)));
+    }
 }

--- a/crates/gantz_format/src/model.rs
+++ b/crates/gantz_format/src/model.rs
@@ -60,9 +60,6 @@ pub struct GraphBody {
 pub struct NodeDecl {
     /// File-local label, referenced by connections and layout.
     pub name: String,
-    /// Explicit node index, overriding the sequential default (reserved for
-    /// reproducing `StableGraph` holes); `None` means "previous index + 1".
-    pub index: Option<usize>,
     /// The node specification.
     pub spec: NodeSpec,
 }

--- a/crates/gantz_format/src/parse.rs
+++ b/crates/gantz_format/src/parse.rs
@@ -111,11 +111,7 @@ fn parse_node_decl(
         )
     })?;
     let spec = parse_node_spec(&args[1], src, sugar)?;
-    Ok(NodeDecl {
-        name,
-        index: None,
-        spec,
-    })
+    Ok(NodeDecl { name, spec })
 }
 
 // -- node specs --------------------------------------------------------------

--- a/crates/gantz_format/src/raise.rs
+++ b/crates/gantz_format/src/raise.rs
@@ -158,11 +158,7 @@ where
         let (spec, keyword) = node_spec_from_datum(value, sugar, pin)?;
         let label = format!("{keyword}{}", ix.index());
         labels.insert(ix.index(), label.clone());
-        nodes.push(NodeDecl {
-            name: label,
-            index: None,
-            spec,
-        });
+        nodes.push(NodeDecl { name: label, spec });
     }
 
     let mut conns = Vec::new();


### PR DESCRIPTION
Closes #233 

## Summary

Graph content addresses (`GraphAddr` / `CaHash`) were computed from **raw `StableGraph` node indices**, which are not stable across a `gantz_format` round-trip. `StableGraph` develops "holes" (vacant index slots) after node removals, and the format cannot reproduce them on import (petgraph 0.8.3 has no index-placement API, `add_node` reuses the free-list head, and a generic node type has no `Default` to synthesise placeholders). So an edited graph `[0,1,3]` round-trips to a compacted `[0,1,2]` and gets a **different address**.

This hashes each node by its **canonical rank** - its position in ascending-index order - instead of its raw index, for both node hashing and edge endpoints. For a hole-free graph the rank equals the raw index, so **existing addresses are unchanged**. Vacant slots are compacted away, making the address independent of the physical slot layout and stable across a round-trip.

## Changes

- **`gantz_ca`**: `hash_graph_with_nodes` builds a canonical rank map
  (`node_references().enumerate()`) and hashes node/edge endpoints by rank.
  Removed the now-dead `NodeIndexable` bound. Rewrote the stale `addr` docs.
- **`gantz_ca`**: regression tests - address is stable across hole compaction,
  deterministic, and still structure-sensitive.
- **`gantz_format`**: dropped the reserved-but-unused `NodeDecl.index` field
  (it only ever existed to reproduce holes, now address-irrelevant).

## Trade-off

Two *structurally identical* graphs differing only in physical slot layout now share an address and dedup. The only path to both reaching one registry is export-then-merge-back, and the failure mode is a recoverable layout glitch (re-layout fixes it) - already tolerated by the existing name-recovery design.

Closes #233.