### PR TITLE
Misc GUI tweaks and fixes

### DIFF
--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -183,7 +183,7 @@ pub struct HeadGuiState(pub gantz_egui::widget::gantz::OpenHeadState);
 
 /// Views for a single head's graphs (keyed by subgraph path).
 #[derive(Component, Default, Clone)]
-pub struct GraphView(pub egui_graph::View);
+pub struct GraphView(pub gantz_egui::SceneView);
 
 // ----------------------------------------------------------------------------
 // Resources
@@ -207,7 +207,7 @@ pub struct GuiState(pub gantz_egui::widget::GantzState);
 
 /// Views (layout + camera) for all known commits.
 #[derive(Resource, Default)]
-pub struct Views(pub HashMap<ca::CommitAddr, egui_graph::View>);
+pub struct Views(pub HashMap<ca::CommitAddr, gantz_egui::SceneView>);
 
 /// Demo graph associations: maps a graph *name* to its associated `demo-*`
 /// graph name. Keyed by name (not commit) so the association survives edits,
@@ -465,7 +465,7 @@ impl DerefMut for GuiState {
 }
 
 impl Deref for Views {
-    type Target = HashMap<ca::CommitAddr, egui_graph::View>;
+    type Target = HashMap<ca::CommitAddr, gantz_egui::SceneView>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -491,7 +491,7 @@ impl DerefMut for Demos {
 }
 
 impl Deref for GraphView {
-    type Target = egui_graph::View;
+    type Target = gantz_egui::SceneView;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -575,12 +575,12 @@ pub fn on_head_changed<N: 'static + Send + Sync>(
         .and_then(|ca| views.get(ca).cloned())
         .unwrap_or_default();
 
-    // Camera (`scene_rect`) is excluded from undo: on a same-graph navigation
-    // (a layout undo/redo) keep the live camera rather than restoring the target
-    // commit's stored camera.
+    // Camera is excluded from undo: on a same-graph navigation (a layout
+    // undo/redo) keep the live camera rather than restoring the target commit's
+    // stored camera.
     if event.same_graph {
         if let Ok(current) = graph_views.get(event.entity) {
-            head_view.scene_rect = current.scene_rect;
+            head_view.camera = current.camera;
         }
     }
 
@@ -1273,8 +1273,8 @@ where
 /// stored `layout` (node positions) *frozen* as an undo baseline: it is written
 /// exactly once - when a commit first has a populated live layout - and is never
 /// overwritten in place. Node-position changes only ever produce a *new* commit
-/// (see [`settle_layout`]). The camera (`scene_rect`) is excluded from undo, so
-/// it tracks the live view in place every frame.
+/// (see [`settle_layout`]). The camera is excluded from undo, so it tracks the
+/// live view in place every frame.
 pub fn persist_camera_and_seed<N: 'static + Send + Sync>(
     registry: Res<Registry<N>>,
     mut views: ResMut<Views>,
@@ -1286,7 +1286,7 @@ pub fn persist_camera_and_seed<N: 'static + Send + Sync>(
         };
         match views.get_mut(&commit_addr) {
             // Layout frozen as the undo baseline; only the camera tracks live.
-            Some(view) => view.scene_rect = head_view.scene_rect,
+            Some(view) => view.camera = head_view.camera,
             // Seed the baseline once the scene has laid the graph out. Guarding
             // on a non-empty layout avoids capturing an empty pre-layout frame.
             None if !head_view.layout.is_empty() => {

--- a/crates/bevy_gantz_egui/src/storage.rs
+++ b/crates/bevy_gantz_egui/src/storage.rs
@@ -41,7 +41,7 @@ mod key {
 ///
 /// Seed it from the disk-loaded views via [`PersistedViews::from_views`].
 #[derive(Resource, Default)]
-pub struct PersistedViews(HashMap<ca::CommitAddr, egui_graph::View>);
+pub struct PersistedViews(HashMap<ca::CommitAddr, gantz_egui::SceneView>);
 
 impl PersistedViews {
     /// Snapshot the views known to be on disk.
@@ -108,7 +108,8 @@ pub fn load_views(storage: &impl Load) -> Views {
     }
     // Legacy: a single whole-map blob.
     Views(
-        load::<HashMap<ca::CommitAddr, egui_graph::View>>(storage, key::VIEWS).unwrap_or_default(),
+        load::<HashMap<ca::CommitAddr, gantz_egui::SceneView>>(storage, key::VIEWS)
+            .unwrap_or_default(),
     )
 }
 
@@ -249,9 +250,12 @@ mod tests {
     }
 
     /// A view distinguishable by `n` (so changing it is detectable).
-    fn view(n: f32) -> egui_graph::View {
-        egui_graph::View {
-            scene_rect: egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(n, n)),
+    fn view(n: f32) -> gantz_egui::SceneView {
+        gantz_egui::SceneView {
+            camera: gantz_egui::Camera {
+                center: egui::pos2(n, n),
+                zoom: 1.0,
+            },
             layout: Default::default(),
         }
     }

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -379,7 +379,7 @@ mod tests {
     }
 
     /// The Export-level format (gantz_egui over gantz_format) round-trips
-    /// `(layout ...)` view state: node positions and the scene rect survive
+    /// `(layout ...)` view state: node positions and the camera survive
     /// text -> Export -> text -> Export.
     #[test]
     fn layout_roundtrips() {
@@ -395,7 +395,7 @@ mod tests {
 
 (layout mul
   (m -10 20) (l 3.5 -4.5)
-  (scene -50 -50 100 100))";
+  (camera 25 -15 1.5))";
 
         let e1: gantz_egui::export::Export<G> =
             gantz_egui::format::from_str(text1, now).expect("from_str 1");
@@ -410,8 +410,8 @@ mod tests {
             view.layout.get(&egui_graph::NodeId(1)).map(|p| (p.x, p.y)),
             Some((3.5, -4.5))
         );
-        assert_eq!(view.scene_rect.min.x, -50.0);
-        assert_eq!(view.scene_rect.max.y, 100.0);
+        assert_eq!((view.camera.center.x, view.camera.center.y), (25.0, -15.0));
+        assert_eq!(view.camera.zoom, 1.5);
 
         let text2 = gantz_egui::format::to_string(&e1).expect("to_string");
         let e2: gantz_egui::export::Export<G> =
@@ -423,7 +423,34 @@ mod tests {
             view2.layout.get(&egui_graph::NodeId(0)).map(|p| (p.x, p.y)),
             Some((-10.0, 20.0))
         );
-        assert_eq!(view2.scene_rect, view.scene_rect);
+        assert_eq!(view2.camera, view.camera);
+    }
+
+    /// The legacy `(scene min-x min-y max-x max-y)` view form (pre-camera) still
+    /// parses: it maps to a camera centred on the rect at the default zoom.
+    #[test]
+    fn legacy_scene_form_parses_to_camera() {
+        use std::time::Duration;
+        type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
+
+        let now = Duration::from_secs(5);
+        let text = "\
+(graph mul
+  (m (expr (* $l $r)))
+  (l inlet) (r inlet) (out outlet)
+  (-> l (m 0)) (-> r (m 1)) (-> m out))
+
+(layout mul
+  (m -10 20)
+  (scene -50 -50 100 100))";
+
+        let e: gantz_egui::export::Export<G> =
+            gantz_egui::format::from_str(text, now).expect("from_str");
+        let head = *e.registry.names().get("mul").expect("mul name");
+        let view = e.views.get(&head).expect("view");
+        // Centre of (-50,-50)..(100,100), default zoom.
+        assert_eq!((view.camera.center.x, view.camera.center.y), (25.0, 25.0));
+        assert_eq!(view.camera.zoom, 1.0);
     }
 
     /// A clipboard payload round-trips through the `.gantz` text format: the

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -372,7 +372,7 @@ struct DemoHeadAccess<'a> {
     /// Map from head to index for lookup.
     head_to_ix: HashMap<gantz_ca::Head, usize>,
     /// The underlying data.
-    data: &'a mut Vec<(gantz_ca::Head, Graph, egui_graph::View)>,
+    data: &'a mut Vec<(gantz_ca::Head, Graph, gantz_egui::SceneView)>,
     modules: &'a [Option<gantz_core::vm::Compiled>],
     compile_errors: &'a [Option<String>],
     diagnostics: &'a [Vec<gantz_core::Diagnostic>],
@@ -381,7 +381,7 @@ struct DemoHeadAccess<'a> {
 
 impl<'a> DemoHeadAccess<'a> {
     fn new(
-        data: &'a mut Vec<(gantz_ca::Head, Graph, egui_graph::View)>,
+        data: &'a mut Vec<(gantz_ca::Head, Graph, gantz_egui::SceneView)>,
         modules: &'a [Option<gantz_core::vm::Compiled>],
         compile_errors: &'a [Option<String>],
         diagnostics: &'a [Vec<gantz_core::Diagnostic>],
@@ -473,7 +473,7 @@ struct App {
 struct State {
     /// The currently open graphs/heads.
     /// Each entry is a head (branch or commit), its associated graph, and view state.
-    heads: Vec<(gantz_ca::Head, Graph, egui_graph::View)>,
+    heads: Vec<(gantz_ca::Head, Graph, gantz_egui::SceneView)>,
     /// Per-head compiled modules, indexed to match `heads`.
     compile_errors: Vec<Option<String>>,
     /// Per-head module artifacts for span resolution, indexed to match `heads`.
@@ -543,7 +543,7 @@ impl App {
             .into_iter()
             .filter_map(|head| {
                 let graph = clone_graph(registry.head_graph(&head)?);
-                let view = egui_graph::View::default();
+                let view = gantz_egui::SceneView::default();
                 Some((head, graph, view))
             })
             .collect();
@@ -552,7 +552,7 @@ impl App {
         let heads = if heads.is_empty() {
             let head = registry.init_head(timestamp());
             let graph = clone_graph(registry.head_graph(&head).unwrap());
-            let view = egui_graph::View::default();
+            let view = gantz_egui::SceneView::default();
             vec![(head, graph, view)]
         } else {
             heads
@@ -1444,7 +1444,7 @@ fn open_head(state: &mut State, new_head: gantz_ca::Head) {
     // Head is not open - add it as a new tab.
     let graph = state.env.registry.head_graph(&new_head).unwrap();
     let new_graph = clone_graph(graph);
-    let view = egui_graph::View::default();
+    let view = gantz_egui::SceneView::default();
 
     state
         .heads
@@ -1486,7 +1486,7 @@ fn replace_head(ctx: &egui::Context, state: &mut State, new_head: gantz_ca::Head
     // Load the new graph.
     let graph = state.env.registry.head_graph(&new_head).unwrap();
     let new_graph = clone_graph(graph);
-    let view = egui_graph::View::default();
+    let view = gantz_egui::SceneView::default();
 
     // Replace at the focused index.
     state.heads[ix] = (new_head.clone(), new_graph.clone(), view);
@@ -1542,7 +1542,7 @@ fn refresh_branch_head(state: &mut State) {
     let (ref head, ref mut graph, ref mut view) = state.heads[ix];
     let new_graph = state.env.registry.head_graph(head).unwrap();
     *graph = clone_graph(new_graph);
-    *view = egui_graph::View::default();
+    *view = gantz_egui::SceneView::default();
     let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
     let eps = push_pull_entrypoints(&get_node, &*graph);
     let result = match gantz_core::vm::init(&get_node, &*graph, &eps, &state.compile_config) {

--- a/crates/gantz_egui/src/export.rs
+++ b/crates/gantz_egui/src/export.rs
@@ -1,7 +1,7 @@
 //! Export/import representation for sharing node sets between gantz instances.
 //!
 //! The [`Export`] type bundles a [`gantz_ca::Registry`] subset with optional
-//! [`egui_graph::View`] layout data. Serialization uses the `.gantz` S-expression text
+//! [`crate::SceneView`] layout data. Serialization uses the `.gantz` S-expression text
 //! format (see [`crate::format`]) under the `.gantz` file extension.
 
 use gantz_ca::{CaHash, CommitAddr, registry::MergeResult};
@@ -43,7 +43,7 @@ impl std::error::Error for ParseExportError {
 pub struct Export<G> {
     pub registry: gantz_ca::Registry<G>,
     #[serde(default, serialize_with = "gantz_ca::serde_sorted::serialize_map")]
-    pub views: HashMap<CommitAddr, egui_graph::View>,
+    pub views: HashMap<CommitAddr, crate::SceneView>,
     /// Maps a graph *name* to its associated demo graph name (a `demo-*` name).
     ///
     /// Keyed by name (rather than commit) so the association survives an edit:
@@ -56,7 +56,7 @@ pub struct Export<G> {
 /// present in the registry.
 pub fn export_with<G>(
     registry: gantz_ca::Registry<G>,
-    all_views: &HashMap<CommitAddr, egui_graph::View>,
+    all_views: &HashMap<CommitAddr, crate::SceneView>,
     all_demos: &HashMap<String, String>,
 ) -> Export<G>
 where
@@ -140,7 +140,7 @@ where
 pub fn export_heads_sexpr<N>(
     get_node: GetNode,
     registry: &gantz_ca::Registry<Graph<N>>,
-    all_views: &HashMap<CommitAddr, egui_graph::View>,
+    all_views: &HashMap<CommitAddr, crate::SceneView>,
     all_demos: &HashMap<String, String>,
     heads: impl IntoIterator<Item = impl std::borrow::Borrow<gantz_ca::Head>>,
 ) -> Result<String, crate::format::FormatError>
@@ -159,7 +159,7 @@ where
 pub fn export_heads_sexpr_named<N>(
     get_node: GetNode,
     registry: &gantz_ca::Registry<Graph<N>>,
-    all_views: &HashMap<CommitAddr, egui_graph::View>,
+    all_views: &HashMap<CommitAddr, crate::SceneView>,
     all_demos: &HashMap<String, String>,
     heads: impl IntoIterator<Item = impl std::borrow::Borrow<gantz_ca::Head>>,
 ) -> Result<String, crate::format::FormatError>
@@ -177,7 +177,7 @@ where
 /// known commits are kept.
 pub fn merge_with<G>(
     registry: &mut gantz_ca::Registry<G>,
-    views: &mut HashMap<CommitAddr, egui_graph::View>,
+    views: &mut HashMap<CommitAddr, crate::SceneView>,
     demos: &mut HashMap<String, String>,
     export: Export<G>,
 ) -> MergeResult {
@@ -273,7 +273,7 @@ pub struct Copied<N> {
 /// Build a [`Copied`] payload from the selected nodes in a graph.
 pub fn copy<N>(
     registry: &gantz_ca::Registry<Graph<N>>,
-    all_views: &HashMap<CommitAddr, egui_graph::View>,
+    all_views: &HashMap<CommitAddr, crate::SceneView>,
     graph: &Graph<N>,
     selected: &HashSet<node::graph::NodeIx>,
     layout: &egui_graph::Layout,
@@ -336,7 +336,7 @@ where
 /// target graph.
 pub fn paste<N>(
     registry: &mut gantz_ca::Registry<Graph<N>>,
-    views: &mut HashMap<CommitAddr, egui_graph::View>,
+    views: &mut HashMap<CommitAddr, crate::SceneView>,
     demos: &mut HashMap<String, String>,
     target_graph: &mut Graph<N>,
     target_layout: &mut egui_graph::Layout,
@@ -382,12 +382,13 @@ where
     ));
     registry.insert_name(CLIPBOARD_NAME.to_string(), commit_ca);
 
-    // Carry the positions as the clipboard graph's layout view.
+    // Carry the positions as the clipboard graph's layout view. The camera is
+    // irrelevant for a clipboard payload, so use the default.
     let mut views = copied.export.views.clone();
     views.insert(
         commit_ca,
-        egui_graph::View {
-            scene_rect: egui::Rect::ZERO,
+        crate::SceneView {
+            camera: crate::Camera::default(),
             layout: copied.positions.clone(),
         },
     );
@@ -506,8 +507,8 @@ mod tests {
             BTreeMap::new(),
         );
         let mut all_views = HashMap::new();
-        all_views.insert(ca, egui_graph::View::default());
-        all_views.insert(cb, egui_graph::View::default()); // cb not in registry
+        all_views.insert(ca, crate::SceneView::default());
+        all_views.insert(cb, crate::SceneView::default()); // cb not in registry
         let export = export_with(registry, &all_views, &HashMap::new());
         assert!(export.views.contains_key(&ca));
         assert!(!export.views.contains_key(&cb));
@@ -546,7 +547,7 @@ mod tests {
             HashMap::from([(ca, commit.clone())]),
             BTreeMap::new(),
         );
-        let mut existing_view = egui_graph::View::default();
+        let mut existing_view = crate::SceneView::default();
         existing_view
             .layout
             .insert(egui_graph::NodeId(0), Default::default());
@@ -558,7 +559,7 @@ mod tests {
                 HashMap::from([(ca, commit)]),
                 BTreeMap::new(),
             ),
-            views: HashMap::from([(ca, egui_graph::View::default())]),
+            views: HashMap::from([(ca, crate::SceneView::default())]),
             demos: HashMap::new(),
         };
         merge_with(&mut registry, &mut views, &mut demos, export);

--- a/crates/gantz_egui/src/format.rs
+++ b/crates/gantz_egui/src/format.rs
@@ -27,7 +27,7 @@ where
     N: Serialize + DeserializeOwned + CaHash + 'static,
 {
     let loaded = gantz_format::from_str::<N>(text, now)?;
-    let mut views: HashMap<CommitAddr, egui_graph::View> = HashMap::new();
+    let mut views: HashMap<CommitAddr, crate::SceneView> = HashMap::new();
     let mut demos: HashMap<String, String> = HashMap::new();
     for form in &loaded.extra {
         match form.head.as_str() {
@@ -118,7 +118,7 @@ where
 fn apply_layout<N>(
     form: &Form,
     loaded: &Loaded<N>,
-    views: &mut HashMap<CommitAddr, egui_graph::View>,
+    views: &mut HashMap<CommitAddr, crate::SceneView>,
 ) {
     let src = &form.raw;
     let Ok(forms) = sexpr::read(src) else { return };
@@ -137,7 +137,7 @@ fn apply_layout<N>(
     };
 
     let mut layout = egui_graph::Layout::default();
-    let mut scene = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(0.0, 0.0));
+    let mut camera = crate::Camera::default();
     for entry in &args[2..] {
         let Some(eargs) = sexpr::list_args(entry) else {
             continue;
@@ -145,13 +145,31 @@ fn apply_layout<N>(
         let Some(head_sym) = eargs.first().and_then(sexpr::as_symbol) else {
             continue;
         };
-        if head_sym == "scene" {
+        if head_sym == "camera" {
+            let f: Vec<f32> = eargs[1..]
+                .iter()
+                .filter_map(|n| sexpr::as_f32(n, src))
+                .collect();
+            if f.len() == 3 {
+                camera = crate::Camera {
+                    center: egui::pos2(f[0], f[1]),
+                    zoom: f[2],
+                };
+            }
+        } else if head_sym == "scene" {
+            // Legacy: a visible-region rect (pre-camera format). Recover the
+            // centre at the default zoom; the exact zoom can't be reconstructed
+            // without the viewport the rect was captured against.
             let f: Vec<f32> = eargs[1..]
                 .iter()
                 .filter_map(|n| sexpr::as_f32(n, src))
                 .collect();
             if f.len() == 4 {
-                scene = egui::Rect::from_min_max(egui::pos2(f[0], f[1]), egui::pos2(f[2], f[3]));
+                let rect = egui::Rect::from_min_max(egui::pos2(f[0], f[1]), egui::pos2(f[2], f[3]));
+                camera = crate::Camera {
+                    center: rect.center(),
+                    zoom: 1.0,
+                };
             }
         } else if let (Some(x), Some(y)) = (
             eargs.get(1).and_then(|n| sexpr::as_f32(n, src)),
@@ -163,10 +181,7 @@ fn apply_layout<N>(
         }
     }
 
-    let view = egui_graph::View {
-        scene_rect: scene,
-        layout,
-    };
+    let view = crate::SceneView { camera, layout };
     views.insert(head, view);
 }
 
@@ -174,7 +189,7 @@ fn apply_layout<N>(
 /// the graph itself is `(graph <name> ...)`); otherwise it is quoted (the
 /// address-based format, `(graph "<hex>" ...)`). The id must round-trip to the
 /// same `Addr` kind as the graph, or the layout fails to resolve on load.
-fn layout_text(labels: &GraphLabels, view: &egui_graph::View, bare_id: bool) -> String {
+fn layout_text(labels: &GraphLabels, view: &crate::SceneView, bare_id: bool) -> String {
     let mut positions: Vec<(String, f32, f32)> = view
         .layout
         .iter()
@@ -200,13 +215,12 @@ fn layout_text(labels: &GraphLabels, view: &egui_graph::View, bare_id: bool) -> 
             sexpr::num(y)
         ));
     }
-    let r = view.scene_rect;
+    let c = view.camera;
     s.push_str(&format!(
-        "\n  (scene {} {} {} {}))",
-        sexpr::num(r.min.x),
-        sexpr::num(r.min.y),
-        sexpr::num(r.max.x),
-        sexpr::num(r.max.y),
+        "\n  (camera {} {} {}))",
+        sexpr::num(c.center.x),
+        sexpr::num(c.center.y),
+        sexpr::num(c.zoom),
     ));
     s
 }

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -18,6 +18,7 @@ pub mod ops;
 pub mod reg;
 pub mod response;
 pub mod sync;
+pub mod view;
 pub mod widget;
 
 // Re-export traits that make up the Registry supertrait.
@@ -28,6 +29,7 @@ pub use response::{
     ContextMenuResponse, DynResponse, InspectorRowsResponse, InspectorUiResponse, NodeUiResponse,
     ResponseData, Responses,
 };
+pub use view::{Camera, SceneView};
 pub use widget::gantz::NodeTypeRegistry;
 pub use widget::graph_select::GraphRegistry;
 
@@ -265,7 +267,7 @@ pub struct HeadDataMut<'a, N> {
     /// View state (node layout + camera) for this head's graph. Nested graphs
     /// are separate named heads with their own view, so one view per head
     /// suffices (no path-keyed map).
-    pub view: &'a mut egui_graph::View,
+    pub view: &'a mut crate::SceneView,
     pub vm: &'a mut Engine,
 }
 

--- a/crates/gantz_egui/src/ops.rs
+++ b/crates/gantz_egui/src/ops.rs
@@ -64,9 +64,9 @@ pub fn branch_node<N>(
 /// responsibility.
 pub fn copy_nodes<N>(
     registry: &gantz_ca::Registry<Graph<N>>,
-    all_views: &HashMap<CommitAddr, egui_graph::View>,
+    all_views: &HashMap<CommitAddr, crate::SceneView>,
     graph: &Graph<N>,
-    head_view: &egui_graph::View,
+    head_view: &crate::SceneView,
     selection: &HashSet<NodeIndex>,
 ) -> Option<String>
 where
@@ -95,7 +95,7 @@ pub fn create_node<N>(
     get_node: GetNode,
     new_node: impl FnOnce(&str) -> Option<N>,
     graph: &mut Graph<N>,
-    view: &mut egui_graph::View,
+    view: &mut crate::SceneView,
     head_state: &mut OpenHeadState,
     vm: &mut Engine,
     cmd: CreateNode,
@@ -124,7 +124,7 @@ where
 
     // Position the new node under the pointer, falling back to the center of the
     // current view.
-    let pos = pos.unwrap_or_else(|| view.scene_rect.center());
+    let pos = pos.unwrap_or_else(|| view.camera.center);
     let egui_id = egui_graph::NodeId::from_u64(node_ix.index() as u64);
     view.layout.insert(egui_id, pos);
 
@@ -147,7 +147,7 @@ pub fn create_nested_graph<N>(
     registry: &mut gantz_ca::Registry<Graph<N>>,
     timestamp: std::time::Duration,
     graph: &mut Graph<N>,
-    view: &mut egui_graph::View,
+    view: &mut crate::SceneView,
     head_state: &mut OpenHeadState,
     pos: Option<egui::Pos2>,
     parent: &str,
@@ -179,7 +179,7 @@ where
 
     // Position the new node under the pointer, falling back to the center of the
     // current view.
-    let pos = pos.unwrap_or_else(|| view.scene_rect.center());
+    let pos = pos.unwrap_or_else(|| view.camera.center);
     let egui_id = egui_graph::NodeId::from_u64(node_ix.index() as u64);
     view.layout.insert(egui_id, pos);
 
@@ -252,7 +252,7 @@ pub fn inspect_edge<N>(
     get_node: GetNode,
     new_inspect: impl FnOnce() -> Option<N>,
     graph: &mut Graph<N>,
-    view: &mut egui_graph::View,
+    view: &mut crate::SceneView,
     vm: &mut Engine,
     cmd: InspectEdge,
 ) where
@@ -310,10 +310,10 @@ pub fn inspect_edge<N>(
 pub fn paste<N>(
     registry: &mut gantz_ca::Registry<Graph<N>>,
     editing: Option<&str>,
-    all_views: &mut HashMap<CommitAddr, egui_graph::View>,
+    all_views: &mut HashMap<CommitAddr, crate::SceneView>,
     all_demos: &mut HashMap<String, String>,
     graph: &mut Graph<N>,
-    head_view: &mut egui_graph::View,
+    head_view: &mut crate::SceneView,
     head_state: &mut OpenHeadState,
     text: &str,
     pos: &PastePos,
@@ -401,8 +401,8 @@ pub fn redo(
 /// [`gantz_ca::GraphAddr`]: the registry dedups the graph (the `graph` closure
 /// passed to [`gantz_ca::Registry::commit_graph_to_head`] is never called) and
 /// the VM does not need to recompile. Only `layout` (node positions) is
-/// compared; `scene_rect` (camera) is excluded, so camera pan/zoom never
-/// produces a layout commit.
+/// compared; the `camera` is excluded, so camera pan/zoom never produces a
+/// layout commit.
 ///
 /// Returns the new commit address when a layout commit was created, else `None`
 /// (no baseline view yet - i.e. the head commit's layout has not been seeded -
@@ -410,10 +410,10 @@ pub fn redo(
 /// and migrating GUI state stay with the caller.
 pub fn commit_layout<G>(
     registry: &mut gantz_ca::Registry<G>,
-    views: &HashMap<CommitAddr, egui_graph::View>,
+    views: &HashMap<CommitAddr, crate::SceneView>,
     timestamp: gantz_ca::Timestamp,
     head: &mut gantz_ca::Head,
-    live: &egui_graph::View,
+    live: &crate::SceneView,
 ) -> Option<CommitAddr> {
     let head_commit_ca = *registry.head_commit_ca(head)?;
     let baseline = views.get(&head_commit_ca)?;

--- a/crates/gantz_egui/src/view.rs
+++ b/crates/gantz_egui/src/view.rs
@@ -1,0 +1,102 @@
+//! Viewport-independent camera + layout state for a graph scene.
+//!
+//! The persisted/runtime currency for a graph's view is [`SceneView`] (a
+//! [`Camera`] plus a node [`Layout`](egui_graph::Layout)). It is deliberately
+//! *viewport independent*: the camera stores a centre and a zoom factor (screen
+//! points per graph unit) rather than a visible rectangle, so the zoom level is
+//! preserved across sessions and window sizes. An [`egui_graph::View`] (whose
+//! `scene_rect` *is* viewport dependent) is materialised from a `SceneView` only
+//! at the `egui_graph` API boundary, where the live viewport size is known - see
+//! [`SceneView::take_egui`] / [`SceneView::restore_egui`].
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// A graph scene camera, independent of the viewport size.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Camera {
+    /// The point in graph space at the centre of the view.
+    pub center: egui::Pos2,
+    /// The zoom factor in screen points per graph unit. `1.0` shows one graph
+    /// unit per point (i.e. no scaling).
+    pub zoom: f32,
+}
+
+impl Default for Camera {
+    fn default() -> Self {
+        Self {
+            center: egui::Pos2::ZERO,
+            zoom: 1.0,
+        }
+    }
+}
+
+impl Camera {
+    /// The visible [`egui::Rect`] (in graph space) this camera maps to for a
+    /// viewport of the given size: a `viewport / zoom` sized rect centred on
+    /// [`Camera::center`]. `egui`'s `Scene` fits this rect back into the
+    /// viewport, reproducing exactly `zoom` points per graph unit.
+    pub fn to_scene_rect(self, viewport: egui::Vec2) -> egui::Rect {
+        let zoom = if self.zoom > 0.0 { self.zoom } else { 1.0 };
+        egui::Rect::from_center_size(self.center, viewport / zoom)
+    }
+
+    /// Recover the camera from a `scene_rect` and the viewport it was fit into.
+    /// The inverse of [`Camera::to_scene_rect`] (exact when the rect shares the
+    /// viewport's aspect ratio, which holds once `egui`'s `Scene` has fit it).
+    pub fn from_scene_rect(rect: egui::Rect, viewport: egui::Vec2) -> Self {
+        let size = rect.size();
+        let zoom = if size.x > 0.0 && size.y > 0.0 {
+            (viewport / size).min_elem()
+        } else {
+            1.0
+        };
+        Self {
+            center: rect.center(),
+            zoom,
+        }
+    }
+}
+
+/// A graph scene's persisted view: a [`Camera`] plus the node
+/// [`Layout`](egui_graph::Layout).
+///
+/// This is the viewport-independent currency stored in memory and on disk. See
+/// the [module docs](self).
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct SceneView {
+    #[serde(default)]
+    pub camera: Camera,
+    /// Node positions in graph space. Serialised sorted for deterministic output.
+    #[serde(default, serialize_with = "serialize_sorted_layout")]
+    pub layout: egui_graph::Layout,
+}
+
+impl SceneView {
+    /// Materialise an [`egui_graph::View`] for a viewport of `viewport` size,
+    /// *taking* the layout (left empty) to avoid a per-frame clone. Pair with
+    /// [`SceneView::restore_egui`] to write the (mutated) view back.
+    pub fn take_egui(&mut self, viewport: egui::Vec2) -> egui_graph::View {
+        egui_graph::View {
+            scene_rect: self.camera.to_scene_rect(viewport),
+            layout: std::mem::take(&mut self.layout),
+        }
+    }
+
+    /// Write back an [`egui_graph::View`] mutated by the `egui_graph` pass,
+    /// recovering the viewport-independent [`Camera`] from its `scene_rect`.
+    pub fn restore_egui(&mut self, view: egui_graph::View, viewport: egui::Vec2) {
+        self.camera = Camera::from_scene_rect(view.scene_rect, viewport);
+        self.layout = view.layout;
+    }
+}
+
+/// Serialise a [`Layout`](egui_graph::Layout) with deterministically sorted keys
+/// (mirrors `egui_graph`'s own sorted-layout serialisation).
+fn serialize_sorted_layout<S: serde::Serializer>(
+    layout: &egui_graph::Layout,
+    s: S,
+) -> Result<S::Ok, S::Error> {
+    let sorted: BTreeMap<_, _> = layout.iter().collect();
+    sorted.serialize(s)
+}

--- a/crates/gantz_egui/src/widget.rs
+++ b/crates/gantz_egui/src/widget.rs
@@ -66,7 +66,53 @@ pub(crate) fn format_local_datetime(system_time: std::time::SystemTime) -> Strin
         .unwrap_or_else(|_| "<invalid-timestamp>".to_string())
 }
 
+/// Group consecutive slice elements considered equal by `eq` into runs,
+/// returned as `(index_of_first, count)` pairs in order.
+///
+/// Used by the log/trace views to collapse runs of repeated entries (equal but
+/// for their timestamp) into a single row carrying an occurrence count.
+pub(crate) fn group_runs<T>(items: &[T], eq: impl Fn(&T, &T) -> bool) -> Vec<(usize, usize)> {
+    let mut runs: Vec<(usize, usize)> = Vec::new();
+    for (i, item) in items.iter().enumerate() {
+        if let Some((first, count)) = runs.last_mut() {
+            if eq(&items[*first], item) {
+                *count += 1;
+                continue;
+            }
+        }
+        runs.push((i, 1));
+    }
+    runs
+}
+
 /// Simple shorthand for viewing steel code without highlights.
 pub fn steel_view(ui: &mut egui::Ui, code: &str) {
     SteelView::new(code).show(ui);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::group_runs;
+
+    #[test]
+    fn group_runs_collapses_consecutive_equal_items() {
+        // The trailing `a` is a *separate* run from the leading ones - only
+        // consecutive equals collapse.
+        let items = ['a', 'a', 'a', 'b', 'a', 'a'];
+        let runs = group_runs(&items, |x, y| x == y);
+        assert_eq!(runs, vec![(0, 3), (3, 1), (4, 2)]);
+    }
+
+    #[test]
+    fn group_runs_empty_is_empty() {
+        let items: [char; 0] = [];
+        assert!(group_runs(&items, |x, y| x == y).is_empty());
+    }
+
+    #[test]
+    fn group_runs_all_distinct() {
+        let items = [1, 2, 3];
+        let runs = group_runs(&items, |x, y| x == y);
+        assert_eq!(runs, vec![(0, 1), (1, 1), (2, 1)]);
+    }
 }

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -317,6 +317,11 @@ impl SceneConfig {
             SnapMode::Grid => self.grid.step * self.snap.grid_ratio,
         };
         graph
+            // gantz owns zoom persistence (the camera stores centre + zoom, and
+            // the scene rect is rebuilt from it each frame against the live
+            // viewport). Use `MaintainView` so `egui_graph` does not *also*
+            // rescale the rect on resize and double-adjust the zoom.
+            .resize_behavior(egui_graph::ResizeBehavior::MaintainView)
             .dot_grid(self.grid.show)
             .dot_grid_step(self.grid.step)
             .snap(Some(egui_graph::Snap::Round))
@@ -2217,7 +2222,7 @@ fn graph_scene<N>(
     head: &gantz_ca::Head,
     head_state: &mut OpenHeadState,
     view_toggles: &mut ViewToggles,
-    head_view: &mut egui_graph::View,
+    head_view: &mut crate::SceneView,
     layout_params: egui_graph::LayoutParams,
     scene_config: SceneConfig,
     immutable: bool,
@@ -2231,10 +2236,22 @@ where
     // A head shows exactly its root graph (nested graphs are separate heads).
     let id = egui::Id::new(head);
 
-    // Seed the node layout the first time this graph is shown.
+    // Seed the node layout the first time this graph is shown, and centre the
+    // camera on it at zoom 1. Without an explicit camera the scene would fall
+    // back to egui's fit-to-bounds, zooming out to frame every node; a freshly
+    // opened graph should instead sit at its natural 1:1 zoom.
     if head_view.layout.is_empty() {
         head_view.layout =
             widget::graph_scene::layout(registry, graph, id, &layout_params, ui.ctx(), None);
+        let mut bounds: Option<egui::Rect> = None;
+        for &pos in head_view.layout.values() {
+            let r = egui::Rect::from_min_size(pos, egui::Vec2::ZERO);
+            bounds = Some(bounds.map_or(r, |b| b.union(r)));
+        }
+        head_view.camera = crate::Camera {
+            center: bounds.map_or(egui::Pos2::ZERO, |b| b.center()),
+            zoom: 1.0,
+        };
     }
 
     let response = GraphScene::new(registry, graph)

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -307,6 +307,7 @@ where
         let view_toggles = self.view_toggles;
         let mut reset_layout = false;
         let mut request_layout = false;
+        let mut request_center = false;
         if !immutable || view_toggles.is_some() {
             let layer_id = graph_response.response.layer_id;
             graph_response.response.context_menu(|ui| {
@@ -340,6 +341,14 @@ where
                         request_layout = true;
                         ui.close();
                     }
+                    if ui
+                        .button("center-view")
+                        .on_hover_text("frame the whole graph in the view")
+                        .clicked()
+                    {
+                        request_center = true;
+                        ui.close();
+                    }
                 }
                 if let Some(view) = view_toggles {
                     ui.menu_button("panes", |ui| {
@@ -355,6 +364,9 @@ where
         }
         if request_layout {
             state.pending_auto_layout = true;
+        }
+        if request_center {
+            state.pending_center_view = true;
         }
         if reset_layout {
             responses.push(DynResponse::new(ResetTilesLayout));

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -845,6 +845,7 @@ fn edges<N>(
                 state.interaction.edge_context_menu_pos = Some(response.closest_point());
             }
         }
+        let mut delete_edge = false;
         response.context_menu(|ui| {
             if ui.button("inspect").clicked() {
                 if let Some(pos) = state.interaction.edge_context_menu_pos.take() {
@@ -852,7 +853,19 @@ fn edges<N>(
                 }
                 ui.close();
             }
+            if ui.button("delete").clicked() {
+                delete_edge = true;
+                ui.close();
+            }
         });
+        // Apply the deletion after the closure releases its borrows. Same effect
+        // as the keyboard `deleted()` path above; `changed` propagates to the
+        // head's commit so it persists and joins the undo/redo chain.
+        if delete_edge {
+            graph.remove_edge(e);
+            state.interaction.selection.edges.remove(&e);
+            *changed = true;
+        }
     }
 
     // Apply deferred edge deletes. `remove_edge` swap-removes (the former-last

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -175,11 +175,19 @@ where
     /// Returns a response containing both the scene response and all node responses.
     pub fn show(
         self,
-        view: &mut egui_graph::View,
+        scene_view: &mut crate::SceneView,
         state: &mut GraphSceneState,
         vm: &mut Engine,
         ui: &mut egui::Ui,
     ) -> GraphSceneResponse {
+        // Materialise the viewport-dependent `egui_graph::View` from the
+        // viewport-independent camera. The viewport must match the size
+        // `egui_graph` reads (`available_rect_before_wrap`) so the fit
+        // reproduces the camera's zoom exactly. The camera is recovered after
+        // the pass (see `restore_egui` below).
+        let viewport = ui.available_rect_before_wrap().size();
+        let mut egui_view = scene_view.take_egui(viewport);
+        let view = &mut egui_view;
         // Consume one-shot layout/center requests (set by buttons and context
         // menus). A request raised during this pass (e.g. by a context menu)
         // is applied on the next pass.
@@ -351,6 +359,11 @@ where
         if reset_layout {
             responses.push(DynResponse::new(ResetTilesLayout));
         }
+
+        // Recover the viewport-independent camera (centre + zoom) from the
+        // `egui_graph` view (which `egui` may have panned/zoomed this pass) and
+        // write back the possibly-relaid-out node layout.
+        scene_view.restore_egui(egui_view, viewport);
 
         GraphSceneResponse {
             scene: graph_response.response,

--- a/crates/gantz_egui/src/widget/log_view.rs
+++ b/crates/gantz_egui/src/widget/log_view.rs
@@ -186,6 +186,12 @@ impl<'a> LogView<'a> {
 
         entries.reverse();
 
+        // Collapse runs of consecutive entries that differ only by their
+        // timestamp into a single row, carrying an occurrence count.
+        let runs = crate::widget::group_runs(&entries, |a, b| {
+            a.level == b.level && a.message == b.message && a.target == b.target
+        });
+
         // Create table
         TableBuilder::new(ui)
             .striped(true)
@@ -210,10 +216,11 @@ impl<'a> LogView<'a> {
             })
             .body(|mut body| {
                 let row_h = 18.0;
-                let n_rows = entries.len();
+                let n_rows = runs.len();
                 let text_color = body.ui_mut().style().visuals.text_color();
                 body.rows(row_h, n_rows, |mut row| {
-                    let entry = &entries[row.index()];
+                    let (idx, count) = runs[row.index()];
+                    let entry = &entries[idx];
                     let freshness = entry.freshness();
                     let fresh = freshness > 0.0;
                     let text_color = if fresh {
@@ -264,7 +271,16 @@ impl<'a> LogView<'a> {
                     });
 
                     row.col(|ui| {
-                        ui.colored_label(text_color, &entry.message);
+                        ui.horizontal(|ui| {
+                            if count > 1 {
+                                ui.colored_label(
+                                    text_color.gamma_multiply(0.7),
+                                    format!("×{count}"),
+                                )
+                                .on_hover_text("occurrences collapsed (repeated log)");
+                            }
+                            ui.colored_label(text_color, &entry.message);
+                        });
                     });
 
                     if fresh {

--- a/crates/gantz_egui/src/widget/trace_view.rs
+++ b/crates/gantz_egui/src/widget/trace_view.rs
@@ -162,6 +162,12 @@ impl TraceView {
 
         entries.reverse();
 
+        // Collapse runs of consecutive entries that differ only by their
+        // timestamp into a single row, carrying an occurrence count.
+        let runs = crate::widget::group_runs(&entries, |a, b| {
+            a.level == b.level && a.message == b.message && a.target == b.target
+        });
+
         // Create table
         TableBuilder::new(ui)
             .striped(true)
@@ -186,10 +192,11 @@ impl TraceView {
             })
             .body(|mut body| {
                 let row_h = 18.0;
-                let n_rows = entries.len();
+                let n_rows = runs.len();
                 let text_color = body.ui_mut().style().visuals.text_color();
                 body.rows(row_h, n_rows, |mut row| {
-                    let entry = &entries[row.index()];
+                    let (idx, count) = runs[row.index()];
+                    let entry = &entries[idx];
                     let freshness = entry.freshness();
                     let fresh = freshness > 0.0;
                     let text_color = if fresh {
@@ -220,7 +227,16 @@ impl TraceView {
                     });
 
                     row.col(|ui| {
-                        ui.colored_label(text_color, &entry.message);
+                        ui.horizontal(|ui| {
+                            if count > 1 {
+                                ui.colored_label(
+                                    text_color.gamma_multiply(0.7),
+                                    format!("×{count}"),
+                                )
+                                .on_hover_text("occurrences collapsed (repeated log)");
+                            }
+                            ui.colored_label(text_color, &entry.message);
+                        });
                     });
 
                     if fresh {


### PR DESCRIPTION
A grab-bag of small, self-contained GUI improvements landed together (none warrants its own PR).

## Changes

### Edge context menu: delete
Right-clicking an edge offered only **inspect**. Edges could be removed via the keyboard but had no mouse affordance. Adds a **delete** item that reuses the existing direct-mutation path, so it persists and joins undo/redo like the keyboard delete.

### Camera persists as centre + zoom (not a rect)
The graph view stored a viewport-dependent `scene_rect`, so reopening a graph on a differently-sized window changed the zoom, and a freshly opened graph fell back to egui's fit-to-bounds (zooming out to frame every node).

Now the stored view is a viewport-independent `SceneView { camera: Camera { center, zoom }, layout }`. An `egui_graph::View` is materialised only at the egui_graph API boundary, where the live viewport size is known. egui_graph runs with `MaintainView` so it no longer also rescales on resize.

- Zoom persists across sessions and window sizes.
- A first-opened graph centres on its nodes at zoom 1.
- The `.gantz` text format writes `(camera cx cy zoom)`. The legacy `(scene ...)` rect still parses (centre at zoom 1). Old session views load with their layout kept and the camera reset to the default.

### Graph scene context menu: center-view
Adds a **center-view** item under **auto-layout** in the background right-click menu (frames the whole graph), with on-hover text. Reuses the existing `pending_center_view` path.

### Log/trace views: collapse repeated entries
A node spamming one message buried everything else. Runs of consecutive entries that are equal but for their timestamp now collapse into a single row, prefixed with a dim `×N` occurrence count (hover explains it). The collapsed row shows the most recent occurrence's timestamp/freshness. Grouping is render-time via a shared, unit-tested `widget::group_runs`. Capture/storage are unchanged. Applies to both `LogView` and `TraceView`.