### PR TITLE
Optimise persistence, fix related lag spikes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,6 +904,7 @@ dependencies = [
 name = "bevy_gantz_egui"
 version = "0.3.1"
 dependencies = [
+ "base64",
  "bevy_app",
  "bevy_ecs",
  "bevy_egui",
@@ -911,6 +912,7 @@ dependencies = [
  "bevy_log",
  "bevy_tasks",
  "bevy_time",
+ "bincode",
  "egui_graph",
  "gantz_base",
  "gantz_ca",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3188,6 +3188,7 @@ dependencies = [
 name = "gantz"
 version = "0.2.2"
 dependencies = [
+ "async-channel",
  "bevy",
  "bevy_egui",
  "bevy_gantz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 repository = "https://github.com/nannou-org/gantz"
 
 [workspace.dependencies]
+async-channel = "2.5"
 bevy = { version = "0.19", default-features = false, features = [
     "bevy_asset",
     "bevy_camera",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ repository = "https://github.com/nannou-org/gantz"
 
 [workspace.dependencies]
 async-channel = "2.5"
+base64 = "0.22"
+bincode = "1"
 bevy = { version = "0.19", default-features = false, features = [
     "bevy_asset",
     "bevy_camera",

--- a/crates/bevy_gantz/src/debounced_input.rs
+++ b/crates/bevy_gantz/src/debounced_input.rs
@@ -1,126 +1,113 @@
 //! Provides a Bevy plugin for debounced event emission based on input activity.
 //!
-//! The plugin monitors input events and emits a `DebouncedInputEvent` after a
-//! configurable delay from the last input event. This can be used for
-//! auto-saving, or any other behavior that should occur after a period of user
-//! inactivity.
+//! The plugin monitors input events and emits an event after a configurable
+//! delay from the last input event. This can be used for auto-saving, or any
+//! other behavior that should occur after a period of user inactivity.
+//!
+//! The plugin is generic over the event it emits ([`DebouncedEvent`]), so
+//! several instances with different delays - and distinct event types - can run
+//! side by side to debounce independent behaviours.
 
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_input::prelude::*;
 use bevy_time::prelude::*;
 use bevy_window::WindowFocused;
+use std::marker::PhantomData;
 
-/// A plugin that emits debounced events based on input activity.
+/// A plugin that emits a debounced event of type `E` based on input activity.
 ///
-/// The plugin monitors keyboard, mouse, and touch input events. When any input
-/// is detected, it starts a timer. Once the timer expires without new input, a
-/// `DebouncedInputEvent` is emitted. The event is also emitted immediately if
-/// the window loses focus with pending input.
+/// The plugin monitors keyboard, mouse, and touch input. When any input is
+/// detected it (re)starts a timer; once the timer expires without new input, an
+/// `E` is emitted. `E` is also emitted immediately if the window loses focus
+/// with pending input.
 ///
-/// # Example
+/// Add one instance per debounce cadence - each tracks its own timer:
 ///
 /// ```ignore
-/// use bevy::prelude::*;
-///
-/// fn main() {
-///     App::new()
-///         .add_plugins(DebouncedInputPlugin::new(2.0))
-///         .add_systems(Update, handle_autosave)
-///         .run();
-/// }
-///
-/// fn handle_autosave(mut msgs: MessageReader<DebouncedInputEvent>) {
-///     for msg in msgs.read() {
-///         if msg.triggered_by_focus_loss {
-///             println!("Auto-saving due to window focus loss");
-///         } else {
-///             println!("Auto-saving after inactivity");
-///         }
-///         // Perform your save logic here
-///     }
-/// }
+/// app.add_plugins(DebouncedInputPlugin::<DebouncedInputEvent>::new(0.25))
+///    .add_plugins(DebouncedInputPlugin::<SlowSave>::new(0.6));
 /// ```
-pub struct DebouncedInputPlugin {
-    /// Duration in secs to wait after the last input before emitting the event
+pub struct DebouncedInputPlugin<E = DebouncedInputEvent> {
+    /// Seconds to wait after the last input before emitting the event.
     debounce_secs: f32,
+    _marker: PhantomData<E>,
 }
 
-/// Event emitted when the debounce timer expires after input activity.
+/// An event emitted by [`DebouncedInputPlugin`].
 ///
-/// This event is triggered in two scenarios:
+/// Implement this for a custom type to run an additional debounce at a
+/// different delay.
+pub trait DebouncedEvent: Message {
+    /// Construct the event. `triggered_by_focus_loss` is `true` when emitted
+    /// early because the window lost focus rather than the timer expiring.
+    fn debounced(triggered_by_focus_loss: bool) -> Self;
+}
+
+/// The default [`DebouncedEvent`].
 ///
-/// 1. After the debounce delay has passed since the last input event
-/// 2. Immediately when the window loses focus (if there was pending input)
-#[derive(Message)]
+/// Emitted after the debounce delay, or immediately on window focus loss while
+/// input is pending.
+#[derive(Message, Default)]
 pub struct DebouncedInputEvent {
-    /// Indicates whether this event was triggered by window focus loss
+    /// Whether this event was triggered by window focus loss.
     pub triggered_by_focus_loss: bool,
 }
 
+impl DebouncedEvent for DebouncedInputEvent {
+    fn debounced(triggered_by_focus_loss: bool) -> Self {
+        Self {
+            triggered_by_focus_loss,
+        }
+    }
+}
+
 #[derive(Resource)]
-struct DebouncedInputTimer {
+struct DebouncedInputTimer<E: Send + Sync + 'static> {
     timer: Timer,
     has_pending_input: bool,
+    _marker: PhantomData<E>,
 }
 
-impl DebouncedInputPlugin {
-    /// Creates a new plugin instance with the specified debounce duration.
-    ///
-    /// The `debounce_secs` parameter determines how long to wait after the last
-    /// input event before emitting a `DebouncedInputEvent`.
+impl<E> DebouncedInputPlugin<E> {
+    /// Create the plugin, waiting `debounce_secs` after the last input before
+    /// emitting `E`.
     pub fn new(debounce_secs: f32) -> Self {
-        Self { debounce_secs }
-    }
-}
-
-impl DebouncedInputEvent {
-    fn from_timer() -> Self {
         Self {
-            triggered_by_focus_loss: false,
-        }
-    }
-
-    fn from_focus_loss() -> Self {
-        Self {
-            triggered_by_focus_loss: true,
+            debounce_secs,
+            _marker: PhantomData,
         }
     }
 }
 
-impl DebouncedInputTimer {
+impl<E: Send + Sync + 'static> DebouncedInputTimer<E> {
     fn new(secs: f32) -> Self {
         Self {
             timer: Timer::from_seconds(secs, TimerMode::Once),
             has_pending_input: false,
+            _marker: PhantomData,
         }
     }
 }
 
-impl Default for DebouncedInputEvent {
-    fn default() -> Self {
-        Self::from_timer()
-    }
-}
-
-impl Plugin for DebouncedInputPlugin {
+impl<E: DebouncedEvent> Plugin for DebouncedInputPlugin<E> {
     fn build(&self, app: &mut App) {
-        app.add_message::<DebouncedInputEvent>()
-            .insert_resource(DebouncedInputTimer::new(self.debounce_secs))
+        app.add_message::<E>()
+            .insert_resource(DebouncedInputTimer::<E>::new(self.debounce_secs))
             .add_systems(
                 Update,
                 (
-                    detect_input_changes,
-                    handle_debounce_timer,
-                    handle_window_focus,
+                    detect_input_changes::<E>,
+                    handle_debounce_timer::<E>,
+                    handle_window_focus::<E>,
                 )
                     .chain(),
             );
     }
 }
 
-fn detect_input_changes(
-    mut timer: ResMut<DebouncedInputTimer>,
+fn detect_input_changes<E: Send + Sync + 'static>(
+    mut timer: ResMut<DebouncedInputTimer<E>>,
     keyboard: Res<ButtonInput<KeyCode>>,
     mouse: Res<ButtonInput<MouseButton>>,
     mut touch: MessageReader<TouchInput>,
@@ -134,30 +121,30 @@ fn detect_input_changes(
     }
 }
 
-fn handle_debounce_timer(
+fn handle_debounce_timer<E: DebouncedEvent>(
     time: Res<Time>,
-    mut timer: ResMut<DebouncedInputTimer>,
-    mut msgs: MessageWriter<DebouncedInputEvent>,
+    mut timer: ResMut<DebouncedInputTimer<E>>,
+    mut msgs: MessageWriter<E>,
 ) {
     if timer.has_pending_input {
         timer.timer.tick(time.delta());
 
         if timer.timer.just_finished() {
-            msgs.write(DebouncedInputEvent::from_timer());
+            msgs.write(E::debounced(false));
             timer.has_pending_input = false;
         }
     }
 }
 
-fn handle_window_focus(
+fn handle_window_focus<E: DebouncedEvent>(
     mut window_focused: MessageReader<WindowFocused>,
-    mut timer: ResMut<DebouncedInputTimer>,
-    mut msgs: MessageWriter<DebouncedInputEvent>,
+    mut timer: ResMut<DebouncedInputTimer<E>>,
+    mut msgs: MessageWriter<E>,
 ) {
-    // If we lose window focus and have pending input, emit event immediately
+    // If we lose window focus and have pending input, emit the event immediately.
     for msg in window_focused.read() {
         if !msg.focused && timer.has_pending_input {
-            msgs.write(DebouncedInputEvent::from_focus_loss());
+            msgs.write(E::debounced(true));
             timer.has_pending_input = false;
             timer.timer.reset();
         }

--- a/crates/bevy_gantz/src/storage.rs
+++ b/crates/bevy_gantz/src/storage.rs
@@ -29,6 +29,31 @@ pub trait Save {
     fn set_string(&mut self, key: &str, value: &str) -> Result<(), Self::Err>;
 }
 
+/// A [`Save`] that buffers writes instead of committing them.
+///
+/// Lets a caller build a batch on the main thread - serializing in place via the
+/// usual `save_*` functions - then hand the collected `(key, value)` pairs to a
+/// background writer. Never fails.
+#[derive(Default)]
+pub struct BatchWriter {
+    pub writes: Vec<(String, String)>,
+}
+
+impl BatchWriter {
+    /// Take the collected writes, leaving the buffer empty.
+    pub fn take(&mut self) -> Vec<(String, String)> {
+        std::mem::take(&mut self.writes)
+    }
+}
+
+impl Save for BatchWriter {
+    type Err = std::convert::Infallible;
+    fn set_string(&mut self, key: &str, value: &str) -> Result<(), Self::Err> {
+        self.writes.push((key.to_string(), value.to_string()));
+        Ok(())
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Generic helpers
 // ---------------------------------------------------------------------------
@@ -426,5 +451,34 @@ mod tests {
         assert_eq!(loaded.graphs().len(), reg.graphs().len());
         assert_eq!(loaded.commits().len(), reg.commits().len());
         assert_eq!(loaded.names(), reg.names());
+    }
+
+    #[test]
+    fn batch_writer_collects_pairs_and_take_empties() {
+        // Building a batch via the usual `save_*` path collects the same writes
+        // a direct store would, as ordered (key, ron) pairs.
+        let reg = registry(&[(1, 11)], &[("alpha", 11)]);
+        let mut persisted = PersistedRegistry::default();
+        let mut batch = BatchWriter::default();
+        save_registry_incremental(&mut batch, &reg, &mut persisted);
+
+        let keys: Vec<&str> = batch.writes.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(keys.contains(&key::graph(graph_addr(1)).as_str()));
+        assert!(keys.contains(&key::commit(commit_addr(11)).as_str()));
+        assert!(keys.contains(&key::GRAPH_ADDRS));
+        assert!(keys.contains(&key::COMMIT_ADDRS));
+        assert!(keys.contains(&key::NAMES));
+        // Values are the RON the direct `save` path would have written.
+        let (_, names_ron) = batch
+            .writes
+            .iter()
+            .find(|(k, _)| k == key::NAMES)
+            .expect("names written");
+        assert_eq!(names_ron, &ron::to_string(reg.names()).unwrap());
+
+        // `take` hands off the buffer and leaves it empty.
+        let taken = batch.take();
+        assert!(!taken.is_empty());
+        assert!(batch.writes.is_empty());
     }
 }

--- a/crates/bevy_gantz/src/storage.rs
+++ b/crates/bevy_gantz/src/storage.rs
@@ -127,6 +127,16 @@ impl PersistedRegistry {
             descriptions: registry.descriptions().clone(),
         }
     }
+
+    /// The number of graph blobs known to be on disk.
+    pub fn graphs_len(&self) -> usize {
+        self.graphs.len()
+    }
+
+    /// The number of commit blobs known to be on disk.
+    pub fn commits_len(&self) -> usize {
+        self.commits.len()
+    }
 }
 
 /// Incrementally persist the registry, writing only what `persisted` doesn't yet

--- a/crates/bevy_gantz/src/storage.rs
+++ b/crates/bevy_gantz/src/storage.rs
@@ -7,9 +7,11 @@
 //! GUI-related storage (views, gui state) is provided by `bevy_gantz_egui::storage`.
 
 use crate::reg::Registry;
+use bevy_ecs::prelude::Resource;
 use bevy_log as log;
 use gantz_ca as ca;
 use serde::{Serialize, de::DeserializeOwned};
+use std::collections::{BTreeMap, HashSet};
 
 // ---------------------------------------------------------------------------
 // Traits
@@ -101,24 +103,94 @@ mod key {
 // Registry
 // ---------------------------------------------------------------------------
 
-/// Save the registry to storage.
-pub fn save_registry<N: Serialize>(storage: &mut impl Save, registry: &Registry<N>) {
-    let mut graph_addrs: Vec<_> = registry.graphs().keys().copied().collect();
-    graph_addrs.sort();
-    save(storage, key::GRAPH_ADDRS, &graph_addrs);
+/// Tracks which graph/commit content addresses (and the small name-keyed maps)
+/// are already written to storage, so [`save_registry_incremental`] only writes
+/// what changed.
+///
+/// Seed it from the disk-loaded registry via [`PersistedRegistry::from_registry`]:
+/// everything `load_registry` returns is, by definition, already on disk.
+#[derive(Resource, Default)]
+pub struct PersistedRegistry {
+    graphs: HashSet<ca::GraphAddr>,
+    commits: HashSet<ca::CommitAddr>,
+    names: BTreeMap<String, ca::CommitAddr>,
+    descriptions: BTreeMap<String, String>,
+}
+
+impl PersistedRegistry {
+    /// Snapshot the keys of a registry whose blobs are all known to be on disk.
+    pub fn from_registry<N>(registry: &Registry<N>) -> Self {
+        Self {
+            graphs: registry.graphs().keys().copied().collect(),
+            commits: registry.commits().keys().copied().collect(),
+            names: registry.names().clone(),
+            descriptions: registry.descriptions().clone(),
+        }
+    }
+}
+
+/// Incrementally persist the registry, writing only what `persisted` doesn't yet
+/// have. Graphs and commits are content-addressed and immutable (the key *is*
+/// the content hash), so an already-written blob never needs rewriting and this
+/// is O(new blobs) rather than O(graphs + commits).
+///
+/// A fresh [`PersistedRegistry::default`] makes this a full save.
+pub fn save_registry_incremental<N: Serialize>(
+    storage: &mut impl Save,
+    registry: &Registry<N>,
+    persisted: &mut PersistedRegistry,
+) {
+    // Graph blobs: write only newly-seen content addresses.
+    let mut graphs_changed = false;
     for (&ca, graph) in registry.graphs() {
-        save(storage, &key::graph(ca), graph);
+        if persisted.graphs.insert(ca) {
+            save(storage, &key::graph(ca), graph);
+            graphs_changed = true;
+        }
+    }
+    // Prune detection: every live key is now in `persisted`, so it is a superset
+    // of the live keys; a length mismatch means stale (pruned) addrs remain.
+    if persisted.graphs.len() != registry.graphs().len() {
+        persisted
+            .graphs
+            .retain(|ca| registry.graphs().contains_key(ca));
+        graphs_changed = true;
+    }
+    if graphs_changed {
+        let mut addrs: Vec<_> = registry.graphs().keys().copied().collect();
+        addrs.sort();
+        save(storage, key::GRAPH_ADDRS, &addrs);
     }
 
-    let mut commit_addrs: Vec<_> = registry.commits().keys().copied().collect();
-    commit_addrs.sort();
-    save(storage, key::COMMIT_ADDRS, &commit_addrs);
+    // Commit blobs: same pattern.
+    let mut commits_changed = false;
     for (&ca, commit) in registry.commits() {
-        save(storage, &key::commit(ca), commit);
+        if persisted.commits.insert(ca) {
+            save(storage, &key::commit(ca), commit);
+            commits_changed = true;
+        }
+    }
+    if persisted.commits.len() != registry.commits().len() {
+        persisted
+            .commits
+            .retain(|ca| registry.commits().contains_key(ca));
+        commits_changed = true;
+    }
+    if commits_changed {
+        let mut addrs: Vec<_> = registry.commits().keys().copied().collect();
+        addrs.sort();
+        save(storage, key::COMMIT_ADDRS, &addrs);
     }
 
-    save(storage, key::NAMES, registry.names());
-    save(storage, key::DESCRIPTIONS, registry.descriptions());
+    // Tiny name-keyed maps: write only when they differ from last-persisted.
+    if registry.names() != &persisted.names {
+        persisted.names = registry.names().clone();
+        save(storage, key::NAMES, registry.names());
+    }
+    if registry.descriptions() != &persisted.descriptions {
+        persisted.descriptions = registry.descriptions().clone();
+        save(storage, key::DESCRIPTIONS, registry.descriptions());
+    }
 }
 
 /// Load the registry from storage.
@@ -171,4 +243,178 @@ pub fn save_focused_head(storage: &mut impl Save, head: &ca::Head) {
 /// Load the focused head from storage.
 pub fn load_focused_head(storage: &impl Load) -> Option<ca::Head> {
     load(storage, key::FOCUSED_HEAD)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gantz_ca::{Commit, CommitAddr, ContentAddr, GraphAddr};
+    use gantz_core::node::graph::Graph;
+    use std::collections::{HashMap, HashSet};
+    use std::time::Duration;
+
+    /// A mock key-value store recording the keys written to it.
+    #[derive(Default)]
+    struct MockStore {
+        map: HashMap<String, String>,
+        writes: Vec<String>,
+    }
+
+    impl MockStore {
+        fn take_writes(&mut self) -> Vec<String> {
+            std::mem::take(&mut self.writes)
+        }
+    }
+
+    impl Save for MockStore {
+        type Err = std::convert::Infallible;
+        fn set_string(&mut self, key: &str, value: &str) -> Result<(), Self::Err> {
+            self.map.insert(key.to_string(), value.to_string());
+            self.writes.push(key.to_string());
+            Ok(())
+        }
+    }
+
+    impl Load for MockStore {
+        type Err = std::convert::Infallible;
+        fn get_string(&self, key: &str) -> Result<Option<String>, Self::Err> {
+            Ok(self.map.get(key).cloned())
+        }
+    }
+
+    fn graph_addr(n: u8) -> GraphAddr {
+        GraphAddr::from(ContentAddr::from([n; 32]))
+    }
+
+    fn commit_addr(n: u8) -> CommitAddr {
+        CommitAddr::from(ContentAddr::from([n; 32]))
+    }
+
+    fn wrote(writes: &[String], key: &str) -> bool {
+        writes.iter().any(|w| w == key)
+    }
+
+    /// Build a registry from `(graph, commit)` synthetic-addr pairs (one commit
+    /// per graph) plus `(name, commit)` pairs. Graph blob values are empty - the
+    /// dedup is keyed on the map keys, not the values.
+    fn registry(graphs: &[(u8, u8)], names: &[(&str, u8)]) -> Registry<()> {
+        let g = graphs
+            .iter()
+            .map(|&(ga, _)| (graph_addr(ga), Graph::<()>::default()))
+            .collect();
+        let c = graphs
+            .iter()
+            .map(|&(ga, ca)| {
+                let commit = Commit::new(Duration::from_secs(ca as u64), None, graph_addr(ga));
+                (commit_addr(ca), commit)
+            })
+            .collect();
+        let nm = names
+            .iter()
+            .map(|&(n, ca)| (n.to_string(), commit_addr(ca)))
+            .collect();
+        Registry(ca::Registry::new(g, c, nm))
+    }
+
+    #[test]
+    fn first_save_writes_all_blobs_indices_and_names() {
+        let reg = registry(&[(1, 11), (2, 12)], &[("alpha", 11)]);
+        let mut persisted = PersistedRegistry::default();
+        let mut store = MockStore::default();
+        save_registry_incremental(&mut store, &reg, &mut persisted);
+        let writes = store.take_writes();
+        assert!(wrote(&writes, &key::graph(graph_addr(1))));
+        assert!(wrote(&writes, &key::graph(graph_addr(2))));
+        assert!(wrote(&writes, key::GRAPH_ADDRS));
+        assert!(wrote(&writes, &key::commit(commit_addr(11))));
+        assert!(wrote(&writes, &key::commit(commit_addr(12))));
+        assert!(wrote(&writes, key::COMMIT_ADDRS));
+        assert!(wrote(&writes, key::NAMES));
+        // Descriptions is empty, so it is not written.
+        assert!(!wrote(&writes, key::DESCRIPTIONS));
+    }
+
+    #[test]
+    fn resave_unchanged_writes_nothing() {
+        let reg = registry(&[(1, 11), (2, 12)], &[("alpha", 11)]);
+        let mut persisted = PersistedRegistry::default();
+        let mut store = MockStore::default();
+        save_registry_incremental(&mut store, &reg, &mut persisted);
+        store.take_writes();
+        save_registry_incremental(&mut store, &reg, &mut persisted);
+        assert!(store.take_writes().is_empty());
+    }
+
+    #[test]
+    fn adding_graph_and_commit_writes_only_the_new_ones() {
+        let mut persisted = PersistedRegistry::default();
+        let mut store = MockStore::default();
+        save_registry_incremental(
+            &mut store,
+            &registry(&[(1, 11)], &[("alpha", 11)]),
+            &mut persisted,
+        );
+        store.take_writes();
+        let reg = registry(&[(1, 11), (2, 12)], &[("alpha", 11)]);
+        save_registry_incremental(&mut store, &reg, &mut persisted);
+        let writes = store.take_writes();
+        assert!(wrote(&writes, &key::graph(graph_addr(2))));
+        assert!(wrote(&writes, &key::commit(commit_addr(12))));
+        assert!(wrote(&writes, key::GRAPH_ADDRS));
+        assert!(wrote(&writes, key::COMMIT_ADDRS));
+        // Already-persisted blobs and unchanged names are not rewritten.
+        assert!(!wrote(&writes, &key::graph(graph_addr(1))));
+        assert!(!wrote(&writes, &key::commit(commit_addr(11))));
+        assert!(!wrote(&writes, key::NAMES));
+    }
+
+    #[test]
+    fn changing_description_writes_only_descriptions() {
+        let mut reg = registry(&[(1, 11)], &[("alpha", 11)]);
+        let mut persisted = PersistedRegistry::default();
+        let mut store = MockStore::default();
+        save_registry_incremental(&mut store, &reg, &mut persisted);
+        store.take_writes();
+        reg.set_description("alpha".to_string(), "doc".to_string());
+        save_registry_incremental(&mut store, &reg, &mut persisted);
+        assert_eq!(store.take_writes(), vec![key::DESCRIPTIONS.to_string()]);
+    }
+
+    #[test]
+    fn pruning_rewrites_indices_and_trims_tracker() {
+        let mut reg = registry(&[(1, 11), (2, 12)], &[("alpha", 11)]);
+        let mut persisted = PersistedRegistry::default();
+        let mut store = MockStore::default();
+        save_registry_incremental(&mut store, &reg, &mut persisted);
+        store.take_writes();
+        // Keep only commit 11 (and graph 1, which it references).
+        let required: HashSet<CommitAddr> = [commit_addr(11)].into_iter().collect();
+        reg.prune_unreachable(&required);
+        save_registry_incremental(&mut store, &reg, &mut persisted);
+        let writes = store.take_writes();
+        // Nothing new to write, but both indices shrank and are rewritten.
+        assert!(wrote(&writes, key::GRAPH_ADDRS));
+        assert!(wrote(&writes, key::COMMIT_ADDRS));
+        assert!(!wrote(&writes, &key::graph(graph_addr(1))));
+        assert!(!wrote(&writes, &key::commit(commit_addr(11))));
+        // Tracker trimmed to the surviving keys.
+        assert_eq!(persisted.graphs.len(), 1);
+        assert_eq!(persisted.commits.len(), 1);
+    }
+
+    #[test]
+    fn load_round_trips_incremental_save() {
+        let reg = registry(&[(1, 11), (2, 12)], &[("alpha", 11)]);
+        let mut persisted = PersistedRegistry::default();
+        let mut store = MockStore::default();
+        save_registry_incremental(&mut store, &reg, &mut persisted);
+        let loaded: Registry<()> = load_registry(&store);
+        assert_eq!(loaded.graphs().len(), reg.graphs().len());
+        assert_eq!(loaded.commits().len(), reg.commits().len());
+        assert_eq!(loaded.names(), reg.names());
+    }
 }

--- a/crates/bevy_gantz_egui/Cargo.toml
+++ b/crates/bevy_gantz_egui/Cargo.toml
@@ -9,12 +9,14 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+base64.workspace = true
 bevy_app.workspace = true
 bevy_ecs.workspace = true
 bevy_egui.workspace = true
 bevy_time.workspace = true
 bevy_gantz.workspace = true
 bevy_log.workspace = true
+bincode.workspace = true
 bevy_tasks.workspace = true
 egui_graph.workspace = true
 gantz_base.workspace = true

--- a/crates/bevy_gantz_egui/src/storage.rs
+++ b/crates/bevy_gantz_egui/src/storage.rs
@@ -5,6 +5,7 @@
 //! by `bevy_gantz::storage`.
 
 use crate::{GraphView, GuiState, Views};
+use bevy_ecs::prelude::Resource;
 use bevy_egui::egui;
 use bevy_gantz::clone_graph;
 use bevy_gantz::reg::Registry;
@@ -12,28 +13,97 @@ use bevy_gantz::storage::{Load, Save, load, save};
 use gantz_ca as ca;
 use gantz_core::node::graph::Graph;
 use serde::de::DeserializeOwned;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 mod key {
-    /// The key at which all graph views (layout + camera) are stored.
+    /// The key at which all graph views were stored as a single blob (legacy;
+    /// still read for backwards compatibility, see [`super::load_views`]).
     pub const VIEWS: &str = "views";
+    /// Index of commit addresses that have a per-commit persisted view.
+    pub const VIEW_ADDRS: &str = "view-addrs";
     /// The key at which the gantz GUI state is stored.
     pub const GUI_STATE: &str = "gui-state";
     /// The key at which egui memory (widget states) is saved/loaded.
     pub const EGUI_MEMORY: &str = "egui-memory-ron";
+
+    /// The key for a particular commit's view.
+    pub fn view(ca: gantz_ca::CommitAddr) -> String {
+        format!("view-{ca}")
+    }
 }
 
-/// Save all graph views to storage under a single key.
+/// Tracks the views already written to storage (and their last-persisted form),
+/// so [`save_views_incremental`] only serializes/writes those that changed.
 ///
-/// Keys are sorted to produce deterministic output.
+/// Seed it from the disk-loaded views via [`PersistedViews::from_views`].
+#[derive(Resource, Default)]
+pub struct PersistedViews(HashMap<ca::CommitAddr, egui_graph::View>);
+
+impl PersistedViews {
+    /// Snapshot the views known to be on disk.
+    pub fn from_views(views: &Views) -> Self {
+        Self(views.iter().map(|(&ca, v)| (ca, v.clone())).collect())
+    }
+}
+
+/// Save all graph views to storage under a single key (legacy whole-map form).
 pub fn save_views(storage: &mut impl bevy_gantz::storage::Save, views: &Views) {
     let sorted: std::collections::BTreeMap<_, _> = views.iter().collect();
     save(storage, key::VIEWS, &sorted);
 }
 
+/// Incrementally persist views, one key per commit.
+///
+/// Writes only the views whose commit is in `valid_commits` and that differ from
+/// the last-persisted form, and rewrites the small index only when the set of
+/// persisted commits changes. No change since the last persist writes nothing -
+/// a camera pan on one head writes just that one view, not the whole map.
+pub fn save_views_incremental(
+    storage: &mut impl Save,
+    views: &Views,
+    valid_commits: &HashSet<ca::CommitAddr>,
+    persisted: &mut PersistedViews,
+) {
+    let mut index_changed = false;
+    for (&ca, view) in views.iter() {
+        // Only persist views for commits that still exist.
+        if !valid_commits.contains(&ca) {
+            continue;
+        }
+        if persisted.0.get(&ca) != Some(view) {
+            save(storage, &key::view(ca), view);
+            // A newly-seen commit grows the index.
+            index_changed |= persisted.0.insert(ca, view.clone()).is_none();
+        }
+    }
+    // Drop tracked views whose commit no longer exists.
+    let before = persisted.0.len();
+    persisted.0.retain(|ca, _| valid_commits.contains(ca));
+    index_changed |= persisted.0.len() != before;
+
+    if index_changed {
+        let mut addrs: Vec<_> = persisted.0.keys().copied().collect();
+        addrs.sort();
+        save(storage, key::VIEW_ADDRS, &addrs);
+    }
+}
+
 /// Load all graph views from storage.
+///
+/// Reads the per-commit view keys via the [`VIEW_ADDRS`](key::VIEW_ADDRS) index,
+/// falling back to the legacy single-key blob for stores written before views
+/// were split per commit.
 pub fn load_views(storage: &impl Load) -> Views {
+    if let Some(addrs) = load::<Vec<ca::CommitAddr>>(storage, key::VIEW_ADDRS) {
+        return Views(
+            addrs
+                .into_iter()
+                .filter_map(|ca| Some((ca, load(storage, &key::view(ca))?)))
+                .collect(),
+        );
+    }
+    // Legacy: a single whole-map blob.
     Views(
         load::<HashMap<ca::CommitAddr, egui_graph::View>>(storage, key::VIEWS).unwrap_or_default(),
     )
@@ -110,5 +180,147 @@ pub fn load_egui_memory(storage: &impl Load, ctx: &egui::Context) {
             *m = memory;
             m.options.zoom_factor = zoom_factor;
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gantz_ca::{CommitAddr, ContentAddr};
+
+    /// A mock key-value store recording the keys written to it.
+    #[derive(Default)]
+    struct MockStore {
+        map: HashMap<String, String>,
+        writes: Vec<String>,
+    }
+
+    impl MockStore {
+        fn take_writes(&mut self) -> Vec<String> {
+            std::mem::take(&mut self.writes)
+        }
+    }
+
+    impl Save for MockStore {
+        type Err = std::convert::Infallible;
+        fn set_string(&mut self, key: &str, value: &str) -> Result<(), Self::Err> {
+            self.map.insert(key.to_string(), value.to_string());
+            self.writes.push(key.to_string());
+            Ok(())
+        }
+    }
+
+    impl Load for MockStore {
+        type Err = std::convert::Infallible;
+        fn get_string(&self, key: &str) -> Result<Option<String>, Self::Err> {
+            Ok(self.map.get(key).cloned())
+        }
+    }
+
+    fn commit_addr(n: u8) -> CommitAddr {
+        CommitAddr::from(ContentAddr::from([n; 32]))
+    }
+
+    /// A view distinguishable by `n` (so changing it is detectable).
+    fn view(n: f32) -> egui_graph::View {
+        egui_graph::View {
+            scene_rect: egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(n, n)),
+            layout: Default::default(),
+        }
+    }
+
+    fn views(entries: &[(u8, f32)]) -> Views {
+        Views(
+            entries
+                .iter()
+                .map(|&(c, n)| (commit_addr(c), view(n)))
+                .collect(),
+        )
+    }
+
+    fn valid(commits: &[u8]) -> HashSet<CommitAddr> {
+        commits.iter().map(|&c| commit_addr(c)).collect()
+    }
+
+    fn wrote(writes: &[String], key: &str) -> bool {
+        writes.iter().any(|w| w == key)
+    }
+
+    #[test]
+    fn first_save_writes_each_view_and_the_index() {
+        let v = views(&[(1, 10.0), (2, 20.0)]);
+        let mut persisted = PersistedViews::default();
+        let mut store = MockStore::default();
+        save_views_incremental(&mut store, &v, &valid(&[1, 2]), &mut persisted);
+        let writes = store.take_writes();
+        assert!(wrote(&writes, &key::view(commit_addr(1))));
+        assert!(wrote(&writes, &key::view(commit_addr(2))));
+        assert!(wrote(&writes, key::VIEW_ADDRS));
+    }
+
+    #[test]
+    fn unchanged_views_write_nothing() {
+        let v = views(&[(1, 10.0), (2, 20.0)]);
+        let mut persisted = PersistedViews::default();
+        let mut store = MockStore::default();
+        save_views_incremental(&mut store, &v, &valid(&[1, 2]), &mut persisted);
+        store.take_writes();
+        save_views_incremental(&mut store, &v, &valid(&[1, 2]), &mut persisted);
+        assert!(store.take_writes().is_empty());
+    }
+
+    #[test]
+    fn changing_one_view_writes_only_that_view_not_the_index() {
+        let mut persisted = PersistedViews::default();
+        let mut store = MockStore::default();
+        save_views_incremental(
+            &mut store,
+            &views(&[(1, 10.0), (2, 20.0)]),
+            &valid(&[1, 2]),
+            &mut persisted,
+        );
+        store.take_writes();
+        // Commit 2's view moves; commit 1's is untouched.
+        let changed = views(&[(1, 10.0), (2, 25.0)]);
+        save_views_incremental(&mut store, &changed, &valid(&[1, 2]), &mut persisted);
+        let writes = store.take_writes();
+        assert_eq!(writes, vec![key::view(commit_addr(2))]);
+    }
+
+    #[test]
+    fn views_for_unknown_commits_are_skipped() {
+        let v = views(&[(1, 10.0), (9, 90.0)]);
+        let mut persisted = PersistedViews::default();
+        let mut store = MockStore::default();
+        // Only commit 1 exists.
+        save_views_incremental(&mut store, &v, &valid(&[1]), &mut persisted);
+        let writes = store.take_writes();
+        assert!(wrote(&writes, &key::view(commit_addr(1))));
+        assert!(!wrote(&writes, &key::view(commit_addr(9))));
+    }
+
+    #[test]
+    fn pruning_a_commit_rewrites_the_index_and_trims_the_tracker() {
+        let v = views(&[(1, 10.0), (2, 20.0)]);
+        let mut persisted = PersistedViews::default();
+        let mut store = MockStore::default();
+        save_views_incremental(&mut store, &v, &valid(&[1, 2]), &mut persisted);
+        store.take_writes();
+        // Commit 2 is gone; its view should drop from the tracker + index.
+        save_views_incremental(&mut store, &v, &valid(&[1]), &mut persisted);
+        let writes = store.take_writes();
+        assert_eq!(writes, vec![key::VIEW_ADDRS.to_string()]);
+        assert_eq!(persisted.0.len(), 1);
+    }
+
+    #[test]
+    fn load_round_trips_incremental_save() {
+        let v = views(&[(1, 10.0), (2, 20.0)]);
+        let mut persisted = PersistedViews::default();
+        let mut store = MockStore::default();
+        save_views_incremental(&mut store, &v, &valid(&[1, 2]), &mut persisted);
+        let loaded = load_views(&store);
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded.get(&commit_addr(2)), Some(&view(20.0)));
     }
 }

--- a/crates/bevy_gantz_egui/src/storage.rs
+++ b/crates/bevy_gantz_egui/src/storage.rs
@@ -5,11 +5,13 @@
 //! by `bevy_gantz::storage`.
 
 use crate::{GraphView, GuiState, Views};
+use base64::Engine as _;
 use bevy_ecs::prelude::Resource;
 use bevy_egui::egui;
 use bevy_gantz::clone_graph;
 use bevy_gantz::reg::Registry;
 use bevy_gantz::storage::{Load, Save, load, save};
+use bevy_log as log;
 use gantz_ca as ca;
 use gantz_core::node::graph::Graph;
 use serde::de::DeserializeOwned;
@@ -24,8 +26,9 @@ mod key {
     pub const VIEW_ADDRS: &str = "view-addrs";
     /// The key at which the gantz GUI state is stored.
     pub const GUI_STATE: &str = "gui-state";
-    /// The key at which egui memory (widget states) is saved/loaded.
-    pub const EGUI_MEMORY: &str = "egui-memory-ron";
+    /// The key at which egui memory (widget states) is saved/loaded. Versioned
+    /// for the RON -> bincode switch; the old `egui-memory-ron` blob is ignored.
+    pub const EGUI_MEMORY: &str = "egui-memory-bin";
 
     /// The key for a particular commit's view.
     pub fn view(ca: gantz_ca::CommitAddr) -> String {
@@ -91,9 +94,9 @@ pub fn save_views_incremental(
 
 /// Load all graph views from storage.
 ///
-/// Reads the per-commit view keys via the [`VIEW_ADDRS`](key::VIEW_ADDRS) index,
-/// falling back to the legacy single-key blob for stores written before views
-/// were split per commit.
+/// Reads the per-commit view keys via the `view-addrs` index, falling back to
+/// the legacy single-key blob for stores written before views were split per
+/// commit.
 pub fn load_views(storage: &impl Load) -> Views {
     if let Some(addrs) = load::<Vec<ca::CommitAddr>>(storage, key::VIEW_ADDRS) {
         return Views(
@@ -161,13 +164,37 @@ where
 }
 
 /// Save the egui Memory to storage.
+///
+/// Serialized with bincode rather than RON: egui memory is large and
+/// RON-encoding it - escaping the nested per-entry RON strings egui stores -
+/// dominated the persist cost. The compact binary is base64-encoded to fit the
+/// string-keyed store. (egui only re-serializes entries touched this session, so
+/// the inner cost is bounded; the win is removing the outer RON encoding.)
 pub fn save_egui_memory(storage: &mut impl Save, ctx: &egui::Context) {
-    ctx.memory(|m| save(storage, key::EGUI_MEMORY, m));
+    let bytes = match ctx.memory(|m| bincode::serialize(m)) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            log::error!("Failed to serialize egui memory: {e}");
+            return;
+        }
+    };
+    let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+    match storage.set_string(key::EGUI_MEMORY, &encoded) {
+        Ok(()) => log::debug!("Persisted {}", key::EGUI_MEMORY),
+        Err(e) => log::error!("Failed to persist egui memory: {e}"),
+    }
 }
 
-/// Load the egui Memory from storage.
+/// Load the egui Memory from storage (see [`save_egui_memory`]).
 pub fn load_egui_memory(storage: &impl Load, ctx: &egui::Context) {
-    if let Some(memory) = load::<egui::Memory>(storage, key::EGUI_MEMORY) {
+    let Some(encoded) = storage.get_string(key::EGUI_MEMORY).ok().flatten() else {
+        return;
+    };
+    let memory = base64::engine::general_purpose::STANDARD
+        .decode(encoded.as_bytes())
+        .ok()
+        .and_then(|bytes| bincode::deserialize::<egui::Memory>(&bytes).ok());
+    if let Some(memory) = memory {
         ctx.memory_mut(|m| {
             // Preserve the live zoom factor rather than restoring the persisted
             // one. egui's `zoom_factor` is the display-driven scale here (set by
@@ -322,5 +349,16 @@ mod tests {
         let loaded = load_views(&store);
         assert_eq!(loaded.len(), 2);
         assert_eq!(loaded.get(&commit_addr(2)), Some(&view(20.0)));
+    }
+
+    /// `egui::Memory` must survive a bincode round-trip - the format used by
+    /// `save_egui_memory`/`load_egui_memory`. Guards against a serde pattern
+    /// bincode can't handle creeping into egui's `Memory` on an egui bump.
+    #[test]
+    fn egui_memory_round_trips_through_bincode() {
+        let mem = egui::Memory::default();
+        let bytes = bincode::serialize(&mem).expect("serialize egui::Memory");
+        let _decoded: egui::Memory =
+            bincode::deserialize(&bytes).expect("deserialize egui::Memory");
     }
 }

--- a/crates/gantz/Cargo.toml
+++ b/crates/gantz/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 default-run = "gantz"
 
 [dependencies]
+async-channel.workspace = true
 bevy.workspace = true
 bevy_egui.workspace = true
 bevy_gantz.workspace = true

--- a/crates/gantz/src/main.rs
+++ b/crates/gantz/src/main.rs
@@ -154,6 +154,7 @@ fn persist_resources(
     heads_query: Query<OpenHeadDataReadOnly<Box<dyn node::Node>>, With<OpenHead>>,
     primary_window: Query<&Window, With<PrimaryWindow>>,
 ) {
+    let start = web_time::Instant::now();
     // Incrementally save the registry (only newly-seen graphs/commits and any
     // changed name maps). `persist_resources` runs only on debounced events, so
     // `is_changed()` here means "changed since the last persist" - a cheap guard
@@ -192,6 +193,13 @@ fn persist_resources(
     if let Ok(window) = primary_window.single() {
         window::save(&mut *storage, window);
     }
+
+    bevy::log::debug!(
+        "persist_resources took {:?} ({} graphs, {} commits on disk)",
+        start.elapsed(),
+        persisted.graphs_len(),
+        persisted.commits_len(),
+    );
 }
 
 #[cfg(test)]

--- a/crates/gantz/src/main.rs
+++ b/crates/gantz/src/main.rs
@@ -4,28 +4,26 @@ use bevy::{
 };
 use bevy_egui::{EguiContexts, EguiPlugin, EguiPrimaryContextPass};
 use bevy_gantz::{
-    BuiltinNodes, FocusedHead, GantzPlugin, HeadRef, HeadTabOrder, OpenHead, OpenHeadDataReadOnly,
-    Registry, WorkingGraph,
-    debounced_input::{DebouncedEvent, DebouncedInputEvent, DebouncedInputPlugin},
+    BuiltinNodes, FocusedHead, GantzPlugin, HeadRef, HeadTabOrder, OpenHead, Registry,
+    WorkingGraph,
+    debounced_input::{DebouncedInputEvent, DebouncedInputPlugin},
     reg, timestamp,
 };
-use bevy_gantz_egui::{GantzEguiPlugin, GuiState, HeadGuiState, TraceCapture, Views};
+use bevy_gantz_egui::{GantzEguiPlugin, HeadGuiState, TraceCapture, Views};
 use bevy_pkv::PkvStore;
 use builtin::Builtins;
 use storage::Pkv;
 
-#[cfg(not(target_arch = "wasm32"))]
-use bevy::tasks::{IoTaskPool, Task, block_on};
-
 mod builtin;
 mod node;
+mod persist;
 mod storage;
 mod window;
 
 fn main() {
-    let mut app = App::new();
-    // Core gantz plugin (provides FocusedHead, HeadTabOrder, HeadVms, Registry, Views)
-    app.add_plugins(GantzPlugin::<Box<dyn node::Node>>::default())
+    App::new()
+        // Core gantz plugin (provides FocusedHead, HeadTabOrder, HeadVms, Registry, Views)
+        .add_plugins(GantzPlugin::<Box<dyn node::Node>>::default())
         // Egui plugin (provides GuiState, TraceCapture, PerfVm, PerfGui, GUI systems)
         .add_plugins(GantzEguiPlugin::<Box<dyn node::Node>>::default())
         // App-specific builtins
@@ -34,10 +32,10 @@ fn main() {
         )))
         .add_plugins(DefaultPlugins.set(log_plugin()).set(window::plugin()))
         .add_plugins(EguiPlugin::default())
+        // Drives both layout settling and the registry/views persist.
         .add_plugins(DebouncedInputPlugin::<DebouncedInputEvent>::new(0.25))
-        // A separate, slower debounce for egui memory so it doesn't persist on
-        // the same frame as the registry/views.
-        .add_plugins(DebouncedInputPlugin::<PersistEguiMemory>::new(0.6))
+        // Off-thread, debounced persistence of registry/views/gui + egui memory.
+        .add_plugins(persist::PersistPlugin)
         .insert_resource(Pkv::new(PkvStore::new("nannou-org", "gantz")))
         .add_systems(
             Startup,
@@ -52,29 +50,10 @@ fn main() {
                 reg::prune_unused::<Box<dyn node::Node>>
                     .after(setup_resources)
                     .after(setup_open),
-                // Spawn the background disk writer once the store is populated.
-                setup_persister.after(setup_resources).after(setup_open),
             ),
         )
         .add_systems(EguiPrimaryContextPass, load_egui_memory)
-        .add_systems(
-            Update,
-            persist_resources
-                // After `settle_layout` so a layout commit settled this frame
-                // (and its seeded view) is saved in the same pass.
-                .after(bevy_gantz_egui::settle_layout::<Box<dyn node::Node>>)
-                .run_if(on_message::<DebouncedInputEvent>),
-        )
-        .add_systems(
-            Update,
-            persist_egui_memory.run_if(on_message::<PersistEguiMemory>),
-        );
-    // Flush the background writer before the process exits (native only; wasm
-    // writes inline, and the World is consumed by the runner so this can't run
-    // after `run()`).
-    #[cfg(not(target_arch = "wasm32"))]
-    app.add_systems(Last, flush_on_exit);
-    app.run();
+        .run();
 }
 
 fn log_plugin() -> bevy::log::LogPlugin {
@@ -157,231 +136,6 @@ fn load_egui_memory(mut ctxs: EguiContexts, mut storage: ResMut<Pkv>, mut loaded
             *loaded = true;
         }
     }
-}
-
-/// Hands persistence batches to a background writer (native) or writes them
-/// inline on the main thread (wasm - localStorage, no fsync, no threads).
-///
-/// The native/wasm split is encapsulated here so the persist systems stay
-/// platform-agnostic: they build a batch and call [`submit`](Self::submit).
-#[derive(Resource)]
-struct Persister {
-    #[cfg(not(target_arch = "wasm32"))]
-    tx: async_channel::Sender<Vec<(String, String)>>,
-    #[cfg(not(target_arch = "wasm32"))]
-    task: Option<Task<()>>,
-    #[cfg(target_arch = "wasm32")]
-    store: Pkv,
-}
-
-impl Persister {
-    /// Hand a batch of `(key, value)` writes off for persistence.
-    ///
-    /// Non-blocking on native (the worker does the fsync'd writes); inline on
-    /// wasm.
-    fn submit(&mut self, batch: Vec<(String, String)>) {
-        if batch.is_empty() {
-            return;
-        }
-        #[cfg(not(target_arch = "wasm32"))]
-        if let Err(e) = self.tx.try_send(batch) {
-            error!("persist: failed to enqueue batch: {e}");
-        }
-        #[cfg(target_arch = "wasm32")]
-        {
-            let mut store = self.store.0.lock().unwrap();
-            for (key, value) in batch {
-                if let Err(e) = store.set_string(&key, &value) {
-                    error!("persist: {key}: {e}");
-                }
-            }
-        }
-    }
-
-    /// Flush the worker's queue and join it before the process exits.
-    ///
-    /// `close` lets the worker drain queued batches before `recv` errors, so the
-    /// FIFO-final batch is written; `block_on` waits for that drain. Native only.
-    #[cfg(not(target_arch = "wasm32"))]
-    fn shutdown(&mut self) {
-        self.tx.close();
-        if let Some(task) = self.task.take() {
-            block_on(task);
-        }
-    }
-}
-
-/// Create the [`Persister`], spawning the background writer on native.
-#[cfg(not(target_arch = "wasm32"))]
-fn spawn_persister(pkv: Pkv) -> Persister {
-    let (tx, rx) = async_channel::unbounded::<Vec<(String, String)>>();
-    let task = IoTaskPool::get().spawn(async move {
-        while let Ok(batch) = rx.recv().await {
-            let mut store = pkv.0.lock().unwrap();
-            for (key, value) in batch {
-                if let Err(e) = store.set_string(&key, &value) {
-                    error!("persist worker: {key}: {e}");
-                }
-            }
-        }
-    });
-    Persister {
-        tx,
-        task: Some(task),
-    }
-}
-
-/// Create the [`Persister`]; on wasm it writes inline (no worker).
-#[cfg(target_arch = "wasm32")]
-fn spawn_persister(pkv: Pkv) -> Persister {
-    Persister { store: pkv }
-}
-
-/// Spawn the background disk writer, sharing the populated store.
-fn setup_persister(pkv: Res<Pkv>, mut cmds: Commands) {
-    cmds.insert_resource(spawn_persister(pkv.clone()));
-}
-
-/// Serialize the full persisted app state into a `(key, value)` batch.
-///
-/// Registry writes dedup against `persisted` (pass a fresh
-/// [`PersistedRegistry`](bevy_gantz::storage::PersistedRegistry) to force a
-/// complete write); everything else is written each call.
-#[allow(clippy::too_many_arguments)]
-fn build_state_batch(
-    registry: &Registry<Box<dyn node::Node>>,
-    persisted: &mut bevy_gantz::storage::PersistedRegistry,
-    views: &Views,
-    gui_state: &GuiState,
-    tab_order: &HeadTabOrder,
-    focused: &FocusedHead,
-    heads_query: &Query<OpenHeadDataReadOnly<Box<dyn node::Node>>, With<OpenHead>>,
-    window: Option<&Window>,
-) -> Vec<(String, String)> {
-    let mut batch = bevy_gantz::storage::BatchWriter::default();
-    // Registry: only newly-seen graphs/commits and any changed name maps.
-    bevy_gantz::storage::save_registry_incremental(&mut batch, registry, persisted);
-    // Open heads in tab order.
-    let heads: Vec<_> = tab_order
-        .iter()
-        .filter_map(|&entity| {
-            heads_query
-                .get(entity)
-                .ok()
-                .map(|data| (**data.head_ref).clone())
-        })
-        .collect();
-    bevy_gantz::storage::save_open_heads(&mut batch, &heads);
-    // Focused head.
-    if let Some(focused_entity) = **focused {
-        if let Ok(data) = heads_query.get(focused_entity) {
-            bevy_gantz::storage::save_focused_head(&mut batch, &**data.head_ref);
-        }
-    }
-    // Views (kept current by `persist_camera_and_seed` and `settle_layout`).
-    bevy_gantz_egui::storage::save_views(&mut batch, views);
-    // GUI state.
-    bevy_gantz_egui::storage::save_gui_state(&mut batch, gui_state);
-    // Native window size (no-op on web).
-    if let Some(window) = window {
-        window::save(&mut batch, window);
-    }
-    batch.take()
-}
-
-fn persist_resources(
-    registry: Res<Registry<Box<dyn node::Node>>>,
-    mut persisted: ResMut<bevy_gantz::storage::PersistedRegistry>,
-    views: Res<Views>,
-    gui_state: Res<GuiState>,
-    mut persister: ResMut<Persister>,
-    tab_order: Res<HeadTabOrder>,
-    focused: Res<FocusedHead>,
-    heads_query: Query<OpenHeadDataReadOnly<Box<dyn node::Node>>, With<OpenHead>>,
-    primary_window: Query<&Window, With<PrimaryWindow>>,
-) {
-    let start = web_time::Instant::now();
-    let window = primary_window.single().ok();
-    let batch = build_state_batch(
-        &registry,
-        &mut persisted,
-        &views,
-        &gui_state,
-        &tab_order,
-        &focused,
-        &heads_query,
-        window,
-    );
-    let writes = batch.len();
-    // Hand the writes to the worker; the fsync'd writes happen off-thread.
-    persister.submit(batch);
-    bevy::log::debug!(
-        "persisted state ({:?}, {writes} writes, {} graphs, {} commits on disk)",
-        start.elapsed(),
-        persisted.graphs_len(),
-        persisted.commits_len(),
-    );
-}
-
-/// Debounced event driving egui-memory persistence, on a slower cadence than
-/// the registry/views persist so the two don't fsync on the same frame.
-#[derive(Message)]
-struct PersistEguiMemory;
-
-impl DebouncedEvent for PersistEguiMemory {
-    fn debounced(_triggered_by_focus_loss: bool) -> Self {
-        Self
-    }
-}
-
-/// Persist egui memory (widget state) on the slower debounce, so it doesn't
-/// fsync on the same frame as the registry/views persist.
-fn persist_egui_memory(mut persister: ResMut<Persister>, mut ctxs: EguiContexts) {
-    let start = web_time::Instant::now();
-    let mut batch = bevy_gantz::storage::BatchWriter::default();
-    if let Ok(ctx) = ctxs.ctx_mut() {
-        bevy_gantz_egui::storage::save_egui_memory(&mut batch, ctx);
-    }
-    persister.submit(batch.take());
-    bevy::log::debug!("persisted egui memory ({:?})", start.elapsed());
-}
-
-/// On exit, write the full current state and drain the worker before quitting.
-///
-/// A fresh tracker forces a complete registry write as a backstop for any blob
-/// optimistically tracked as persisted but not yet drained by the worker; FIFO
-/// + `shutdown` guarantee it lands last. egui memory is left to the worker's
-/// normal drain (best-effort widget state).
-#[cfg(not(target_arch = "wasm32"))]
-#[allow(clippy::too_many_arguments)]
-fn flush_on_exit(
-    mut exit: MessageReader<AppExit>,
-    registry: Res<Registry<Box<dyn node::Node>>>,
-    views: Res<Views>,
-    gui_state: Res<GuiState>,
-    mut persister: ResMut<Persister>,
-    tab_order: Res<HeadTabOrder>,
-    focused: Res<FocusedHead>,
-    heads_query: Query<OpenHeadDataReadOnly<Box<dyn node::Node>>, With<OpenHead>>,
-    primary_window: Query<&Window, With<PrimaryWindow>>,
-) {
-    if exit.read().next().is_none() {
-        return;
-    }
-    let mut full = bevy_gantz::storage::PersistedRegistry::default();
-    let window = primary_window.single().ok();
-    let batch = build_state_batch(
-        &registry,
-        &mut full,
-        &views,
-        &gui_state,
-        &tab_order,
-        &focused,
-        &heads_query,
-        window,
-    );
-    persister.submit(batch);
-    persister.shutdown();
 }
 
 #[cfg(test)]

--- a/crates/gantz/src/main.rs
+++ b/crates/gantz/src/main.rs
@@ -85,10 +85,13 @@ fn setup_resources(storage: Res<Pkv>, mut cmds: Commands) {
     // (so prunes are detected on the first incremental save).
     let persisted = bevy_gantz::storage::PersistedRegistry::from_registry(&registry);
     let views = bevy_gantz_egui::storage::load_views(&*storage);
+    // Seed the view tracker likewise: the loaded views are all on disk.
+    let persisted_views = bevy_gantz_egui::storage::PersistedViews::from_views(&views);
     let gui_state = bevy_gantz_egui::storage::load_gui_state(&*storage);
     cmds.insert_resource(registry);
     cmds.insert_resource(persisted);
     cmds.insert_resource(views);
+    cmds.insert_resource(persisted_views);
     cmds.insert_resource(gui_state);
 }
 

--- a/crates/gantz/src/main.rs
+++ b/crates/gantz/src/main.rs
@@ -6,7 +6,7 @@ use bevy_egui::{EguiContexts, EguiPlugin, EguiPrimaryContextPass};
 use bevy_gantz::{
     BuiltinNodes, FocusedHead, GantzPlugin, HeadRef, HeadTabOrder, OpenHead, OpenHeadDataReadOnly,
     Registry, WorkingGraph,
-    debounced_input::{DebouncedInputEvent, DebouncedInputPlugin},
+    debounced_input::{DebouncedEvent, DebouncedInputEvent, DebouncedInputPlugin},
     reg, timestamp,
 };
 use bevy_gantz_egui::{GantzEguiPlugin, GuiState, HeadGuiState, TraceCapture, Views};
@@ -31,7 +31,10 @@ fn main() {
         )))
         .add_plugins(DefaultPlugins.set(log_plugin()).set(window::plugin()))
         .add_plugins(EguiPlugin::default())
-        .add_plugins(DebouncedInputPlugin::new(0.25))
+        .add_plugins(DebouncedInputPlugin::<DebouncedInputEvent>::new(0.25))
+        // A separate, slower debounce for egui memory so it doesn't persist on
+        // the same frame as the registry/views.
+        .add_plugins(DebouncedInputPlugin::<PersistEguiMemory>::new(0.6))
         .insert_resource(Pkv(PkvStore::new("nannou-org", "gantz")))
         .add_systems(
             Startup,
@@ -56,6 +59,10 @@ fn main() {
                 // (and its seeded view) is saved in the same pass.
                 .after(bevy_gantz_egui::settle_layout::<Box<dyn node::Node>>)
                 .run_if(on_message::<DebouncedInputEvent>),
+        )
+        .add_systems(
+            Update,
+            persist_egui_memory.run_if(on_message::<PersistEguiMemory>),
         )
         .run();
 }
@@ -148,7 +155,6 @@ fn persist_resources(
     views: Res<Views>,
     gui_state: Res<GuiState>,
     mut storage: ResMut<Pkv>,
-    mut ctxs: EguiContexts,
     tab_order: Res<HeadTabOrder>,
     focused: Res<FocusedHead>,
     heads_query: Query<OpenHeadDataReadOnly<Box<dyn node::Node>>, With<OpenHead>>,
@@ -185,21 +191,38 @@ fn persist_resources(
     bevy_gantz_egui::storage::save_views(&mut *storage, &*views);
     // Save the gantz GUI state.
     bevy_gantz_egui::storage::save_gui_state(&mut *storage, &gui_state);
-    // Save egui memory (widget states).
-    if let Ok(ctx) = ctxs.ctx_mut() {
-        bevy_gantz_egui::storage::save_egui_memory(&mut *storage, ctx);
-    }
     // Save the native window size (no-op on web).
     if let Ok(window) = primary_window.single() {
         window::save(&mut *storage, window);
     }
 
     bevy::log::debug!(
-        "persist_resources took {:?} ({} graphs, {} commits on disk)",
+        "persisted state ({:?}, {} graphs, {} commits on disk)",
         start.elapsed(),
         persisted.graphs_len(),
         persisted.commits_len(),
     );
+}
+
+/// Debounced event driving egui-memory persistence, on a slower cadence than
+/// the registry/views persist so the two don't fsync on the same frame.
+#[derive(Message)]
+struct PersistEguiMemory;
+
+impl DebouncedEvent for PersistEguiMemory {
+    fn debounced(_triggered_by_focus_loss: bool) -> Self {
+        Self
+    }
+}
+
+/// Persist egui memory (widget state) on the slower debounce, so it doesn't
+/// fsync on the same frame as the registry/views persist.
+fn persist_egui_memory(mut storage: ResMut<Pkv>, mut ctxs: EguiContexts) {
+    let start = web_time::Instant::now();
+    if let Ok(ctx) = ctxs.ctx_mut() {
+        bevy_gantz_egui::storage::save_egui_memory(&mut *storage, ctx);
+    }
+    bevy::log::debug!("persisted egui memory ({:?})", start.elapsed());
 }
 
 #[cfg(test)]

--- a/crates/gantz/src/main.rs
+++ b/crates/gantz/src/main.rs
@@ -14,15 +14,18 @@ use bevy_pkv::PkvStore;
 use builtin::Builtins;
 use storage::Pkv;
 
+#[cfg(not(target_arch = "wasm32"))]
+use bevy::tasks::{IoTaskPool, Task, block_on};
+
 mod builtin;
 mod node;
 mod storage;
 mod window;
 
 fn main() {
-    App::new()
-        // Core gantz plugin (provides FocusedHead, HeadTabOrder, HeadVms, Registry, Views)
-        .add_plugins(GantzPlugin::<Box<dyn node::Node>>::default())
+    let mut app = App::new();
+    // Core gantz plugin (provides FocusedHead, HeadTabOrder, HeadVms, Registry, Views)
+    app.add_plugins(GantzPlugin::<Box<dyn node::Node>>::default())
         // Egui plugin (provides GuiState, TraceCapture, PerfVm, PerfGui, GUI systems)
         .add_plugins(GantzEguiPlugin::<Box<dyn node::Node>>::default())
         // App-specific builtins
@@ -35,7 +38,7 @@ fn main() {
         // A separate, slower debounce for egui memory so it doesn't persist on
         // the same frame as the registry/views.
         .add_plugins(DebouncedInputPlugin::<PersistEguiMemory>::new(0.6))
-        .insert_resource(Pkv(PkvStore::new("nannou-org", "gantz")))
+        .insert_resource(Pkv::new(PkvStore::new("nannou-org", "gantz")))
         .add_systems(
             Startup,
             (
@@ -49,6 +52,8 @@ fn main() {
                 reg::prune_unused::<Box<dyn node::Node>>
                     .after(setup_resources)
                     .after(setup_open),
+                // Spawn the background disk writer once the store is populated.
+                setup_persister.after(setup_resources).after(setup_open),
             ),
         )
         .add_systems(EguiPrimaryContextPass, load_egui_memory)
@@ -63,8 +68,13 @@ fn main() {
         .add_systems(
             Update,
             persist_egui_memory.run_if(on_message::<PersistEguiMemory>),
-        )
-        .run();
+        );
+    // Flush the background writer before the process exits (native only; wasm
+    // writes inline, and the World is consumed by the runner so this can't run
+    // after `run()`).
+    #[cfg(not(target_arch = "wasm32"))]
+    app.add_systems(Last, flush_on_exit);
+    app.run();
 }
 
 fn log_plugin() -> bevy::log::LogPlugin {
@@ -149,26 +159,109 @@ fn load_egui_memory(mut ctxs: EguiContexts, mut storage: ResMut<Pkv>, mut loaded
     }
 }
 
-fn persist_resources(
-    registry: Res<Registry<Box<dyn node::Node>>>,
-    mut persisted: ResMut<bevy_gantz::storage::PersistedRegistry>,
-    views: Res<Views>,
-    gui_state: Res<GuiState>,
-    mut storage: ResMut<Pkv>,
-    tab_order: Res<HeadTabOrder>,
-    focused: Res<FocusedHead>,
-    heads_query: Query<OpenHeadDataReadOnly<Box<dyn node::Node>>, With<OpenHead>>,
-    primary_window: Query<&Window, With<PrimaryWindow>>,
-) {
-    let start = web_time::Instant::now();
-    // Incrementally save the registry (only newly-seen graphs/commits and any
-    // changed name maps). `persist_resources` runs only on debounced events, so
-    // `is_changed()` here means "changed since the last persist" - a cheap guard
-    // for the idle case; the per-blob dedup is what removes the spike.
-    if registry.is_changed() {
-        bevy_gantz::storage::save_registry_incremental(&mut *storage, &registry, &mut persisted);
+/// Hands persistence batches to a background writer (native) or writes them
+/// inline on the main thread (wasm - localStorage, no fsync, no threads).
+///
+/// The native/wasm split is encapsulated here so the persist systems stay
+/// platform-agnostic: they build a batch and call [`submit`](Self::submit).
+#[derive(Resource)]
+struct Persister {
+    #[cfg(not(target_arch = "wasm32"))]
+    tx: async_channel::Sender<Vec<(String, String)>>,
+    #[cfg(not(target_arch = "wasm32"))]
+    task: Option<Task<()>>,
+    #[cfg(target_arch = "wasm32")]
+    store: Pkv,
+}
+
+impl Persister {
+    /// Hand a batch of `(key, value)` writes off for persistence.
+    ///
+    /// Non-blocking on native (the worker does the fsync'd writes); inline on
+    /// wasm.
+    fn submit(&mut self, batch: Vec<(String, String)>) {
+        if batch.is_empty() {
+            return;
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Err(e) = self.tx.try_send(batch) {
+            error!("persist: failed to enqueue batch: {e}");
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            let mut store = self.store.0.lock().unwrap();
+            for (key, value) in batch {
+                if let Err(e) = store.set_string(&key, &value) {
+                    error!("persist: {key}: {e}");
+                }
+            }
+        }
     }
-    // Save all open heads in tab order.
+
+    /// Flush the worker's queue and join it before the process exits.
+    ///
+    /// `close` lets the worker drain queued batches before `recv` errors, so the
+    /// FIFO-final batch is written; `block_on` waits for that drain. Native only.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn shutdown(&mut self) {
+        self.tx.close();
+        if let Some(task) = self.task.take() {
+            block_on(task);
+        }
+    }
+}
+
+/// Create the [`Persister`], spawning the background writer on native.
+#[cfg(not(target_arch = "wasm32"))]
+fn spawn_persister(pkv: Pkv) -> Persister {
+    let (tx, rx) = async_channel::unbounded::<Vec<(String, String)>>();
+    let task = IoTaskPool::get().spawn(async move {
+        while let Ok(batch) = rx.recv().await {
+            let mut store = pkv.0.lock().unwrap();
+            for (key, value) in batch {
+                if let Err(e) = store.set_string(&key, &value) {
+                    error!("persist worker: {key}: {e}");
+                }
+            }
+        }
+    });
+    Persister {
+        tx,
+        task: Some(task),
+    }
+}
+
+/// Create the [`Persister`]; on wasm it writes inline (no worker).
+#[cfg(target_arch = "wasm32")]
+fn spawn_persister(pkv: Pkv) -> Persister {
+    Persister { store: pkv }
+}
+
+/// Spawn the background disk writer, sharing the populated store.
+fn setup_persister(pkv: Res<Pkv>, mut cmds: Commands) {
+    cmds.insert_resource(spawn_persister(pkv.clone()));
+}
+
+/// Serialize the full persisted app state into a `(key, value)` batch.
+///
+/// Registry writes dedup against `persisted` (pass a fresh
+/// [`PersistedRegistry`](bevy_gantz::storage::PersistedRegistry) to force a
+/// complete write); everything else is written each call.
+#[allow(clippy::too_many_arguments)]
+fn build_state_batch(
+    registry: &Registry<Box<dyn node::Node>>,
+    persisted: &mut bevy_gantz::storage::PersistedRegistry,
+    views: &Views,
+    gui_state: &GuiState,
+    tab_order: &HeadTabOrder,
+    focused: &FocusedHead,
+    heads_query: &Query<OpenHeadDataReadOnly<Box<dyn node::Node>>, With<OpenHead>>,
+    window: Option<&Window>,
+) -> Vec<(String, String)> {
+    let mut batch = bevy_gantz::storage::BatchWriter::default();
+    // Registry: only newly-seen graphs/commits and any changed name maps.
+    bevy_gantz::storage::save_registry_incremental(&mut batch, registry, persisted);
+    // Open heads in tab order.
     let heads: Vec<_> = tab_order
         .iter()
         .filter_map(|&entity| {
@@ -178,26 +271,52 @@ fn persist_resources(
                 .map(|data| (**data.head_ref).clone())
         })
         .collect();
-    bevy_gantz::storage::save_open_heads(&mut *storage, &heads);
-    // Save the focused head.
+    bevy_gantz::storage::save_open_heads(&mut batch, &heads);
+    // Focused head.
     if let Some(focused_entity) = **focused {
         if let Ok(data) = heads_query.get(focused_entity) {
-            bevy_gantz::storage::save_focused_head(&mut *storage, &**data.head_ref);
+            bevy_gantz::storage::save_focused_head(&mut batch, &**data.head_ref);
         }
     }
-
-    // Save all views (kept up to date by `persist_camera_and_seed` and
-    // `settle_layout`).
-    bevy_gantz_egui::storage::save_views(&mut *storage, &*views);
-    // Save the gantz GUI state.
-    bevy_gantz_egui::storage::save_gui_state(&mut *storage, &gui_state);
-    // Save the native window size (no-op on web).
-    if let Ok(window) = primary_window.single() {
-        window::save(&mut *storage, window);
+    // Views (kept current by `persist_camera_and_seed` and `settle_layout`).
+    bevy_gantz_egui::storage::save_views(&mut batch, views);
+    // GUI state.
+    bevy_gantz_egui::storage::save_gui_state(&mut batch, gui_state);
+    // Native window size (no-op on web).
+    if let Some(window) = window {
+        window::save(&mut batch, window);
     }
+    batch.take()
+}
 
+fn persist_resources(
+    registry: Res<Registry<Box<dyn node::Node>>>,
+    mut persisted: ResMut<bevy_gantz::storage::PersistedRegistry>,
+    views: Res<Views>,
+    gui_state: Res<GuiState>,
+    mut persister: ResMut<Persister>,
+    tab_order: Res<HeadTabOrder>,
+    focused: Res<FocusedHead>,
+    heads_query: Query<OpenHeadDataReadOnly<Box<dyn node::Node>>, With<OpenHead>>,
+    primary_window: Query<&Window, With<PrimaryWindow>>,
+) {
+    let start = web_time::Instant::now();
+    let window = primary_window.single().ok();
+    let batch = build_state_batch(
+        &registry,
+        &mut persisted,
+        &views,
+        &gui_state,
+        &tab_order,
+        &focused,
+        &heads_query,
+        window,
+    );
+    let writes = batch.len();
+    // Hand the writes to the worker; the fsync'd writes happen off-thread.
+    persister.submit(batch);
     bevy::log::debug!(
-        "persisted state ({:?}, {} graphs, {} commits on disk)",
+        "persisted state ({:?}, {writes} writes, {} graphs, {} commits on disk)",
         start.elapsed(),
         persisted.graphs_len(),
         persisted.commits_len(),
@@ -217,12 +336,52 @@ impl DebouncedEvent for PersistEguiMemory {
 
 /// Persist egui memory (widget state) on the slower debounce, so it doesn't
 /// fsync on the same frame as the registry/views persist.
-fn persist_egui_memory(mut storage: ResMut<Pkv>, mut ctxs: EguiContexts) {
+fn persist_egui_memory(mut persister: ResMut<Persister>, mut ctxs: EguiContexts) {
     let start = web_time::Instant::now();
+    let mut batch = bevy_gantz::storage::BatchWriter::default();
     if let Ok(ctx) = ctxs.ctx_mut() {
-        bevy_gantz_egui::storage::save_egui_memory(&mut *storage, ctx);
+        bevy_gantz_egui::storage::save_egui_memory(&mut batch, ctx);
     }
+    persister.submit(batch.take());
     bevy::log::debug!("persisted egui memory ({:?})", start.elapsed());
+}
+
+/// On exit, write the full current state and drain the worker before quitting.
+///
+/// A fresh tracker forces a complete registry write as a backstop for any blob
+/// optimistically tracked as persisted but not yet drained by the worker; FIFO
+/// + `shutdown` guarantee it lands last. egui memory is left to the worker's
+/// normal drain (best-effort widget state).
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(clippy::too_many_arguments)]
+fn flush_on_exit(
+    mut exit: MessageReader<AppExit>,
+    registry: Res<Registry<Box<dyn node::Node>>>,
+    views: Res<Views>,
+    gui_state: Res<GuiState>,
+    mut persister: ResMut<Persister>,
+    tab_order: Res<HeadTabOrder>,
+    focused: Res<FocusedHead>,
+    heads_query: Query<OpenHeadDataReadOnly<Box<dyn node::Node>>, With<OpenHead>>,
+    primary_window: Query<&Window, With<PrimaryWindow>>,
+) {
+    if exit.read().next().is_none() {
+        return;
+    }
+    let mut full = bevy_gantz::storage::PersistedRegistry::default();
+    let window = primary_window.single().ok();
+    let batch = build_state_batch(
+        &registry,
+        &mut full,
+        &views,
+        &gui_state,
+        &tab_order,
+        &focused,
+        &heads_query,
+        window,
+    );
+    persister.submit(batch);
+    persister.shutdown();
 }
 
 #[cfg(test)]

--- a/crates/gantz/src/main.rs
+++ b/crates/gantz/src/main.rs
@@ -83,9 +83,15 @@ fn setup_window(storage: Res<Pkv>, mut windows: Query<&mut Window, With<PrimaryW
 
 fn setup_resources(storage: Res<Pkv>, mut cmds: Commands) {
     let registry: Registry<Box<dyn node::Node>> = bevy_gantz::storage::load_registry(&*storage);
+    // Seed the persist tracker from the disk-loaded registry: everything loaded
+    // is, by definition, already on disk. Done before `base::load` merges base
+    // graphs (so they're written on first persist) and before `prune_unused`
+    // (so prunes are detected on the first incremental save).
+    let persisted = bevy_gantz::storage::PersistedRegistry::from_registry(&registry);
     let views = bevy_gantz_egui::storage::load_views(&*storage);
     let gui_state = bevy_gantz_egui::storage::load_gui_state(&*storage);
     cmds.insert_resource(registry);
+    cmds.insert_resource(persisted);
     cmds.insert_resource(views);
     cmds.insert_resource(gui_state);
 }
@@ -138,6 +144,7 @@ fn load_egui_memory(mut ctxs: EguiContexts, mut storage: ResMut<Pkv>, mut loaded
 
 fn persist_resources(
     registry: Res<Registry<Box<dyn node::Node>>>,
+    mut persisted: ResMut<bevy_gantz::storage::PersistedRegistry>,
     views: Res<Views>,
     gui_state: Res<GuiState>,
     mut storage: ResMut<Pkv>,
@@ -147,8 +154,13 @@ fn persist_resources(
     heads_query: Query<OpenHeadDataReadOnly<Box<dyn node::Node>>, With<OpenHead>>,
     primary_window: Query<&Window, With<PrimaryWindow>>,
 ) {
-    // Save registry (graphs, commits, names).
-    bevy_gantz::storage::save_registry(&mut *storage, &registry);
+    // Incrementally save the registry (only newly-seen graphs/commits and any
+    // changed name maps). `persist_resources` runs only on debounced events, so
+    // `is_changed()` here means "changed since the last persist" - a cheap guard
+    // for the idle case; the per-blob dedup is what removes the spike.
+    if registry.is_changed() {
+        bevy_gantz::storage::save_registry_incremental(&mut *storage, &registry, &mut persisted);
+    }
     // Save all open heads in tab order.
     let heads: Vec<_> = tab_order
         .iter()

--- a/crates/gantz/src/main_update_base.rs
+++ b/crates/gantz/src/main_update_base.rs
@@ -35,7 +35,7 @@ fn main() {
         .add_plugins(DefaultPlugins.set(log_plugin()).set(window_plugin()))
         .add_plugins(EguiPlugin::default())
         .add_plugins(DebouncedInputPlugin::<DebouncedInputEvent>::new(0.25))
-        .insert_resource(Pkv(PkvStore::new("nannou-org", "gantz-update-base")))
+        .insert_resource(Pkv::new(PkvStore::new("nannou-org", "gantz-update-base")))
         .insert_resource(bevy_gantz_egui::base::ExportPath(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../gantz_base/base.gantz"

--- a/crates/gantz/src/main_update_base.rs
+++ b/crates/gantz/src/main_update_base.rs
@@ -34,7 +34,7 @@ fn main() {
         )))
         .add_plugins(DefaultPlugins.set(log_plugin()).set(window_plugin()))
         .add_plugins(EguiPlugin::default())
-        .add_plugins(DebouncedInputPlugin::new(0.25))
+        .add_plugins(DebouncedInputPlugin::<DebouncedInputEvent>::new(0.25))
         .insert_resource(Pkv(PkvStore::new("nannou-org", "gantz-update-base")))
         .insert_resource(bevy_gantz_egui::base::ExportPath(concat!(
             env!("CARGO_MANIFEST_DIR"),

--- a/crates/gantz/src/persist.rs
+++ b/crates/gantz/src/persist.rs
@@ -37,7 +37,7 @@ pub struct PersistPlugin;
 
 impl Plugin for PersistPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(DebouncedInputPlugin::<PersistEguiMemory>::new(0.6))
+        app.add_plugins(DebouncedInputPlugin::<PersistEguiMemory>::new(0.3))
             // Spawn the background writer once the store is populated. No ordering
             // vs the load systems is needed: the worker only locks the store when
             // draining a batch, which can't happen until the first `Update`.

--- a/crates/gantz/src/persist.rs
+++ b/crates/gantz/src/persist.rs
@@ -1,0 +1,288 @@
+//! Off-thread, debounced persistence of app state to the [`Pkv`] store.
+//!
+//! [`PersistPlugin`] wires up the whole thing. On a debounced input the persist
+//! systems serialize the current state into a `(key, value)` batch on the main
+//! thread and hand it to a [`Persister`]; on native a background [`IoTaskPool`]
+//! worker does the fsync'd writes off the render thread, on wasm they're written
+//! inline (no threads, no fsync). On exit the worker is flushed and joined so
+//! nothing is lost.
+//!
+//! This is deliberately self-contained: the goal is to eventually lift it into a
+//! reusable "sync-friendly persistence" crate so downstream gantz apps don't
+//! reimplement this boilerplate.
+
+use crate::storage::Pkv;
+use crate::window;
+use bevy::prelude::*;
+use bevy::window::{PrimaryWindow, Window};
+use bevy_egui::EguiContexts;
+use bevy_gantz::{
+    FocusedHead, HeadTabOrder, OpenHead, OpenHeadDataReadOnly, Registry,
+    debounced_input::{DebouncedEvent, DebouncedInputEvent, DebouncedInputPlugin},
+};
+use bevy_gantz_egui::{GuiState, Views};
+
+#[cfg(not(target_arch = "wasm32"))]
+use bevy::tasks::{IoTaskPool, Task, block_on};
+
+/// The app's node type, as stored in the registry and head entities.
+type BoxNode = Box<dyn crate::node::Node>;
+
+/// Registers off-thread, debounced persistence of the app's state.
+///
+/// Expects the [`Pkv`] resource and a `DebouncedInputPlugin<DebouncedInputEvent>`
+/// to already be present (the latter also drives layout settling, so it lives in
+/// the app, not here).
+pub struct PersistPlugin;
+
+impl Plugin for PersistPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(DebouncedInputPlugin::<PersistEguiMemory>::new(0.6))
+            // Spawn the background writer once the store is populated. No ordering
+            // vs the load systems is needed: the worker only locks the store when
+            // draining a batch, which can't happen until the first `Update`.
+            .add_systems(Startup, setup_persister)
+            .add_systems(
+                Update,
+                persist_resources
+                    // After `settle_layout` so a layout commit settled this frame
+                    // (and its seeded view) is saved in the same pass.
+                    .after(bevy_gantz_egui::settle_layout::<BoxNode>)
+                    .run_if(on_message::<DebouncedInputEvent>),
+            )
+            .add_systems(
+                Update,
+                persist_egui_memory.run_if(on_message::<PersistEguiMemory>),
+            );
+        // Flush the worker before the process exits (native only; wasm writes
+        // inline, and the World is consumed by the runner so this can't run after
+        // `run()`).
+        #[cfg(not(target_arch = "wasm32"))]
+        app.add_systems(Last, flush_on_exit);
+    }
+}
+
+/// Hands persistence batches to a background writer (native) or writes them
+/// inline on the main thread (wasm - localStorage, no fsync, no threads).
+///
+/// The native/wasm split is encapsulated here so the persist systems stay
+/// platform-agnostic: they build a batch and call [`submit`](Self::submit).
+#[derive(Resource)]
+struct Persister {
+    #[cfg(not(target_arch = "wasm32"))]
+    tx: async_channel::Sender<Vec<(String, String)>>,
+    #[cfg(not(target_arch = "wasm32"))]
+    task: Option<Task<()>>,
+    #[cfg(target_arch = "wasm32")]
+    store: Pkv,
+}
+
+impl Persister {
+    /// Hand a batch of `(key, value)` writes off for persistence.
+    ///
+    /// Non-blocking on native (the worker does the fsync'd writes); inline on
+    /// wasm.
+    fn submit(&mut self, batch: Vec<(String, String)>) {
+        if batch.is_empty() {
+            return;
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Err(e) = self.tx.try_send(batch) {
+            error!("persist: failed to enqueue batch: {e}");
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            let mut store = self.store.0.lock().unwrap();
+            for (key, value) in batch {
+                if let Err(e) = store.set_string(&key, &value) {
+                    error!("persist: {key}: {e}");
+                }
+            }
+        }
+    }
+
+    /// Flush the worker's queue and join it before the process exits.
+    ///
+    /// `close` lets the worker drain queued batches before `recv` errors, so the
+    /// FIFO-final batch is written; `block_on` waits for that drain. Native only.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn shutdown(&mut self) {
+        self.tx.close();
+        if let Some(task) = self.task.take() {
+            block_on(task);
+        }
+    }
+}
+
+/// Create the [`Persister`], spawning the background writer on native.
+#[cfg(not(target_arch = "wasm32"))]
+fn spawn_persister(pkv: Pkv) -> Persister {
+    let (tx, rx) = async_channel::unbounded::<Vec<(String, String)>>();
+    let task = IoTaskPool::get().spawn(async move {
+        while let Ok(batch) = rx.recv().await {
+            let mut store = pkv.0.lock().unwrap();
+            for (key, value) in batch {
+                if let Err(e) = store.set_string(&key, &value) {
+                    error!("persist worker: {key}: {e}");
+                }
+            }
+        }
+    });
+    Persister {
+        tx,
+        task: Some(task),
+    }
+}
+
+/// Create the [`Persister`]; on wasm it writes inline (no worker).
+#[cfg(target_arch = "wasm32")]
+fn spawn_persister(pkv: Pkv) -> Persister {
+    Persister { store: pkv }
+}
+
+/// Spawn the background disk writer, sharing the populated store.
+fn setup_persister(pkv: Res<Pkv>, mut cmds: Commands) {
+    cmds.insert_resource(spawn_persister(pkv.clone()));
+}
+
+/// Serialize the full persisted app state into a `(key, value)` batch.
+///
+/// Registry writes dedup against `persisted` (pass a fresh
+/// [`PersistedRegistry`](bevy_gantz::storage::PersistedRegistry) to force a
+/// complete write); everything else is written each call.
+#[allow(clippy::too_many_arguments)]
+fn build_state_batch(
+    registry: &Registry<BoxNode>,
+    persisted: &mut bevy_gantz::storage::PersistedRegistry,
+    views: &Views,
+    gui_state: &GuiState,
+    tab_order: &HeadTabOrder,
+    focused: &FocusedHead,
+    heads_query: &Query<OpenHeadDataReadOnly<BoxNode>, With<OpenHead>>,
+    window: Option<&Window>,
+) -> Vec<(String, String)> {
+    let mut batch = bevy_gantz::storage::BatchWriter::default();
+    // Registry: only newly-seen graphs/commits and any changed name maps.
+    bevy_gantz::storage::save_registry_incremental(&mut batch, registry, persisted);
+    // Open heads in tab order.
+    let heads: Vec<_> = tab_order
+        .iter()
+        .filter_map(|&entity| {
+            heads_query
+                .get(entity)
+                .ok()
+                .map(|data| (**data.head_ref).clone())
+        })
+        .collect();
+    bevy_gantz::storage::save_open_heads(&mut batch, &heads);
+    // Focused head.
+    if let Some(focused_entity) = **focused {
+        if let Ok(data) = heads_query.get(focused_entity) {
+            bevy_gantz::storage::save_focused_head(&mut batch, &**data.head_ref);
+        }
+    }
+    // Views (kept current by `persist_camera_and_seed` and `settle_layout`).
+    bevy_gantz_egui::storage::save_views(&mut batch, views);
+    // GUI state.
+    bevy_gantz_egui::storage::save_gui_state(&mut batch, gui_state);
+    // Native window size (no-op on web).
+    if let Some(window) = window {
+        window::save(&mut batch, window);
+    }
+    batch.take()
+}
+
+fn persist_resources(
+    registry: Res<Registry<BoxNode>>,
+    mut persisted: ResMut<bevy_gantz::storage::PersistedRegistry>,
+    views: Res<Views>,
+    gui_state: Res<GuiState>,
+    mut persister: ResMut<Persister>,
+    tab_order: Res<HeadTabOrder>,
+    focused: Res<FocusedHead>,
+    heads_query: Query<OpenHeadDataReadOnly<BoxNode>, With<OpenHead>>,
+    primary_window: Query<&Window, With<PrimaryWindow>>,
+) {
+    let start = web_time::Instant::now();
+    let window = primary_window.single().ok();
+    let batch = build_state_batch(
+        &registry,
+        &mut persisted,
+        &views,
+        &gui_state,
+        &tab_order,
+        &focused,
+        &heads_query,
+        window,
+    );
+    let writes = batch.len();
+    // Hand the writes to the worker; the fsync'd writes happen off-thread.
+    persister.submit(batch);
+    debug!(
+        "persisted state ({:?}, {writes} writes, {} graphs, {} commits on disk)",
+        start.elapsed(),
+        persisted.graphs_len(),
+        persisted.commits_len(),
+    );
+}
+
+/// Debounced event driving egui-memory persistence, on a slower cadence than
+/// the registry/views persist so the two don't fsync on the same frame.
+#[derive(Message)]
+struct PersistEguiMemory;
+
+impl DebouncedEvent for PersistEguiMemory {
+    fn debounced(_triggered_by_focus_loss: bool) -> Self {
+        Self
+    }
+}
+
+/// Persist egui memory (widget state) on the slower debounce, so it doesn't
+/// fsync on the same frame as the registry/views persist.
+fn persist_egui_memory(mut persister: ResMut<Persister>, mut ctxs: EguiContexts) {
+    let start = web_time::Instant::now();
+    let mut batch = bevy_gantz::storage::BatchWriter::default();
+    if let Ok(ctx) = ctxs.ctx_mut() {
+        bevy_gantz_egui::storage::save_egui_memory(&mut batch, ctx);
+    }
+    persister.submit(batch.take());
+    debug!("persisted egui memory ({:?})", start.elapsed());
+}
+
+/// On exit, write the full current state and drain the worker before quitting.
+///
+/// A fresh tracker forces a complete registry write as a backstop for any blob
+/// optimistically tracked as persisted but not yet drained by the worker; FIFO
+/// + `shutdown` guarantee it lands last. egui memory is left to the worker's
+/// normal drain (best-effort widget state).
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(clippy::too_many_arguments)]
+fn flush_on_exit(
+    mut exit: MessageReader<AppExit>,
+    registry: Res<Registry<BoxNode>>,
+    views: Res<Views>,
+    gui_state: Res<GuiState>,
+    mut persister: ResMut<Persister>,
+    tab_order: Res<HeadTabOrder>,
+    focused: Res<FocusedHead>,
+    heads_query: Query<OpenHeadDataReadOnly<BoxNode>, With<OpenHead>>,
+    primary_window: Query<&Window, With<PrimaryWindow>>,
+) {
+    if exit.read().next().is_none() {
+        return;
+    }
+    let mut full = bevy_gantz::storage::PersistedRegistry::default();
+    let window = primary_window.single().ok();
+    let batch = build_state_batch(
+        &registry,
+        &mut full,
+        &views,
+        &gui_state,
+        &tab_order,
+        &focused,
+        &heads_query,
+        window,
+    );
+    persister.submit(batch);
+    persister.shutdown();
+}

--- a/crates/gantz/src/persist.rs
+++ b/crates/gantz/src/persist.rs
@@ -145,16 +145,18 @@ fn setup_persister(pkv: Res<Pkv>, mut cmds: Commands) {
     cmds.insert_resource(spawn_persister(pkv.clone()));
 }
 
-/// Serialize the full persisted app state into a `(key, value)` batch.
+/// Collect the registry/heads/views/gui/window into a `(key, value)` batch to
+/// persist.
 ///
 /// Registry writes dedup against `persisted` (pass a fresh
 /// [`PersistedRegistry`](bevy_gantz::storage::PersistedRegistry) to force a
 /// complete write); everything else is written each call.
 #[allow(clippy::too_many_arguments)]
-fn build_state_batch(
+fn collect_batch_to_persist(
     registry: &Registry<BoxNode>,
     persisted: &mut bevy_gantz::storage::PersistedRegistry,
     views: &Views,
+    persisted_views: &mut bevy_gantz_egui::storage::PersistedViews,
     gui_state: &GuiState,
     tab_order: &HeadTabOrder,
     focused: &FocusedHead,
@@ -181,8 +183,15 @@ fn build_state_batch(
             bevy_gantz::storage::save_focused_head(&mut batch, &**data.head_ref);
         }
     }
-    // Views (kept current by `persist_camera_and_seed` and `settle_layout`).
-    bevy_gantz_egui::storage::save_views(&mut batch, views);
+    // Views (kept current by `persist_camera_and_seed` and `settle_layout`):
+    // write only the per-commit views that changed, for commits that still exist.
+    let valid_commits: std::collections::HashSet<_> = registry.commits().keys().copied().collect();
+    bevy_gantz_egui::storage::save_views_incremental(
+        &mut batch,
+        views,
+        &valid_commits,
+        persisted_views,
+    );
     // GUI state.
     bevy_gantz_egui::storage::save_gui_state(&mut batch, gui_state);
     // Native window size (no-op on web).
@@ -196,6 +205,7 @@ fn persist_resources(
     registry: Res<Registry<BoxNode>>,
     mut persisted: ResMut<bevy_gantz::storage::PersistedRegistry>,
     views: Res<Views>,
+    mut persisted_views: ResMut<bevy_gantz_egui::storage::PersistedViews>,
     gui_state: Res<GuiState>,
     mut persister: ResMut<Persister>,
     tab_order: Res<HeadTabOrder>,
@@ -205,10 +215,11 @@ fn persist_resources(
 ) {
     let start = web_time::Instant::now();
     let window = primary_window.single().ok();
-    let batch = build_state_batch(
+    let batch = collect_batch_to_persist(
         &registry,
         &mut persisted,
         &views,
+        &mut persisted_views,
         &gui_state,
         &tab_order,
         &focused,
@@ -251,10 +262,10 @@ fn persist_egui_memory(mut persister: ResMut<Persister>, mut ctxs: EguiContexts)
 
 /// On exit, write the full current state and drain the worker before quitting.
 ///
-/// A fresh tracker forces a complete registry write as a backstop for any blob
-/// optimistically tracked as persisted but not yet drained by the worker; FIFO
-/// + `shutdown` guarantee it lands last. egui memory is left to the worker's
-/// normal drain (best-effort widget state).
+/// Fresh trackers force a complete registry + views write as a backstop for any
+/// blob optimistically tracked as persisted but not yet drained by the worker;
+/// FIFO + `shutdown` guarantee it lands last. egui memory is left to the
+/// worker's normal drain (best-effort widget state).
 #[cfg(not(target_arch = "wasm32"))]
 #[allow(clippy::too_many_arguments)]
 fn flush_on_exit(
@@ -272,11 +283,13 @@ fn flush_on_exit(
         return;
     }
     let mut full = bevy_gantz::storage::PersistedRegistry::default();
+    let mut full_views = bevy_gantz_egui::storage::PersistedViews::default();
     let window = primary_window.single().ok();
-    let batch = build_state_batch(
+    let batch = collect_batch_to_persist(
         &registry,
         &mut full,
         &views,
+        &mut full_views,
         &gui_state,
         &tab_order,
         &focused,

--- a/crates/gantz/src/storage.rs
+++ b/crates/gantz/src/storage.rs
@@ -6,15 +6,29 @@
 use bevy::prelude::Resource;
 use bevy_gantz::storage::{Load, Save};
 use bevy_pkv::PkvStore;
+use std::sync::{Arc, Mutex};
 
-/// A [`Resource`] wrapping [`PkvStore`] that implements [`Load`] and [`Save`].
-#[derive(Resource)]
-pub struct Pkv(pub PkvStore);
+/// A [`Resource`] wrapping a shared [`PkvStore`] that implements [`Load`] and
+/// [`Save`].
+///
+/// `Arc<Mutex<_>>` so a background persistence worker can share the single store
+/// handle with the main thread (which reads at startup and on the first frame).
+/// redb permits only one handle per database file, so sharing - rather than a
+/// second handle - is required.
+#[derive(Resource, Clone)]
+pub struct Pkv(pub Arc<Mutex<PkvStore>>);
+
+impl Pkv {
+    /// Wrap a store for sharing between the main thread and the worker.
+    pub fn new(store: PkvStore) -> Self {
+        Self(Arc::new(Mutex::new(store)))
+    }
+}
 
 impl Load for Pkv {
     type Err = bevy_pkv::GetError;
     fn get_string(&self, key: &str) -> Result<Option<String>, Self::Err> {
-        match self.0.get::<String>(key) {
+        match self.0.lock().unwrap().get::<String>(key) {
             Ok(v) => Ok(Some(v)),
             Err(bevy_pkv::GetError::NotFound) => Ok(None),
             Err(e) => Err(e),
@@ -25,6 +39,6 @@ impl Load for Pkv {
 impl Save for Pkv {
     type Err = bevy_pkv::SetError;
     fn set_string(&mut self, key: &str, value: &str) -> Result<(), Self::Err> {
-        self.0.set_string(key, value)
+        self.0.lock().unwrap().set_string(key, value)
     }
 }

--- a/crates/gantz/src/storage.rs
+++ b/crates/gantz/src/storage.rs
@@ -11,10 +11,17 @@ use std::sync::{Arc, Mutex};
 /// A [`Resource`] wrapping a shared [`PkvStore`] that implements [`Load`] and
 /// [`Save`].
 ///
-/// `Arc<Mutex<_>>` so a background persistence worker can share the single store
-/// handle with the main thread (which reads at startup and on the first frame).
-/// redb permits only one handle per database file, so sharing - rather than a
-/// second handle - is required.
+/// `Arc<Mutex<_>>` lets a background persistence worker share the single store
+/// handle with the main thread - redb permits only one handle per database file,
+/// so sharing, rather than a second handle, is required.
+///
+/// Despite the `Mutex`, there is no lock contention during the steady-state
+/// render loop. The main thread only ever *reads* the store, and every read
+/// happens during startup and the first-frame egui-memory load - before any
+/// debounced persist can fire (a persist needs prior input). From then on the
+/// worker is the sole accessor: the persist systems hand their writes to it over
+/// a channel rather than locking the store themselves. So the worker's fsync'd
+/// writes, however long they take, never block a frame.
 #[derive(Resource, Clone)]
 pub struct Pkv(pub Arc<Mutex<PkvStore>>);
 

--- a/crates/gantz_egui/Cargo.toml
+++ b/crates/gantz_egui/Cargo.toml
@@ -27,6 +27,7 @@ hex.workspace = true
 humantime.workspace = true
 log.workspace = true
 petgraph.workspace = true
+ron.workspace = true
 serde.workspace = true
 steel-core.workspace = true
 sublime_fuzzy.workspace = true

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -355,6 +355,46 @@ struct GraphPane(gantz_ca::Head);
 /// The egui ID used to store the inner graph tree.
 const GRAPH_TREE_ID: &str = "gantz-graph-tiles-tree";
 
+/// Load a tile tree from egui's persisted memory.
+///
+/// The tree is stored as a RON `String` rather than the typed `Tree<_>`: a
+/// `String`'s `TypeId` is stable across recompiles, whereas `Tree<Pane>`'s
+/// changes whenever this crate is rebuilt. Storing the typed value would leave a
+/// stale copy behind in egui's per-type persisted map on every dev build (egui
+/// never evicts entries of a type the running build no longer uses), bloating
+/// the persisted memory without bound.
+fn load_tree<P: serde::de::DeserializeOwned>(
+    ctx: &egui::Context,
+    id: egui::Id,
+) -> Option<egui_tiles::Tree<P>> {
+    let ron = ctx.memory_mut(|m| m.data.get_persisted::<String>(id))?;
+    ron::from_str(&ron).ok()
+}
+
+/// Persist a tile tree to egui memory as a RON `String` (see [`load_tree`]).
+fn store_tree<P: serde::Serialize>(ctx: &egui::Context, id: egui::Id, tree: &egui_tiles::Tree<P>) {
+    if let Ok(ron) = ron::to_string(tree) {
+        ctx.memory_mut(|m| m.data.insert_persisted(id, ron));
+    }
+}
+
+/// egui temp-memory flag id for a pending "clear egui memory" request.
+fn clear_egui_memory_id() -> egui::Id {
+    egui::Id::new("gantz-clear-egui-memory-request")
+}
+
+/// Request that egui's persisted memory be cleared at the start of the next
+/// `Gantz::show`.
+///
+/// A recovery tool (exposed in Global settings) for when egui's persisted memory
+/// accumulates stale state: it discards the UI memory (panel layout, widget
+/// state) but leaves the graph registry and other app storage untouched.
+/// Deferring to the next frame keeps the clear deterministic - it runs before
+/// any persisted UI state is loaded, rather than racing this frame's widgets.
+pub fn request_clear_egui_memory(ctx: &egui::Context) {
+    ctx.data_mut(|d| d.insert_temp(clear_egui_memory_id(), true));
+}
+
 /// Update the head stored in a graph pane when a commit CA changes.
 ///
 /// This should be called after `commit_graph_to_head` modifies a head's commit CA.
@@ -368,24 +408,23 @@ pub fn update_graph_pane_head(
         return;
     }
     let graph_tree_id = egui::Id::new(GRAPH_TREE_ID);
-    ctx.memory_mut(|m| {
-        let Some(tree) = m
-            .data
-            .get_persisted_mut_or_default::<Option<egui_tiles::Tree<GraphPane>>>(graph_tree_id)
-            .as_mut()
-        else {
-            return;
-        };
-        // Find and update the pane with the old head.
-        for (_, tile) in tree.tiles.iter_mut() {
-            if let egui_tiles::Tile::Pane(GraphPane(head)) = tile {
-                if head == old_head {
-                    *head = new_head.clone();
-                    break;
-                }
+    let Some(mut tree) = load_tree::<GraphPane>(ctx, graph_tree_id) else {
+        return;
+    };
+    // Find and update the pane with the old head.
+    let mut changed = false;
+    for (_, tile) in tree.tiles.iter_mut() {
+        if let egui_tiles::Tile::Pane(GraphPane(head)) = tile {
+            if head == old_head {
+                *head = new_head.clone();
+                changed = true;
+                break;
             }
         }
-    });
+    }
+    if changed {
+        store_tree(ctx, graph_tree_id, &tree);
+    }
 }
 
 /// The context passed to the `egui_tiles::Tree` widget.
@@ -637,19 +676,24 @@ impl<'a> Gantz<'a> {
         Access: HeadAccess,
         Access::Node: Node + NodeUi,
     {
+        // Honour a pending "clear egui memory" request (from Global settings)
+        // before loading any persisted UI state this frame.
+        if ui
+            .ctx()
+            .data(|d| d.get_temp::<bool>(clear_egui_memory_id()))
+            .unwrap_or(false)
+        {
+            ui.ctx().memory_mut(|m| m.data.clear());
+        }
+
         // The persisted outer tree. The version suffix invalidates any tree
         // persisted before the sidebar overhaul (which lacks the new panes and
         // tab containers), forcing a rebuild via `create_tree`.
         let tree_id = egui::Id::new("gantz-tiles-tree-storage-v3");
 
-        // Retrieve the tree of persistent storage, or load the default.
-        let mut tree: egui_tiles::Tree<Pane> = ui
-            .memory_mut(|m| {
-                m.data
-                    .get_persisted_mut_or_default::<Option<egui_tiles::Tree<Pane>>>(tree_id)
-                    .take()
-            })
-            .unwrap_or_else(create_tree);
+        // Retrieve the tree from persistent storage, or load the default.
+        let mut tree: egui_tiles::Tree<Pane> =
+            load_tree(ui.ctx(), tree_id).unwrap_or_else(create_tree);
 
         // Check the `view_toggles` match the pane visibility.
         set_tile_visibility(&mut tree, &state.view_toggles);
@@ -727,7 +771,7 @@ impl<'a> Gantz<'a> {
         }
 
         // Persist the tree.
-        ui.memory_mut(|m| m.data.insert_persisted(tree_id, Some(tree)));
+        store_tree(ui.ctx(), tree_id, &tree);
 
         response
     }
@@ -987,15 +1031,8 @@ where
 
                 // Retrieve the inner graph tree from persistent storage, or create empty.
                 let graph_tree_id = egui::Id::new(GRAPH_TREE_ID);
-                let mut graph_tree: egui_tiles::Tree<GraphPane> = ui
-                    .memory_mut(|m| {
-                        m.data
-                            .get_persisted_mut_or_default::<Option<egui_tiles::Tree<GraphPane>>>(
-                                graph_tree_id,
-                            )
-                            .take()
-                    })
-                    .unwrap_or_else(create_empty_graph_tree);
+                let mut graph_tree: egui_tiles::Tree<GraphPane> =
+                    load_tree(ui.ctx(), graph_tree_id).unwrap_or_else(create_empty_graph_tree);
 
                 // Sync the graph tree panes with the heads list.
                 sync_graph_panes(&mut graph_tree, access.heads());
@@ -1025,7 +1062,7 @@ where
                 graph_tree.ui(&mut graph_behaviour, ui);
 
                 // Persist the inner tree.
-                ui.memory_mut(|m| m.data.insert_persisted(graph_tree_id, Some(graph_tree)));
+                store_tree(ui.ctx(), graph_tree_id, &graph_tree);
 
                 // Show the command palette once (not per-pane), operating on the focused head.
                 if let Some(fh) = access.heads().get(*focused_head).cloned() {

--- a/crates/gantz_egui/src/widget/global_config.rs
+++ b/crates/gantz_egui/src/widget/global_config.rs
@@ -5,7 +5,7 @@
 //! snap-align options, and a button to reset all demo graphs to their initial
 //! state.
 
-use super::gantz::{AlignConfig, LayoutConfig, SnapConfig, SnapMode};
+use super::gantz::{AlignConfig, LayoutConfig, SnapConfig, SnapMode, request_clear_egui_memory};
 
 /// Response from [`global_config`].
 #[derive(Default)]
@@ -161,6 +161,23 @@ pub fn global_config(
         ui.checkbox(&mut align.centers, "Centres")
             .on_hover_text("Align to neighbours' horizontal/vertical centres.");
     });
+    ui.separator();
+
+    // Maintenance: a recovery tool to drop egui's persisted UI memory if it
+    // accumulates stale state (e.g. tile-layout snapshots from old builds),
+    // without touching the graph registry.
+    ui.label("Maintenance:");
+    if ui
+        .button("Clear egui memory")
+        .on_hover_text(
+            "Discard egui's persisted UI memory (panel layout, widget state) on \
+             the next frame. Recovers from accumulated or stale egui state \
+             without touching your graphs. The UI layout resets to default.",
+        )
+        .clicked()
+    {
+        request_clear_egui_memory(ui.ctx());
+    }
     ui.separator();
 
     let reset_all_demos = ui


### PR DESCRIPTION
Closes #270 

## Problem

With ~30-40 graphs, persisting the registry + egui state to storage on every debounced input caused visible lag spikes (longer than a 60Hz frame), most obvious against a running animation (e.g. a phasor → plot scope) when interacting with the UI.

Root causes, in order of impact:
- The `bevy_pkv` redb backend does one fsync'd write transaction per `set_string`, and we persisted the **whole** registry (one key per graph and per commit) on every debounce → hundreds of synchronous fsyncs.
- All of this ran **synchronously on the render thread**.
- Large state (views map, egui memory) was **RON-serialised** on the main thread - and views were re-serialised in full even when nothing changed.

## What changed

Incremental, off-thread, content-optimised persistence:

- **Incremental registry persistence** - graphs/commits are content-addressed and immutable, so a `PersistedRegistry` tracker writes only newly-seen blobs. Cost becomes O(new blobs), independent of registry size.
- **Off-thread writes** - the fsync'd writes run on a background `IoTaskPool` worker (inline on wasm); the render thread only serialises and hands off a batch via a channel. The worker is flushed + joined on exit so nothing is lost.
- **Per-commit incremental views** - views are split one key per commit behind a `view-addrs` index with a cheap `PartialEq` dirty check. No change -> 0 bytes written (was the whole `HashMap<CommitAddr, View>`, ~1MB, every time). A camera pan writes just that one view. Falls back to the legacy blob for old stores.
- **egui memory** - tile trees are now stored under a stable (`String`) key so they stop accumulating across recompiles (egui keys persisted data by `TypeId`, which churns on every build); a **Clear egui memory** button was added to Global settings; and egui-memory serialisation moved from RON to **bincode** (binary, no escaping of egui's nested per-entry RON strings).
- Plus: staggered egui-memory persistence onto a separate, slightly-slower debounce. Added persist timing/count debug logs, and the persistence code has been extracted into a self-contained `persist` module (a step toward a reusable crate).

## Result (measured locally, ~49 graphs / 52 commits)

| persist                | before        | after        |
|------------------------|---------------|--------------|
| registry/views/etc.    | ~10-100 ms spike (grew with graph count) | **~90-120µs** |
| egui memory            | ~5-6 ms       | **~200-400µs** |

## Notes

- No more visible stutter, and plotting `frame!` deltas directly looks smooth.
- **No new crates** - `async-channel`, `bincode`, `base64` were already in the dependency tree.