### PR TITLE
Rename `frame!` -> `update!` and add a self-driven `tick!` clock node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -913,6 +913,7 @@ dependencies = [
  "bevy_tasks",
  "bevy_time",
  "bincode",
+ "egui_extras",
  "egui_graph",
  "gantz_base",
  "gantz_ca",

--- a/crates/bevy_gantz/src/vm.rs
+++ b/crates/bevy_gantz/src/vm.rs
@@ -291,7 +291,7 @@ pub fn sync<N>(
         // Rebuild the VM. On an in-place compile error the VM is kept (its
         // previous module remains evaluable) and the error surfaces via the
         // module/diagnostics components; a failed init leaves no VM, so eval
-        // systems (e.g. `drive_frame_bangs`, `on_eval_entry`) skip the head
+        // systems (e.g. `drive_update_bangs`, `on_eval_entry`) skip the head
         // rather than driving a stale graph.
         let graph: &Graph<N> = &*data.working_graph;
         let get_node = |ca: &ca::ContentAddr| lookup_node(&registry, &**builtins, ca);

--- a/crates/bevy_gantz_egui/Cargo.toml
+++ b/crates/bevy_gantz_egui/Cargo.toml
@@ -18,6 +18,7 @@ bevy_gantz.workspace = true
 bevy_log.workspace = true
 bincode.workspace = true
 bevy_tasks.workspace = true
+egui_extras.workspace = true
 egui_graph.workspace = true
 gantz_base.workspace = true
 gantz_ca.workspace = true

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -82,6 +82,7 @@ where
         + gantz_egui::sync::AsNamedRef
         + gantz_egui::NodeUi
         + node::ToUpdateBang
+        + node::ToTickBang
         + serde::Serialize
         + serde::de::DeserializeOwned
         + Send
@@ -89,12 +90,18 @@ where
         + 'static,
 {
     fn build(&self, app: &mut App) {
-        // Register update_bang entrypoint provider.
+        // Register update_bang + tick_bang entrypoint providers.
         app.world_mut()
             .resource_mut::<bevy_gantz::EntrypointFns<N>>()
             .0
             .push(Box::new(|get_node, graph| {
                 node::update_bang::entrypoints(get_node, graph)
+            }));
+        app.world_mut()
+            .resource_mut::<bevy_gantz::EntrypointFns<N>>()
+            .0
+            .push(Box::new(|get_node, graph| {
+                node::tick_bang::entrypoints(get_node, graph)
             }));
 
         // Builtin GUI response payload dispatchers. Head-scoped payloads
@@ -154,6 +161,7 @@ where
                 Update,
                 (
                     node::update_bang::drive_update_bangs::<N>.after(bevy_gantz::VmSet),
+                    node::tick_bang::drive_tick_bangs::<N>.after(bevy_gantz::VmSet),
                     persist_camera_and_seed::<N>,
                     // On layout settle, fork a layout-only commit. Runs after
                     // `VmSet` (so a graph edit commits first and its baseline is

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -81,7 +81,7 @@ where
         + gantz_egui::sync::AsNamedRefMut
         + gantz_egui::sync::AsNamedRef
         + gantz_egui::NodeUi
-        + node::ToFrameBang
+        + node::ToUpdateBang
         + serde::Serialize
         + serde::de::DeserializeOwned
         + Send
@@ -89,12 +89,12 @@ where
         + 'static,
 {
     fn build(&self, app: &mut App) {
-        // Register frame_bang entrypoint provider.
+        // Register update_bang entrypoint provider.
         app.world_mut()
             .resource_mut::<bevy_gantz::EntrypointFns<N>>()
             .0
             .push(Box::new(|get_node, graph| {
-                node::frame_bang::entrypoints(get_node, graph)
+                node::update_bang::entrypoints(get_node, graph)
             }));
 
         // Builtin GUI response payload dispatchers. Head-scoped payloads
@@ -147,13 +147,13 @@ where
             .add_observer(on_export_all_named::<N>)
             .add_observer(on_import_file::<N>)
             .add_observer(on_reset_base_graph::<N>)
-            // Systems. `drive_frame_bangs` evaluates head VMs, so it must not
+            // Systems. `drive_update_bangs` evaluates head VMs, so it must not
             // observe the gap between a head pointing at a new graph and
             // `vm::sync` (re)initializing its VM.
             .add_systems(
                 Update,
                 (
-                    node::frame_bang::drive_frame_bangs::<N>.after(bevy_gantz::VmSet),
+                    node::update_bang::drive_update_bangs::<N>.after(bevy_gantz::VmSet),
                     persist_camera_and_seed::<N>,
                     // On layout settle, fork a layout-only commit. Runs after
                     // `VmSet` (so a graph edit commits first and its baseline is

--- a/crates/bevy_gantz_egui/src/node/mod.rs
+++ b/crates/bevy_gantz_egui/src/node/mod.rs
@@ -1,4 +1,4 @@
 pub mod tick_bang;
 pub mod update_bang;
-pub use tick_bang::{TickBang, ToTickBang};
+pub use tick_bang::{Interval, TickBang, ToTickBang};
 pub use update_bang::{ToUpdateBang, UpdateBang};

--- a/crates/bevy_gantz_egui/src/node/mod.rs
+++ b/crates/bevy_gantz_egui/src/node/mod.rs
@@ -1,2 +1,2 @@
-pub mod frame_bang;
-pub use frame_bang::{FrameBang, ToFrameBang};
+pub mod update_bang;
+pub use update_bang::{ToUpdateBang, UpdateBang};

--- a/crates/bevy_gantz_egui/src/node/mod.rs
+++ b/crates/bevy_gantz_egui/src/node/mod.rs
@@ -1,2 +1,4 @@
+pub mod tick_bang;
 pub mod update_bang;
+pub use tick_bang::{TickBang, ToTickBang};
 pub use update_bang::{ToUpdateBang, UpdateBang};

--- a/crates/bevy_gantz_egui/src/node/tick_bang.rs
+++ b/crates/bevy_gantz_egui/src/node/tick_bang.rs
@@ -1,0 +1,332 @@
+//! A self-driven node that fires once per configurable tick duration.
+//!
+//! Unlike `update!`, which bangs once per update, `tick!` owns its own time
+//! accumulator fed from Bevy `Time` and fires once for *every* whole tick
+//! duration elapsed since the last update (fixed-timestep catch-up). This keeps
+//! the tick *count* correct even when the app updates more slowly than the tick
+//! rate. Evaluation is driven by the [`drive_tick_bangs`] Bevy system rather
+//! than from the node's `ui()` method, so it continues even when the graph tab
+//! is not visible.
+
+use bevy_ecs::prelude::*;
+use bevy_egui::egui;
+use bevy_time::prelude::*;
+use gantz_ca::CaHash;
+use gantz_core::node::{self, ExprCtx, ExprResult, MetaCtx, RegCtx};
+use gantz_core::visit;
+use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
+use steel::SteelVal;
+
+/// The default tick duration in seconds when unconfigured.
+const DEFAULT_DURATION: f64 = 1.0;
+
+/// The smallest tick duration the inspector allows, in seconds.
+const MIN_DURATION: f64 = 0.001;
+
+/// The most ticks a single `tick!` node may fire in one update.
+///
+/// Caps fixed-timestep catch-up so a long stall (e.g. the window was hidden or
+/// a breakpoint paused the app) cannot trigger an unbounded burst of
+/// evaluations - any backlog beyond this many ticks is discarded.
+const MAX_CATCHUP_TICKS: f64 = 64.0;
+
+fn default_duration() -> f64 {
+    DEFAULT_DURATION
+}
+
+// ---------------------------------------------------------------------------
+// TickBang node
+// ---------------------------------------------------------------------------
+
+/// A self-driven node that fires once per `duration` seconds.
+///
+/// Outputs the tick duration in seconds as `f64` on each tick. The driver fires
+/// it once for every whole `duration` elapsed since the last update, so the
+/// tick *count* stays correct even when updates are slower than the tick rate.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TickBang {
+    #[serde(default = "default_duration")]
+    duration: f64,
+}
+
+impl TickBang {
+    /// The tick interval in seconds.
+    pub fn duration(&self) -> f64 {
+        self.duration
+    }
+
+    /// Set the tick interval in seconds (content-address affecting).
+    pub fn set_duration(&mut self, duration: f64) {
+        self.duration = duration;
+    }
+}
+
+impl Default for TickBang {
+    fn default() -> Self {
+        TickBang {
+            duration: DEFAULT_DURATION,
+        }
+    }
+}
+
+impl PartialEq for TickBang {
+    fn eq(&self, other: &Self) -> bool {
+        self.duration.to_bits() == other.duration.to_bits()
+    }
+}
+
+impl Eq for TickBang {}
+
+impl Hash for TickBang {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Fully qualified to disambiguate from `gantz_ca::CaHash::hash`.
+        Hash::hash(&self.duration.to_bits(), state);
+    }
+}
+
+impl CaHash for TickBang {
+    fn hash(&self, hasher: &mut gantz_ca::Hasher) {
+        hasher.update("gantz.tick!".as_bytes());
+        // The duration is part of the node's identity: editing it gives the
+        // node a new address, which is how the commit-on-change model persists
+        // it (the working graph is only saved when it commits).
+        CaHash::hash(&self.duration.to_bits(), hasher);
+    }
+}
+
+impl gantz_core::Node for TickBang {
+    fn n_outputs(&self, _ctx: MetaCtx) -> usize {
+        1
+    }
+
+    fn stateful(&self, _ctx: MetaCtx) -> bool {
+        true
+    }
+
+    fn expr(&self, _ctx: ExprCtx<'_, '_>) -> ExprResult {
+        // The per-tick output is the (constant) tick duration. The time
+        // accumulator also lives in this node's state but is owned entirely by
+        // `drive_tick_bangs`; eval reads `state` and writes it back untouched.
+        // `{:?}` formats the float with a guaranteed `.`/exponent so Steel
+        // parses it as a number rather than an integer.
+        node::parse_expr(&format!("(begin {:?})", self.duration))
+    }
+
+    fn register(&self, mut ctx: RegCtx<'_, '_>) {
+        let path = ctx.path();
+        node::state::init_value_if_absent(ctx.vm(), path, || SteelVal::NumV(0.0)).unwrap()
+    }
+}
+
+impl gantz_egui::NodeUi for TickBang {
+    fn name(&self, _: &dyn gantz_egui::Registry) -> &str {
+        "tick!"
+    }
+
+    fn description(&self) -> Option<&'static str> {
+        Some(
+            "Self-driven clock that fires once per configurable tick duration. \
+             Fires once for every whole duration elapsed since the last update, so \
+             the tick count stays correct even when the app updates slower than the \
+             tick rate. Outputs the tick duration in seconds.",
+        )
+    }
+
+    fn ui(
+        &mut self,
+        _ctx: gantz_egui::NodeCtx,
+        uictx: egui_graph::NodeCtx,
+    ) -> gantz_egui::NodeUiResponse {
+        let framed =
+            uictx.framed(|ui, _sockets| ui.add(egui::Label::new("tick!").selectable(false)));
+        gantz_egui::NodeUiResponse::new(framed)
+    }
+
+    fn inspector_rows(
+        &mut self,
+        _ctx: &mut gantz_egui::NodeCtx,
+        body: &mut egui_extras::TableBody,
+    ) -> gantz_egui::InspectorRowsResponse {
+        let row_h = gantz_egui::widget::node_inspector::table_row_h(body.ui_mut());
+        let mut changed = false;
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("dur.")
+                    .on_hover_text("tick duration: seconds between ticks");
+            });
+            row.col(|ui| {
+                let mut dur = self.duration();
+                let resp = ui.add(
+                    egui::DragValue::new(&mut dur)
+                        .speed(0.01)
+                        .range(MIN_DURATION..=f64::INFINITY)
+                        .suffix(" s"),
+                );
+                if resp.changed() {
+                    self.set_duration(dur.max(MIN_DURATION));
+                    changed = true;
+                }
+            });
+        });
+        let mut resp = gantz_egui::InspectorRowsResponse::default();
+        if changed {
+            resp.mark_changed();
+        }
+        resp
+    }
+
+    fn socket_doc(
+        &self,
+        _: &dyn gantz_egui::Registry,
+        kind: gantz_egui::SocketKind,
+        _ix: usize,
+    ) -> Option<gantz_egui::SocketDoc> {
+        match kind {
+            gantz_egui::SocketKind::Output => Some(
+                gantz_egui::SocketDoc::ty("number")
+                    .with_description("tick duration in seconds; emitted once per elapsed tick"),
+            ),
+            gantz_egui::SocketKind::Input => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ToTickBang trait
+// ---------------------------------------------------------------------------
+
+/// Trait for types that may contain a [`TickBang`] node.
+///
+/// Implement this for your top-level node wrapper so that the
+/// [`drive_tick_bangs`] system can discover `tick!` nodes.
+pub trait ToTickBang {
+    fn to_tick_bang(&self) -> Option<&TickBang>;
+}
+
+impl ToTickBang for TickBang {
+    fn to_tick_bang(&self) -> Option<&TickBang> {
+        Some(self)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TickBangCollector
+// ---------------------------------------------------------------------------
+
+/// Collects the path and configured duration of every [`TickBang`] node found
+/// during graph traversal.
+struct TickBangCollector {
+    pub ticks: Vec<(Vec<usize>, f64)>,
+}
+
+impl<N: ToTickBang> visit::TypedVisitor<N> for TickBangCollector {
+    fn visit_pre(&mut self, ctx: visit::Ctx<'_, '_>, node: &N) {
+        if let Some(tick) = node.to_tick_bang() {
+            self.ticks.push((ctx.path().to_vec(), tick.duration()));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entrypoints
+// ---------------------------------------------------------------------------
+
+/// Return one push entrypoint per `TickBang` node in the graph.
+///
+/// Unlike `update!` - whose nodes all fire together every update and so share a
+/// single multi-source entrypoint - `tick!` nodes fire independently (each on
+/// its own duration), so each gets its own single-source entrypoint that the
+/// [`drive_tick_bangs`] driver can trigger the right number of times.
+pub fn entrypoints<N>(
+    get_node: node::GetNode<'_>,
+    graph: &gantz_core::node::graph::Graph<N>,
+) -> Vec<gantz_core::compile::Entrypoint>
+where
+    N: gantz_core::Node + ToTickBang,
+{
+    let mut collector = TickBangCollector { ticks: vec![] };
+    gantz_core::graph::visit_typed(get_node, graph, &[], &mut collector);
+    collector
+        .ticks
+        .into_iter()
+        .map(|(path, _dur)| {
+            let source = gantz_core::compile::entrypoint::push_source(path, 1);
+            gantz_core::compile::entrypoint::from_sources([source])
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Bevy system
+// ---------------------------------------------------------------------------
+
+/// Drives `tick!` nodes every update, independent of GUI visibility.
+///
+/// For each open head and each `tick!` node, advances the node's time
+/// accumulator by the update delta time and triggers one push evaluation for
+/// every whole tick duration elapsed (capped by [`MAX_CATCHUP_TICKS`]).
+pub fn drive_tick_bangs<N>(
+    time: Res<Time>,
+    registry: Res<crate::Registry<N>>,
+    builtins: Res<bevy_gantz::BuiltinNodes<N>>,
+    demos: Res<crate::Demos>,
+    mut vms: NonSendMut<bevy_gantz::head::HeadVms>,
+    heads: Query<(Entity, &bevy_gantz::head::WorkingGraph<N>), With<bevy_gantz::head::OpenHead>>,
+    mut cmds: Commands,
+) where
+    N: gantz_core::Node + ToTickBang + Send + Sync,
+{
+    let dt = time.delta_secs_f64();
+
+    for (entity, wg) in heads.iter() {
+        let node_reg = crate::registry_ref(&registry, &builtins, &demos);
+        let get_node = |ca: &gantz_ca::ContentAddr| node_reg.node(ca);
+
+        // Collect all TickBang paths + durations.
+        let mut collector = TickBangCollector { ticks: vec![] };
+        gantz_core::graph::visit_typed(&get_node, &**wg, &[], &mut collector);
+
+        if collector.ticks.is_empty() {
+            continue;
+        }
+
+        let Some(vm) = vms.get_mut(&entity) else {
+            continue;
+        };
+
+        for (path, dur) in &collector.ticks {
+            // Defensive: the inspector clamps to `MIN_DURATION`, but never
+            // divide by a non-positive duration.
+            if !(*dur > 0.0) {
+                continue;
+            }
+
+            // Advance this node's accumulator and count whole ticks elapsed,
+            // capping catch-up so a long stall can't burst.
+            let mut acc = node::state::extract::<f64>(vm, path)
+                .ok()
+                .flatten()
+                .unwrap_or(0.0);
+            acc += dt;
+            let full = (acc / dur).floor();
+            let n = full.min(MAX_CATCHUP_TICKS) as u32;
+            // Subtract the full elapsed so the remainder is < dur; any backlog
+            // beyond the cap is dropped rather than carried forward.
+            acc -= full * dur;
+            if let Err(e) = node::state::update_value(vm, path, SteelVal::NumV(acc)) {
+                bevy_log::error!("tick! state update failed: {e}");
+            }
+
+            // Trigger one eval per elapsed tick.
+            for _ in 0..n {
+                let source = gantz_core::compile::entrypoint::push_source(path.clone(), 1);
+                let entrypoint = gantz_core::compile::entrypoint::from_sources([source]);
+                cmds.trigger(bevy_gantz::vm::EvalEntryEvent {
+                    head: entity,
+                    entrypoint,
+                });
+            }
+        }
+    }
+}

--- a/crates/bevy_gantz_egui/src/node/tick_bang.rs
+++ b/crates/bevy_gantz_egui/src/node/tick_bang.rs
@@ -14,6 +14,7 @@ use bevy_time::prelude::*;
 use gantz_ca::CaHash;
 use gantz_core::node::{self, ExprCtx, ExprResult, MetaCtx, RegCtx};
 use gantz_core::visit;
+use gantz_egui::widget::node_inspector::radio_option;
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 use steel::SteelVal;
@@ -24,6 +25,9 @@ const DEFAULT_DURATION: f64 = 1.0;
 /// The smallest tick duration the inspector allows, in seconds.
 const MIN_DURATION: f64 = 0.001;
 
+/// The smallest tick rate the inspector allows, in Hz.
+const MIN_RATE: f64 = 0.001;
+
 /// The most ticks a single `tick!` node may fire in one update.
 ///
 /// Caps fixed-timestep catch-up so a long stall (e.g. the window was hidden or
@@ -31,67 +35,125 @@ const MIN_DURATION: f64 = 0.001;
 /// evaluations - any backlog beyond this many ticks is discarded.
 const MAX_CATCHUP_TICKS: f64 = 64.0;
 
-fn default_duration() -> f64 {
-    DEFAULT_DURATION
-}
-
 // ---------------------------------------------------------------------------
 // TickBang node
 // ---------------------------------------------------------------------------
 
-/// A self-driven node that fires once per `duration` seconds.
+/// How a [`TickBang`]'s tick interval is specified.
 ///
-/// Outputs the tick duration in seconds as `f64` on each tick. The driver fires
-/// it once for every whole `duration` elapsed since the last update, so the
+/// Stored in the user's chosen unit so it round-trips exactly - deriving Hz
+/// from a stored duration (or vice versa) would accumulate float error across
+/// edits.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub enum Interval {
+    /// A duration in seconds between ticks.
+    Duration(f64),
+    /// A rate in Hz (ticks per second).
+    Rate(f64),
+}
+
+impl Interval {
+    /// The effective tick duration in seconds.
+    pub fn duration(self) -> f64 {
+        match self {
+            Interval::Duration(secs) => secs,
+            Interval::Rate(hz) => 1.0 / hz,
+        }
+    }
+
+    /// Whether the interval is specified as a rate (Hz) rather than a duration.
+    pub fn is_rate(self) -> bool {
+        matches!(self, Interval::Rate(_))
+    }
+}
+
+impl Default for Interval {
+    fn default() -> Self {
+        Interval::Duration(DEFAULT_DURATION)
+    }
+}
+
+impl PartialEq for Interval {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Interval::Duration(a), Interval::Duration(b)) => a.to_bits() == b.to_bits(),
+            (Interval::Rate(a), Interval::Rate(b)) => a.to_bits() == b.to_bits(),
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Interval {}
+
+impl Hash for Interval {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Fully qualified to disambiguate from `gantz_ca::CaHash::hash`.
+        match self {
+            Interval::Duration(secs) => {
+                Hash::hash(&0u8, state);
+                Hash::hash(&secs.to_bits(), state);
+            }
+            Interval::Rate(hz) => {
+                Hash::hash(&1u8, state);
+                Hash::hash(&hz.to_bits(), state);
+            }
+        }
+    }
+}
+
+/// A self-driven node that fires once per configurable tick interval.
+///
+/// The interval is set either as a duration (seconds) or a rate (Hz). Outputs
+/// the effective tick duration in seconds as `f64` on each tick. The driver
+/// fires it once for every whole interval elapsed since the last update, so the
 /// tick *count* stays correct even when updates are slower than the tick rate.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TickBang {
-    #[serde(default = "default_duration")]
-    duration: f64,
+    #[serde(default)]
+    interval: Interval,
 }
 
 impl TickBang {
-    /// The tick interval in seconds.
-    pub fn duration(&self) -> f64 {
-        self.duration
+    /// How the tick interval is specified (a duration in seconds or rate in Hz).
+    pub fn interval(&self) -> Interval {
+        self.interval
     }
 
-    /// Set the tick interval in seconds (content-address affecting).
-    pub fn set_duration(&mut self, duration: f64) {
-        self.duration = duration;
+    /// Set how the tick interval is specified (content-address affecting).
+    pub fn set_interval(&mut self, interval: Interval) {
+        self.interval = interval;
+    }
+
+    /// The effective tick duration in seconds.
+    pub fn duration(&self) -> f64 {
+        self.interval.duration()
     }
 }
 
 impl Default for TickBang {
     fn default() -> Self {
         TickBang {
-            duration: DEFAULT_DURATION,
+            interval: Interval::default(),
         }
-    }
-}
-
-impl PartialEq for TickBang {
-    fn eq(&self, other: &Self) -> bool {
-        self.duration.to_bits() == other.duration.to_bits()
-    }
-}
-
-impl Eq for TickBang {}
-
-impl Hash for TickBang {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        // Fully qualified to disambiguate from `gantz_ca::CaHash::hash`.
-        Hash::hash(&self.duration.to_bits(), state);
     }
 }
 
 impl CaHash for TickBang {
     fn hash(&self, hasher: &mut gantz_ca::Hasher) {
         hasher.update("gantz.tick!".as_bytes());
-        // The duration is part of the node's identity: editing it gives the
-        // node a new address, which is how the commit-on-change model persists
-        // it (the working graph is only saved when it commits).
-        CaHash::hash(&self.duration.to_bits(), hasher);
+        // The interval - and the unit it's specified in - is part of the node's
+        // identity: editing it gives the node a new address, which is how the
+        // commit-on-change model persists it (only committed graphs are saved).
+        match self.interval {
+            Interval::Duration(secs) => {
+                hasher.update(b"duration");
+                CaHash::hash(&secs.to_bits(), hasher);
+            }
+            Interval::Rate(hz) => {
+                hasher.update(b"rate");
+                CaHash::hash(&hz.to_bits(), hasher);
+            }
+        }
     }
 }
 
@@ -110,7 +172,7 @@ impl gantz_core::Node for TickBang {
         // `drive_tick_bangs`; eval reads `state` and writes it back untouched.
         // `{:?}` formats the float with a guaranteed `.`/exponent so Steel
         // parses it as a number rather than an integer.
-        node::parse_expr(&format!("(begin {:?})", self.duration))
+        node::parse_expr(&format!("(begin {:?})", self.duration()))
     }
 
     fn register(&self, mut ctx: RegCtx<'_, '_>) {
@@ -126,10 +188,11 @@ impl gantz_egui::NodeUi for TickBang {
 
     fn description(&self) -> Option<&'static str> {
         Some(
-            "Self-driven clock that fires once per configurable tick duration. \
-             Fires once for every whole duration elapsed since the last update, so \
-             the tick count stays correct even when the app updates slower than the \
-             tick rate. Outputs the tick duration in seconds.",
+            "Self-driven clock that fires once per configurable tick interval, set \
+             as a duration (seconds) or a rate (Hz). Fires once for every whole \
+             interval elapsed since the last update, so the tick count stays \
+             correct even when the app updates slower than the tick rate. Outputs \
+             the tick duration in seconds.",
         )
     }
 
@@ -150,25 +213,74 @@ impl gantz_egui::NodeUi for TickBang {
     ) -> gantz_egui::InspectorRowsResponse {
         let row_h = gantz_egui::widget::node_inspector::table_row_h(body.ui_mut());
         let mut changed = false;
+
+        // Mode row: specify the interval as a duration (seconds) or rate (Hz).
         body.row(row_h, |mut row| {
             row.col(|ui| {
-                ui.label("dur.")
-                    .on_hover_text("tick duration: seconds between ticks");
+                ui.label("mode").on_hover_text(
+                    "specify the tick interval as a duration (seconds) or a rate (Hz)",
+                );
             });
             row.col(|ui| {
-                let mut dur = self.duration();
-                let resp = ui.add(
-                    egui::DragValue::new(&mut dur)
-                        .speed(0.01)
-                        .range(MIN_DURATION..=f64::INFINITY)
-                        .suffix(" s"),
-                );
-                if resp.changed() {
-                    self.set_duration(dur.max(MIN_DURATION));
+                let mut rate = self.interval.is_rate();
+                let mut switched = false;
+                ui.horizontal(|ui| {
+                    switched |= radio_option(ui, &mut rate, false, "dur.", "seconds between ticks");
+                    switched |= radio_option(ui, &mut rate, true, "rate", "ticks per second (Hz)");
+                });
+                if switched {
+                    // Toggle units while preserving the effective tick duration.
+                    let dur = self.duration();
+                    self.interval = if rate {
+                        Interval::Rate(1.0 / dur)
+                    } else {
+                        Interval::Duration(dur)
+                    };
                     changed = true;
                 }
             });
         });
+
+        // Value row: the duration (seconds) or rate (Hz), in the chosen unit.
+        body.row(row_h, |mut row| {
+            let is_rate = self.interval.is_rate();
+            row.col(|ui| {
+                if is_rate {
+                    ui.label("rate").on_hover_text("ticks per second (Hz)");
+                } else {
+                    ui.label("dur.").on_hover_text("seconds between ticks");
+                }
+            });
+            row.col(|ui| match &mut self.interval {
+                Interval::Duration(secs) => {
+                    let mut v = *secs;
+                    let resp = ui.add(
+                        egui::DragValue::new(&mut v)
+                            .speed(0.01)
+                            .range(MIN_DURATION..=f64::INFINITY)
+                            .suffix(" s"),
+                    );
+                    if resp.changed() {
+                        *secs = v.max(MIN_DURATION);
+                        changed = true;
+                    }
+                }
+                Interval::Rate(hz) => {
+                    let mut v = *hz;
+                    let resp = ui.add(
+                        egui::DragValue::new(&mut v)
+                            .speed(0.1)
+                            .range(MIN_RATE..=f64::INFINITY)
+                            .suffix(" Hz"),
+                    );
+                    if resp.changed() {
+                        *hz = v.max(MIN_RATE);
+                        changed = true;
+                    }
+                }
+            });
+        });
+
         let mut resp = gantz_egui::InspectorRowsResponse::default();
         if changed {
             resp.mark_changed();
@@ -265,7 +377,7 @@ where
 ///
 /// For each open head and each `tick!` node, advances the node's time
 /// accumulator by the update delta time and triggers one push evaluation for
-/// every whole tick duration elapsed (capped by [`MAX_CATCHUP_TICKS`]).
+/// every whole tick duration elapsed (capped by `MAX_CATCHUP_TICKS`).
 pub fn drive_tick_bangs<N>(
     time: Res<Time>,
     registry: Res<crate::Registry<N>>,

--- a/crates/bevy_gantz_egui/src/node/update_bang.rs
+++ b/crates/bevy_gantz_egui/src/node/update_bang.rs
@@ -1,9 +1,13 @@
-//! A node that triggers push evaluation every frame, outputting delta time.
+//! A node that triggers push evaluation every update, outputting delta time.
 //!
-//! All `FrameBang` nodes in a graph are combined into a single multi-source
+//! All `UpdateBang` nodes in a graph are combined into a single multi-source
 //! entrypoint via [`entrypoints()`]. Evaluation is driven by the
-//! [`drive_frame_bangs`] Bevy system rather than from the node's `ui()` method,
+//! [`drive_update_bangs`] Bevy system rather than from the node's `ui()` method,
 //! so it continues even when the graph tab is not visible.
+//!
+//! Note this bangs once per *update*, not once per rendered frame. Under
+//! presentation modes like Mailbox, updates can occur more frequently than
+//! frames are presented.
 
 use bevy_ecs::prelude::*;
 use bevy_egui::egui;
@@ -15,16 +19,19 @@ use serde::{Deserialize, Serialize};
 use steel::SteelVal;
 
 // ---------------------------------------------------------------------------
-// FrameBang node
+// UpdateBang node
 // ---------------------------------------------------------------------------
 
-/// A node that drives continuous evaluation every frame.
-/// Outputs the frame's delta time in seconds as `f64`.
+/// A node that drives continuous evaluation every update.
+///
+/// Outputs the update's delta time in seconds as `f64`. This fires once per
+/// *update*, which may be more frequent than rendered frames under presentation
+/// modes like Mailbox.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Deserialize, Serialize, CaHash)]
-#[cahash("gantz.frame!")]
-pub struct FrameBang;
+#[cahash("gantz.update!")]
+pub struct UpdateBang;
 
-impl gantz_core::Node for FrameBang {
+impl gantz_core::Node for UpdateBang {
     fn n_outputs(&self, _ctx: MetaCtx) -> usize {
         1
     }
@@ -43,9 +50,17 @@ impl gantz_core::Node for FrameBang {
     }
 }
 
-impl gantz_egui::NodeUi for FrameBang {
+impl gantz_egui::NodeUi for UpdateBang {
     fn name(&self, _: &dyn gantz_egui::Registry) -> &str {
-        "frame!"
+        "update!"
+    }
+
+    fn description(&self) -> Option<&'static str> {
+        Some(
+            "Drives continuous evaluation, banging once per update with the update \
+             delta time in seconds. Updates can fire more frequently than rendered \
+             frames under presentation modes like Mailbox.",
+        )
     }
 
     fn ui(
@@ -54,7 +69,7 @@ impl gantz_egui::NodeUi for FrameBang {
         uictx: egui_graph::NodeCtx,
     ) -> gantz_egui::NodeUiResponse {
         let framed =
-            uictx.framed(|ui, _sockets| ui.add(egui::Label::new("frame!").selectable(false)));
+            uictx.framed(|ui, _sockets| ui.add(egui::Label::new("update!").selectable(false)));
         gantz_egui::NodeUiResponse::new(framed)
     }
 
@@ -67,7 +82,7 @@ impl gantz_egui::NodeUi for FrameBang {
         match kind {
             gantz_egui::SocketKind::Output => Some(
                 gantz_egui::SocketDoc::ty("number")
-                    .with_description("frame delta time in seconds; emitted every frame"),
+                    .with_description("update delta time in seconds; emitted every update"),
             ),
             gantz_egui::SocketKind::Input => None,
         }
@@ -75,35 +90,35 @@ impl gantz_egui::NodeUi for FrameBang {
 }
 
 // ---------------------------------------------------------------------------
-// ToFrameBang trait
+// ToUpdateBang trait
 // ---------------------------------------------------------------------------
 
-/// Trait for types that may contain a [`FrameBang`] node.
+/// Trait for types that may contain an [`UpdateBang`] node.
 ///
 /// Implement this for your top-level node wrapper so that the
-/// [`drive_frame_bangs`] system can discover `frame!` nodes.
-pub trait ToFrameBang {
-    fn to_frame_bang(&self) -> Option<&FrameBang>;
+/// [`drive_update_bangs`] system can discover `update!` nodes.
+pub trait ToUpdateBang {
+    fn to_update_bang(&self) -> Option<&UpdateBang>;
 }
 
-impl ToFrameBang for FrameBang {
-    fn to_frame_bang(&self) -> Option<&FrameBang> {
+impl ToUpdateBang for UpdateBang {
+    fn to_update_bang(&self) -> Option<&UpdateBang> {
         Some(self)
     }
 }
 
 // ---------------------------------------------------------------------------
-// FrameBangCollector
+// UpdateBangCollector
 // ---------------------------------------------------------------------------
 
-/// Collects paths to all [`FrameBang`] nodes found during graph traversal.
-struct FrameBangCollector {
+/// Collects paths to all [`UpdateBang`] nodes found during graph traversal.
+struct UpdateBangCollector {
     pub paths: Vec<Vec<usize>>,
 }
 
-impl<N: ToFrameBang> visit::TypedVisitor<N> for FrameBangCollector {
+impl<N: ToUpdateBang> visit::TypedVisitor<N> for UpdateBangCollector {
     fn visit_pre(&mut self, ctx: visit::Ctx<'_, '_>, node: &N) {
-        if node.to_frame_bang().is_some() {
+        if node.to_update_bang().is_some() {
             self.paths.push(ctx.path().to_vec());
         }
     }
@@ -113,18 +128,18 @@ impl<N: ToFrameBang> visit::TypedVisitor<N> for FrameBangCollector {
 // Entrypoints
 // ---------------------------------------------------------------------------
 
-/// Collect all `FrameBang` nodes in the graph and return a single multi-source
+/// Collect all `UpdateBang` nodes in the graph and return a single multi-source
 /// entrypoint covering all of them.
 ///
-/// Returns an empty vec if no `FrameBang` nodes are found.
+/// Returns an empty vec if no `UpdateBang` nodes are found.
 pub fn entrypoints<N>(
     get_node: node::GetNode<'_>,
     graph: &gantz_core::node::graph::Graph<N>,
 ) -> Vec<gantz_core::compile::Entrypoint>
 where
-    N: gantz_core::Node + ToFrameBang,
+    N: gantz_core::Node + ToUpdateBang,
 {
-    let mut collector = FrameBangCollector { paths: vec![] };
+    let mut collector = UpdateBangCollector { paths: vec![] };
     gantz_core::graph::visit_typed(get_node, graph, &[], &mut collector);
     if collector.paths.is_empty() {
         return vec![];
@@ -140,12 +155,12 @@ where
 // Bevy system
 // ---------------------------------------------------------------------------
 
-/// Drives `frame!` nodes every frame, independent of GUI visibility.
+/// Drives `update!` nodes every update, independent of GUI visibility.
 ///
-/// For each open head, traverses the working graph to find all `FrameBang`
-/// nodes, updates their state to the current frame delta time, and triggers
+/// For each open head, traverses the working graph to find all `UpdateBang`
+/// nodes, updates their state to the current update delta time, and triggers
 /// a single push evaluation for all of them.
-pub fn drive_frame_bangs<N>(
+pub fn drive_update_bangs<N>(
     time: Res<Time>,
     registry: Res<crate::Registry<N>>,
     builtins: Res<bevy_gantz::BuiltinNodes<N>>,
@@ -154,7 +169,7 @@ pub fn drive_frame_bangs<N>(
     heads: Query<(Entity, &bevy_gantz::head::WorkingGraph<N>), With<bevy_gantz::head::OpenHead>>,
     mut cmds: Commands,
 ) where
-    N: gantz_core::Node + ToFrameBang + Send + Sync,
+    N: gantz_core::Node + ToUpdateBang + Send + Sync,
 {
     let dt = time.delta_secs_f64();
 
@@ -162,25 +177,25 @@ pub fn drive_frame_bangs<N>(
         let node_reg = crate::registry_ref(&registry, &builtins, &demos);
         let get_node = |ca: &gantz_ca::ContentAddr| node_reg.node(ca);
 
-        // Collect all FrameBang paths.
-        let mut collector = FrameBangCollector { paths: vec![] };
+        // Collect all UpdateBang paths.
+        let mut collector = UpdateBangCollector { paths: vec![] };
         gantz_core::graph::visit_typed(&get_node, &**wg, &[], &mut collector);
 
         if collector.paths.is_empty() {
             continue;
         }
 
-        // Update state for each FrameBang.
+        // Update state for each UpdateBang.
         let Some(vm) = vms.get_mut(&entity) else {
             continue;
         };
         for path in &collector.paths {
             if let Err(e) = node::state::update_value(vm, path, SteelVal::NumV(dt)) {
-                bevy_log::error!("frame! state update failed: {e}");
+                bevy_log::error!("update! state update failed: {e}");
             }
         }
 
-        // Trigger a single eval for all FrameBangs combined.
+        // Trigger a single eval for all UpdateBangs combined.
         let sources = collector
             .paths
             .into_iter()

--- a/crates/gantz/src/builtin.rs
+++ b/crates/gantz/src/builtin.rs
@@ -99,6 +99,9 @@ fn primitives() -> Primitives {
     register_primitive(&mut p, "update!", || {
         Box::new(bevy_gantz_egui::node::UpdateBang) as Box<_>
     });
+    register_primitive(&mut p, "tick!", || {
+        Box::new(bevy_gantz_egui::node::TickBang::default()) as Box<_>
+    });
     register_primitive(&mut p, "expr", || {
         Box::new(gantz_core::node::Expr::new("()").unwrap()) as Box<_>
     });

--- a/crates/gantz/src/builtin.rs
+++ b/crates/gantz/src/builtin.rs
@@ -96,8 +96,8 @@ fn primitives() -> Primitives {
     register_primitive(&mut p, "delay", || {
         Box::new(gantz_core::node::Delay::default()) as Box<_>
     });
-    register_primitive(&mut p, "frame!", || {
-        Box::new(bevy_gantz_egui::node::FrameBang) as Box<_>
+    register_primitive(&mut p, "update!", || {
+        Box::new(bevy_gantz_egui::node::UpdateBang) as Box<_>
     });
     register_primitive(&mut p, "expr", || {
         Box::new(gantz_core::node::Expr::new("()").unwrap()) as Box<_>

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -44,6 +44,8 @@ impl Node for gantz_egui::node::Comment {}
 #[typetag::serde]
 impl Node for bevy_gantz_egui::node::UpdateBang {}
 #[typetag::serde]
+impl Node for bevy_gantz_egui::node::TickBang {}
+#[typetag::serde]
 impl Node for gantz_egui::node::Inspect {}
 #[typetag::serde]
 impl Node for gantz_egui::node::Plot {}
@@ -70,6 +72,13 @@ impl gantz_egui::sync::AsNamedRef for Box<dyn Node> {
 
 impl bevy_gantz_egui::node::ToUpdateBang for Box<dyn Node> {
     fn to_update_bang(&self) -> Option<&bevy_gantz_egui::node::UpdateBang> {
+        let any: &dyn std::any::Any = &**self;
+        any.downcast_ref()
+    }
+}
+
+impl bevy_gantz_egui::node::ToTickBang for Box<dyn Node> {
+    fn to_tick_bang(&self) -> Option<&bevy_gantz_egui::node::TickBang> {
         let any: &dyn std::any::Any = &**self;
         any.downcast_ref()
     }
@@ -120,6 +129,7 @@ mod tests {
             node_datum("Bang", vec![]),
             node_datum("Inspect", vec![]),
             node_datum("UpdateBang", vec![]),
+            node_datum("TickBang", vec![("duration", Datum::F64(0.5))]),
             node_datum("Number", vec![]),
             node_datum("Expr", vec![("src", Datum::Str("(* $l $r)".into()))]),
             node_datum(
@@ -359,6 +369,53 @@ mod tests {
         let out = gantz_egui::format::to_string(&export).expect("to_string");
         steel::parser::parser::Parser::parse(&out)
             .unwrap_or_else(|e| panic!("output is not valid Steel: {e}\n--- output ---\n{out}"));
+    }
+
+    /// A `tick!` node compiles to valid, runnable Steel. `base.gantz` doesn't use
+    /// `tick!`, so this is the only coverage of its constant-duration expr, its
+    /// stateful accumulator slot, and the per-node push entrypoint registered by
+    /// `tick_bang::entrypoints` (which `push_pull_entrypoints` does NOT discover,
+    /// since `tick!` is driven externally rather than via `Node::push_eval`).
+    #[test]
+    fn tick_node_compiles() {
+        use std::time::Duration;
+        type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
+
+        let text = "\
+(graph g
+  (t (tick-bang #:duration 0.5))
+  (l (log warn))
+  (-> t (l 0)))";
+        let export: gantz_egui::export::Export<G> =
+            gantz_egui::format::from_str(text, Duration::from_secs(0)).expect("from_str");
+        let head = gantz_ca::Head::Branch("g".into());
+        let graph = export.registry.head_graph(&head).expect("g graph");
+
+        let builtins = crate::builtin::Builtins::new();
+        let reg_ref = gantz_egui::RegistryRef::new(&export.registry, &builtins, &export.demos);
+        let get_node = |ca: &gantz_ca::ContentAddr| reg_ref.node(ca);
+
+        let entrypoints = bevy_gantz_egui::node::tick_bang::entrypoints(&get_node, graph);
+        assert_eq!(
+            entrypoints.len(),
+            1,
+            "tick! must register exactly one push entrypoint",
+        );
+
+        for config in [
+            gantz_core::compile::Config::default(),
+            gantz_core::compile::Config {
+                validate_ir: true,
+                emit_all_node_fns: true,
+            },
+        ] {
+            gantz_core::vm::init(&get_node, graph, &entrypoints, &config).unwrap_or_else(|e| {
+                panic!(
+                    "tick! graph failed to compile:\n{}",
+                    gantz_core::vm::error_chain(&e),
+                )
+            });
+        }
     }
 
     /// Importing a commit whose parent is not present in the file records that

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -129,7 +129,20 @@ mod tests {
             node_datum("Bang", vec![]),
             node_datum("Inspect", vec![]),
             node_datum("UpdateBang", vec![]),
-            node_datum("TickBang", vec![("duration", Datum::F64(0.5))]),
+            node_datum(
+                "TickBang",
+                vec![(
+                    "interval",
+                    Datum::Map(vec![("Duration".to_string(), Datum::F64(0.5))]),
+                )],
+            ),
+            node_datum(
+                "TickBang",
+                vec![(
+                    "interval",
+                    Datum::Map(vec![("Rate".to_string(), Datum::F64(60.0))]),
+                )],
+            ),
             node_datum("Number", vec![]),
             node_datum("Expr", vec![("src", Datum::Str("(* $l $r)".into()))]),
             node_datum(
@@ -383,7 +396,7 @@ mod tests {
 
         let text = "\
 (graph g
-  (t (tick-bang #:duration 0.5))
+  (t (tick-bang #:rate 2))
   (l (log warn))
   (-> t (l 0)))";
         let export: gantz_egui::export::Export<G> =

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -42,7 +42,7 @@ impl Node for gantz_egui::node::NamedRef {}
 #[typetag::serde]
 impl Node for gantz_egui::node::Comment {}
 #[typetag::serde]
-impl Node for bevy_gantz_egui::node::FrameBang {}
+impl Node for bevy_gantz_egui::node::UpdateBang {}
 #[typetag::serde]
 impl Node for gantz_egui::node::Inspect {}
 #[typetag::serde]
@@ -68,8 +68,8 @@ impl gantz_egui::sync::AsNamedRef for Box<dyn Node> {
     }
 }
 
-impl bevy_gantz_egui::node::ToFrameBang for Box<dyn Node> {
-    fn to_frame_bang(&self) -> Option<&bevy_gantz_egui::node::FrameBang> {
+impl bevy_gantz_egui::node::ToUpdateBang for Box<dyn Node> {
+    fn to_update_bang(&self) -> Option<&bevy_gantz_egui::node::UpdateBang> {
         let any: &dyn std::any::Any = &**self;
         any.downcast_ref()
     }
@@ -119,7 +119,7 @@ mod tests {
             node_datum("Identity", vec![]),
             node_datum("Bang", vec![]),
             node_datum("Inspect", vec![]),
-            node_datum("FrameBang", vec![]),
+            node_datum("UpdateBang", vec![]),
             node_datum("Number", vec![]),
             node_datum("Expr", vec![("src", Datum::Str("(* $l $r)".into()))]),
             node_datum(

--- a/crates/gantz_core/tests/nested.rs
+++ b/crates/gantz_core/tests/nested.rs
@@ -761,7 +761,7 @@ fn test_graph_nested_push_through_outlet_deep() {
 }
 
 // Test that `push_pull_entrypoints` discovers push eval nodes inside nested
-// graphs. This mirrors the real-world scenario of a FrameBang node inside a
+// graphs. This mirrors the real-world scenario of a UpdateBang node inside a
 // nested graph placed in a top-level graph via NamedRef.
 //
 // INNER GRAPH:
@@ -844,7 +844,7 @@ fn test_push_pull_entrypoints_discovers_nested_push() {
 // propagate through their outlets to the parent graph.
 //
 // This mirrors the scenario of two NamedRef "deltams" nodes in a top-level
-// graph, where both contain a FrameBang and are combined into a single
+// graph, where both contain a UpdateBang and are combined into a single
 // multi-source entrypoint.
 //
 // INNER GRAPH (shared by both):
@@ -919,8 +919,8 @@ fn test_graph_nested_multi_source_outlet_propagation() {
 // a direct push source at the root and a nested push source inside a graph
 // node that propagates through an outlet.
 //
-// This mirrors the scenario of a top-level FrameBang + a NamedRef "deltams"
-// (which contains its own FrameBang inside) combined into one entrypoint.
+// This mirrors the scenario of a top-level UpdateBang + a NamedRef "deltams"
+// (which contains its own UpdateBang inside) combined into one entrypoint.
 //
 // INNER GRAPH:
 //    push_inner -> int(10) -> outlet

--- a/crates/gantz_egui/src/node/plot.rs
+++ b/crates/gantz_egui/src/node/plot.rs
@@ -15,6 +15,7 @@
 //! breaking the chain it flows through.
 
 use crate::widget::node_inspector;
+use crate::widget::node_inspector::radio_option;
 use crate::{
     ContextMenuResponse, InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, Registry,
     SocketDoc, SocketKind,
@@ -597,30 +598,6 @@ impl NodeUi for Plot {
 
     fn show_state(&self) -> bool {
         // The raw history is a long list; the inspector summarises it instead.
-        false
-    }
-}
-
-/// Render `text` as a label-styled radio option: dim when unselected, strong
-/// when selected (no fill, like the app's tabs). Returns whether it was just
-/// selected.
-fn radio_option<T: Copy + PartialEq>(
-    ui: &mut egui::Ui,
-    current: &mut T,
-    value: T,
-    text: &str,
-    hover: &str,
-) -> bool {
-    let strong = ui.visuals().strong_text_color();
-    let mut selected = *current == value;
-    let resp = ui
-        .add(crate::widget::LabelToggle::new(text, &mut selected).selected_color(strong))
-        .on_hover_text(hover);
-    // Clicking an already-selected option is a no-op (it stays selected).
-    if resp.changed() && selected {
-        *current = value;
-        true
-    } else {
         false
     }
 }

--- a/crates/gantz_egui/src/widget/node_inspector.rs
+++ b/crates/gantz_egui/src/widget/node_inspector.rs
@@ -89,6 +89,31 @@ pub fn bound_col<T: egui::emath::Numeric>(
     false
 }
 
+/// Render `text` as a label-styled radio option for a mode/style row: dim when
+/// unselected, strong when selected (no fill, like the app's tabs). Lay several
+/// out in a `ui.horizontal` to form a selector. Returns whether it was just
+/// selected.
+pub fn radio_option<T: Copy + PartialEq>(
+    ui: &mut egui::Ui,
+    current: &mut T,
+    value: T,
+    text: &str,
+    hover: &str,
+) -> bool {
+    let strong = ui.visuals().strong_text_color();
+    let mut selected = *current == value;
+    let resp = ui
+        .add(crate::widget::LabelToggle::new(text, &mut selected).selected_color(strong))
+        .on_hover_text(hover);
+    // Clicking an already-selected option is a no-op (it stays selected).
+    if resp.changed() && selected {
+        *current = value;
+        true
+    } else {
+        false
+    }
+}
+
 pub fn table(
     node: &mut (impl Node + NodeUi),
     ctx: &mut NodeCtx,

--- a/crates/gantz_format/src/sugar.rs
+++ b/crates/gantz_format/src/sugar.rs
@@ -363,25 +363,55 @@ fn write_comment(node: &Datum) -> String {
     format!("(comment {} {w} {h})", quote(text))
 }
 
-/// Write a `Number` as a bare `number` when all config is default, else as
-/// `(number #:min m #:max m #:precision n #:no-push-eval)` with only the
-/// non-default fields.
+/// Read `(tick-bang [#:duration secs | #:rate hz])` into a `TickBang`'s
+/// `interval` enum field. `#:duration` and `#:rate` are mutually exclusive;
+/// neither given yields the default duration.
 fn tick_bang_spec(args: &[ExprKind], src: &str) -> Result<Datum, FormatError> {
-    let mut fields = Vec::new();
-    if let Some(duration) = keyword_f64(args, "duration", src)? {
-        fields.push(("duration", Datum::F64(duration)));
-    }
+    let duration = keyword_f64(args, "duration", src)?;
+    let rate = keyword_f64(args, "rate", src)?;
+    let fields = match (duration, rate) {
+        (Some(_), Some(_)) => {
+            return Err(FormatError::new(ErrorKind::Malformed(
+                "tick-bang: specify #:duration or #:rate, not both".into(),
+            )));
+        }
+        (Some(secs), None) => vec![("interval", tick_interval_datum("Duration", secs))],
+        (None, Some(hz)) => vec![("interval", tick_interval_datum("Rate", hz))],
+        (None, None) => vec![],
+    };
     Ok(node_datum("TickBang", fields))
 }
 
+/// The `interval` field datum for a `TickBang` `Interval` enum variant
+/// (externally tagged, e.g. `(("Rate" hz))`).
+fn tick_interval_datum(variant: &str, value: f64) -> Datum {
+    Datum::Map(vec![(variant.to_string(), Datum::F64(value))])
+}
+
+/// Write a `TickBang` as a bare `tick-bang` for the default duration, else as
+/// `(tick-bang #:duration secs)` or `(tick-bang #:rate hz)` per its unit.
 fn write_tick_bang(node: &Datum) -> String {
-    // Omit the default duration so a plain `tick!` writes as the bare keyword.
-    match node.get("duration").and_then(Datum::as_f64) {
-        Some(duration) if duration != 1.0 => format!("(tick-bang #:duration {duration})"),
+    match tick_interval(node) {
+        Some(("Rate", hz)) => format!("(tick-bang #:rate {hz})"),
+        Some(("Duration", secs)) if secs != 1.0 => format!("(tick-bang #:duration {secs})"),
         _ => "tick-bang".to_string(),
     }
 }
 
+/// Read a `TickBang`'s `interval` field as `(variant, value)`.
+fn tick_interval(node: &Datum) -> Option<(&str, f64)> {
+    match node.get("interval")? {
+        Datum::Map(entries) => {
+            let (variant, value) = entries.first()?;
+            Some((variant.as_str(), value.as_f64()?))
+        }
+        _ => None,
+    }
+}
+
+/// Write a `Number` as a bare `number` when all config is default, else as
+/// `(number #:min m #:max m #:precision n #:no-push-eval)` with only the
+/// non-default fields.
 fn write_number(node: &Datum) -> String {
     let min = node.get("min").and_then(Datum::as_f64);
     let max = node.get("max").and_then(Datum::as_f64);
@@ -692,16 +722,28 @@ mod tests {
             Some("tick-bang")
         );
 
-        // A custom duration round-trips via the `#:duration` keyword.
+        // A custom duration round-trips via the `#:duration` keyword (seconds).
         let d = read_spec(&s, "(tick-bang #:duration 0.5)").expect("duration");
-        assert_eq!(d.get("duration").and_then(Datum::as_f64), Some(0.5));
         assert_eq!(
             s.write_spec("TickBang", &d).as_deref(),
             Some("(tick-bang #:duration 0.5)"),
         );
 
+        // A rate round-trips via the `#:rate` keyword (Hz), stored exactly.
+        let r = read_spec(&s, "(tick-bang #:rate 60)").expect("rate");
+        assert_eq!(
+            s.write_spec("TickBang", &r).as_deref(),
+            Some("(tick-bang #:rate 60)"),
+        );
+
         // An explicit default duration also writes as the bare keyword.
         let one = read_spec(&s, "(tick-bang #:duration 1)").expect("default duration");
         assert_eq!(s.write_spec("TickBang", &one).as_deref(), Some("tick-bang"));
+
+        // `#:duration` and `#:rate` are mutually exclusive.
+        let text = "(tick-bang #:duration 0.5 #:rate 60)";
+        let exprs = sexpr::read(text).expect("read");
+        let args = sexpr::list_args(&exprs[0]).expect("list");
+        assert!(s.read_spec("tick-bang", &args[1..], text).is_err());
     }
 }

--- a/crates/gantz_format/src/sugar.rs
+++ b/crates/gantz_format/src/sugar.rs
@@ -114,7 +114,7 @@ const KEYWORD_TAG: &[(&str, &str)] = &[
     ("id", "Identity"),
     ("bang", "Bang"),
     ("inspect", "Inspect"),
-    ("frame-bang", "FrameBang"),
+    ("update-bang", "UpdateBang"),
     ("number", "Number"),
     ("log", "Log"),
     ("expr", "Expr"),

--- a/crates/gantz_format/src/sugar.rs
+++ b/crates/gantz_format/src/sugar.rs
@@ -115,6 +115,7 @@ const KEYWORD_TAG: &[(&str, &str)] = &[
     ("bang", "Bang"),
     ("inspect", "Inspect"),
     ("update-bang", "UpdateBang"),
+    ("tick-bang", "TickBang"),
     ("number", "Number"),
     ("log", "Log"),
     ("expr", "Expr"),
@@ -153,6 +154,7 @@ impl Sugar for DefaultSugar {
             "comment" => comment_spec(args, src)?,
             "number" => number_spec(args, src)?,
             "log" => log_spec(args, src)?,
+            "tick-bang" => tick_bang_spec(args, src)?,
             _ => return Ok(None),
         };
         Ok(Some(datum))
@@ -177,6 +179,7 @@ impl Sugar for DefaultSugar {
             "Comment" => Some(write_comment(node)),
             "Number" => Some(write_number(node)),
             "Log" => Some(write_log(node)),
+            "TickBang" => Some(write_tick_bang(node)),
             other => keyword_for_tag(other).map(str::to_string),
         }
     }
@@ -363,6 +366,22 @@ fn write_comment(node: &Datum) -> String {
 /// Write a `Number` as a bare `number` when all config is default, else as
 /// `(number #:min m #:max m #:precision n #:no-push-eval)` with only the
 /// non-default fields.
+fn tick_bang_spec(args: &[ExprKind], src: &str) -> Result<Datum, FormatError> {
+    let mut fields = Vec::new();
+    if let Some(duration) = keyword_f64(args, "duration", src)? {
+        fields.push(("duration", Datum::F64(duration)));
+    }
+    Ok(node_datum("TickBang", fields))
+}
+
+fn write_tick_bang(node: &Datum) -> String {
+    // Omit the default duration so a plain `tick!` writes as the bare keyword.
+    match node.get("duration").and_then(Datum::as_f64) {
+        Some(duration) if duration != 1.0 => format!("(tick-bang #:duration {duration})"),
+        _ => "tick-bang".to_string(),
+    }
+}
+
 fn write_number(node: &Datum) -> String {
     let min = node.get("min").and_then(Datum::as_f64);
     let max = node.get("max").and_then(Datum::as_f64);
@@ -660,5 +679,29 @@ mod tests {
             s.write_spec("Number", &all).as_deref(),
             Some("(number #:min -1.5 #:max 1.5 #:precision 3 #:no-push-eval)"),
         );
+    }
+
+    #[test]
+    fn tick_bang_config_round_trips() {
+        let s = DefaultSugar;
+
+        // A bare (default-duration) tick! stays bare, read as keyword or spec.
+        let bare = s.read_bare("tick-bang").expect("bare tick-bang");
+        assert_eq!(
+            s.write_spec("TickBang", &bare).as_deref(),
+            Some("tick-bang")
+        );
+
+        // A custom duration round-trips via the `#:duration` keyword.
+        let d = read_spec(&s, "(tick-bang #:duration 0.5)").expect("duration");
+        assert_eq!(d.get("duration").and_then(Datum::as_f64), Some(0.5));
+        assert_eq!(
+            s.write_spec("TickBang", &d).as_deref(),
+            Some("(tick-bang #:duration 0.5)"),
+        );
+
+        // An explicit default duration also writes as the bare keyword.
+        let one = read_spec(&s, "(tick-bang #:duration 1)").expect("default duration");
+        assert_eq!(s.write_spec("TickBang", &one).as_deref(), Some("tick-bang"));
     }
 }


### PR DESCRIPTION
## Summary

Two related changes to gantz's time-driven nodes:

1. **Rename `frame!` -> `update!`** - the node is driven once per *update*, not once per rendered frame (updates can outpace frames under presentation modes like Mailbox), so the old name and docs were misleading.
2. **New `tick!` node** - a self-driven clock that fires once per configurable interval, set as a **duration (seconds)** or a **rate (Hz)**. It guarantees the correct *number* of ticks even when the app updates slower than the tick rate (fixed-timestep catch-up).

## `frame!` -> `update!`

Full, consistent rename: `FrameBang` -> `UpdateBang`, cahash tag `gantz.frame!` -> `gantz.update!`, `drive_frame_bangs` -> `drive_update_bangs`, the `ToFrameBang` discovery trait, the `frame-bang` -> `update-bang` text keyword, and the `frame!` -> `update!` builtin. Adds a node description spelling out the per-update (not per-frame) behaviour. `frame!` appeared in no `.gantz` file, so the change is contained to Rust.

## `tick!`

A clock **source** (sibling to `update!`, the `!` denotes a driven push source), implemented as `TickBang` in `bevy_gantz_egui`. It owns a time accumulator fed from Bevy `Time`. On each update its `drive_tick_bangs` system triggers a push evaluation once for **every** whole interval elapsed since the last update (`N = floor(acc / dur)`, wrapping the remainder, capped by `MAX_CATCHUP_TICKS` to avoid a burst after a stall). Each tick outputs the effective tick duration in seconds.

- **Duration or rate**: the interval is an `Interval` enum (`Duration(secs)` | `Rate(hz)`) stored in the chosen unit, so a Hz rate round-trips exactly (deriving Hz from a stored duration would drift). The inspector has a `dur.`/`rate` mode selector (reusing the plot node's label-styled toggle, promoted to the shared `widget::node_inspector`) plus a unit-aware dialer.
- **Persistence**: content-addressed via `CaHash` (the unit is folded in, so the two representations are distinct addresses). `(tick-bang #:duration secs)` / `(tick-bang #:rate hz)` text sugar (mutually exclusive), bare `tick-bang` for the default 1 s.
- Each `tick!` gets its own single-source push entrypoint (unlike `update!`, whose nodes share one combined entrypoint and fire together), so the driver can trigger each the right number of times.

## Notes

- An input-driven rate-limiter variant (gating the `update!` bang to at most once per duration) was considered and deferred - it can fire at most once per update, so it down-samples rather than guaranteeing the tick count. `tick!`'s self-driven catch-up is the reliable answer. The rate-limiter approach might still be worth sussing in the future.