### PR TITLE
Open a node's UI in a pane to monitor it

### DIFF
--- a/crates/gantz_egui/src/impls/branch.rs
+++ b/crates/gantz_egui/src/impls/branch.rs
@@ -1,11 +1,15 @@
 use crate::{
-    InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind,
+    InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, NodeViewResponse, Registry, SocketDoc,
+    SocketKind,
 };
 
 /// A widget used to allow for editing and parsing a branch expression.
 pub struct BranchEdit<'a> {
     branch: &'a mut gantz_core::node::Branch,
     pub id: egui::Id,
+    /// When `true`, the editor fills the available width/height (for the
+    /// detached view) instead of sizing to its widest line.
+    fill: bool,
 }
 
 #[derive(Clone, Default)]
@@ -16,7 +20,7 @@ struct BranchEditState {
 
 impl<'a> egui::Widget for BranchEdit<'a> {
     fn ui(self, ui: &mut egui::Ui) -> egui::Response {
-        let Self { branch, id } = self;
+        let Self { branch, id, fill } = self;
         let code_id = id.with("code");
 
         // Retrieve the working state.
@@ -52,8 +56,17 @@ impl<'a> egui::Widget for BranchEdit<'a> {
         // matching `desired_width` and `margin`.
         let font_id = egui::FontSelection::from(egui::TextStyle::Monospace).resolve(ui.style());
         let margin = egui::Margin::symmetric(4, 2);
-        let desired_width =
-            super::code_edit_desired_width(ui, &theme, &state.code, language, margin);
+        // Fill the pane (detached view) or size to the widest line (in-graph).
+        let (desired_width, desired_rows) = if fill {
+            let row_h = ui.text_style_height(&egui::TextStyle::Monospace);
+            let rows = ((ui.available_height() / row_h).floor() as usize).max(1);
+            (ui.available_width(), rows)
+        } else {
+            (
+                super::code_edit_desired_width(ui, &theme, &state.code, language, margin),
+                1,
+            )
+        };
 
         let response = ui.add(
             egui::TextEdit::multiline(&mut state.code)
@@ -61,7 +74,7 @@ impl<'a> egui::Widget for BranchEdit<'a> {
                 .code_editor()
                 .font(font_id)
                 .margin(margin)
-                .desired_rows(1)
+                .desired_rows(desired_rows)
                 .desired_width(desired_width)
                 .hint_text("(if (= 0 $x) (list 0 '()) (list 1 '()))")
                 .layouter(&mut layouter),
@@ -100,6 +113,19 @@ impl NodeUi for gantz_core::node::Branch {
             ui.add(BranchEdit::new(self, id))
         });
         let mut resp = NodeUiResponse::new(framed);
+        resp.set_changed(branch_hash(self) != before);
+        resp
+    }
+
+    fn view_ui(&mut self, _ctx: NodeCtx, ui: &mut egui::Ui) -> NodeViewResponse {
+        // The same code editor as the in-graph node, but filling the pane (the
+        // pane keeps its margin). A distinct id (the pane scopes `ui.id`) keeps
+        // its WIP edit state separate from the in-graph editor.
+        let before = branch_hash(self);
+        let id = ui.id().with("branch-view");
+        let res = ui.add(BranchEdit::new(self, id).fill(true));
+        let mut resp = NodeViewResponse::default();
+        resp.inner = Some(res);
         resp.set_changed(branch_hash(self) != before);
         resp
     }
@@ -236,7 +262,18 @@ fn resize_branches(branch: &mut gantz_core::node::Branch, new_count: usize) {
 
 impl<'a> BranchEdit<'a> {
     pub fn new(branch: &'a mut gantz_core::node::Branch, id: egui::Id) -> Self {
-        Self { branch, id }
+        Self {
+            branch,
+            id,
+            fill: false,
+        }
+    }
+
+    /// Fill the available width/height (for the detached view) rather than
+    /// sizing to the widest line.
+    pub fn fill(mut self, fill: bool) -> Self {
+        self.fill = fill;
+        self
     }
 }
 

--- a/crates/gantz_egui/src/impls/expr.rs
+++ b/crates/gantz_egui/src/impls/expr.rs
@@ -1,11 +1,15 @@
 use crate::{
-    InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind,
+    InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, NodeViewResponse, Registry, SocketDoc,
+    SocketKind,
 };
 
 /// A widget used to allow for editing and parsing a steel expression.
 pub struct ExprEdit<'a> {
     expr: &'a mut gantz_core::node::Expr,
     pub id: egui::Id,
+    /// When `true`, the editor fills the available width/height (for the
+    /// detached view) instead of sizing to its widest line.
+    fill: bool,
 }
 
 #[derive(Clone, Default)]
@@ -16,7 +20,7 @@ struct ExprEditState {
 
 impl<'a> egui::Widget for ExprEdit<'a> {
     fn ui(self, ui: &mut egui::Ui) -> egui::Response {
-        let Self { expr, id } = self;
+        let Self { expr, id, fill } = self;
         let code_id = id.with("code");
 
         // Retrieve the working state.
@@ -52,8 +56,17 @@ impl<'a> egui::Widget for ExprEdit<'a> {
         // matching `desired_width` and `margin`.
         let font_id = egui::FontSelection::from(egui::TextStyle::Monospace).resolve(ui.style());
         let margin = egui::Margin::symmetric(4, 2);
-        let desired_width =
-            super::code_edit_desired_width(ui, &theme, &state.code, language, margin);
+        // Fill the pane (detached view) or size to the widest line (in-graph).
+        let (desired_width, desired_rows) = if fill {
+            let row_h = ui.text_style_height(&egui::TextStyle::Monospace);
+            let rows = ((ui.available_height() / row_h).floor() as usize).max(1);
+            (ui.available_width(), rows)
+        } else {
+            (
+                super::code_edit_desired_width(ui, &theme, &state.code, language, margin),
+                1,
+            )
+        };
 
         let response = ui.add(
             egui::TextEdit::multiline(&mut state.code)
@@ -61,7 +74,7 @@ impl<'a> egui::Widget for ExprEdit<'a> {
                 .code_editor()
                 .font(font_id)
                 .margin(margin)
-                .desired_rows(1)
+                .desired_rows(desired_rows)
                 .desired_width(desired_width)
                 .hint_text("(+ $l $r)")
                 .layouter(&mut layouter),
@@ -100,6 +113,19 @@ impl NodeUi for gantz_core::node::Expr {
             ui.add(ExprEdit::new(self, id))
         });
         let mut resp = NodeUiResponse::new(framed);
+        resp.set_changed(expr_hash(self) != before);
+        resp
+    }
+
+    fn view_ui(&mut self, _ctx: NodeCtx, ui: &mut egui::Ui) -> NodeViewResponse {
+        // The same code editor as the in-graph node, but filling the pane (the
+        // pane keeps its margin). A distinct id (the pane scopes `ui.id`) keeps
+        // its WIP edit state separate from the in-graph editor.
+        let before = expr_hash(self);
+        let id = ui.id().with("expr-view");
+        let res = ui.add(ExprEdit::new(self, id).fill(true));
+        let mut resp = NodeViewResponse::default();
+        resp.inner = Some(res);
         resp.set_changed(expr_hash(self) != before);
         resp
     }
@@ -159,7 +185,18 @@ impl NodeUi for gantz_core::node::Expr {
 impl<'a> ExprEdit<'a> {
     /// Create a new Steel code editing widget.
     pub fn new(expr: &'a mut gantz_core::node::Expr, id: egui::Id) -> Self {
-        Self { expr, id }
+        Self {
+            expr,
+            id,
+            fill: false,
+        }
+    }
+
+    /// Fill the available width/height (for the detached view) rather than
+    /// sizing to the widest line.
+    pub fn fill(mut self, fill: bool) -> Self {
+        self.fill = fill;
+        self
     }
 }
 

--- a/crates/gantz_egui/src/impls/number.rs
+++ b/crates/gantz_egui/src/impls/number.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ContextMenuResponse, InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, Registry,
-    SocketDoc, SocketKind,
+    ContextMenuResponse, InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, NodeViewResponse,
+    Registry, SocketDoc, SocketKind,
 };
 use gantz_std::number::Number;
 use steel::SteelVal;
@@ -20,50 +20,26 @@ impl NodeUi for Number {
         // only queue an evaluation (when enabled), never mark `changed`.
         let frame = egui_graph::node::default_frame(uictx.style(), uictx.interaction());
         let frame_fill = frame.fill;
-        let push = self.push_eval_on_edit();
-        let (min, max, precision) = (self.min(), self.max(), self.precision());
         let mut do_eval = false;
         let framed = uictx.framed_with(frame, |ui, _sockets| {
-            // When push-eval is disabled, flatten the dialer so it merges with
-            // the node frame - a cue that editing won't fire downstream.
-            if !push {
-                let widgets = &mut ui.visuals_mut().widgets;
-                widgets.inactive.weak_bg_fill = frame_fill;
-                widgets.inactive.bg_fill = frame_fill;
-            }
-            let mut val = ctx.extract_value().unwrap().unwrap();
-            let res = match val {
-                SteelVal::NumV(ref mut f) => {
-                    let mut dv = egui::DragValue::new(f);
-                    if min.is_some() || max.is_some() {
-                        dv = dv
-                            .range(min.unwrap_or(f64::NEG_INFINITY)..=max.unwrap_or(f64::INFINITY));
-                    }
-                    if let Some(p) = precision {
-                        dv = dv.max_decimals(p as usize);
-                    }
-                    ui.add(dv)
-                }
-                SteelVal::IntV(ref mut i) => {
-                    let mut dv = egui::DragValue::new(i);
-                    if min.is_some() || max.is_some() {
-                        let lo = min.map_or(isize::MIN, |m| m as isize);
-                        let hi = max.map_or(isize::MAX, |m| m as isize);
-                        dv = dv.range(lo..=hi);
-                    }
-                    ui.add(dv)
-                }
-                _ => ui.add(egui::Label::new("ERR")),
-            };
-            if res.changed() {
-                ctx.update_value(val).unwrap();
-                if push {
-                    do_eval = true;
-                }
-            }
+            let (res, eval) = dialer_ui(self, &mut ctx, frame_fill, ui);
+            do_eval = eval;
             res
         });
         let mut resp = NodeUiResponse::new(framed);
+        if do_eval {
+            resp.push_eval(ctx.path(), 1);
+        }
+        resp
+    }
+
+    fn view_ui(&mut self, mut ctx: NodeCtx, ui: &mut egui::Ui) -> NodeViewResponse {
+        // The same dialer as the in-graph node; the pane provides the background
+        // and margin. Editing updates VM state and (when enabled) queues an eval.
+        let bg = ui.visuals().panel_fill;
+        let (res, do_eval) = dialer_ui(self, &mut ctx, bg, ui);
+        let mut resp = NodeViewResponse::default();
+        resp.inner = Some(res);
         if do_eval {
             resp.push_eval(ctx.path(), 1);
         }
@@ -181,6 +157,57 @@ impl NodeUi for Number {
             }
         })
     }
+}
+
+/// Render the value dialer (updating VM state on edit), shared by the in-graph
+/// node body and the detached view. `bg` is the surrounding fill used to
+/// "flatten" the dialer when push-eval is off - a cue that editing won't fire
+/// downstream. Returns the dialer's response and whether a push-eval should fire
+/// (an edit happened and push-eval is enabled).
+fn dialer_ui(
+    num: &Number,
+    ctx: &mut NodeCtx,
+    bg: egui::Color32,
+    ui: &mut egui::Ui,
+) -> (egui::Response, bool) {
+    let push = num.push_eval_on_edit();
+    if !push {
+        let widgets = &mut ui.visuals_mut().widgets;
+        widgets.inactive.weak_bg_fill = bg;
+        widgets.inactive.bg_fill = bg;
+    }
+    let (min, max, precision) = (num.min(), num.max(), num.precision());
+    let mut val = ctx.extract_value().unwrap().unwrap();
+    let res = match val {
+        SteelVal::NumV(ref mut f) => {
+            let mut dv = egui::DragValue::new(f);
+            if min.is_some() || max.is_some() {
+                dv = dv.range(min.unwrap_or(f64::NEG_INFINITY)..=max.unwrap_or(f64::INFINITY));
+            }
+            if let Some(p) = precision {
+                dv = dv.max_decimals(p as usize);
+            }
+            ui.add(dv)
+        }
+        SteelVal::IntV(ref mut i) => {
+            let mut dv = egui::DragValue::new(i);
+            if min.is_some() || max.is_some() {
+                let lo = min.map_or(isize::MIN, |m| m as isize);
+                let hi = max.map_or(isize::MAX, |m| m as isize);
+                dv = dv.range(lo..=hi);
+            }
+            ui.add(dv)
+        }
+        _ => ui.add(egui::Label::new("ERR")),
+    };
+    let mut do_eval = false;
+    if res.changed() {
+        ctx.update_value(val).unwrap();
+        if push {
+            do_eval = true;
+        }
+    }
+    (res, do_eval)
 }
 
 /// Keep `max >= min` and re-clamp the stored value into the new bounds so the

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -29,7 +29,7 @@ pub use node::{FnNodeNames, NameRegistry};
 pub use reg::RegistryRef;
 pub use response::{
     ContextMenuResponse, DynResponse, InspectorRowsResponse, InspectorUiResponse, NodeUiResponse,
-    ResponseData, Responses,
+    NodeViewResponse, ResponseData, Responses,
 };
 pub use view::{Camera, SceneView};
 pub use widget::gantz::NodeTypeRegistry;
@@ -335,6 +335,21 @@ pub trait NodeUi {
         InspectorUiResponse::default()
     }
 
+    /// The node's UI when detached from the graph into its own pane via the
+    /// "open view" action, for monitoring it in a fixed location.
+    ///
+    /// Unlike [`ui`](NodeUi::ui), this receives a plain [`egui::Ui`] filling the
+    /// pane (no graph frame or sockets). The default renders the node name and
+    /// its current VM state value, so every node is viewable with something
+    /// useful; "viewer" nodes (e.g. [`Plot`](crate::node::Plot)) override it to
+    /// render their full visualisation. Mark the returned response
+    /// [`changed`](NodeViewResponse::mark_changed) on CA-affecting edits and
+    /// [`emit`](NodeViewResponse::emit) any payloads.
+    fn view_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> NodeViewResponse {
+        let name = self.name(ctx.registry()).to_string();
+        default_view_ui(&name, &ctx, ui)
+    }
+
     /// Add node-specific items to the node's right-click context menu.
     ///
     /// Called after the built-in items (copy, reset, delete, ...). Mark the
@@ -397,6 +412,23 @@ pub trait NodeUi {
     fn show_state(&self) -> bool {
         true
     }
+}
+
+/// The default [`NodeUi::view_ui`] body: the node `name` as a heading followed by
+/// the node's current VM state value. Used by any node that doesn't override
+/// `view_ui` with a richer visualisation.
+fn default_view_ui(name: &str, ctx: &NodeCtx, ui: &mut egui::Ui) -> NodeViewResponse {
+    let mut resp = NodeViewResponse::default();
+    egui::ScrollArea::both().auto_shrink(false).show(ui, |ui| {
+        ui.heading(name);
+        let text = match ctx.extract_value() {
+            Ok(Some(val)) => format!("{val:?}"),
+            Ok(None) => "∅".to_string(),
+            Err(_) => "ERR".to_string(),
+        };
+        resp.inner = Some(ui.add(egui::Label::new(text).selectable(true)));
+    });
+    resp
 }
 
 /// A wrapper around a node's path and the VM providing easy access to the
@@ -535,6 +567,21 @@ pub struct ResetTilesLayout;
 #[derive(Clone, Copy, Debug)]
 pub struct OpenLogs;
 
+/// Open the given node's view ([`NodeUi::view_ui`]) as a tile in the Node Views
+/// pane, for monitoring it in a fixed location. The node is identified by its
+/// `path` within the emitting head's graph (the head is taken from the payload's
+/// head tag).
+///
+/// Handled by `Gantz::show` itself - applications never see this payload.
+#[derive(Clone, Debug)]
+pub struct OpenNodeView {
+    /// Path to the node within its head's graph (last element = node index).
+    pub path: Vec<node::Id>,
+    /// The node's type name ([`NodeUi::name`]), captured at emit time for the
+    /// view tile's title (the registry is in scope there, not at the drain).
+    pub ty_name: String,
+}
+
 /// Open a head (named or commit) as a new tab.
 #[derive(Clone, Debug)]
 pub struct OpenHead(pub gantz_ca::Head);
@@ -592,6 +639,10 @@ where
         (**self).inspector_ui(ctx, ui)
     }
 
+    fn view_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> NodeViewResponse {
+        (**self).view_ui(ctx, ui)
+    }
+
     fn flow(&self, registry: &dyn Registry) -> egui::Direction {
         (**self).flow(registry)
     }
@@ -646,6 +697,10 @@ macro_rules! impl_node_ui_for_ptr {
 
             fn inspector_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> InspectorUiResponse {
                 (**self).inspector_ui(ctx, ui)
+            }
+
+            fn view_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> NodeViewResponse {
+                (**self).view_ui(ctx, ui)
             }
 
             fn flow(&self, registry: &dyn Registry) -> egui::Direction {

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -349,13 +349,13 @@ pub trait NodeUi {
         default_view_ui(&ctx, ui)
     }
 
-    /// Whether the node's [`view_ui`](NodeUi::view_ui) should fill its pane
-    /// edge-to-edge, i.e. without the usual pane margin.
+    /// Whether the node's [`view_ui`](NodeUi::view_ui) should render without the
+    /// usual pane margin, filling the pane edge-to-edge.
     ///
     /// Returns `false` by default (the view is inset like the other panes).
-    /// Visualisations that should bleed to the pane edges - e.g.
-    /// [`Plot`](crate::node::Plot) - override this to `true`.
-    fn view_full_bleed(&self) -> bool {
+    /// Visualisations that should fill the pane - e.g. [`Plot`](crate::node::Plot)
+    /// - override this to `true`.
+    fn view_no_margin(&self) -> bool {
         false
     }
 
@@ -654,8 +654,8 @@ where
         (**self).view_ui(ctx, ui)
     }
 
-    fn view_full_bleed(&self) -> bool {
-        (**self).view_full_bleed()
+    fn view_no_margin(&self) -> bool {
+        (**self).view_no_margin()
     }
 
     fn flow(&self, registry: &dyn Registry) -> egui::Direction {
@@ -718,8 +718,8 @@ macro_rules! impl_node_ui_for_ptr {
                 (**self).view_ui(ctx, ui)
             }
 
-            fn view_full_bleed(&self) -> bool {
-                (**self).view_full_bleed()
+            fn view_no_margin(&self) -> bool {
+                (**self).view_no_margin()
             }
 
             fn flow(&self, registry: &dyn Registry) -> egui::Direction {

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -339,15 +339,14 @@ pub trait NodeUi {
     /// "open view" action, for monitoring it in a fixed location.
     ///
     /// Unlike [`ui`](NodeUi::ui), this receives a plain [`egui::Ui`] filling the
-    /// pane (no graph frame or sockets). The default renders the node name and
-    /// its current VM state value, so every node is viewable with something
+    /// pane (no graph frame or sockets). The default renders the node's current
+    /// VM state value (its debug repr), so every node is viewable with something
     /// useful; "viewer" nodes (e.g. [`Plot`](crate::node::Plot)) override it to
     /// render their full visualisation. Mark the returned response
     /// [`changed`](NodeViewResponse::mark_changed) on CA-affecting edits and
     /// [`emit`](NodeViewResponse::emit) any payloads.
     fn view_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> NodeViewResponse {
-        let name = self.name(ctx.registry()).to_string();
-        default_view_ui(&name, &ctx, ui)
+        default_view_ui(&ctx, ui)
     }
 
     /// Add node-specific items to the node's right-click context menu.
@@ -414,20 +413,22 @@ pub trait NodeUi {
     }
 }
 
-/// The default [`NodeUi::view_ui`] body: the node `name` as a heading followed by
-/// the node's current VM state value. Used by any node that doesn't override
-/// `view_ui` with a richer visualisation.
-fn default_view_ui(name: &str, ctx: &NodeCtx, ui: &mut egui::Ui) -> NodeViewResponse {
+/// The default [`NodeUi::view_ui`] body: the node's current VM state value (its
+/// debug repr), matching what [`Inspect`](crate::node::Inspect) shows in-graph.
+/// No type label - the tab title already names the node. Used by any node that
+/// doesn't override `view_ui` with a richer visualisation.
+fn default_view_ui(ctx: &NodeCtx, ui: &mut egui::Ui) -> NodeViewResponse {
     let mut resp = NodeViewResponse::default();
-    egui::ScrollArea::both().auto_shrink(false).show(ui, |ui| {
-        ui.heading(name);
-        let text = match ctx.extract_value() {
-            Ok(Some(val)) => format!("{val:?}"),
-            Ok(None) => "∅".to_string(),
-            Err(_) => "ERR".to_string(),
-        };
-        resp.inner = Some(ui.add(egui::Label::new(text).selectable(true)));
-    });
+    let text = match ctx.extract_value() {
+        Ok(Some(val)) => format!("{val:?}"),
+        Ok(None) => "∅".to_string(),
+        Err(_) => "ERR".to_string(),
+    };
+    let inner = egui::ScrollArea::both()
+        .auto_shrink(false)
+        .show(ui, |ui| ui.add(egui::Label::new(text).selectable(true)))
+        .inner;
+    resp.inner = Some(inner);
     resp
 }
 

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -349,6 +349,16 @@ pub trait NodeUi {
         default_view_ui(&ctx, ui)
     }
 
+    /// Whether the node's [`view_ui`](NodeUi::view_ui) should fill its pane
+    /// edge-to-edge, i.e. without the usual pane margin.
+    ///
+    /// Returns `false` by default (the view is inset like the other panes).
+    /// Visualisations that should bleed to the pane edges - e.g.
+    /// [`Plot`](crate::node::Plot) - override this to `true`.
+    fn view_full_bleed(&self) -> bool {
+        false
+    }
+
     /// Add node-specific items to the node's right-click context menu.
     ///
     /// Called after the built-in items (copy, reset, delete, ...). Mark the
@@ -644,6 +654,10 @@ where
         (**self).view_ui(ctx, ui)
     }
 
+    fn view_full_bleed(&self) -> bool {
+        (**self).view_full_bleed()
+    }
+
     fn flow(&self, registry: &dyn Registry) -> egui::Direction {
         (**self).flow(registry)
     }
@@ -702,6 +716,10 @@ macro_rules! impl_node_ui_for_ptr {
 
             fn view_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> NodeViewResponse {
                 (**self).view_ui(ctx, ui)
+            }
+
+            fn view_full_bleed(&self) -> bool {
+                (**self).view_full_bleed()
             }
 
             fn flow(&self, registry: &dyn Registry) -> egui::Direction {

--- a/crates/gantz_egui/src/node/plot.rs
+++ b/crates/gantz_egui/src/node/plot.rs
@@ -404,7 +404,7 @@ impl NodeUi for Plot {
         resp
     }
 
-    fn view_full_bleed(&self) -> bool {
+    fn view_no_margin(&self) -> bool {
         // The plot fills its pane edge-to-edge, with no surrounding margin.
         true
     }

--- a/crates/gantz_egui/src/node/plot.rs
+++ b/crates/gantz_egui/src/node/plot.rs
@@ -17,8 +17,8 @@
 use crate::widget::node_inspector;
 use crate::widget::node_inspector::radio_option;
 use crate::{
-    ContextMenuResponse, InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, Registry,
-    SocketDoc, SocketKind,
+    ContextMenuResponse, InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, NodeViewResponse,
+    Registry, SocketDoc, SocketKind,
 };
 use gantz_ca::CaHash;
 use gantz_core::node::{self, ExprCtx, ExprResult, MetaCtx, RegCtx};
@@ -245,6 +245,87 @@ impl gantz_core::Node for Plot {
     }
 }
 
+impl Plot {
+    /// Render the plot itself (axes, grid, series and bounds) filling `size`,
+    /// returning the plot's response. Shared by the in-graph node body
+    /// ([`NodeUi::ui`]) and the detached view ([`NodeUi::view_ui`]).
+    fn plot_body(
+        &self,
+        ys: &[f64],
+        plot_id: egui::Id,
+        size: egui::Vec2,
+        ui: &mut egui::Ui,
+    ) -> egui::Response {
+        let color = resolve_color(self.color, ui);
+        let plot_style = self.style;
+        let interactive = self.interactive;
+        let bounds = value_bounds(ys, plot_style, self.y_min, self.y_max);
+
+        let mut plot = egui_plot::Plot::new(plot_id)
+            .width(size.x)
+            .height(size.y)
+            .show_background(false)
+            .show_axes(egui::Vec2b::new(self.show_axes, self.show_axes))
+            .show_grid(egui::Vec2b::new(self.show_grid, self.show_grid))
+            // Pan/zoom are always off. `Sense::hover` lets the node frame beneath
+            // capture drags and right-clicks, so the node moves and its context
+            // menu opens as usual.
+            .allow_drag(false)
+            .allow_zoom(false)
+            .allow_scroll(false)
+            .allow_boxed_zoom(false)
+            .sense(egui::Sense::hover());
+        if !interactive {
+            // Purely visual: hide the crosshair (the value readout is also
+            // suppressed via `allow_hover(false)` below).
+            plot = plot.cursor_color(egui::Color32::TRANSPARENT);
+        }
+
+        let plot_resp = plot
+            .show(ui, |plot_ui| {
+                match plot_style {
+                    PlotStyle::Bars => {
+                        let bars = ys
+                            .iter()
+                            .enumerate()
+                            .map(|(i, &y)| {
+                                egui_plot::Bar::new(i as f64, y)
+                                    .width(1.0)
+                                    .fill(color)
+                                    .stroke(egui::Stroke::NONE)
+                            })
+                            .collect();
+                        plot_ui
+                            .bar_chart(egui_plot::BarChart::new("", bars).allow_hover(interactive));
+                    }
+                    PlotStyle::Line => {
+                        let points = egui_plot::PlotPoints::from_ys_f64(ys);
+                        plot_ui.line(
+                            egui_plot::Line::new("", points)
+                                .color(color)
+                                .allow_hover(interactive),
+                        );
+                    }
+                }
+                // Drive the view deterministically from the data + config (the
+                // plot never pans), so live updates and min/max apply.
+                let ([xlo, ylo], [xhi, yhi]) = bounds;
+                plot_ui.set_plot_bounds_x(xlo..=xhi);
+                plot_ui.set_plot_bounds_y(ylo..=yhi);
+            })
+            .response;
+
+        // egui_plot sets a crosshair *mouse cursor* on hover; when not
+        // interactive, restore the default arrow so the plot reads as a static
+        // node. (The resize corner sets its own cursor after this, so it is
+        // unaffected.)
+        if !interactive && plot_resp.hovered() {
+            ui.ctx().set_cursor_icon(egui::CursorIcon::Default);
+        }
+        plot_resp
+    }
+}
+
 impl NodeUi for Plot {
     fn name(&self, _: &dyn Registry) -> &str {
         "plot"
@@ -314,81 +395,28 @@ impl NodeUi for Plot {
                         changed = true;
                     }
 
-                    let color = resolve_color(self.color, ui);
-                    let plot_style = self.style;
-                    let interactive = self.interactive;
-                    let bounds = value_bounds(&ys, plot_style, self.y_min, self.y_max);
-
-                    let mut plot = egui_plot::Plot::new(plot_id)
-                        .width(avail.x)
-                        .height(avail.y)
-                        .show_background(false)
-                        .show_axes(egui::Vec2b::new(self.show_axes, self.show_axes))
-                        .show_grid(egui::Vec2b::new(self.show_grid, self.show_grid))
-                        // Pan/zoom are always off. `Sense::hover` lets the node
-                        // frame beneath capture drags and right-clicks, so the
-                        // node moves and its context menu opens as usual.
-                        .allow_drag(false)
-                        .allow_zoom(false)
-                        .allow_scroll(false)
-                        .allow_boxed_zoom(false)
-                        .sense(egui::Sense::hover());
-                    if !interactive {
-                        // Purely visual: hide the crosshair (the value readout is
-                        // also suppressed via `allow_hover(false)` below).
-                        plot = plot.cursor_color(egui::Color32::TRANSPARENT);
-                    }
-
-                    let plot_resp = plot
-                        .show(ui, |plot_ui| {
-                            match plot_style {
-                                PlotStyle::Bars => {
-                                    let bars = ys
-                                        .iter()
-                                        .enumerate()
-                                        .map(|(i, &y)| {
-                                            egui_plot::Bar::new(i as f64, y)
-                                                .width(1.0)
-                                                .fill(color)
-                                                .stroke(egui::Stroke::NONE)
-                                        })
-                                        .collect();
-                                    plot_ui.bar_chart(
-                                        egui_plot::BarChart::new("", bars).allow_hover(interactive),
-                                    );
-                                }
-                                PlotStyle::Line => {
-                                    let points = egui_plot::PlotPoints::from_ys_f64(&ys);
-                                    plot_ui.line(
-                                        egui_plot::Line::new("", points)
-                                            .color(color)
-                                            .allow_hover(interactive),
-                                    );
-                                }
-                            }
-                            // Drive the view deterministically from the data +
-                            // config (the plot never pans), so live updates and
-                            // min/max apply.
-                            let ([xlo, ylo], [xhi, yhi]) = bounds;
-                            plot_ui.set_plot_bounds_x(xlo..=xhi);
-                            plot_ui.set_plot_bounds_y(ylo..=yhi);
-                        })
-                        .response;
-
-                    // egui_plot sets a crosshair *mouse cursor* on hover; when not
-                    // interactive, restore the default arrow so the plot reads as a
-                    // static node. (The resize corner sets its own cursor after
-                    // this, so it is unaffected.)
-                    if !interactive && plot_resp.hovered() {
-                        ui.ctx().set_cursor_icon(egui::CursorIcon::Default);
-                    }
-                    plot_resp
+                    self.plot_body(&ys, plot_id, avail, ui)
                 })
         });
 
         let mut resp = NodeUiResponse::new(framed);
         resp.set_changed(changed);
         resp
+    }
+
+    fn view_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> NodeViewResponse {
+        // The detached view fills the pane. Unlike the in-graph body it has no
+        // resize handle and never writes back the node's CA-affecting
+        // `width`/`height` (so `changed` stays false). The plot id is derived
+        // from `ui` (scoped per pane by the caller), keeping it distinct from
+        // the in-graph plot's id.
+        let plot_id = ui.id().with("plot-view");
+        let ys = series(&ctx);
+        let size = ui.available_size();
+        let resp = self.plot_body(&ys, plot_id, size, ui);
+        let mut out = NodeViewResponse::default();
+        out.inner = Some(resp);
+        out
     }
 
     fn inspector_rows(

--- a/crates/gantz_egui/src/node/plot.rs
+++ b/crates/gantz_egui/src/node/plot.rs
@@ -404,6 +404,11 @@ impl NodeUi for Plot {
         resp
     }
 
+    fn view_full_bleed(&self) -> bool {
+        // The plot fills its pane edge-to-edge, with no surrounding margin.
+        true
+    }
+
     fn view_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> NodeViewResponse {
         // The detached view fills the pane. Unlike the in-graph body it has no
         // resize handle and never writes back the node's CA-affecting

--- a/crates/gantz_egui/src/ops.rs
+++ b/crates/gantz_egui/src/ops.rs
@@ -192,6 +192,43 @@ where
     Some(node_ix)
 }
 
+/// A single node removal recorded by [`remove_nodes`]: the node at `removed`
+/// was deleted, and (when `Some`) the node that was at `moved_from` was
+/// swapped down into the `removed` slot.
+#[derive(Clone, Copy, Debug)]
+pub struct RemoveOp {
+    pub removed: usize,
+    pub moved_from: Option<usize>,
+}
+
+/// The ordered index changes performed by a [`remove_nodes`] call, for callers
+/// that key persistent data by node index and must migrate it the same way (e.g.
+/// detached node views - see `migrate_node_view_paths`).
+#[derive(Clone, Debug, Default)]
+pub struct Reindex(pub Vec<RemoveOp>);
+
+impl Reindex {
+    /// Whether any node was removed.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Replay the removals onto a single node index, returning its new index, or
+    /// `None` if that node was the one removed. Mirrors how `remove_nodes`
+    /// migrates state/layout/selection, so index-keyed data stays consistent.
+    pub fn apply_to_index(&self, mut ix: usize) -> Option<usize> {
+        for op in &self.0 {
+            if ix == op.removed {
+                return None;
+            }
+            if op.moved_from == Some(ix) {
+                ix = op.removed;
+            }
+        }
+        Some(ix)
+    }
+}
+
 /// Remove `nodes` from `graph`, migrating the per-node state, layout and
 /// selection that are keyed by node index.
 ///
@@ -201,8 +238,11 @@ where
 /// surviving node down into an already-freed higher slot and never invalidates a
 /// pending target. The swapped node's state, layout entry and selection are then
 /// moved to its new index. Edge selection is cleared because removing a node
-/// drops its incident edges with compounded edge swaps. Returns whether any node
-/// was removed.
+/// drops its incident edges with compounded edge swaps.
+///
+/// Returns the ordered [`Reindex`] describing each removal/swap, so other
+/// index-keyed data can be migrated the same way (any future reindexing edit
+/// must do likewise).
 ///
 /// Run this before the next recompile (`vm::sync`): the regenerated code reads
 /// state by the new index, so the migration must already be in place.
@@ -212,12 +252,12 @@ pub fn remove_nodes<N>(
     layout: &mut egui_graph::Layout,
     selection: &mut crate::widget::graph_scene::Selection,
     nodes: impl IntoIterator<Item = NodeIndex>,
-) -> bool {
+) -> Reindex {
     let node_id = |ix: usize| egui_graph::NodeId::from_u64(ix as u64);
     let mut targets: Vec<NodeIndex> = nodes.into_iter().collect();
     targets.sort_unstable_by_key(|n| std::cmp::Reverse(n.index()));
     targets.dedup();
-    let mut removed_any = false;
+    let mut ops = Vec::new();
     for t in targets {
         if graph.node_weight(t).is_none() {
             continue;
@@ -229,7 +269,8 @@ pub fn remove_nodes<N>(
         selection.nodes.remove(&t);
         graph.remove_node(t);
         // Migrate the node that swapped into `t` (the former `last`), if any.
-        if t.index() != last {
+        let moved_from = (t.index() != last).then_some(last);
+        if let Some(last) = moved_from {
             let _ = node::state::move_value(vm, &[last], &[t.index()]);
             if let Some(pos) = layout.remove(&node_id(last)) {
                 layout.insert(node_id(t.index()), pos);
@@ -238,12 +279,15 @@ pub fn remove_nodes<N>(
                 selection.nodes.insert(t);
             }
         }
-        removed_any = true;
+        ops.push(RemoveOp {
+            removed: t.index(),
+            moved_from,
+        });
     }
-    if removed_any {
+    if !ops.is_empty() {
         selection.edges.clear();
     }
-    removed_any
+    Reindex(ops)
 }
 
 /// Cut: serialize `nodes` to a `.gantz` clipboard payload, then remove them.
@@ -520,14 +564,18 @@ mod tests {
         let mut vm = Engine::new_base();
 
         // Delete index 1: node 4 (weight 14) swap-removes into slot 1.
-        let removed = remove_nodes(
+        let reindex = remove_nodes(
             &mut graph,
             &mut vm,
             &mut layout,
             &mut selection,
             [NodeIx::new(1)],
         );
-        assert!(removed);
+        assert!(!reindex.is_empty());
+        // The reindex maps the swapped node (old index 4) down to 1, and reports
+        // the deleted index 1 as gone.
+        assert_eq!(reindex.apply_to_index(4), Some(1));
+        assert_eq!(reindex.apply_to_index(1), None);
 
         // The swapped node now sits at index 1.
         assert_eq!(graph.node_count(), 4);

--- a/crates/gantz_egui/src/response.rs
+++ b/crates/gantz_egui/src/response.rs
@@ -193,6 +193,20 @@ pub struct InspectorUiResponse {
     pub payloads: Vec<DynResponse>,
 }
 
+/// The response from [`NodeUi::view_ui`][crate::NodeUi::view_ui].
+///
+/// Mirrors [`InspectorUiResponse`]'s shape today, but is a distinct type so the
+/// detached node view and the inspector can diverge as each grows.
+#[derive(Debug, Default)]
+pub struct NodeViewResponse {
+    /// The egui response for the node's view, if any.
+    pub inner: Option<egui::Response>,
+    /// Whether the node mutated CA-affecting state this frame.
+    pub changed: bool,
+    /// Payloads emitted by the node for the application to handle.
+    pub payloads: Vec<DynResponse>,
+}
+
 /// The response from [`NodeUi::context_menu`][crate::NodeUi::context_menu].
 #[derive(Debug, Default)]
 pub struct ContextMenuResponse {
@@ -252,6 +266,7 @@ impl_node_response_emit!(
     NodeUiResponse,
     InspectorRowsResponse,
     InspectorUiResponse,
+    NodeViewResponse,
     ContextMenuResponse,
 );
 

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -1034,13 +1034,6 @@ where
         egui_tiles::SimplificationOptions::OFF
     }
 
-    fn min_size(&self) -> f32 {
-        // No pane (split) may shrink below this, so a thin pane - e.g. a freshly
-        // placed node view - stays visible and grabbable rather than collapsing
-        // to a sliver. (egui_tiles' default is 32.)
-        64.0
-    }
-
     fn pane_ui(
         &mut self,
         ui: &mut egui::Ui,
@@ -1373,23 +1366,23 @@ where
                 // A detached node view: render the node's `view_ui` against its
                 // head's live graph + VM (a mirror sharing state with the
                 // in-graph node). A `CentralPanel` gives it the same background
-                // as the other panes; full-bleed views (e.g. plot) drop the pane
+                // as the other panes; no-margin views (e.g. plot) drop the pane
                 // margin so they fill edge-to-edge. A placeholder shows when the
                 // head is closed.
                 let head = view.head.clone();
                 let path = view.path.clone();
-                let full_bleed = access
+                let no_margin = access
                     .with_head_mut(&head, |data| {
                         let &[ix] = path.as_slice() else {
                             return false;
                         };
                         data.graph
                             .node_weight(graph_scene::NodeIndex::new(ix))
-                            .is_some_and(|n| n.view_full_bleed())
+                            .is_some_and(|n| n.view_no_margin())
                     })
                     .unwrap_or(false);
                 let mut frame = egui::Frame::central_panel(ui.style());
-                if full_bleed {
+                if no_margin {
                     frame.inner_margin = egui::Margin::ZERO;
                 }
                 egui::CentralPanel::default()

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -349,9 +349,11 @@ pub enum Pane {
     History,
     Logs,
     NodeInspector,
-    /// Contains the inner node-views tree: nodes detached from a graph via the
-    /// "open view" action, each rendered via [`NodeUi::view_ui`] for monitoring.
-    NodeViews,
+    /// A node detached from a graph via the "open view" action, rendered via
+    /// [`NodeUi::view_ui`] for monitoring. A data-carrying pane (unlike the
+    /// singleton variants), so any number can be opened and freely placed
+    /// anywhere in the top-level tree.
+    NodeView(NodeViewPane),
     /// Globally relevant configuration grouped into Panes / Style / Global
     /// subtabs (pane visibility, style, compile options, reset all demos).
     Settings,
@@ -364,13 +366,13 @@ pub enum Pane {
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 struct GraphPane(gantz_ca::Head);
 
-/// A pane within the inner node-views tree: one detached node view, identified
-/// by its `head` and `path` within that head's graph. `ty_name` is the node's
-/// type name ([`NodeUi::name`]), cached at open-time so the tab title is stable
-/// even while the head is closed (the node type never changes; only its index
-/// does, and that is migrated in [`migrate_node_view_paths`]).
+/// The payload of a [`Pane::NodeView`]: one detached node view, identified by
+/// its `head` and `path` within that head's graph. `ty_name` is the node's type
+/// name ([`NodeUi::name`]), cached at open-time so the tab title is stable even
+/// while the head is closed (the node type never changes; only its index does,
+/// and that is migrated by `migrate_node_view_paths`).
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
-struct NodeViewPane {
+pub struct NodeViewPane {
     head: gantz_ca::Head,
     path: Vec<node::Id>,
     ty_name: String,
@@ -378,9 +380,6 @@ struct NodeViewPane {
 
 /// The egui ID used to store the inner graph tree.
 const GRAPH_TREE_ID: &str = "gantz-graph-tiles-tree";
-
-/// The egui ID used to store the inner node-views tree.
-const NODE_VIEWS_TREE_ID: &str = "gantz-node-views-tiles-tree";
 
 /// Load a tile tree from egui's persisted memory.
 ///
@@ -454,27 +453,23 @@ pub fn update_graph_pane_head(
     }
 }
 
-/// Migrate the persisted node-view panes for `head` after a node removal
+/// Migrate the [`Pane::NodeView`] panes for `head` after a node removal
 /// reindexed its graph, mirroring the state/layout/selection migration in
-/// [`crate::ops::remove_nodes`]: a pane whose node was removed is dropped; a pane
+/// [`crate::ops::remove_nodes`]: a view whose node was removed is dropped; a view
 /// whose node was swapped to a new index has its path rewritten. This keeps a
 /// detached view pointing at the same node across deletions, with no staleness
-/// guard.
+/// guard. Operates on the top-level `tree` (where node views live as tiles).
 fn migrate_node_view_paths(
-    ctx: &egui::Context,
+    tree: &mut egui_tiles::Tree<Pane>,
     head: &gantz_ca::Head,
     reindex: &crate::ops::Reindex,
 ) {
     if reindex.is_empty() {
         return;
     }
-    let tree_id = egui::Id::new(NODE_VIEWS_TREE_ID);
-    let Some(mut tree) = load_tree::<NodeViewPane>(ctx, tree_id) else {
-        return;
-    };
     let mut to_remove = Vec::new();
     for (id, tile) in tree.tiles.iter_mut() {
-        let egui_tiles::Tile::Pane(pane) = tile else {
+        let egui_tiles::Tile::Pane(Pane::NodeView(pane)) = tile else {
             continue;
         };
         if pane.head != *head {
@@ -490,7 +485,6 @@ fn migrate_node_view_paths(
     for id in to_remove {
         tree.tiles.remove(id);
     }
-    store_tree(ctx, tree_id, &tree);
 }
 
 /// The context passed to the `egui_tiles::Tree` widget.
@@ -545,6 +539,11 @@ pub struct GantzResponse {
     /// Dynamic payloads emitted from within the widget tree, tagged with the
     /// emitting head. See [`crate::response`] for the handling contract.
     pub responses: Responses,
+    /// Per-head node index remappings from this frame's deletions, collected
+    /// during traversal and applied to the top-level tree's [`Pane::NodeView`]
+    /// paths by `Gantz::show` after layout. Internal scratch - drained before
+    /// the response is returned, so applications can ignore it.
+    pub(crate) node_view_reindexes: Vec<(gantz_ca::Head, crate::ops::Reindex)>,
 }
 
 /// State for editing a tab name via double-click.
@@ -568,7 +567,6 @@ pub struct ViewToggles {
     pub settings: bool,
     pub logs: bool,
     pub node_inspector: bool,
-    pub node_views: bool,
     pub perf_gui: bool,
     pub perf_vm: bool,
     pub steel: bool,
@@ -588,7 +586,6 @@ impl Default for ViewToggles {
             settings: true,
             logs: false,
             node_inspector: true,
-            node_views: false,
             perf_gui: false,
             perf_vm: false,
             steel: false,
@@ -755,9 +752,9 @@ impl<'a> Gantz<'a> {
         }
 
         // The persisted outer tree. The version suffix invalidates any tree
-        // persisted before a layout change that adds/moves panes (here, the
-        // Node Views tray pane), forcing a rebuild via `create_tree`.
-        let tree_id = egui::Id::new("gantz-tiles-tree-storage-v4");
+        // persisted before the sidebar overhaul (which lacks the new panes and
+        // tab containers), forcing a rebuild via `create_tree`.
+        let tree_id = egui::Id::new("gantz-tiles-tree-storage-v3");
 
         // Retrieve the tree from persistent storage, or load the default.
         let mut tree: egui_tiles::Tree<Pane> =
@@ -791,6 +788,7 @@ impl<'a> Gantz<'a> {
             validate_change_tracking: None,
             changed_heads: Vec::new(),
             responses: Responses::default(),
+            node_view_reindexes: Vec::new(),
         };
 
         // The context for traversing the tree of tiles.
@@ -837,16 +835,16 @@ impl<'a> Gantz<'a> {
         for _ in response.responses.take::<OpenLogs>() {
             state.view_toggles.logs = true;
         }
-        // "open view": add (or focus) a tile in the inner node-views tree and
-        // reveal the Node Views pane. The node's head is the payload's head tag.
+        // Migrate node-view tiles past this frame's node deletions (collected
+        // during traversal, since the live top-level tree wasn't reachable then).
+        for (head, reindex) in &response.node_view_reindexes {
+            migrate_node_view_paths(&mut tree, head, reindex);
+        }
+        // "open view": add (or focus) a node-view tile in the top-level tree.
+        // The node's head is the payload's head tag.
         for (head, view) in response.responses.take::<OpenNodeView>() {
             let Some(head) = head else { continue };
-            let views_id = egui::Id::new(NODE_VIEWS_TREE_ID);
-            let mut views_tree: egui_tiles::Tree<NodeViewPane> =
-                load_tree(ui.ctx(), views_id).unwrap_or_else(create_empty_node_views_tree);
-            add_node_view_pane(&mut views_tree, head, view.path, view.ty_name);
-            store_tree(ui.ctx(), views_id, &views_tree);
-            state.view_toggles.node_views = true;
+            add_node_view_pane(&mut tree, head, view.path, view.ty_name);
         }
 
         // Persist the tree.
@@ -923,7 +921,7 @@ where
                 Some(head) => format!("Node Inspector - {head}").into(),
                 None => "Node Inspector".into(),
             },
-            Pane::NodeViews => "Node Views".into(),
+            Pane::NodeView(p) => node_view_title(p).into(),
             Pane::Steel => match self.access.heads().get(self.focused_head) {
                 Some(head) => format!("Steel - {head}").into(),
                 None => "Steel".into(),
@@ -957,9 +955,12 @@ where
         tiles: &egui_tiles::Tiles<Pane>,
         tile_id: egui_tiles::TileId,
     ) -> bool {
-        // The tray panes get a close button; the rest are toggled via the
-        // Panes settings or the tab right-click menu.
-        matches!(tiles.get_pane(&tile_id), Some(Pane::Logs | Pane::Steel))
+        // The tray panes and detached node views get a close button; the rest
+        // are toggled via the Panes settings or the tab right-click menu.
+        matches!(
+            tiles.get_pane(&tile_id),
+            Some(Pane::Logs | Pane::Steel | Pane::NodeView(_))
+        )
     }
 
     fn on_tab_close(
@@ -967,12 +968,18 @@ where
         tiles: &mut egui_tiles::Tiles<Pane>,
         tile_id: egui_tiles::TileId,
     ) -> bool {
-        // Hide the pane via its toggle (so it can be reopened) rather than
-        // letting egui_tiles remove the tile from the tree.
-        if let Some(pane) = tiles.get_pane(&tile_id).cloned() {
-            set_pane_visible(&mut self.state.view_toggles, &pane, false);
+        match tiles.get_pane(&tile_id) {
+            // Node views are user-created tiles: closing removes them entirely.
+            Some(Pane::NodeView(_)) => true,
+            // Hide other panes via their toggle (so they can be reopened) rather
+            // than letting egui_tiles remove the tile from the tree.
+            Some(pane) => {
+                let pane = pane.clone();
+                set_pane_visible(&mut self.state.view_toggles, &pane, false);
+                false
+            }
+            None => false,
         }
-        false
     }
 
     fn tab_ui(
@@ -1137,6 +1144,7 @@ where
                     new_branch: &mut gantz_response.new_branch,
                     responses: &mut gantz_response.responses,
                     changed_heads: &mut gantz_response.changed_heads,
+                    reindexes: &mut gantz_response.node_view_reindexes,
                     base_names,
                     base_immutable: gantz.base_immutable,
                 };
@@ -1354,20 +1362,52 @@ where
                     }
                 }
             }
-            Pane::NodeViews => {
-                // The inner node-views tree (detached node views), persisted and
-                // rendered like the inner graph tree under the graph scene.
-                let tree_id = egui::Id::new(NODE_VIEWS_TREE_ID);
-                let mut views_tree: egui_tiles::Tree<NodeViewPane> =
-                    load_tree(ui.ctx(), tree_id).unwrap_or_else(create_empty_node_views_tree);
-                let mut views_behaviour = NodeViewsTreeBehaviour {
-                    env: gantz.env,
-                    access: *access,
-                    changed_heads: &mut gantz_response.changed_heads,
-                    responses: &mut gantz_response.responses,
-                };
-                views_tree.ui(&mut views_behaviour, ui);
-                store_tree(ui.ctx(), tree_id, &views_tree);
+            Pane::NodeView(view) => {
+                // A detached node view: render the node's `view_ui` against its
+                // head's live graph + VM (a mirror sharing state with the
+                // in-graph node). Renders a placeholder when its head is closed.
+                if !access.heads().iter().any(|h| h == &view.head) {
+                    ui.centered_and_justified(|ui| {
+                        ui.weak("node's graph is not open");
+                    });
+                } else {
+                    let env = gantz.env;
+                    let head = view.head.clone();
+                    let path = view.path.clone();
+                    // Scope child widget ids by (head, path) so views never share
+                    // ids with each other or the in-graph node.
+                    let result = ui
+                        .push_id((&head, &path), |ui| {
+                            access.with_head_mut(&head, |data| {
+                                let &[n_ix] = path.as_slice() else {
+                                    return None;
+                                };
+                                let (inlets, outlets) = crate::inlet_outlet_ids(env, data.graph);
+                                let node = data
+                                    .graph
+                                    .node_weight_mut(graph_scene::NodeIndex::new(n_ix))?;
+                                let ctx = NodeCtx::new(env, &path, &inlets, &outlets, data.vm);
+                                let r = node.view_ui(ctx, ui);
+                                Some((r.changed, r.payloads))
+                            })
+                        })
+                        .inner;
+                    match result {
+                        Some(Some((changed, payloads))) => {
+                            if changed {
+                                gantz_response.changed_heads.push(head.clone());
+                            }
+                            gantz_response.responses.extend(Some(&head), payloads);
+                        }
+                        _ => {
+                            // Head open but node missing at `path` (e.g. removed
+                            // this frame, before migration drops the view).
+                            ui.centered_and_justified(|ui| {
+                                ui.weak("node not found");
+                            });
+                        }
+                    }
+                }
             }
             Pane::Steel => {
                 // Use the focused head's compiled module, highlighting the
@@ -1482,6 +1522,9 @@ where
     responses: &'a mut Responses,
     /// Heads whose graph had a CA-affecting edit this frame.
     changed_heads: &'a mut Vec<gantz_ca::Head>,
+    /// Per-head node index remappings from this frame's deletions, applied to
+    /// the top-level tree's node views after layout (see `migrate_node_view_paths`).
+    reindexes: &'a mut Vec<(gantz_ca::Head, crate::ops::Reindex)>,
     base_names: &'a gantz_ca::registry::Names,
     base_immutable: bool,
 }
@@ -1720,9 +1763,12 @@ where
             if response.changed {
                 self.changed_heads.push(pane_head.clone());
             }
-            // Migrate any detached node-view paths past this frame's deletions so
-            // they keep pointing at the same nodes (or drop if removed).
-            migrate_node_view_paths(ui.ctx(), pane_head, &response.reindex);
+            // Collect this frame's deletions; `Gantz::show` migrates the
+            // top-level tree's node-view paths past them after layout (the live
+            // top-level tree isn't reachable here, mid-traversal).
+            if !response.reindex.is_empty() {
+                self.reindexes.push((pane_head.clone(), response.reindex));
+            }
             // Tag the scene's emissions with this head.
             self.responses.extend(Some(&*pane_head), response.responses);
         }
@@ -1750,108 +1796,6 @@ fn node_view_title(pane: &NodeViewPane) -> String {
         }
     }
     s
-}
-
-/// Behaviour for the inner node-views tree: each pane is one detached node view,
-/// rendered via [`NodeUi::view_ui`] against its head's live graph + VM state.
-struct NodeViewsTreeBehaviour<'a, Access>
-where
-    Access: HeadAccess,
-    Access::Node: Node + NodeUi,
-{
-    env: &'a dyn Registry,
-    access: &'a mut Access,
-    /// Heads whose graph had a CA-affecting edit this frame.
-    changed_heads: &'a mut Vec<gantz_ca::Head>,
-    /// Dynamic payloads emitted from within the node views.
-    responses: &'a mut Responses,
-}
-
-impl<'a, Access> egui_tiles::Behavior<NodeViewPane> for NodeViewsTreeBehaviour<'a, Access>
-where
-    Access: HeadAccess,
-    Access::Node: Node + NodeUi,
-{
-    fn tab_title_for_pane(&mut self, pane: &NodeViewPane) -> egui::WidgetText {
-        node_view_title(pane).into()
-    }
-
-    fn is_tab_closable(
-        &self,
-        _tiles: &egui_tiles::Tiles<NodeViewPane>,
-        _tile_id: egui_tiles::TileId,
-    ) -> bool {
-        true
-    }
-
-    fn on_tab_close(
-        &mut self,
-        _tiles: &mut egui_tiles::Tiles<NodeViewPane>,
-        _tile_id: egui_tiles::TileId,
-    ) -> bool {
-        // These tiles are user-created, so closing removes them entirely (unlike
-        // the outer toggled panes).
-        true
-    }
-
-    fn simplification_options(&self) -> egui_tiles::SimplificationOptions {
-        egui_tiles::SimplificationOptions {
-            all_panes_must_have_tabs: true,
-            ..Default::default()
-        }
-    }
-
-    fn pane_ui(
-        &mut self,
-        ui: &mut egui::Ui,
-        _tile_id: egui_tiles::TileId,
-        pane: &mut NodeViewPane,
-    ) -> egui_tiles::UiResponse {
-        // The head must be open to render a live view.
-        if !self.access.heads().iter().any(|h| *h == pane.head) {
-            ui.centered_and_justified(|ui| {
-                ui.weak("node's graph is not open");
-            });
-            return egui_tiles::UiResponse::None;
-        }
-        let env = self.env;
-        let head = &pane.head;
-        let path = &pane.path;
-        // Scope child widget ids by (head, path) so multiple views - and the
-        // in-graph node - never share ids.
-        let result = ui
-            .push_id((head, path), |ui| {
-                self.access.with_head_mut(head, |data| {
-                    let &[n_ix] = path.as_slice() else {
-                        return None;
-                    };
-                    let (inlets, outlets) = crate::inlet_outlet_ids(env, data.graph);
-                    let node = data
-                        .graph
-                        .node_weight_mut(graph_scene::NodeIndex::new(n_ix))?;
-                    let ctx = NodeCtx::new(env, path, &inlets, &outlets, data.vm);
-                    let r = node.view_ui(ctx, ui);
-                    Some((r.changed, r.payloads))
-                })
-            })
-            .inner;
-        match result {
-            Some(Some((changed, payloads))) => {
-                if changed {
-                    self.changed_heads.push(head.clone());
-                }
-                self.responses.extend(Some(head), payloads);
-            }
-            _ => {
-                // Head open but the node is missing at `path` (e.g. removed this
-                // frame, before migration). Migration drops such panes shortly.
-                ui.centered_and_justified(|ui| {
-                    ui.weak("node not found");
-                });
-            }
-        }
-        egui_tiles::UiResponse::None
-    }
 }
 
 impl widget::command_palette::Command for NodeTyCmd<'_> {
@@ -1916,7 +1860,6 @@ fn create_tree() -> egui_tiles::Tree<Pane> {
     let history = tiles.insert_pane(Pane::History);
     let logs = tiles.insert_pane(Pane::Logs);
     let node_inspector = tiles.insert_pane(Pane::NodeInspector);
-    let node_views = tiles.insert_pane(Pane::NodeViews);
     let settings = tiles.insert_pane(Pane::Settings);
     let steel = tiles.insert_pane(Pane::Steel);
     let vm_perf = tiles.insert_pane(Pane::VmPerf);
@@ -1937,9 +1880,8 @@ fn create_tree() -> egui_tiles::Tree<Pane> {
         shares,
     });
 
-    // Logs, steel code and detached node views in the bottom "tray". All three
-    // default to hidden; the tray appears when any is toggled on.
-    let tray = tiles.insert_horizontal_tile(vec![logs, steel, node_views]);
+    // Logs and steel code in bottom "tray".
+    let tray = tiles.insert_horizontal_tile(vec![logs, steel]);
 
     // The right column with main area (graph scene above logs and steel code).
     let right_column = tiles.insert_container(egui_tiles::Linear::new_binary(
@@ -1965,42 +1907,36 @@ fn create_empty_graph_tree() -> egui_tiles::Tree<GraphPane> {
     egui_tiles::Tree::empty("graph-tiles")
 }
 
-/// Create an empty node-views tree. Panes are added by the "open view" action
-/// (see [`add_node_view_pane`]) and removed on tab-close or node deletion.
-fn create_empty_node_views_tree() -> egui_tiles::Tree<NodeViewPane> {
-    egui_tiles::Tree::empty("node-views-tiles")
-}
-
-/// Insert a node-view pane for `(head, path)` into the node-views `tree`, or
+/// Insert a [`Pane::NodeView`] for `(head, path)` into the top-level `tree`, or
 /// activate the existing one (deduped by head + path). `ty_name` is the node's
-/// type name used for the tab title. Mirrors the insertion in
-/// [`sync_graph_panes`].
+/// type name used for the tab title. New views land in the tray - a layout-safe
+/// default (opaque to the fixed-size anchors); the user can then drag them
+/// anywhere in the tree.
 fn add_node_view_pane(
-    tree: &mut egui_tiles::Tree<NodeViewPane>,
+    tree: &mut egui_tiles::Tree<Pane>,
     head: gantz_ca::Head,
     path: Vec<node::Id>,
     ty_name: String,
 ) {
     // Dedupe: if a view for this (head, path) already exists, just focus it.
     let existing = tree.tiles.iter().find_map(|(id, tile)| match tile {
-        egui_tiles::Tile::Pane(p) if p.head == head && p.path == path => Some(*id),
+        egui_tiles::Tile::Pane(Pane::NodeView(p)) if p.head == head && p.path == path => Some(*id),
         _ => None,
     });
     if let Some(id) = existing {
         tree.make_active(|tile_id, _| tile_id == id);
         return;
     }
-    let pane_id = tree.tiles.insert_pane(NodeViewPane {
+    let pane_id = tree.tiles.insert_pane(Pane::NodeView(NodeViewPane {
         head,
         path,
         ty_name,
-    });
-    match tree.root() {
-        Some(root) => tree.move_tile_to_container(pane_id, root, usize::MAX, true),
-        None => {
-            let root = tree.tiles.insert_tab_tile(vec![pane_id]);
-            tree.root = Some(root);
-        }
+    }));
+    // Default to the tray; fall back to the root if the layout isn't canonical.
+    let container = layout_anchors(tree).map(|a| a.tray).or_else(|| tree.root());
+    match container {
+        Some(c) => tree.move_tile_to_container(pane_id, c, usize::MAX, true),
+        None => tree.root = Some(pane_id),
     }
 }
 
@@ -2269,9 +2205,9 @@ fn linear_child_points(
 }
 
 /// Whether a tab's pane can be hidden via its right-click menu. The main graph
-/// scene and the Settings control surface are not hideable this way.
+/// scene is not hideable; node views are closed (removed), not hidden.
 fn pane_is_hideable(pane: &Pane) -> bool {
-    !matches!(pane, Pane::GraphScene)
+    !matches!(pane, Pane::GraphScene | Pane::NodeView(_))
 }
 
 /// Set a pane's visibility toggle. No-op for panes without one.
@@ -2282,12 +2218,12 @@ fn set_pane_visible(view: &mut ViewToggles, pane: &Pane, visible: bool) {
         Pane::Settings => view.settings = visible,
         Pane::GraphConfig => view.graph_config = visible,
         Pane::NodeInspector => view.node_inspector = visible,
-        Pane::NodeViews => view.node_views = visible,
         Pane::VmPerf => view.perf_vm = visible,
         Pane::GuiPerf => view.perf_gui = visible,
         Pane::Logs => view.logs = visible,
         Pane::Steel => view.steel = visible,
-        Pane::GraphScene => {}
+        // No visibility toggle: always-visible scene / closable node views.
+        Pane::GraphScene | Pane::NodeView(_) => {}
     }
 }
 
@@ -2312,8 +2248,8 @@ fn set_tile_visibility(tree: &mut egui_tiles::Tree<Pane>, view: &ViewToggles) {
                 Pane::VmPerf => tree.set_visible(id, open && view.perf_vm),
                 Pane::Logs => tree.set_visible(id, view.logs),
                 Pane::Steel => tree.set_visible(id, view.steel),
-                // Tray-style: independent of the sidebar, like Logs/Steel.
-                Pane::NodeViews => tree.set_visible(id, view.node_views),
+                // Always visible: a node view is removed by closing, not hiding.
+                Pane::NodeView(_) => tree.set_visible(id, true),
             }
         }
     }

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -1,7 +1,7 @@
 use crate::{
     Action, CopyNodes, CreateNestedGraph, CreateNode, CutNodes, DuplicateNodes, ExportAllNamed,
-    ExportHead, HeadAccess, Keymap, NodeCtx, NodeUi, OpenCommandPalette, OpenLogs, Paste, Redo,
-    Registry, ReplaceHead, ResetTilesLayout, Undo, export,
+    ExportHead, HeadAccess, Keymap, NodeCtx, NodeUi, OpenCommandPalette, OpenLogs, OpenNodeView,
+    Paste, Redo, Registry, ReplaceHead, ResetTilesLayout, Undo, export,
     response::{DynResponse, Responses},
     widget::{self, GraphScene, GraphSceneState, graph_scene},
 };
@@ -349,6 +349,9 @@ pub enum Pane {
     History,
     Logs,
     NodeInspector,
+    /// Contains the inner node-views tree: nodes detached from a graph via the
+    /// "open view" action, each rendered via [`NodeUi::view_ui`] for monitoring.
+    NodeViews,
     /// Globally relevant configuration grouped into Panes / Style / Global
     /// subtabs (pane visibility, style, compile options, reset all demos).
     Settings,
@@ -361,8 +364,23 @@ pub enum Pane {
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 struct GraphPane(gantz_ca::Head);
 
+/// A pane within the inner node-views tree: one detached node view, identified
+/// by its `head` and `path` within that head's graph. `ty_name` is the node's
+/// type name ([`NodeUi::name`]), cached at open-time so the tab title is stable
+/// even while the head is closed (the node type never changes; only its index
+/// does, and that is migrated in [`migrate_node_view_paths`]).
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+struct NodeViewPane {
+    head: gantz_ca::Head,
+    path: Vec<node::Id>,
+    ty_name: String,
+}
+
 /// The egui ID used to store the inner graph tree.
 const GRAPH_TREE_ID: &str = "gantz-graph-tiles-tree";
+
+/// The egui ID used to store the inner node-views tree.
+const NODE_VIEWS_TREE_ID: &str = "gantz-node-views-tiles-tree";
 
 /// Load a tile tree from egui's persisted memory.
 ///
@@ -434,6 +452,45 @@ pub fn update_graph_pane_head(
     if changed {
         store_tree(ctx, graph_tree_id, &tree);
     }
+}
+
+/// Migrate the persisted node-view panes for `head` after a node removal
+/// reindexed its graph, mirroring the state/layout/selection migration in
+/// [`crate::ops::remove_nodes`]: a pane whose node was removed is dropped; a pane
+/// whose node was swapped to a new index has its path rewritten. This keeps a
+/// detached view pointing at the same node across deletions, with no staleness
+/// guard.
+fn migrate_node_view_paths(
+    ctx: &egui::Context,
+    head: &gantz_ca::Head,
+    reindex: &crate::ops::Reindex,
+) {
+    if reindex.is_empty() {
+        return;
+    }
+    let tree_id = egui::Id::new(NODE_VIEWS_TREE_ID);
+    let Some(mut tree) = load_tree::<NodeViewPane>(ctx, tree_id) else {
+        return;
+    };
+    let mut to_remove = Vec::new();
+    for (id, tile) in tree.tiles.iter_mut() {
+        let egui_tiles::Tile::Pane(pane) = tile else {
+            continue;
+        };
+        if pane.head != *head {
+            continue;
+        }
+        // Root-level node views have a single-element path.
+        let [ix] = pane.path[..] else { continue };
+        match reindex.apply_to_index(ix) {
+            Some(new_ix) => pane.path = vec![new_ix],
+            None => to_remove.push(*id),
+        }
+    }
+    for id in to_remove {
+        tree.tiles.remove(id);
+    }
+    store_tree(ctx, tree_id, &tree);
 }
 
 /// The context passed to the `egui_tiles::Tree` widget.
@@ -511,6 +568,7 @@ pub struct ViewToggles {
     pub settings: bool,
     pub logs: bool,
     pub node_inspector: bool,
+    pub node_views: bool,
     pub perf_gui: bool,
     pub perf_vm: bool,
     pub steel: bool,
@@ -530,6 +588,7 @@ impl Default for ViewToggles {
             settings: true,
             logs: false,
             node_inspector: true,
+            node_views: false,
             perf_gui: false,
             perf_vm: false,
             steel: false,
@@ -696,9 +755,9 @@ impl<'a> Gantz<'a> {
         }
 
         // The persisted outer tree. The version suffix invalidates any tree
-        // persisted before the sidebar overhaul (which lacks the new panes and
-        // tab containers), forcing a rebuild via `create_tree`.
-        let tree_id = egui::Id::new("gantz-tiles-tree-storage-v3");
+        // persisted before a layout change that adds/moves panes (here, the
+        // Node Views tray pane), forcing a rebuild via `create_tree`.
+        let tree_id = egui::Id::new("gantz-tiles-tree-storage-v4");
 
         // Retrieve the tree from persistent storage, or load the default.
         let mut tree: egui_tiles::Tree<Pane> =
@@ -778,6 +837,17 @@ impl<'a> Gantz<'a> {
         for _ in response.responses.take::<OpenLogs>() {
             state.view_toggles.logs = true;
         }
+        // "open view": add (or focus) a tile in the inner node-views tree and
+        // reveal the Node Views pane. The node's head is the payload's head tag.
+        for (head, view) in response.responses.take::<OpenNodeView>() {
+            let Some(head) = head else { continue };
+            let views_id = egui::Id::new(NODE_VIEWS_TREE_ID);
+            let mut views_tree: egui_tiles::Tree<NodeViewPane> =
+                load_tree(ui.ctx(), views_id).unwrap_or_else(create_empty_node_views_tree);
+            add_node_view_pane(&mut views_tree, head, view.path, view.ty_name);
+            store_tree(ui.ctx(), views_id, &views_tree);
+            state.view_toggles.node_views = true;
+        }
 
         // Persist the tree.
         store_tree(ui.ctx(), tree_id, &tree);
@@ -853,6 +923,7 @@ where
                 Some(head) => format!("Node Inspector - {head}").into(),
                 None => "Node Inspector".into(),
             },
+            Pane::NodeViews => "Node Views".into(),
             Pane::Steel => match self.access.heads().get(self.focused_head) {
                 Some(head) => format!("Steel - {head}").into(),
                 None => "Steel".into(),
@@ -1283,6 +1354,21 @@ where
                     }
                 }
             }
+            Pane::NodeViews => {
+                // The inner node-views tree (detached node views), persisted and
+                // rendered like the inner graph tree under the graph scene.
+                let tree_id = egui::Id::new(NODE_VIEWS_TREE_ID);
+                let mut views_tree: egui_tiles::Tree<NodeViewPane> =
+                    load_tree(ui.ctx(), tree_id).unwrap_or_else(create_empty_node_views_tree);
+                let mut views_behaviour = NodeViewsTreeBehaviour {
+                    env: gantz.env,
+                    access: *access,
+                    changed_heads: &mut gantz_response.changed_heads,
+                    responses: &mut gantz_response.responses,
+                };
+                views_tree.ui(&mut views_behaviour, ui);
+                store_tree(ui.ctx(), tree_id, &views_tree);
+            }
             Pane::Steel => {
                 // Use the focused head's compiled module, highlighting the
                 // selected nodes' emitted fns/call sites and any diagnostic
@@ -1634,6 +1720,9 @@ where
             if response.changed {
                 self.changed_heads.push(pane_head.clone());
             }
+            // Migrate any detached node-view paths past this frame's deletions so
+            // they keep pointing at the same nodes (or drop if removed).
+            migrate_node_view_paths(ui.ctx(), pane_head, &response.reindex);
             // Tag the scene's emissions with this head.
             self.responses.extend(Some(&*pane_head), response.responses);
         }
@@ -1642,6 +1731,125 @@ where
         let crumbs = name_breadcrumb(rect, pane_head, ui);
         self.responses.extend(Some(&*pane_head), crumbs);
 
+        egui_tiles::UiResponse::None
+    }
+}
+
+/// The tab title for a node-view pane: `<head>:<path>` with the final path
+/// segment rendered as `<ty_name><index>`, echoing gantz_format's node labels
+/// (e.g. `main:add3`). Intermediate segments, if any, are shown as raw indices.
+fn node_view_title(pane: &NodeViewPane) -> String {
+    use std::fmt::Write;
+    let mut s = format!("{}", pane.head);
+    let last = pane.path.len().saturating_sub(1);
+    for (i, seg) in pane.path.iter().enumerate() {
+        if i == last {
+            let _ = write!(s, ":{}{}", pane.ty_name, seg);
+        } else {
+            let _ = write!(s, ":{seg}");
+        }
+    }
+    s
+}
+
+/// Behaviour for the inner node-views tree: each pane is one detached node view,
+/// rendered via [`NodeUi::view_ui`] against its head's live graph + VM state.
+struct NodeViewsTreeBehaviour<'a, Access>
+where
+    Access: HeadAccess,
+    Access::Node: Node + NodeUi,
+{
+    env: &'a dyn Registry,
+    access: &'a mut Access,
+    /// Heads whose graph had a CA-affecting edit this frame.
+    changed_heads: &'a mut Vec<gantz_ca::Head>,
+    /// Dynamic payloads emitted from within the node views.
+    responses: &'a mut Responses,
+}
+
+impl<'a, Access> egui_tiles::Behavior<NodeViewPane> for NodeViewsTreeBehaviour<'a, Access>
+where
+    Access: HeadAccess,
+    Access::Node: Node + NodeUi,
+{
+    fn tab_title_for_pane(&mut self, pane: &NodeViewPane) -> egui::WidgetText {
+        node_view_title(pane).into()
+    }
+
+    fn is_tab_closable(
+        &self,
+        _tiles: &egui_tiles::Tiles<NodeViewPane>,
+        _tile_id: egui_tiles::TileId,
+    ) -> bool {
+        true
+    }
+
+    fn on_tab_close(
+        &mut self,
+        _tiles: &mut egui_tiles::Tiles<NodeViewPane>,
+        _tile_id: egui_tiles::TileId,
+    ) -> bool {
+        // These tiles are user-created, so closing removes them entirely (unlike
+        // the outer toggled panes).
+        true
+    }
+
+    fn simplification_options(&self) -> egui_tiles::SimplificationOptions {
+        egui_tiles::SimplificationOptions {
+            all_panes_must_have_tabs: true,
+            ..Default::default()
+        }
+    }
+
+    fn pane_ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _tile_id: egui_tiles::TileId,
+        pane: &mut NodeViewPane,
+    ) -> egui_tiles::UiResponse {
+        // The head must be open to render a live view.
+        if !self.access.heads().iter().any(|h| *h == pane.head) {
+            ui.centered_and_justified(|ui| {
+                ui.weak("node's graph is not open");
+            });
+            return egui_tiles::UiResponse::None;
+        }
+        let env = self.env;
+        let head = &pane.head;
+        let path = &pane.path;
+        // Scope child widget ids by (head, path) so multiple views - and the
+        // in-graph node - never share ids.
+        let result = ui
+            .push_id((head, path), |ui| {
+                self.access.with_head_mut(head, |data| {
+                    let &[n_ix] = path.as_slice() else {
+                        return None;
+                    };
+                    let (inlets, outlets) = crate::inlet_outlet_ids(env, data.graph);
+                    let node = data
+                        .graph
+                        .node_weight_mut(graph_scene::NodeIndex::new(n_ix))?;
+                    let ctx = NodeCtx::new(env, path, &inlets, &outlets, data.vm);
+                    let r = node.view_ui(ctx, ui);
+                    Some((r.changed, r.payloads))
+                })
+            })
+            .inner;
+        match result {
+            Some(Some((changed, payloads))) => {
+                if changed {
+                    self.changed_heads.push(head.clone());
+                }
+                self.responses.extend(Some(head), payloads);
+            }
+            _ => {
+                // Head open but the node is missing at `path` (e.g. removed this
+                // frame, before migration). Migration drops such panes shortly.
+                ui.centered_and_justified(|ui| {
+                    ui.weak("node not found");
+                });
+            }
+        }
         egui_tiles::UiResponse::None
     }
 }
@@ -1708,6 +1916,7 @@ fn create_tree() -> egui_tiles::Tree<Pane> {
     let history = tiles.insert_pane(Pane::History);
     let logs = tiles.insert_pane(Pane::Logs);
     let node_inspector = tiles.insert_pane(Pane::NodeInspector);
+    let node_views = tiles.insert_pane(Pane::NodeViews);
     let settings = tiles.insert_pane(Pane::Settings);
     let steel = tiles.insert_pane(Pane::Steel);
     let vm_perf = tiles.insert_pane(Pane::VmPerf);
@@ -1728,8 +1937,9 @@ fn create_tree() -> egui_tiles::Tree<Pane> {
         shares,
     });
 
-    // Logs and steel code in bottom "tray".
-    let tray = tiles.insert_horizontal_tile(vec![logs, steel]);
+    // Logs, steel code and detached node views in the bottom "tray". All three
+    // default to hidden; the tray appears when any is toggled on.
+    let tray = tiles.insert_horizontal_tile(vec![logs, steel, node_views]);
 
     // The right column with main area (graph scene above logs and steel code).
     let right_column = tiles.insert_container(egui_tiles::Linear::new_binary(
@@ -1753,6 +1963,45 @@ fn create_tree() -> egui_tiles::Tree<Pane> {
 /// Create an empty graph tree. Panes will be added by `sync_graph_panes`.
 fn create_empty_graph_tree() -> egui_tiles::Tree<GraphPane> {
     egui_tiles::Tree::empty("graph-tiles")
+}
+
+/// Create an empty node-views tree. Panes are added by the "open view" action
+/// (see [`add_node_view_pane`]) and removed on tab-close or node deletion.
+fn create_empty_node_views_tree() -> egui_tiles::Tree<NodeViewPane> {
+    egui_tiles::Tree::empty("node-views-tiles")
+}
+
+/// Insert a node-view pane for `(head, path)` into the node-views `tree`, or
+/// activate the existing one (deduped by head + path). `ty_name` is the node's
+/// type name used for the tab title. Mirrors the insertion in
+/// [`sync_graph_panes`].
+fn add_node_view_pane(
+    tree: &mut egui_tiles::Tree<NodeViewPane>,
+    head: gantz_ca::Head,
+    path: Vec<node::Id>,
+    ty_name: String,
+) {
+    // Dedupe: if a view for this (head, path) already exists, just focus it.
+    let existing = tree.tiles.iter().find_map(|(id, tile)| match tile {
+        egui_tiles::Tile::Pane(p) if p.head == head && p.path == path => Some(*id),
+        _ => None,
+    });
+    if let Some(id) = existing {
+        tree.make_active(|tile_id, _| tile_id == id);
+        return;
+    }
+    let pane_id = tree.tiles.insert_pane(NodeViewPane {
+        head,
+        path,
+        ty_name,
+    });
+    match tree.root() {
+        Some(root) => tree.move_tile_to_container(pane_id, root, usize::MAX, true),
+        None => {
+            let root = tree.tiles.insert_tab_tile(vec![pane_id]);
+            tree.root = Some(root);
+        }
+    }
 }
 
 /// Sync the graph tree panes with the current heads.
@@ -2033,6 +2282,7 @@ fn set_pane_visible(view: &mut ViewToggles, pane: &Pane, visible: bool) {
         Pane::Settings => view.settings = visible,
         Pane::GraphConfig => view.graph_config = visible,
         Pane::NodeInspector => view.node_inspector = visible,
+        Pane::NodeViews => view.node_views = visible,
         Pane::VmPerf => view.perf_vm = visible,
         Pane::GuiPerf => view.perf_gui = visible,
         Pane::Logs => view.logs = visible,
@@ -2062,6 +2312,8 @@ fn set_tile_visibility(tree: &mut egui_tiles::Tree<Pane>, view: &ViewToggles) {
                 Pane::VmPerf => tree.set_visible(id, open && view.perf_vm),
                 Pane::Logs => tree.set_visible(id, view.logs),
                 Pane::Steel => tree.set_visible(id, view.steel),
+                // Tray-style: independent of the sidebar, like Logs/Steel.
+                Pane::NodeViews => tree.set_visible(id, view.node_views),
             }
         }
     }

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -1372,53 +1372,71 @@ where
             Pane::NodeView(view) => {
                 // A detached node view: render the node's `view_ui` against its
                 // head's live graph + VM (a mirror sharing state with the
-                // in-graph node). Wrapped in `pane_ui` so the background and
-                // margin match the other panes; a placeholder shows when the
+                // in-graph node). A `CentralPanel` gives it the same background
+                // as the other panes; full-bleed views (e.g. plot) drop the pane
+                // margin so they fill edge-to-edge. A placeholder shows when the
                 // head is closed.
-                pane_ui(ui, |ui| {
-                    if !access.heads().iter().any(|h| h == &view.head) {
-                        ui.centered_and_justified(|ui| {
-                            ui.weak("node's graph is not open");
-                        });
-                        return;
-                    }
-                    let env = gantz.env;
-                    let head = view.head.clone();
-                    let path = view.path.clone();
-                    // Scope child widget ids by (head, path) so views never share
-                    // ids with each other or the in-graph node.
-                    let result = ui
-                        .push_id((&head, &path), |ui| {
-                            access.with_head_mut(&head, |data| {
-                                let &[n_ix] = path.as_slice() else {
-                                    return None;
-                                };
-                                let (inlets, outlets) = crate::inlet_outlet_ids(env, data.graph);
-                                let node = data
-                                    .graph
-                                    .node_weight_mut(graph_scene::NodeIndex::new(n_ix))?;
-                                let ctx = NodeCtx::new(env, &path, &inlets, &outlets, data.vm);
-                                let r = node.view_ui(ctx, ui);
-                                Some((r.changed, r.payloads))
-                            })
-                        })
-                        .inner;
-                    match result {
-                        Some(Some((changed, payloads))) => {
-                            if changed {
-                                gantz_response.changed_heads.push(head.clone());
-                            }
-                            gantz_response.responses.extend(Some(&head), payloads);
-                        }
-                        _ => {
-                            // Head open but node missing at `path` (e.g. removed
-                            // this frame, before migration drops the view).
+                let head = view.head.clone();
+                let path = view.path.clone();
+                let full_bleed = access
+                    .with_head_mut(&head, |data| {
+                        let &[ix] = path.as_slice() else {
+                            return false;
+                        };
+                        data.graph
+                            .node_weight(graph_scene::NodeIndex::new(ix))
+                            .is_some_and(|n| n.view_full_bleed())
+                    })
+                    .unwrap_or(false);
+                let mut frame = egui::Frame::central_panel(ui.style());
+                if full_bleed {
+                    frame.inner_margin = egui::Margin::ZERO;
+                }
+                egui::CentralPanel::default()
+                    .frame(frame)
+                    .show_inside(ui, |ui| {
+                        if !access.heads().iter().any(|h| h == &head) {
                             ui.centered_and_justified(|ui| {
-                                ui.weak("node not found");
+                                ui.weak("node's graph is not open");
                             });
+                            return;
                         }
-                    }
-                });
+                        let env = gantz.env;
+                        // Scope child widget ids by (head, path) so views never share
+                        // ids with each other or the in-graph node.
+                        let result = ui
+                            .push_id((&head, &path), |ui| {
+                                access.with_head_mut(&head, |data| {
+                                    let &[n_ix] = path.as_slice() else {
+                                        return None;
+                                    };
+                                    let (inlets, outlets) =
+                                        crate::inlet_outlet_ids(env, data.graph);
+                                    let node = data
+                                        .graph
+                                        .node_weight_mut(graph_scene::NodeIndex::new(n_ix))?;
+                                    let ctx = NodeCtx::new(env, &path, &inlets, &outlets, data.vm);
+                                    let r = node.view_ui(ctx, ui);
+                                    Some((r.changed, r.payloads))
+                                })
+                            })
+                            .inner;
+                        match result {
+                            Some(Some((changed, payloads))) => {
+                                if changed {
+                                    gantz_response.changed_heads.push(head.clone());
+                                }
+                                gantz_response.responses.extend(Some(&head), payloads);
+                            }
+                            _ => {
+                                // Head open but node missing at `path` (e.g. removed
+                                // this frame, before migration drops the view).
+                                ui.centered_and_justified(|ui| {
+                                    ui.weak("node not found");
+                                });
+                            }
+                        }
+                    });
             }
             Pane::Steel => {
                 // Use the focused head's compiled module, highlighting the

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -1034,6 +1034,13 @@ where
         egui_tiles::SimplificationOptions::OFF
     }
 
+    fn min_size(&self) -> f32 {
+        // No pane (split) may shrink below this, so a thin pane - e.g. a freshly
+        // placed node view - stays visible and grabbable rather than collapsing
+        // to a sliver. (egui_tiles' default is 32.)
+        64.0
+    }
+
     fn pane_ui(
         &mut self,
         ui: &mut egui::Ui,
@@ -1365,12 +1372,16 @@ where
             Pane::NodeView(view) => {
                 // A detached node view: render the node's `view_ui` against its
                 // head's live graph + VM (a mirror sharing state with the
-                // in-graph node). Renders a placeholder when its head is closed.
-                if !access.heads().iter().any(|h| h == &view.head) {
-                    ui.centered_and_justified(|ui| {
-                        ui.weak("node's graph is not open");
-                    });
-                } else {
+                // in-graph node). Wrapped in `pane_ui` so the background and
+                // margin match the other panes; a placeholder shows when the
+                // head is closed.
+                pane_ui(ui, |ui| {
+                    if !access.heads().iter().any(|h| h == &view.head) {
+                        ui.centered_and_justified(|ui| {
+                            ui.weak("node's graph is not open");
+                        });
+                        return;
+                    }
                     let env = gantz.env;
                     let head = view.head.clone();
                     let path = view.path.clone();
@@ -1407,7 +1418,7 @@ where
                             });
                         }
                     }
-                }
+                });
             }
             Pane::Steel => {
                 // Use the focused head's compiled module, highlighting the
@@ -1782,15 +1793,15 @@ where
 }
 
 /// The tab title for a node-view pane: `<head>:<path>` with the final path
-/// segment rendered as `<ty_name><index>`, echoing gantz_format's node labels
-/// (e.g. `main:add3`). Intermediate segments, if any, are shown as raw indices.
+/// segment rendered as `<index>-<ty_name>` (e.g. `main:3-plot`, or for a nested
+/// path `main:2:5-plot`). Intermediate segments are shown as raw indices.
 fn node_view_title(pane: &NodeViewPane) -> String {
     use std::fmt::Write;
     let mut s = format!("{}", pane.head);
     let last = pane.path.len().saturating_sub(1);
     for (i, seg) in pane.path.iter().enumerate() {
         if i == last {
-            let _ = write!(s, ":{}{}", pane.ty_name, seg);
+            let _ = write!(s, ":{seg}-{}", pane.ty_name);
         } else {
             let _ = write!(s, ":{seg}");
         }

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -1,6 +1,6 @@
 use crate::{
-    CopyNodes, InspectEdge, NodeUi, OpenCommandPalette, OpenHead, Paste, PastePos, Registry,
-    ResetTilesLayout, SocketDoc, response::DynResponse,
+    CopyNodes, InspectEdge, NodeUi, OpenCommandPalette, OpenHead, OpenNodeView, Paste, PastePos,
+    Registry, ResetTilesLayout, SocketDoc, response::DynResponse,
 };
 use egui::emath::GuiRounding;
 use egui_graph::{self, SocketKind, node::EdgeEvent};
@@ -29,6 +29,9 @@ pub struct GraphSceneResponse {
     /// Dynamic payloads emitted within the scene (node UIs, context menus),
     /// to be handled by the application after the pass.
     pub responses: Vec<DynResponse>,
+    /// The index changes from any node deletions this frame, so callers can
+    /// migrate their own index-keyed data (e.g. detached node views).
+    pub reindex: crate::ops::Reindex,
 }
 
 /// An alias for the node response type returned from gantz nodes.
@@ -276,14 +279,16 @@ where
 
         // Apply deferred deletes now the scene no longer borrows `view`. Removal
         // swap-removes nodes, so this migrates the swapped node's state, layout
-        // and selection (see `crate::ops::remove_nodes`).
-        if crate::ops::remove_nodes(
+        // and selection (see `crate::ops::remove_nodes`). The returned reindex is
+        // surfaced so callers can migrate their own index-keyed data too.
+        let reindex = crate::ops::remove_nodes(
             self.graph,
             vm,
             &mut view.layout,
             &mut state.interaction.selection,
             to_delete,
-        ) {
+        );
+        if !reindex.is_empty() {
             changed = true;
         }
 
@@ -382,6 +387,7 @@ where
             nodes: node_responses,
             changed,
             responses,
+            reindex,
         }
     }
 }
@@ -704,6 +710,21 @@ where
                     responses.push(DynResponse::new(OpenHead(head)));
                     ui.close();
                 }
+            }
+            // "open view": detach the right-clicked node's UI into a tile in the
+            // Node Views pane (a live mirror, sharing VM state). Always available,
+            // even for immutable graphs - it only observes the node.
+            if ui
+                .button("open view")
+                .on_hover_text("open this node's view in the Node Views pane")
+                .clicked()
+            {
+                let ty_name = graph[n_id].name(registry).to_string();
+                responses.push(DynResponse::new(OpenNodeView {
+                    path: vec![n_ix],
+                    ty_name,
+                }));
+                ui.close();
             }
             if !immutable {
                 let stateful = target


### PR DESCRIPTION
Addresses **#271 (part 2)** - "popping out" a node's `NodeUi::ui` into a pane/tile in the top-level tile tree. (Part 1, popping a *pane* into a *window*, is left for a follow-up.)

## What it does

A new **"open view"** action on a node's right-click menu detaches that node's UI into its own tile in the top-level tile tree. The tile is a live **mirror** of the in-graph node - it shares the same VM state, so it updates as the graph runs - and it can be dragged and placed freely anywhere alongside the graph scene, sidebar and tray. This is handy for keeping a plot, value or code view in a fixed spot while you work elsewhere in the graph.

Each node view is a first-class top-level tile (a data-carrying `Pane::NodeView`), so any number can be opened, rearranged, and closed independently. Closing a view's graph tab leaves a placeholder. Reopening it goes live again.

## Per-node views

Nodes render their own view via a new `NodeUi::view_ui`. The default shows the node's current value (its debug repr).

- **plot** - the full chart, filling the pane edge-to-edge (`view_no_margin`).
- **number** - its dialer (editing updates VM state / queues an eval, like the in-graph node).
- **expr** / **branch** - their Steel code editor, sized to fill the pane.
- **inspect** / others - the value display (the default).