### PR TITLE
Decentralize `.gantz` keyword sugar so each crate owns its nodes' sugar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,7 @@ dependencies = [
  "gantz_ca",
  "gantz_core",
  "gantz_egui",
+ "gantz_format",
  "rfd",
  "serde",
  "steel-core",
@@ -3304,6 +3305,7 @@ version = "0.3.0"
 dependencies = [
  "gantz_ca",
  "gantz_core",
+ "gantz_format",
  "log",
  "petgraph",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3297,6 +3297,7 @@ dependencies = [
  "petgraph",
  "serde",
  "steel-core",
+ "typetag",
 ]
 
 [[package]]

--- a/crates/bevy_gantz_egui/Cargo.toml
+++ b/crates/bevy_gantz_egui/Cargo.toml
@@ -24,6 +24,7 @@ gantz_base.workspace = true
 gantz_ca.workspace = true
 gantz_core.workspace = true
 gantz_egui.workspace = true
+gantz_format.workspace = true
 rfd.workspace = true
 serde.workspace = true
 steel-core.workspace = true

--- a/crates/bevy_gantz_egui/src/base.rs
+++ b/crates/bevy_gantz_egui/src/base.rs
@@ -36,7 +36,13 @@ pub fn load<N>(
     mut views: ResMut<crate::Views>,
     mut demos: ResMut<crate::Demos>,
 ) where
-    N: 'static + serde::Serialize + serde::de::DeserializeOwned + gantz_ca::CaHash + Send + Sync,
+    N: 'static
+        + serde::Serialize
+        + serde::de::DeserializeOwned
+        + gantz_ca::CaHash
+        + gantz_format::NodeSugar
+        + Send
+        + Sync,
 {
     let export: gantz_egui::export::Export<Graph<N>> =
         match gantz_egui::export::parse_export_at(BYTES, BASE_TIMESTAMP) {
@@ -76,6 +82,7 @@ pub fn export_to_file<N>(
         + serde::de::DeserializeOwned
         + gantz_core::Node
         + Clone
+        + gantz_format::NodeSugar
         + Send
         + Sync,
 {
@@ -107,6 +114,7 @@ where
         + serde::de::DeserializeOwned
         + gantz_core::Node
         + Clone
+        + gantz_format::NodeSugar
         + Send
         + Sync,
 {

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -28,6 +28,9 @@ use std::ops::{Deref, DerefMut};
 pub mod base;
 pub mod node;
 pub mod storage;
+pub mod sugar;
+
+pub use sugar::BevySugar;
 
 // ----------------------------------------------------------------------------
 // Plugin
@@ -85,6 +88,7 @@ where
         + node::ToTickBang
         + serde::Serialize
         + serde::de::DeserializeOwned
+        + gantz_format::NodeSugar
         + Send
         + Sync
         + 'static,
@@ -937,6 +941,7 @@ pub fn on_copy_nodes<N>(
         + serde::Serialize
         + serde::de::DeserializeOwned
         + ca::CaHash
+        + gantz_format::NodeSugar
         + Send
         + Sync,
 {
@@ -984,6 +989,7 @@ pub fn on_paste<N>(
         + serde::de::DeserializeOwned
         + ca::CaHash
         + gantz_egui::sync::AsNamedRef
+        + gantz_format::NodeSugar
         + Send
         + Sync,
 {
@@ -1055,6 +1061,7 @@ pub fn on_cut_nodes<N>(
         + serde::Serialize
         + serde::de::DeserializeOwned
         + ca::CaHash
+        + gantz_format::NodeSugar
         + Send
         + Sync,
 {
@@ -1116,6 +1123,7 @@ pub fn on_duplicate_nodes<N>(
         + serde::de::DeserializeOwned
         + ca::CaHash
         + gantz_egui::sync::AsNamedRef
+        + gantz_format::NodeSugar
         + Send
         + Sync,
 {
@@ -1211,7 +1219,14 @@ pub fn on_export_head<N>(
     demos: Res<Demos>,
     heads: Query<&head::HeadRef, With<head::OpenHead>>,
 ) where
-    N: 'static + serde::Serialize + serde::de::DeserializeOwned + Node + Clone + Send + Sync,
+    N: 'static
+        + serde::Serialize
+        + serde::de::DeserializeOwned
+        + Node
+        + Clone
+        + gantz_format::NodeSugar
+        + Send
+        + Sync,
 {
     let event = trigger.event();
     let Ok(head_ref) = heads.get(event.head) else {
@@ -1268,7 +1283,14 @@ pub fn on_export_all_named<N>(
     views: Res<Views>,
     demos: Res<Demos>,
 ) where
-    N: 'static + serde::Serialize + serde::de::DeserializeOwned + Node + Clone + Send + Sync,
+    N: 'static
+        + serde::Serialize
+        + serde::de::DeserializeOwned
+        + Node
+        + Clone
+        + gantz_format::NodeSugar
+        + Send
+        + Sync,
 {
     let node_reg = registry_ref(&registry, &builtins, &demos);
     let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
@@ -1333,6 +1355,7 @@ pub fn on_import_file<N>(
         + ca::CaHash
         + Node
         + Clone
+        + gantz_format::NodeSugar
         + Send
         + Sync,
 {
@@ -1369,7 +1392,14 @@ pub fn on_import_file<N>(
 /// Reset a base graph to its original state by re-merging from the base export.
 pub fn on_reset_base_graph<N>(trigger: On<ResetBaseGraphEvent>, mut registry: ResMut<Registry<N>>)
 where
-    N: 'static + Clone + serde::Serialize + serde::de::DeserializeOwned + ca::CaHash + Send + Sync,
+    N: 'static
+        + Clone
+        + serde::Serialize
+        + serde::de::DeserializeOwned
+        + ca::CaHash
+        + gantz_format::NodeSugar
+        + Send
+        + Sync,
 {
     let name = &trigger.event().0;
     let export: gantz_egui::export::Export<Graph<N>> = match gantz_egui::export::parse_export_at::<N>(

--- a/crates/bevy_gantz_egui/src/node/tick_bang.rs
+++ b/crates/bevy_gantz_egui/src/node/tick_bang.rs
@@ -15,6 +15,7 @@ use gantz_ca::CaHash;
 use gantz_core::node::{self, ExprCtx, ExprResult, MetaCtx, RegCtx};
 use gantz_core::visit;
 use gantz_egui::widget::node_inspector::radio_option;
+use gantz_format::{Datum, FormatError, SugarArgs, node_datum};
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 use steel::SteelVal;
@@ -70,6 +71,58 @@ impl Interval {
 impl Default for Interval {
     fn default() -> Self {
         Interval::Duration(DEFAULT_DURATION)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.gantz` keyword sugar
+// ---------------------------------------------------------------------------
+
+/// Read a `(tick-bang [#:duration secs | #:rate hz])` form into a [`TickBang`]'s
+/// `interval` enum field. `#:duration` and `#:rate` are mutually exclusive;
+/// neither given yields the default duration. Dispatched by
+/// [`crate::sugar::BevySugar`].
+pub(crate) fn read_sugar(args: SugarArgs<'_>) -> Result<Datum, FormatError> {
+    let duration = args.keyword_f64("duration")?;
+    let rate = args.keyword_f64("rate")?;
+    let fields = match (duration, rate) {
+        (Some(_), Some(_)) => {
+            return Err(FormatError::malformed(
+                "tick-bang: specify #:duration or #:rate, not both",
+            ));
+        }
+        (Some(secs), None) => vec![("interval", interval_datum("Duration", secs))],
+        (None, Some(hz)) => vec![("interval", interval_datum("Rate", hz))],
+        (None, None) => vec![],
+    };
+    Ok(node_datum("TickBang", fields))
+}
+
+/// Write a [`TickBang`] as a bare `tick-bang` for the default duration, else as
+/// `(tick-bang #:duration secs)` or `(tick-bang #:rate hz)` per its unit.
+pub(crate) fn write_sugar(node: &Datum) -> String {
+    match interval_of(node) {
+        Some(("Rate", hz)) => format!("(tick-bang #:rate {hz})"),
+        Some(("Duration", secs)) if secs != DEFAULT_DURATION => {
+            format!("(tick-bang #:duration {secs})")
+        }
+        _ => "tick-bang".to_string(),
+    }
+}
+
+/// The externally-tagged `interval` enum datum for a variant (e.g. `(("Rate" hz))`).
+fn interval_datum(variant: &str, value: f64) -> Datum {
+    Datum::Map(vec![(variant.to_string(), Datum::F64(value))])
+}
+
+/// Read a [`TickBang`]'s `interval` field back as `(variant, value)`.
+fn interval_of(node: &Datum) -> Option<(&str, f64)> {
+    match node.get("interval")? {
+        Datum::Map(entries) => {
+            let (variant, value) = entries.first()?;
+            Some((variant.as_str(), value.as_f64()?))
+        }
+        _ => None,
     }
 }
 

--- a/crates/bevy_gantz_egui/src/sugar.rs
+++ b/crates/bevy_gantz_egui/src/sugar.rs
@@ -1,0 +1,127 @@
+//! `.gantz` keyword sugar for this crate's self-driven node set.
+//!
+//! [`BevySugar`] provides the keywords for the bevy nodes: bare `update-bang`
+//! and `(tick-bang [#:duration secs | #:rate hz])`. The `tick-bang` read/write
+//! logic lives with the node in [`crate::node::tick_bang`]. Compose it with
+//! [`gantz_format::CoreSugar`] (and the other crates' sugars) via
+//! [`gantz_format::Sugars`].
+
+use crate::node::tick_bang;
+use gantz_format::{Datum, FormatError, Sugar, SugarArgs, node_datum};
+
+/// Keyword sugar for [`UpdateBang`](crate::node::UpdateBang) and
+/// [`TickBang`](crate::node::TickBang).
+#[derive(Clone, Copy, Debug, Default)]
+pub struct BevySugar;
+
+/// Sugar keyword -> typetag tag, for the bevy builtins that lower to a plain
+/// serde object with no extra arguments.
+const KEYWORD_TAG: &[(&str, &str)] = &[("update-bang", "UpdateBang"), ("tick-bang", "TickBang")];
+
+/// The typetag tag for a sugar keyword.
+fn tag_for_keyword(kw: &str) -> Option<&'static str> {
+    KEYWORD_TAG
+        .iter()
+        .find(|(k, _)| *k == kw)
+        .map(|&(_, tag)| tag)
+}
+
+/// The sugar keyword for a typetag tag, if one exists.
+fn keyword_for_tag(tag: &str) -> Option<&'static str> {
+    KEYWORD_TAG
+        .iter()
+        .find(|(_, t)| *t == tag)
+        .map(|&(kw, _)| kw)
+}
+
+impl Sugar for BevySugar {
+    fn read_spec(&self, head: &str, args: SugarArgs<'_>) -> Result<Option<Datum>, FormatError> {
+        let datum = match head {
+            "tick-bang" => tick_bang::read_sugar(args)?,
+            _ => return Ok(None),
+        };
+        Ok(Some(datum))
+    }
+
+    fn read_bare(&self, keyword: &str) -> Option<Datum> {
+        tag_for_keyword(keyword).map(|tag| node_datum(tag, vec![]))
+    }
+
+    fn write_spec(&self, tag: &str, node: &Datum) -> Option<String> {
+        match tag {
+            "TickBang" => Some(tick_bang::write_sugar(node)),
+            other => keyword_for_tag(other).map(str::to_string),
+        }
+    }
+
+    fn keyword_for_tag(&self, tag: &str) -> Option<&str> {
+        keyword_for_tag(tag)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gantz_format::sexpr;
+
+    /// Read a single sugar form's text through `BevySugar`, as the format does.
+    fn read_spec(text: &str) -> Option<Datum> {
+        let exprs = sexpr::read(text).expect("read");
+        let args = sexpr::list_args(&exprs[0]).expect("list");
+        let head = sexpr::as_symbol(&args[0]).expect("head");
+        BevySugar
+            .read_spec(&head, SugarArgs::new(&args[1..], text))
+            .expect("read_spec")
+    }
+
+    #[test]
+    fn update_bang_round_trips() {
+        let bare = BevySugar
+            .read_bare("update-bang")
+            .expect("bare update-bang");
+        assert_eq!(bare.get("type").and_then(Datum::as_str), Some("UpdateBang"));
+        assert_eq!(
+            BevySugar.write_spec("UpdateBang", &bare).as_deref(),
+            Some("update-bang")
+        );
+    }
+
+    #[test]
+    fn tick_bang_config_round_trips() {
+        let s = BevySugar;
+
+        // A bare (default-duration) tick! stays bare, read as keyword or spec.
+        let bare = s.read_bare("tick-bang").expect("bare tick-bang");
+        assert_eq!(
+            s.write_spec("TickBang", &bare).as_deref(),
+            Some("tick-bang")
+        );
+
+        // A custom duration round-trips via the `#:duration` keyword (seconds).
+        let d = read_spec("(tick-bang #:duration 0.5)").expect("duration");
+        assert_eq!(
+            s.write_spec("TickBang", &d).as_deref(),
+            Some("(tick-bang #:duration 0.5)"),
+        );
+
+        // A rate round-trips via the `#:rate` keyword (Hz), stored exactly.
+        let r = read_spec("(tick-bang #:rate 60)").expect("rate");
+        assert_eq!(
+            s.write_spec("TickBang", &r).as_deref(),
+            Some("(tick-bang #:rate 60)"),
+        );
+
+        // An explicit default duration also writes as the bare keyword.
+        let one = read_spec("(tick-bang #:duration 1)").expect("default duration");
+        assert_eq!(s.write_spec("TickBang", &one).as_deref(), Some("tick-bang"));
+
+        // `#:duration` and `#:rate` are mutually exclusive.
+        let text = "(tick-bang #:duration 0.5 #:rate 60)";
+        let exprs = sexpr::read(text).expect("read");
+        let args = sexpr::list_args(&exprs[0]).expect("list");
+        assert!(
+            s.read_spec("tick-bang", SugarArgs::new(&args[1..], text))
+                .is_err()
+        );
+    }
+}

--- a/crates/gantz/Cargo.toml
+++ b/crates/gantz/Cargo.toml
@@ -23,15 +23,13 @@ gantz_base.workspace = true
 gantz_ca.workspace = true
 gantz_core.workspace = true
 gantz_egui.workspace = true
+gantz_format.workspace = true
 gantz_std.workspace = true
 petgraph.workspace = true
 serde.workspace = true
 steel-core.workspace = true
 typetag.workspace = true
 web-time.workspace = true
-
-[dev-dependencies]
-gantz_format.workspace = true
 
 [[bin]]
 name = "gantz"

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -87,6 +87,19 @@ impl bevy_gantz_egui::node::ToTickBang for Box<dyn Node> {
 #[typetag::serde]
 impl Node for Box<dyn Node> {}
 
+/// The composite `.gantz` keyword sugar for this app's full node set: the
+/// `gantz_core`, `gantz_std`, `gantz_egui` and `bevy_gantz_egui` node sugars.
+impl gantz_format::NodeSugar for Box<dyn Node> {
+    fn sugar() -> gantz_format::Sugars<'static> {
+        gantz_format::Sugars(vec![
+            &gantz_format::CoreSugar,
+            &gantz_std::StdSugar,
+            &gantz_egui::EguiSugar,
+            &bevy_gantz_egui::BevySugar,
+        ])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Node;

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -335,6 +335,18 @@ impl Node for gantz_egui::node::Plot {}
 #[typetag::serde]
 impl Node for Box<dyn Node> {}
 
+/// The composite `.gantz` keyword sugar for the demo's node set: the
+/// `gantz_core`, `gantz_std` and `gantz_egui` node sugars (no bevy nodes here).
+impl gantz_format::NodeSugar for Box<dyn Node> {
+    fn sugar() -> gantz_format::Sugars<'static> {
+        gantz_format::Sugars(vec![
+            &gantz_format::CoreSugar,
+            &gantz_std::StdSugar,
+            &gantz_egui::EguiSugar,
+        ])
+    }
+}
+
 // Required by `gantz_egui::ops::branch_node` to replace branched nodes.
 impl From<gantz_egui::node::NamedRef> for Box<dyn Node> {
     fn from(named: gantz_egui::node::NamedRef) -> Self {

--- a/crates/gantz_egui/src/export.rs
+++ b/crates/gantz_egui/src/export.rs
@@ -89,7 +89,7 @@ where
 /// [`parse_export_at`] to stamp them with a fixed timestamp instead.
 pub fn parse_export<N>(bytes: &[u8]) -> Result<Export<Graph<N>>, ParseExportError>
 where
-    N: Serialize + DeserializeOwned + CaHash + 'static,
+    N: Serialize + DeserializeOwned + CaHash + gantz_format::NodeSugar + 'static,
 {
     parse_export_at(bytes, now())
 }
@@ -108,7 +108,7 @@ pub fn parse_export_at<N>(
     now: gantz_ca::Timestamp,
 ) -> Result<Export<Graph<N>>, ParseExportError>
 where
-    N: Serialize + DeserializeOwned + CaHash + 'static,
+    N: Serialize + DeserializeOwned + CaHash + gantz_format::NodeSugar + 'static,
 {
     let text = std::str::from_utf8(bytes).map_err(ParseExportError::Utf8)?;
     crate::format::from_str(text, now).map_err(ParseExportError::Format)
@@ -145,7 +145,7 @@ pub fn export_heads_sexpr<N>(
     heads: impl IntoIterator<Item = impl std::borrow::Borrow<gantz_ca::Head>>,
 ) -> Result<String, crate::format::FormatError>
 where
-    N: Serialize + DeserializeOwned + gantz_core::Node + Clone,
+    N: Serialize + DeserializeOwned + gantz_core::Node + Clone + gantz_format::NodeSugar,
 {
     let export_registry = gantz_core::reg::export_heads(get_node, registry, heads);
     let export = export_with(export_registry, all_views, all_demos);
@@ -164,7 +164,7 @@ pub fn export_heads_sexpr_named<N>(
     heads: impl IntoIterator<Item = impl std::borrow::Borrow<gantz_ca::Head>>,
 ) -> Result<String, crate::format::FormatError>
 where
-    N: Serialize + DeserializeOwned + gantz_core::Node + Clone,
+    N: Serialize + DeserializeOwned + gantz_core::Node + Clone + gantz_format::NodeSugar,
 {
     let export_registry = gantz_core::reg::export_heads(get_node, registry, heads);
     let export = export_with(export_registry, all_views, all_demos);
@@ -369,7 +369,7 @@ where
 /// this.
 pub fn copied_to_string<N>(copied: &Copied<N>) -> Result<String, crate::format::FormatError>
 where
-    N: Serialize + DeserializeOwned + CaHash + Clone + 'static,
+    N: Serialize + DeserializeOwned + CaHash + Clone + gantz_format::NodeSugar + 'static,
 {
     // Add the subgraph to the dependency registry as a fresh root commit named
     // `CLIPBOARD_NAME`. A fixed timestamp keeps the payload deterministic.
@@ -407,7 +407,7 @@ where
 /// dependencies.
 pub fn copied_from_str<N>(text: &str) -> Result<Copied<N>, ParseCopiedError>
 where
-    N: Serialize + DeserializeOwned + CaHash + Clone + 'static,
+    N: Serialize + DeserializeOwned + CaHash + Clone + gantz_format::NodeSugar + 'static,
 {
     let mut export = crate::format::from_str::<N>(text, now()).map_err(ParseCopiedError::Format)?;
 

--- a/crates/gantz_egui/src/format.rs
+++ b/crates/gantz_egui/src/format.rs
@@ -24,7 +24,7 @@ pub use gantz_format::FormatError;
 /// explicitly (hand-authored graphs).
 pub fn from_str<N>(text: &str, now: Timestamp) -> Result<Export<Graph<N>>, FormatError>
 where
-    N: Serialize + DeserializeOwned + CaHash + 'static,
+    N: Serialize + DeserializeOwned + CaHash + gantz_format::NodeSugar + 'static,
 {
     let loaded = gantz_format::from_str::<N>(text, now)?;
     let mut views: HashMap<CommitAddr, crate::SceneView> = HashMap::new();
@@ -46,7 +46,7 @@ where
 /// Serialize an [`Export`] to a `.gantz` document.
 pub fn to_string<N>(export: &Export<Graph<N>>) -> Result<String, FormatError>
 where
-    N: Serialize + DeserializeOwned,
+    N: Serialize + DeserializeOwned + gantz_format::NodeSugar,
 {
     let dumped = gantz_format::to_string::<N>(&export.registry)?;
     // Each top-level block is a section; they are joined with a blank line.
@@ -83,7 +83,7 @@ where
 /// suited to a hand-editable, git-friendly base file.
 pub fn to_string_named<N>(export: &Export<Graph<N>>) -> Result<String, FormatError>
 where
-    N: Serialize + DeserializeOwned,
+    N: Serialize + DeserializeOwned + gantz_format::NodeSugar,
 {
     let dumped = gantz_format::to_string_named::<N>(&export.registry)?;
     let mut sections = vec![dumped.text.trim_end().to_string()];

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -18,6 +18,7 @@ pub mod node;
 pub mod ops;
 pub mod reg;
 pub mod response;
+pub mod sugar;
 pub mod sync;
 pub mod view;
 pub mod widget;
@@ -31,6 +32,7 @@ pub use response::{
     ContextMenuResponse, DynResponse, InspectorRowsResponse, InspectorUiResponse, NodeUiResponse,
     NodeViewResponse, ResponseData, Responses,
 };
+pub use sugar::EguiSugar;
 pub use view::{Camera, SceneView};
 pub use widget::gantz::NodeTypeRegistry;
 pub use widget::graph_select::GraphRegistry;

--- a/crates/gantz_egui/src/ops.rs
+++ b/crates/gantz_egui/src/ops.rs
@@ -70,7 +70,13 @@ pub fn copy_nodes<N>(
     selection: &HashSet<NodeIndex>,
 ) -> Option<String>
 where
-    N: gantz_core::Node + Clone + Serialize + DeserializeOwned + CaHash + 'static,
+    N: gantz_core::Node
+        + Clone
+        + Serialize
+        + DeserializeOwned
+        + CaHash
+        + gantz_format::NodeSugar
+        + 'static,
 {
     if selection.is_empty() {
         return None;
@@ -306,7 +312,13 @@ pub fn cut_nodes<N>(
     nodes: &HashSet<NodeIndex>,
 ) -> Option<String>
 where
-    N: gantz_core::Node + Clone + Serialize + DeserializeOwned + CaHash + 'static,
+    N: gantz_core::Node
+        + Clone
+        + Serialize
+        + DeserializeOwned
+        + CaHash
+        + gantz_format::NodeSugar
+        + 'static,
 {
     let text = copy_nodes(registry, all_views, graph, head_view, nodes)?;
     remove_nodes(
@@ -392,7 +404,13 @@ pub fn paste<N>(
     pos: &PastePos,
 ) -> bool
 where
-    N: Clone + Serialize + DeserializeOwned + CaHash + AsNamedRef + 'static,
+    N: Clone
+        + Serialize
+        + DeserializeOwned
+        + CaHash
+        + AsNamedRef
+        + gantz_format::NodeSugar
+        + 'static,
 {
     let copied: export::Copied<N> = match export::copied_from_str(text) {
         Ok(c) => c,
@@ -457,7 +475,14 @@ pub fn duplicate_nodes<N>(
     nodes: &HashSet<NodeIndex>,
 ) -> bool
 where
-    N: gantz_core::Node + Clone + Serialize + DeserializeOwned + CaHash + AsNamedRef + 'static,
+    N: gantz_core::Node
+        + Clone
+        + Serialize
+        + DeserializeOwned
+        + CaHash
+        + AsNamedRef
+        + gantz_format::NodeSugar
+        + 'static,
 {
     let Some(text) = copy_nodes(registry, all_views, graph, head_view, nodes) else {
         return false;

--- a/crates/gantz_egui/src/sugar.rs
+++ b/crates/gantz_egui/src/sugar.rs
@@ -1,0 +1,133 @@
+//! `.gantz` keyword sugar for this crate's GUI node set.
+//!
+//! [`EguiSugar`] provides the keywords for the egui nodes: `(comment <text> [w
+//! h])` and bare `inspect`. Compose it with [`gantz_format::CoreSugar`] (and the
+//! other crates' sugars) via [`gantz_format::Sugars`].
+
+use gantz_format::sexpr::quote;
+use gantz_format::{Datum, FormatError, Sugar, SugarArgs, node_datum};
+
+/// Keyword sugar for [`Comment`](crate::node::Comment) and
+/// [`Inspect`](crate::node::Inspect).
+#[derive(Clone, Copy, Debug, Default)]
+pub struct EguiSugar;
+
+/// Sugar keyword -> typetag tag, for the egui builtins that lower to a plain
+/// serde object with no extra arguments.
+const KEYWORD_TAG: &[(&str, &str)] = &[("inspect", "Inspect"), ("comment", "Comment")];
+
+/// The typetag tag for a sugar keyword.
+fn tag_for_keyword(kw: &str) -> Option<&'static str> {
+    KEYWORD_TAG
+        .iter()
+        .find(|(k, _)| *k == kw)
+        .map(|&(_, tag)| tag)
+}
+
+/// The sugar keyword for a typetag tag, if one exists.
+fn keyword_for_tag(tag: &str) -> Option<&'static str> {
+    KEYWORD_TAG
+        .iter()
+        .find(|(_, t)| *t == tag)
+        .map(|&(kw, _)| kw)
+}
+
+impl Sugar for EguiSugar {
+    fn read_spec(&self, head: &str, args: SugarArgs<'_>) -> Result<Option<Datum>, FormatError> {
+        let datum = match head {
+            "comment" => comment_spec(args)?,
+            _ => return Ok(None),
+        };
+        Ok(Some(datum))
+    }
+
+    fn read_bare(&self, keyword: &str) -> Option<Datum> {
+        tag_for_keyword(keyword).map(|tag| node_datum(tag, vec![]))
+    }
+
+    fn write_spec(&self, tag: &str, node: &Datum) -> Option<String> {
+        match tag {
+            "Comment" => Some(write_comment(node)),
+            other => keyword_for_tag(other).map(str::to_string),
+        }
+    }
+
+    fn keyword_for_tag(&self, tag: &str) -> Option<&str> {
+        keyword_for_tag(tag)
+    }
+}
+
+/// Read a `(comment <text> [w h])` form: required text plus an optional `[w h]`
+/// size, defaulting to `[100 40]`.
+fn comment_spec(args: SugarArgs<'_>) -> Result<Datum, FormatError> {
+    let text = args
+        .str_at(0)
+        .ok_or_else(|| FormatError::malformed("comment requires text"))?;
+    let [w, h] = match (args.int_at(1)?, args.int_at(2)?) {
+        (Some(w), Some(h)) => [w.max(0) as u64, h.max(0) as u64],
+        _ => [100, 40],
+    };
+    Ok(node_datum(
+        "Comment",
+        vec![
+            ("text", Datum::Str(text)),
+            ("size", Datum::Seq(vec![Datum::U64(w), Datum::U64(h)])),
+        ],
+    ))
+}
+
+fn write_comment(node: &Datum) -> String {
+    let text = node.get("text").and_then(Datum::as_str).unwrap_or("");
+    let (w, h) = node
+        .get("size")
+        .and_then(Datum::as_seq)
+        .and_then(|a| Some((a.first()?.as_i64()?, a.get(1)?.as_i64()?)))
+        .unwrap_or((100, 40));
+    format!("(comment {} {w} {h})", quote(text))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gantz_format::sexpr;
+
+    /// Read a single sugar form's text through `EguiSugar`, as the format does.
+    fn read_spec(text: &str) -> Option<Datum> {
+        let exprs = sexpr::read(text).expect("read");
+        let args = sexpr::list_args(&exprs[0]).expect("list");
+        let head = sexpr::as_symbol(&args[0]).expect("head");
+        EguiSugar
+            .read_spec(&head, SugarArgs::new(&args[1..], text))
+            .expect("read_spec")
+    }
+
+    #[test]
+    fn inspect_round_trips() {
+        let bare = EguiSugar.read_bare("inspect").expect("bare inspect");
+        assert_eq!(bare.get("type").and_then(Datum::as_str), Some("Inspect"));
+        assert_eq!(
+            EguiSugar.write_spec("Inspect", &bare).as_deref(),
+            Some("inspect")
+        );
+    }
+
+    #[test]
+    fn comment_round_trips() {
+        let s = EguiSugar;
+
+        // Default size when none is given.
+        let d = read_spec(r#"(comment "hi")"#).expect("comment");
+        assert_eq!(d.get("text").and_then(Datum::as_str), Some("hi"));
+        assert_eq!(
+            s.write_spec("Comment", &d).as_deref(),
+            Some(r#"(comment "hi" 100 40)"#),
+        );
+
+        // Explicit size round-trips.
+        let sized = read_spec(r#"(comment "note" 220 80)"#).expect("sized");
+        assert_eq!(
+            s.write_spec("Comment", &sized).as_deref(),
+            Some(r#"(comment "note" 220 80)"#),
+        );
+    }
+}

--- a/crates/gantz_format/Cargo.toml
+++ b/crates/gantz_format/Cargo.toml
@@ -15,3 +15,6 @@ log.workspace = true
 petgraph.workspace = true
 serde.workspace = true
 steel-core.workspace = true
+
+[dev-dependencies]
+typetag.workspace = true

--- a/crates/gantz_format/src/datum.rs
+++ b/crates/gantz_format/src/datum.rs
@@ -81,7 +81,9 @@ where
 impl Datum {
     /// Build a node datum: a `type` field (the typetag tag) prepended to
     /// `fields`. The single canonical way the format constructs a tagged map.
-    pub(crate) fn tagged(tag: &str, fields: Vec<(String, Datum)>) -> Datum {
+    /// Out-of-crate [`Sugar`](crate::Sugar) impls usually want the `&str`-keyed
+    /// [`node_datum`] convenience instead.
+    pub fn tagged(tag: &str, fields: Vec<(String, Datum)>) -> Datum {
         let mut entries = Vec::with_capacity(fields.len() + 1);
         entries.push(("type".to_string(), Datum::Str(tag.to_string())));
         entries.extend(fields);
@@ -89,7 +91,7 @@ impl Datum {
     }
 
     /// The value of the map entry `key`, if this is a map containing it.
-    pub(crate) fn get(&self, key: &str) -> Option<&Datum> {
+    pub fn get(&self, key: &str) -> Option<&Datum> {
         match self {
             Datum::Map(entries) => entries
                 .iter()
@@ -100,7 +102,7 @@ impl Datum {
     }
 
     /// The contents of a string datum.
-    pub(crate) fn as_str(&self) -> Option<&str> {
+    pub fn as_str(&self) -> Option<&str> {
         match self {
             Datum::Str(s) => Some(s),
             _ => None,
@@ -108,7 +110,7 @@ impl Datum {
     }
 
     /// The value of a boolean datum.
-    pub(crate) fn as_bool(&self) -> Option<bool> {
+    pub fn as_bool(&self) -> Option<bool> {
         match self {
             Datum::Bool(b) => Some(*b),
             _ => None,
@@ -116,7 +118,7 @@ impl Datum {
     }
 
     /// The value of an integer datum (signed or unsigned, if it fits in `i64`).
-    pub(crate) fn as_i64(&self) -> Option<i64> {
+    pub fn as_i64(&self) -> Option<i64> {
         match self {
             Datum::I64(n) => Some(*n),
             Datum::U64(n) => i64::try_from(*n).ok(),
@@ -125,7 +127,7 @@ impl Datum {
     }
 
     /// The value of a float datum, coercing integer datums to `f64`.
-    pub(crate) fn as_f64(&self) -> Option<f64> {
+    pub fn as_f64(&self) -> Option<f64> {
         match self {
             Datum::F64(n) => Some(*n),
             Datum::I64(n) => Some(*n as f64),
@@ -135,12 +137,25 @@ impl Datum {
     }
 
     /// The elements of a sequence datum.
-    pub(crate) fn as_seq(&self) -> Option<&[Datum]> {
+    pub fn as_seq(&self) -> Option<&[Datum]> {
         match self {
             Datum::Seq(items) => Some(items),
             _ => None,
         }
     }
+}
+
+/// Build a node datum from a typetag tag and ordered `&str`-keyed fields - the
+/// ergonomic builder a [`Sugar`](crate::Sugar) uses to construct the value its
+/// `read_spec` returns, without depending on `Datum`'s internal map shape.
+pub fn node_datum(tag: &str, fields: Vec<(&str, Datum)>) -> Datum {
+    Datum::tagged(
+        tag,
+        fields
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect(),
+    )
 }
 
 // -- error -------------------------------------------------------------------

--- a/crates/gantz_format/src/error.rs
+++ b/crates/gantz_format/src/error.rs
@@ -78,6 +78,13 @@ impl FormatError {
         }
     }
 
+    /// Construct an [`ErrorKind::Malformed`] error (wrong shape or arity) with no
+    /// source location - the constructor an out-of-crate [`Sugar`](crate::Sugar)
+    /// uses to report a malformed form.
+    pub fn malformed(msg: impl Into<String>) -> Self {
+        Self::new(ErrorKind::Malformed(msg.into()))
+    }
+
     /// Construct a [`ErrorKind::NodeDeserialize`] error for node `tag`.
     pub(crate) fn node_deserialize(tag: impl Into<String>, msg: impl Into<String>) -> Self {
         Self::new(ErrorKind::NodeDeserialize {

--- a/crates/gantz_format/src/lib.rs
+++ b/crates/gantz_format/src/lib.rs
@@ -13,10 +13,12 @@
 //! context returned by [`from_str`]/[`to_string`].
 //!
 //! Node keywords (`expr`, `inlet`, ...) are pluggable [`Sugar`]: [`from_str`]
-//! and [`to_string`] use [`DefaultSugar`] (gantz's built-ins); the `_with`
-//! variants accept any `&dyn Sugar` so other node sets can supply their own
-//! first-class keywords while still falling back to the generic `(node ...)`
-//! form. Any node type that is `Serialize + DeserializeOwned + CaHash` works.
+//! and [`to_string`] read the node set's composite via [`NodeSugar`]
+//! (`N::sugar()`), so each crate owns the sugar for its own nodes ([`CoreSugar`]
+//! covers `gantz_core`'s). The `_with` variants accept any `&dyn Sugar`
+//! explicitly (compose with [`Sugars`]), still falling back to the generic
+//! `(node ...)` form. Any node type that is `Serialize + DeserializeOwned +
+//! CaHash` works.
 
 mod datum;
 mod error;
@@ -29,32 +31,32 @@ mod writer;
 
 pub mod sexpr;
 
-pub use datum::{Datum, DatumError, datum_from_expr, datum_text, from_datum, to_datum};
+pub use datum::{Datum, DatumError, datum_from_expr, datum_text, from_datum, node_datum, to_datum};
 pub use error::{ErrorKind, FormatError, Span};
 pub use lower::Loaded;
 pub use model::{Addr, Document, Form};
 pub use raise::{Dumped, GraphLabels};
-pub use sugar::{DefaultSugar, Sugar, Sugars};
+pub use sugar::{CoreSugar, NodeSugar, Sugar, SugarArgs, Sugars};
 
 use gantz_ca::{CaHash, Registry, Timestamp};
 use gantz_core::node::graph::Graph;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
-/// Parse a `.gantz` document (with gantz's built-in node keywords) into its
-/// [`Loaded`] registry, resolution context and preserved extra forms.
+/// Parse a `.gantz` document (using the node set's composite [`NodeSugar`]) into
+/// its [`Loaded`] registry, resolution context and preserved extra forms.
 ///
 /// `now` provides the timestamp for any graph the `(commits ...)` table does not
 /// describe (hand-authored graphs with no commit entry).
 pub fn from_str<N>(text: &str, now: Timestamp) -> Result<Loaded<N>, FormatError>
 where
-    N: Serialize + DeserializeOwned + CaHash + 'static,
+    N: Serialize + DeserializeOwned + CaHash + NodeSugar + 'static,
 {
-    from_str_with(text, now, &DefaultSugar)
+    from_str_with(text, now, &N::sugar())
 }
 
 /// Parse a `.gantz` document using a custom keyword [`Sugar`] (compose with
-/// [`DefaultSugar`] via [`Sugars`] to keep the built-ins).
+/// [`CoreSugar`] via [`Sugars`] to keep `gantz_core`'s built-ins).
 pub fn from_str_with<N>(
     text: &str,
     now: Timestamp,
@@ -72,9 +74,9 @@ where
 /// to emit its own forms.
 pub fn to_string<N>(registry: &Registry<Graph<N>>) -> Result<Dumped, FormatError>
 where
-    N: Serialize + DeserializeOwned,
+    N: Serialize + DeserializeOwned + NodeSugar,
 {
-    to_string_with(registry, &DefaultSugar)
+    to_string_with(registry, &N::sugar())
 }
 
 /// Serialize a registry to `.gantz` text using a custom keyword [`Sugar`].
@@ -94,9 +96,9 @@ where
 /// such as the baked-in base.
 pub fn to_string_named<N>(registry: &Registry<Graph<N>>) -> Result<Dumped, FormatError>
 where
-    N: Serialize + DeserializeOwned,
+    N: Serialize + DeserializeOwned + NodeSugar,
 {
-    to_string_named_with(registry, &DefaultSugar)
+    to_string_named_with(registry, &N::sugar())
 }
 
 /// As [`to_string_named`], with a custom keyword [`Sugar`].

--- a/crates/gantz_format/src/lib.rs
+++ b/crates/gantz_format/src/lib.rs
@@ -111,3 +111,71 @@ where
 {
     raise::raise_named(registry, sugar)
 }
+
+#[cfg(test)]
+mod tests {
+    //! `NodeSugar` and `Sugar` are both entirely optional for a downstream
+    //! node-set type. The `_with` entry points carry no `NodeSugar` bound, and a
+    //! node whose tag no sugar recognises simply round-trips through the generic
+    //! `(node "Tag" ...)` form. This guards that property.
+
+    use super::*;
+    use gantz_ca::{CaHash, Hasher};
+    use serde::{Deserialize, Serialize};
+
+    // A self-contained node-set with one node type that implements neither
+    // `NodeSugar` nor any `Sugar` - it carries no first-class keyword at all.
+    #[typetag::serde(tag = "type")]
+    trait Widget: CaHash {}
+
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+    struct Knob {
+        value: i64,
+    }
+
+    impl CaHash for Knob {
+        fn hash(&self, hasher: &mut Hasher) {
+            self.value.hash(hasher);
+        }
+    }
+
+    #[typetag::serde]
+    impl Widget for Knob {}
+
+    // `Box<dyn Widget>` is the node-set type `N`: typetag supplies its
+    // Serialize/Deserialize, and `gantz_ca`'s blanket `CaHash for Box<T>` covers
+    // the rest. It implements no `NodeSugar`.
+
+    #[test]
+    fn the_with_variants_need_no_node_sugar() {
+        // A graph with one node written in the generic form. `Knob` is unknown to
+        // every sugar, so it must round-trip via `(node "Knob" ...)`.
+        let text = "(graph g (k (node \"Knob\" (value 7))))";
+
+        // Both `_with` calls compile and run even though `Box<dyn Widget>`
+        // implements neither `NodeSugar` nor `Sugar`. (The convenience
+        // `from_str`/`to_string` would instead require a `NodeSugar` impl.)
+        let loaded = from_str_with::<Box<dyn Widget>>(text, std::time::Duration::ZERO, &CoreSugar)
+            .expect("parse without NodeSugar");
+        let dumped = to_string_with(&loaded.registry, &CoreSugar).expect("write without NodeSugar");
+
+        // The node survived the round-trip through the generic form.
+        assert!(
+            dumped.text.contains("(node \"Knob\""),
+            "expected generic node form, got:\n{}",
+            dumped.text,
+        );
+        assert!(dumped.text.contains("(value 7)"));
+
+        // And the reparse is stable.
+        let reloaded =
+            from_str_with::<Box<dyn Widget>>(&dumped.text, std::time::Duration::ZERO, &CoreSugar)
+                .expect("reparse");
+        assert_eq!(
+            to_string_with(&reloaded.registry, &CoreSugar)
+                .expect("rewrite")
+                .text,
+            dumped.text,
+        );
+    }
+}

--- a/crates/gantz_format/src/parse.rs
+++ b/crates/gantz_format/src/parse.rs
@@ -14,7 +14,7 @@ use crate::model::{
     NameDecl, NodeDecl, NodeSpec, RefSpec,
 };
 use crate::sexpr::{self, as_keyword, as_string, as_symbol, err_at, list_args, span_src};
-use crate::sugar::Sugar;
+use crate::sugar::{Sugar, SugarArgs};
 use steel::parser::ast::ExprKind;
 
 /// Parse a complete `.gantz` document, interpreting node sugar with `sugar`.
@@ -143,7 +143,7 @@ fn parse_node_spec(e: &ExprKind, src: &str, sugar: &dyn Sugar) -> Result<NodeSpe
         "ref" => parse_ref_spec(false, rest, src),
         "fn-ref" => parse_ref_spec(true, rest, src),
         "node" => parse_generic_spec(rest, e, src),
-        other => match sugar.read_spec(other, rest, src)? {
+        other => match sugar.read_spec(other, SugarArgs::new(rest, src))? {
             Some(datum) => Ok(NodeSpec::Value(datum)),
             None => Err(err_at(
                 e,
@@ -445,7 +445,7 @@ fn int_field(e: &ExprKind, src: &str) -> Result<i64, FormatError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sugar::DefaultSugar;
+    use crate::sugar::CoreSugar;
 
     #[test]
     fn reads_zero_ceremony_mul() {
@@ -454,7 +454,7 @@ mod tests {
   (l inlet) (r inlet) (out outlet)
   (m (expr (* $l $r)))
   (-> l (m 0)) (-> r (m 1)) (-> m out))";
-        let doc = parse(text, &DefaultSugar).expect("parse");
+        let doc = parse(text, &CoreSugar).expect("parse");
         assert_eq!(doc.graphs.len(), 1);
         let g = &doc.graphs[0];
         assert_eq!(g.id, Addr::Label("mul".to_string()));
@@ -479,7 +479,7 @@ mod tests {
     #[test]
     fn preserves_unrecognized_forms() {
         let text = "(graph mul (m (expr 1)))\n(layout mul (m 1 2))";
-        let doc = parse(text, &DefaultSugar).expect("parse");
+        let doc = parse(text, &CoreSugar).expect("parse");
         assert_eq!(doc.graphs.len(), 1);
         assert_eq!(doc.extra.len(), 1);
         assert_eq!(doc.extra[0].head, "layout");
@@ -492,28 +492,17 @@ mod tests {
 (graph mul (m (expr 1)))
 (descriptions
   (mul \"multiply two numbers\"))";
-        let doc = parse(text, &DefaultSugar).expect("parse");
+        let doc = parse(text, &CoreSugar).expect("parse");
         assert_eq!(doc.descriptions.len(), 1);
         assert_eq!(doc.descriptions[0].name, "mul");
         assert_eq!(doc.descriptions[0].description, "multiply two numbers");
 
         // write -> parse preserves the description verbatim.
-        let written = crate::writer::write_document(&doc, &DefaultSugar);
-        let reparsed = parse(&written, &DefaultSugar).expect("reparse");
+        let written = crate::writer::write_document(&doc, &CoreSugar);
+        let reparsed = parse(&written, &CoreSugar).expect("reparse");
         assert_eq!(reparsed.descriptions.len(), 1);
         assert_eq!(reparsed.descriptions[0].name, "mul");
         assert_eq!(reparsed.descriptions[0].description, "multiply two numbers");
-    }
-
-    /// The shipped `base.gantz` parses, including its `(descriptions ...)` form
-    /// over names with `?`/`-` (e.g. `empty?`, `list-ref`).
-    #[test]
-    fn parses_base_gantz() {
-        let text = include_str!("../../gantz_base/base.gantz");
-        let doc = parse(text, &DefaultSugar).expect("base.gantz must parse");
-        assert!(doc.descriptions.iter().any(|d| d.name == "add"));
-        assert!(doc.descriptions.iter().any(|d| d.name == "empty?"));
-        assert!(doc.descriptions.iter().any(|d| d.name == "list-ref"));
     }
 
     #[test]
@@ -523,7 +512,7 @@ mod tests {
   (s (expr (values $x (* $x 2)) #:out 2))
   (b (branch (if $n (list 0 0) (list 1 0)) \"10\" \"01\"))
   (m (ref mul \"834568e9\")))";
-        let doc = parse(text, &DefaultSugar).expect("parse");
+        let doc = parse(text, &CoreSugar).expect("parse");
         let g = &doc.graphs[0];
         let s = g.body.nodes.iter().find(|n| n.name == "s").unwrap();
         match &s.spec {
@@ -567,7 +556,7 @@ mod tests {
        (cfg ((gain 6) (mode \"hi\")))
        (tags #(\"a\" \"b\"))
        (flag #t))))";
-        let doc1 = parse(text, &DefaultSugar).expect("parse 1");
+        let doc1 = parse(text, &CoreSugar).expect("parse 1");
         let node1 = &doc1.graphs[0].body.nodes[0];
         match &node1.spec {
             NodeSpec::Value(v) => {
@@ -587,8 +576,8 @@ mod tests {
             }
             other => panic!("expected value, got {other:?}"),
         }
-        let text2 = crate::writer::write_document(&doc1, &DefaultSugar);
-        let doc2 = parse(&text2, &DefaultSugar).expect("parse 2");
+        let text2 = crate::writer::write_document(&doc1, &CoreSugar);
+        let doc2 = parse(&text2, &CoreSugar).expect("parse 2");
         let node2 = &doc2.graphs[0].body.nodes[0];
         assert_eq!(
             format!("{:?}", node1.spec),

--- a/crates/gantz_format/src/sugar.rs
+++ b/crates/gantz_format/src/sugar.rs
@@ -4,17 +4,140 @@
 //! over the universal generic form `(node "Tag" (field datum)...)`. The format
 //! *core* reserves `ref`/`fn-ref` (references), `graph` (inline nesting) and
 //! `node` (the generic fallback) - those need format or `gantz_core` context and
-//! are never pluggable. Everything else is provided by a [`Sugar`]:
-//! [`DefaultSugar`] carries gantz's built-in node set, and other node sets can
-//! implement `Sugar` and compose via [`Sugars`].
+//! are never pluggable. Everything else is provided by a [`Sugar`]: [`CoreSugar`]
+//! carries `gantz_core`'s own node set, and each downstream crate implements
+//! `Sugar` for its nodes and composes them via [`Sugars`].
 //!
-//! A `Sugar` only ever deals in tag *strings* and serde [`Datum`]s, so it adds
-//! no dependency on the concrete node crates.
+//! A `Sugar` only ever deals in tag *strings* and serde [`Datum`]s (read through
+//! [`SugarArgs`] and built with [`node_datum`]), so it adds no dependency on the
+//! concrete node crates and never sees the raw s-expression AST.
+//!
+//! Which sugars an application uses is a static property of its node-type
+//! universe: [`NodeSugar`] ties a top-level node type to its composite, and the
+//! convenience entry points read it via `N::sugar()`.
 
-use crate::datum::Datum;
+use crate::datum::{Datum, node_datum};
 use crate::error::{ErrorKind, FormatError};
 use crate::sexpr::{self, as_keyword, as_string, as_symbol, err_at, quote, span_src};
 use steel::parser::ast::ExprKind;
+
+/// The arguments of a list-headed sugar form `(<head> <args>...)`, with helpers
+/// to read keyword and positional values without touching the raw s-expression
+/// AST. Constructed by the format and handed to [`Sugar::read_spec`].
+#[derive(Clone, Copy)]
+pub struct SugarArgs<'a> {
+    args: &'a [ExprKind],
+    src: &'a str,
+}
+
+impl<'a> SugarArgs<'a> {
+    /// Wrap a slice of argument datums and the source they were read from.
+    ///
+    /// The format builds this for [`Sugar::read_spec`]; it is also exposed so a
+    /// `Sugar` can be unit-tested in isolation (read args with [`crate::sexpr`]).
+    pub fn new(args: &'a [ExprKind], src: &'a str) -> Self {
+        SugarArgs { args, src }
+    }
+
+    /// The number of arguments.
+    pub fn count(&self) -> usize {
+        self.args.len()
+    }
+
+    /// Find a `#:<key>` keyword and return the following integer value.
+    pub fn keyword_int(&self, key: &str) -> Result<Option<i64>, FormatError> {
+        match self.keyword_at(key) {
+            Some((i, kw)) => Ok(Some(
+                self.args
+                    .get(i + 1)
+                    .map(|v| parse_int(v, self.src))
+                    .transpose()?
+                    .ok_or_else(|| {
+                        err_at(
+                            kw,
+                            self.src,
+                            ErrorKind::Malformed(format!("#:{key} requires an integer")),
+                        )
+                    })?,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    /// Find a `#:<key>` keyword and return the following float value.
+    pub fn keyword_f64(&self, key: &str) -> Result<Option<f64>, FormatError> {
+        match self.keyword_at(key) {
+            Some((i, kw)) => Ok(Some(
+                self.args
+                    .get(i + 1)
+                    .map(|v| parse_f64(v, self.src))
+                    .transpose()?
+                    .ok_or_else(|| {
+                        err_at(
+                            kw,
+                            self.src,
+                            ErrorKind::Malformed(format!("#:{key} requires a number")),
+                        )
+                    })?,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    /// Whether a bare `#:<key>` flag keyword is present.
+    pub fn has_flag(&self, key: &str) -> bool {
+        self.args
+            .iter()
+            .any(|a| as_keyword(a).as_deref() == Some(key))
+    }
+
+    /// The `n`-th positional argument as a string literal.
+    pub fn str_at(&self, n: usize) -> Option<String> {
+        self.args.get(n).and_then(as_string)
+    }
+
+    /// The `n`-th positional argument as a symbol (e.g. a log level).
+    pub fn symbol_at(&self, n: usize) -> Option<String> {
+        self.args.get(n).and_then(as_symbol)
+    }
+
+    /// The `n`-th positional argument as an integer.
+    pub fn int_at(&self, n: usize) -> Result<Option<i64>, FormatError> {
+        self.args.get(n).map(|e| parse_int(e, self.src)).transpose()
+    }
+
+    /// The `n`-th positional argument as a float.
+    pub fn f64_at(&self, n: usize) -> Result<Option<f64>, FormatError> {
+        self.args.get(n).map(|e| parse_f64(e, self.src)).transpose()
+    }
+
+    /// The verbatim source slice of the `n`-th argument.
+    ///
+    /// The load-bearing primitive for code-carrying forms (`expr`/`branch`):
+    /// embedded Steel is captured byte-for-byte so node `src` strings - and the
+    /// content addresses that hash them - are preserved exactly.
+    pub fn verbatim_at(&self, n: usize) -> Option<&'a str> {
+        self.args.get(n).and_then(|e| span_src(e, self.src))
+    }
+
+    /// A malformed-form error located at the `n`-th argument (unlocated if the
+    /// argument is absent).
+    pub fn malformed_at(&self, n: usize, msg: impl Into<String>) -> FormatError {
+        match self.args.get(n) {
+            Some(e) => err_at(e, self.src, ErrorKind::Malformed(msg.into())),
+            None => FormatError::malformed(msg),
+        }
+    }
+
+    /// The index and keyword datum of the first `#:<key>` argument, if present.
+    fn keyword_at(&self, key: &str) -> Option<(usize, &'a ExprKind)> {
+        self.args
+            .iter()
+            .enumerate()
+            .find(|(_, a)| as_keyword(a).as_deref() == Some(key))
+            .map(|(i, a)| (i, a))
+    }
+}
 
 /// A set of keyword sugars layered over the generic `(node "Tag" ...)` form.
 ///
@@ -25,12 +148,7 @@ use steel::parser::ast::ExprKind;
 pub trait Sugar {
     /// Read a list-headed sugar form `(<head> <args>...)` into a node datum.
     /// `Ok(None)` means this sugar does not recognise `head` (try the next).
-    fn read_spec(
-        &self,
-        head: &str,
-        args: &[ExprKind],
-        src: &str,
-    ) -> Result<Option<Datum>, FormatError>;
+    fn read_spec(&self, head: &str, args: SugarArgs<'_>) -> Result<Option<Datum>, FormatError>;
 
     /// Read a bare keyword (a unit node, e.g. `inlet`) into a node datum.
     fn read_bare(&self, keyword: &str) -> Option<Datum>;
@@ -46,13 +164,8 @@ pub trait Sugar {
 
 /// Treat a reference to a sugar as a sugar, so `&S`/`&dyn Sugar` compose freely.
 impl<S: Sugar + ?Sized> Sugar for &S {
-    fn read_spec(
-        &self,
-        head: &str,
-        args: &[ExprKind],
-        src: &str,
-    ) -> Result<Option<Datum>, FormatError> {
-        (**self).read_spec(head, args, src)
+    fn read_spec(&self, head: &str, args: SugarArgs<'_>) -> Result<Option<Datum>, FormatError> {
+        (**self).read_spec(head, args)
     }
 
     fn read_bare(&self, keyword: &str) -> Option<Datum> {
@@ -73,14 +186,9 @@ impl<S: Sugar + ?Sized> Sugar for &S {
 pub struct Sugars<'a>(pub Vec<&'a dyn Sugar>);
 
 impl Sugar for Sugars<'_> {
-    fn read_spec(
-        &self,
-        head: &str,
-        args: &[ExprKind],
-        src: &str,
-    ) -> Result<Option<Datum>, FormatError> {
+    fn read_spec(&self, head: &str, args: SugarArgs<'_>) -> Result<Option<Datum>, FormatError> {
         for sugar in &self.0 {
-            if let Some(datum) = sugar.read_spec(head, args, src)? {
+            if let Some(datum) = sugar.read_spec(head, args)? {
                 return Ok(Some(datum));
             }
         }
@@ -100,27 +208,34 @@ impl Sugar for Sugars<'_> {
     }
 }
 
-/// The keyword sugars for gantz's built-in node set.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct DefaultSugar;
+/// The composite keyword sugar for a node-type universe.
+///
+/// Implemented once on an application's top-level `Box<dyn Node>` to select which
+/// [`Sugar`]s its node set uses; the convenience entry points
+/// ([`from_str`](crate::from_str)/[`to_string`](crate::to_string)) read it via
+/// `N::sugar()`. Use the `_with` variants to pass a sugar explicitly instead.
+pub trait NodeSugar {
+    /// The composed sugar for this node set.
+    fn sugar() -> Sugars<'static>;
+}
 
-/// Sugar keyword -> typetag tag, for the built-ins that lower to a plain serde
-/// object with no extra arguments. Order is the canonical display order.
+/// The keyword sugars for `gantz_core`'s built-in node set: `inlet`, `outlet`,
+/// `apply`, `delay`, `id`, `expr` and `branch`. Downstream crates provide a
+/// [`Sugar`] for their own nodes and compose via [`Sugars`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CoreSugar;
+
+/// Sugar keyword -> typetag tag, for the `gantz_core` builtins that lower to a
+/// plain serde object with no extra arguments. Order is the canonical display
+/// order.
 const KEYWORD_TAG: &[(&str, &str)] = &[
     ("inlet", "Inlet"),
     ("outlet", "Outlet"),
     ("apply", "Apply"),
     ("delay", "Delay"),
     ("id", "Identity"),
-    ("bang", "Bang"),
-    ("inspect", "Inspect"),
-    ("update-bang", "UpdateBang"),
-    ("tick-bang", "TickBang"),
-    ("number", "Number"),
-    ("log", "Log"),
     ("expr", "Expr"),
     ("branch", "Branch"),
-    ("comment", "Comment"),
 ];
 
 /// The typetag tag for a sugar keyword.
@@ -139,35 +254,20 @@ fn keyword_for_tag(tag: &str) -> Option<&'static str> {
         .map(|&(kw, _)| kw)
 }
 
-impl Sugar for DefaultSugar {
-    fn read_spec(
-        &self,
-        head: &str,
-        args: &[ExprKind],
-        src: &str,
-    ) -> Result<Option<Datum>, FormatError> {
+impl Sugar for CoreSugar {
+    fn read_spec(&self, head: &str, args: SugarArgs<'_>) -> Result<Option<Datum>, FormatError> {
         let datum = match head {
             "inlet" => inlet_outlet_spec("Inlet", args),
             "outlet" => inlet_outlet_spec("Outlet", args),
-            "expr" => expr_spec(args, src)?,
-            "branch" => branch_spec(args, src)?,
-            "comment" => comment_spec(args, src)?,
-            "number" => number_spec(args, src)?,
-            "log" => log_spec(args, src)?,
-            "tick-bang" => tick_bang_spec(args, src)?,
+            "expr" => expr_spec(args)?,
+            "branch" => branch_spec(args)?,
             _ => return Ok(None),
         };
         Ok(Some(datum))
     }
 
     fn read_bare(&self, keyword: &str) -> Option<Datum> {
-        match keyword {
-            "log" => Some(node_datum(
-                "Log",
-                vec![("level", Datum::Str("INFO".into()))],
-            )),
-            _ => tag_for_keyword(keyword).map(|tag| node_datum(tag, vec![])),
-        }
+        tag_for_keyword(keyword).map(|tag| node_datum(tag, vec![]))
     }
 
     fn write_spec(&self, tag: &str, node: &Datum) -> Option<String> {
@@ -176,10 +276,6 @@ impl Sugar for DefaultSugar {
             "Outlet" => Some(write_inlet_outlet("outlet", node)),
             "Expr" => Some(write_expr(node)),
             "Branch" => Some(write_branch(node)),
-            "Comment" => Some(write_comment(node)),
-            "Number" => Some(write_number(node)),
-            "Log" => Some(write_log(node)),
-            "TickBang" => Some(write_tick_bang(node)),
             other => keyword_for_tag(other).map(str::to_string),
         }
     }
@@ -191,125 +287,51 @@ impl Sugar for DefaultSugar {
 
 // -- built-in reading --------------------------------------------------------
 
-/// Build a node datum from a typetag tag and ordered fields - an `&str`-keyed
-/// convenience over [`Datum::tagged`].
-fn node_datum(tag: &str, fields: Vec<(&str, Datum)>) -> Datum {
-    Datum::tagged(
-        tag,
-        fields
-            .into_iter()
-            .map(|(k, v)| (k.to_string(), v))
-            .collect(),
-    )
-}
-
 /// Read an `(inlet [ty [description]])` / `(outlet ...)` form: two optional
 /// string args carrying the socket's hover-doc type label and description.
 /// Empty strings are omitted so they serialize as the struct's defaults.
-fn inlet_outlet_spec(tag: &str, args: &[ExprKind]) -> Datum {
+fn inlet_outlet_spec(tag: &str, args: SugarArgs<'_>) -> Datum {
     let mut fields = Vec::new();
-    if let Some(ty) = args.first().and_then(as_string).filter(|s| !s.is_empty()) {
+    if let Some(ty) = args.str_at(0).filter(|s| !s.is_empty()) {
         fields.push(("ty", Datum::Str(ty)));
     }
-    if let Some(desc) = args.get(1).and_then(as_string).filter(|s| !s.is_empty()) {
+    if let Some(desc) = args.str_at(1).filter(|s| !s.is_empty()) {
         fields.push(("description", Datum::Str(desc)));
     }
     node_datum(tag, fields)
 }
 
-fn expr_spec(args: &[ExprKind], src: &str) -> Result<Datum, FormatError> {
-    let code = args
-        .first()
-        .ok_or_else(|| FormatError::new(ErrorKind::Malformed("expr requires code".into())))?;
-    let code_src = span_src(code, src).ok_or_else(|| {
-        err_at(
-            code,
-            src,
-            ErrorKind::Malformed("could not slice expr code".into()),
-        )
+fn expr_spec(args: SugarArgs<'_>) -> Result<Datum, FormatError> {
+    let code = args.verbatim_at(0).ok_or_else(|| match args.count() {
+        0 => FormatError::malformed("expr requires code"),
+        _ => args.malformed_at(0, "could not slice expr code"),
     })?;
-    let mut fields = vec![("src", Datum::Str(code_src.to_string()))];
-    if let Some(out) = keyword_int(&args[1..], "out", src)? {
+    let mut fields = vec![("src", Datum::Str(code.to_string()))];
+    if let Some(out) = args.keyword_int("out")? {
         fields.push(("outputs", Datum::U64(out.max(0) as u64)));
     }
     Ok(node_datum("Expr", fields))
 }
 
-fn branch_spec(args: &[ExprKind], src: &str) -> Result<Datum, FormatError> {
-    let code = args
-        .first()
-        .ok_or_else(|| FormatError::new(ErrorKind::Malformed("branch requires code".into())))?;
-    let code_src = span_src(code, src).ok_or_else(|| {
-        err_at(
-            code,
-            src,
-            ErrorKind::Malformed("could not slice branch code".into()),
-        )
+fn branch_spec(args: SugarArgs<'_>) -> Result<Datum, FormatError> {
+    let code = args.verbatim_at(0).ok_or_else(|| match args.count() {
+        0 => FormatError::malformed("branch requires code"),
+        _ => args.malformed_at(0, "could not slice branch code"),
     })?;
-    let masks: Vec<Datum> = args[1..]
-        .iter()
-        .map(|m| {
-            as_string(m).map(Datum::Str).ok_or_else(|| {
-                err_at(
-                    m,
-                    src,
-                    ErrorKind::Malformed("branch mask must be a string".into()),
-                )
-            })
-        })
-        .collect::<Result<_, _>>()?;
+    let mut masks = Vec::with_capacity(args.count().saturating_sub(1));
+    for n in 1..args.count() {
+        let mask = args
+            .str_at(n)
+            .ok_or_else(|| args.malformed_at(n, "branch mask must be a string"))?;
+        masks.push(Datum::Str(mask));
+    }
     Ok(node_datum(
         "Branch",
         vec![
-            ("src", Datum::Str(code_src.to_string())),
+            ("src", Datum::Str(code.to_string())),
             ("branches", Datum::Seq(masks)),
         ],
     ))
-}
-
-fn comment_spec(args: &[ExprKind], src: &str) -> Result<Datum, FormatError> {
-    let text = args
-        .first()
-        .and_then(as_string)
-        .ok_or_else(|| FormatError::new(ErrorKind::Malformed("comment requires text".into())))?;
-    let [w, h] = match (args.get(1), args.get(2)) {
-        (Some(w), Some(h)) => [int_at(w, src)?.max(0) as u64, int_at(h, src)?.max(0) as u64],
-        _ => [100, 40],
-    };
-    Ok(node_datum(
-        "Comment",
-        vec![
-            ("text", Datum::Str(text)),
-            ("size", Datum::Seq(vec![Datum::U64(w), Datum::U64(h)])),
-        ],
-    ))
-}
-
-/// Read a `(number [#:min m] [#:max m] [#:precision n] [#:no-push-eval])` form.
-/// Only the non-default fields are emitted, so a bare `number` stays bare.
-fn number_spec(args: &[ExprKind], src: &str) -> Result<Datum, FormatError> {
-    let mut fields = Vec::new();
-    if let Some(min) = keyword_f64(args, "min", src)? {
-        fields.push(("min", Datum::F64(min)));
-    }
-    if let Some(max) = keyword_f64(args, "max", src)? {
-        fields.push(("max", Datum::F64(max)));
-    }
-    if let Some(precision) = keyword_int(args, "precision", src)? {
-        fields.push(("precision", Datum::U64(precision.max(0) as u64)));
-    }
-    if has_flag(args, "no-push-eval") {
-        fields.push(("push_eval_on_edit", Datum::Bool(false)));
-    }
-    Ok(node_datum("Number", fields))
-}
-
-fn log_spec(args: &[ExprKind], src: &str) -> Result<Datum, FormatError> {
-    let level = match args.first().and_then(as_symbol) {
-        Some(s) => log_level(&s, &args[0], src)?,
-        None => "INFO".to_string(),
-    };
-    Ok(node_datum("Log", vec![("level", Datum::Str(level))]))
 }
 
 // -- built-in writing --------------------------------------------------------
@@ -353,174 +375,16 @@ fn write_inlet_outlet(keyword: &str, node: &Datum) -> String {
     }
 }
 
-fn write_comment(node: &Datum) -> String {
-    let text = node.get("text").and_then(Datum::as_str).unwrap_or("");
-    let (w, h) = node
-        .get("size")
-        .and_then(Datum::as_seq)
-        .and_then(|a| Some((a.first()?.as_i64()?, a.get(1)?.as_i64()?)))
-        .unwrap_or((100, 40));
-    format!("(comment {} {w} {h})", quote(text))
-}
-
-/// Read `(tick-bang [#:duration secs | #:rate hz])` into a `TickBang`'s
-/// `interval` enum field. `#:duration` and `#:rate` are mutually exclusive;
-/// neither given yields the default duration.
-fn tick_bang_spec(args: &[ExprKind], src: &str) -> Result<Datum, FormatError> {
-    let duration = keyword_f64(args, "duration", src)?;
-    let rate = keyword_f64(args, "rate", src)?;
-    let fields = match (duration, rate) {
-        (Some(_), Some(_)) => {
-            return Err(FormatError::new(ErrorKind::Malformed(
-                "tick-bang: specify #:duration or #:rate, not both".into(),
-            )));
-        }
-        (Some(secs), None) => vec![("interval", tick_interval_datum("Duration", secs))],
-        (None, Some(hz)) => vec![("interval", tick_interval_datum("Rate", hz))],
-        (None, None) => vec![],
-    };
-    Ok(node_datum("TickBang", fields))
-}
-
-/// The `interval` field datum for a `TickBang` `Interval` enum variant
-/// (externally tagged, e.g. `(("Rate" hz))`).
-fn tick_interval_datum(variant: &str, value: f64) -> Datum {
-    Datum::Map(vec![(variant.to_string(), Datum::F64(value))])
-}
-
-/// Write a `TickBang` as a bare `tick-bang` for the default duration, else as
-/// `(tick-bang #:duration secs)` or `(tick-bang #:rate hz)` per its unit.
-fn write_tick_bang(node: &Datum) -> String {
-    match tick_interval(node) {
-        Some(("Rate", hz)) => format!("(tick-bang #:rate {hz})"),
-        Some(("Duration", secs)) if secs != 1.0 => format!("(tick-bang #:duration {secs})"),
-        _ => "tick-bang".to_string(),
-    }
-}
-
-/// Read a `TickBang`'s `interval` field as `(variant, value)`.
-fn tick_interval(node: &Datum) -> Option<(&str, f64)> {
-    match node.get("interval")? {
-        Datum::Map(entries) => {
-            let (variant, value) = entries.first()?;
-            Some((variant.as_str(), value.as_f64()?))
-        }
-        _ => None,
-    }
-}
-
-/// Write a `Number` as a bare `number` when all config is default, else as
-/// `(number #:min m #:max m #:precision n #:no-push-eval)` with only the
-/// non-default fields.
-fn write_number(node: &Datum) -> String {
-    let min = node.get("min").and_then(Datum::as_f64);
-    let max = node.get("max").and_then(Datum::as_f64);
-    let precision = node.get("precision").and_then(Datum::as_i64);
-    let push = node
-        .get("push_eval_on_edit")
-        .and_then(Datum::as_bool)
-        .unwrap_or(true);
-    if min.is_none() && max.is_none() && precision.is_none() && push {
-        return "number".to_string();
-    }
-    let mut parts = Vec::new();
-    if let Some(min) = min {
-        parts.push(format!("#:min {min}"));
-    }
-    if let Some(max) = max {
-        parts.push(format!("#:max {max}"));
-    }
-    if let Some(precision) = precision {
-        parts.push(format!("#:precision {precision}"));
-    }
-    if !push {
-        parts.push("#:no-push-eval".to_string());
-    }
-    format!("(number {})", parts.join(" "))
-}
-
-fn write_log(node: &Datum) -> String {
-    match node.get("level").and_then(Datum::as_str) {
-        Some(level) if !level.eq_ignore_ascii_case("info") => {
-            format!("(log {})", level.to_ascii_lowercase())
-        }
-        _ => "(log)".to_string(),
-    }
-}
-
 // -- helpers -----------------------------------------------------------------
 
-fn int_at(e: &ExprKind, src: &str) -> Result<i64, FormatError> {
+fn parse_int(e: &ExprKind, src: &str) -> Result<i64, FormatError> {
     sexpr::as_i64(e, src)
         .ok_or_else(|| err_at(e, src, ErrorKind::Malformed("expected an integer".into())))
 }
 
-/// Find a `#:<key>` keyword in `args` and return the following integer value.
-fn keyword_int(args: &[ExprKind], key: &str, src: &str) -> Result<Option<i64>, FormatError> {
-    for (i, a) in args.iter().enumerate() {
-        if as_keyword(a).as_deref() == Some(key) {
-            let val = args
-                .get(i + 1)
-                .map(|v| int_at(v, src))
-                .transpose()?
-                .ok_or_else(|| {
-                    err_at(
-                        a,
-                        src,
-                        ErrorKind::Malformed(format!("#:{key} requires an integer")),
-                    )
-                })?;
-            return Ok(Some(val));
-        }
-    }
-    Ok(None)
-}
-
-fn float_at(e: &ExprKind, src: &str) -> Result<f64, FormatError> {
+fn parse_f64(e: &ExprKind, src: &str) -> Result<f64, FormatError> {
     sexpr::as_f64(e, src)
         .ok_or_else(|| err_at(e, src, ErrorKind::Malformed("expected a number".into())))
-}
-
-/// Find a `#:<key>` keyword in `args` and return the following float value.
-fn keyword_f64(args: &[ExprKind], key: &str, src: &str) -> Result<Option<f64>, FormatError> {
-    for (i, a) in args.iter().enumerate() {
-        if as_keyword(a).as_deref() == Some(key) {
-            let val = args
-                .get(i + 1)
-                .map(|v| float_at(v, src))
-                .transpose()?
-                .ok_or_else(|| {
-                    err_at(
-                        a,
-                        src,
-                        ErrorKind::Malformed(format!("#:{key} requires a number")),
-                    )
-                })?;
-            return Ok(Some(val));
-        }
-    }
-    Ok(None)
-}
-
-/// Whether a bare `#:<key>` flag keyword is present in `args`.
-fn has_flag(args: &[ExprKind], key: &str) -> bool {
-    args.iter().any(|a| as_keyword(a).as_deref() == Some(key))
-}
-
-/// Map a log-level symbol to the `log::Level` serde representation.
-fn log_level(sym: &str, e: &ExprKind, src: &str) -> Result<String, FormatError> {
-    match sym.to_ascii_lowercase().as_str() {
-        "error" => Ok("ERROR".into()),
-        "warn" => Ok("WARN".into()),
-        "info" => Ok("INFO".into()),
-        "debug" => Ok("DEBUG".into()),
-        "trace" => Ok("TRACE".into()),
-        other => Err(err_at(
-            e,
-            src,
-            ErrorKind::Malformed(format!("unknown log level `{other}`")),
-        )),
-    }
 }
 
 #[cfg(test)]
@@ -531,19 +395,11 @@ mod tests {
     struct GainSugar;
 
     impl Sugar for GainSugar {
-        fn read_spec(
-            &self,
-            head: &str,
-            args: &[ExprKind],
-            src: &str,
-        ) -> Result<Option<Datum>, FormatError> {
+        fn read_spec(&self, head: &str, args: SugarArgs<'_>) -> Result<Option<Datum>, FormatError> {
             if head != "gain" {
                 return Ok(None);
             }
-            let db = args
-                .first()
-                .and_then(|e| sexpr::as_i64(e, src))
-                .unwrap_or(0);
+            let db = args.int_at(0)?.unwrap_or(0);
             Ok(Some(node_datum("Gain", vec![("db", Datum::I64(db))])))
         }
 
@@ -575,7 +431,9 @@ mod tests {
         let exprs = sexpr::read(text).expect("read");
         let args = sexpr::list_args(&exprs[0]).expect("list");
         let head = sexpr::as_symbol(&args[0]).expect("head");
-        sugar.read_spec(&head, &args[1..], text).expect("read_spec")
+        sugar
+            .read_spec(&head, SugarArgs::new(&args[1..], text))
+            .expect("read_spec")
     }
 
     #[test]
@@ -594,14 +452,14 @@ mod tests {
 
     #[test]
     fn sugars_compose_first_hit_wins() {
-        let (gain, default) = (GainSugar, DefaultSugar);
-        let sugars = Sugars(vec![&gain, &default]);
+        let (gain, core) = (GainSugar, CoreSugar);
+        let sugars = Sugars(vec![&gain, &core]);
 
         // The custom keyword is handled by GainSugar.
         let g = read_spec(&sugars, "(gain 3)").expect("gain recognised");
         assert_eq!(g.get("db").and_then(Datum::as_i64), Some(3));
 
-        // A built-in keyword still resolves through the composed DefaultSugar.
+        // A built-in keyword still resolves through the composed CoreSugar.
         let e = read_spec(&sugars, "(expr (+ 1 2))").expect("expr recognised");
         assert_eq!(e.get("type").and_then(Datum::as_str), Some("Expr"));
 
@@ -616,7 +474,11 @@ mod tests {
         // None (so the reader would reject the keyword) and writes return None
         // (so the writer emits the generic `(node ...)` form).
         let s = GainSugar;
-        assert!(s.read_spec("expr", &[], "").expect("ok").is_none());
+        assert!(
+            s.read_spec("expr", SugarArgs::new(&[], ""))
+                .expect("ok")
+                .is_none()
+        );
         assert!(s.read_bare("inlet").is_none());
         assert!(
             s.write_spec("Inlet", &node_datum("Inlet", vec![]))
@@ -627,7 +489,7 @@ mod tests {
 
     #[test]
     fn inlet_outlet_docs_round_trip() {
-        let s = DefaultSugar;
+        let s = CoreSugar;
 
         // Both type and description.
         let d = read_spec(&s, r#"(inlet "number" "left operand")"#).expect("recognised");
@@ -659,91 +521,5 @@ mod tests {
         // A bare (undocumented) inlet still writes as the bare keyword.
         let bare = s.read_bare("inlet").expect("bare inlet");
         assert_eq!(s.write_spec("Inlet", &bare).as_deref(), Some("inlet"));
-    }
-
-    #[test]
-    fn number_config_round_trips() {
-        let s = DefaultSugar;
-
-        // A bare (default) number stays bare, whether read as a keyword or spec.
-        let bare = s.read_bare("number").expect("bare number");
-        assert_eq!(s.write_spec("Number", &bare).as_deref(), Some("number"));
-        let empty = read_spec(&s, "(number)").expect("empty spec");
-        assert_eq!(s.write_spec("Number", &empty).as_deref(), Some("number"));
-
-        // Min/max bounds.
-        let mm = read_spec(&s, "(number #:min 0 #:max 100)").expect("min/max");
-        assert_eq!(mm.get("min").and_then(Datum::as_f64), Some(0.0));
-        assert_eq!(mm.get("max").and_then(Datum::as_f64), Some(100.0));
-        assert_eq!(
-            s.write_spec("Number", &mm).as_deref(),
-            Some("(number #:min 0 #:max 100)"),
-        );
-
-        // Display precision.
-        let p = read_spec(&s, "(number #:precision 2)").expect("precision");
-        assert_eq!(p.get("precision").and_then(Datum::as_i64), Some(2));
-        assert_eq!(
-            s.write_spec("Number", &p).as_deref(),
-            Some("(number #:precision 2)"),
-        );
-
-        // Disabled push-eval.
-        let np = read_spec(&s, "(number #:no-push-eval)").expect("no push-eval");
-        assert_eq!(
-            np.get("push_eval_on_edit").and_then(Datum::as_bool),
-            Some(false)
-        );
-        assert_eq!(
-            s.write_spec("Number", &np).as_deref(),
-            Some("(number #:no-push-eval)"),
-        );
-
-        // Everything at once round-trips in canonical order.
-        let all = read_spec(
-            &s,
-            "(number #:min -1.5 #:max 1.5 #:precision 3 #:no-push-eval)",
-        )
-        .expect("all");
-        assert_eq!(
-            s.write_spec("Number", &all).as_deref(),
-            Some("(number #:min -1.5 #:max 1.5 #:precision 3 #:no-push-eval)"),
-        );
-    }
-
-    #[test]
-    fn tick_bang_config_round_trips() {
-        let s = DefaultSugar;
-
-        // A bare (default-duration) tick! stays bare, read as keyword or spec.
-        let bare = s.read_bare("tick-bang").expect("bare tick-bang");
-        assert_eq!(
-            s.write_spec("TickBang", &bare).as_deref(),
-            Some("tick-bang")
-        );
-
-        // A custom duration round-trips via the `#:duration` keyword (seconds).
-        let d = read_spec(&s, "(tick-bang #:duration 0.5)").expect("duration");
-        assert_eq!(
-            s.write_spec("TickBang", &d).as_deref(),
-            Some("(tick-bang #:duration 0.5)"),
-        );
-
-        // A rate round-trips via the `#:rate` keyword (Hz), stored exactly.
-        let r = read_spec(&s, "(tick-bang #:rate 60)").expect("rate");
-        assert_eq!(
-            s.write_spec("TickBang", &r).as_deref(),
-            Some("(tick-bang #:rate 60)"),
-        );
-
-        // An explicit default duration also writes as the bare keyword.
-        let one = read_spec(&s, "(tick-bang #:duration 1)").expect("default duration");
-        assert_eq!(s.write_spec("TickBang", &one).as_deref(), Some("tick-bang"));
-
-        // `#:duration` and `#:rate` are mutually exclusive.
-        let text = "(tick-bang #:duration 0.5 #:rate 60)";
-        let exprs = sexpr::read(text).expect("read");
-        let args = sexpr::list_args(&exprs[0]).expect("list");
-        assert!(s.read_spec("tick-bang", &args[1..], text).is_err());
     }
 }

--- a/crates/gantz_std/Cargo.toml
+++ b/crates/gantz_std/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 [dependencies]
 gantz_ca.workspace = true
 gantz_core.workspace = true
+gantz_format.workspace = true
 log.workspace = true
 serde.workspace = true
 steel-core.workspace = true

--- a/crates/gantz_std/src/lib.rs
+++ b/crates/gantz_std/src/lib.rs
@@ -3,7 +3,9 @@
 pub use bang::Bang;
 pub use log::Log;
 pub use number::Number;
+pub use sugar::StdSugar;
 
 pub mod bang;
 pub mod log;
 pub mod number;
+pub mod sugar;

--- a/crates/gantz_std/src/sugar.rs
+++ b/crates/gantz_std/src/sugar.rs
@@ -1,0 +1,246 @@
+//! `.gantz` keyword sugar for the standard node set.
+//!
+//! [`StdSugar`] provides the human-friendly keywords for this crate's nodes:
+//! bare `bang`, `(number [#:min m] [#:max m] [#:precision n] [#:no-push-eval])`
+//! and `(log [level])`. Compose it with [`gantz_format::CoreSugar`] (and the
+//! other crates' sugars) via [`gantz_format::Sugars`].
+
+use gantz_format::{Datum, FormatError, Sugar, SugarArgs, node_datum};
+
+/// Keyword sugar for [`Bang`](crate::Bang), [`Number`](crate::Number) and
+/// [`Log`](crate::Log).
+#[derive(Clone, Copy, Debug, Default)]
+pub struct StdSugar;
+
+/// Sugar keyword -> typetag tag, for the std builtins that lower to a plain
+/// serde object with no extra arguments.
+const KEYWORD_TAG: &[(&str, &str)] = &[("bang", "Bang"), ("number", "Number"), ("log", "Log")];
+
+/// The typetag tag for a sugar keyword.
+fn tag_for_keyword(kw: &str) -> Option<&'static str> {
+    KEYWORD_TAG
+        .iter()
+        .find(|(k, _)| *k == kw)
+        .map(|&(_, tag)| tag)
+}
+
+/// The sugar keyword for a typetag tag, if one exists.
+fn keyword_for_tag(tag: &str) -> Option<&'static str> {
+    KEYWORD_TAG
+        .iter()
+        .find(|(_, t)| *t == tag)
+        .map(|&(kw, _)| kw)
+}
+
+impl Sugar for StdSugar {
+    fn read_spec(&self, head: &str, args: SugarArgs<'_>) -> Result<Option<Datum>, FormatError> {
+        let datum = match head {
+            "number" => number_spec(args)?,
+            "log" => log_spec(args)?,
+            _ => return Ok(None),
+        };
+        Ok(Some(datum))
+    }
+
+    fn read_bare(&self, keyword: &str) -> Option<Datum> {
+        match keyword {
+            // A bare `log` defaults to the INFO level (not an empty node).
+            "log" => Some(node_datum(
+                "Log",
+                vec![("level", Datum::Str("INFO".into()))],
+            )),
+            _ => tag_for_keyword(keyword).map(|tag| node_datum(tag, vec![])),
+        }
+    }
+
+    fn write_spec(&self, tag: &str, node: &Datum) -> Option<String> {
+        match tag {
+            "Number" => Some(write_number(node)),
+            "Log" => Some(write_log(node)),
+            other => keyword_for_tag(other).map(str::to_string),
+        }
+    }
+
+    fn keyword_for_tag(&self, tag: &str) -> Option<&str> {
+        keyword_for_tag(tag)
+    }
+}
+
+// -- reading -----------------------------------------------------------------
+
+/// Read a `(number [#:min m] [#:max m] [#:precision n] [#:no-push-eval])` form.
+/// Only the non-default fields are emitted, so a bare `number` stays bare.
+fn number_spec(args: SugarArgs<'_>) -> Result<Datum, FormatError> {
+    let mut fields = Vec::new();
+    if let Some(min) = args.keyword_f64("min")? {
+        fields.push(("min", Datum::F64(min)));
+    }
+    if let Some(max) = args.keyword_f64("max")? {
+        fields.push(("max", Datum::F64(max)));
+    }
+    if let Some(precision) = args.keyword_int("precision")? {
+        fields.push(("precision", Datum::U64(precision.max(0) as u64)));
+    }
+    if args.has_flag("no-push-eval") {
+        fields.push(("push_eval_on_edit", Datum::Bool(false)));
+    }
+    Ok(node_datum("Number", fields))
+}
+
+/// Read a `(log [level])` form, mapping the level symbol to the serde string.
+fn log_spec(args: SugarArgs<'_>) -> Result<Datum, FormatError> {
+    let level = match args.symbol_at(0) {
+        Some(sym) => log_level(&sym)
+            .ok_or_else(|| args.malformed_at(0, format!("unknown log level `{sym}`")))?,
+        None => "INFO".to_string(),
+    };
+    Ok(node_datum("Log", vec![("level", Datum::Str(level))]))
+}
+
+/// Map a log-level symbol to the `log::Level` serde representation.
+fn log_level(sym: &str) -> Option<String> {
+    match sym.to_ascii_lowercase().as_str() {
+        "error" => Some("ERROR".into()),
+        "warn" => Some("WARN".into()),
+        "info" => Some("INFO".into()),
+        "debug" => Some("DEBUG".into()),
+        "trace" => Some("TRACE".into()),
+        _ => None,
+    }
+}
+
+// -- writing -----------------------------------------------------------------
+
+/// Write a `Number` as a bare `number` when all config is default, else as
+/// `(number #:min m #:max m #:precision n #:no-push-eval)` with only the
+/// non-default fields.
+fn write_number(node: &Datum) -> String {
+    let min = node.get("min").and_then(Datum::as_f64);
+    let max = node.get("max").and_then(Datum::as_f64);
+    let precision = node.get("precision").and_then(Datum::as_i64);
+    let push = node
+        .get("push_eval_on_edit")
+        .and_then(Datum::as_bool)
+        .unwrap_or(true);
+    if min.is_none() && max.is_none() && precision.is_none() && push {
+        return "number".to_string();
+    }
+    let mut parts = Vec::new();
+    if let Some(min) = min {
+        parts.push(format!("#:min {min}"));
+    }
+    if let Some(max) = max {
+        parts.push(format!("#:max {max}"));
+    }
+    if let Some(precision) = precision {
+        parts.push(format!("#:precision {precision}"));
+    }
+    if !push {
+        parts.push("#:no-push-eval".to_string());
+    }
+    format!("(number {})", parts.join(" "))
+}
+
+fn write_log(node: &Datum) -> String {
+    match node.get("level").and_then(Datum::as_str) {
+        Some(level) if !level.eq_ignore_ascii_case("info") => {
+            format!("(log {})", level.to_ascii_lowercase())
+        }
+        _ => "(log)".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gantz_format::sexpr;
+
+    /// Read a single sugar form's text through `StdSugar`, as the format does.
+    fn read_spec(text: &str) -> Option<Datum> {
+        let exprs = sexpr::read(text).expect("read");
+        let args = sexpr::list_args(&exprs[0]).expect("list");
+        let head = sexpr::as_symbol(&args[0]).expect("head");
+        StdSugar
+            .read_spec(&head, SugarArgs::new(&args[1..], text))
+            .expect("read_spec")
+    }
+
+    #[test]
+    fn bang_round_trips() {
+        let bare = StdSugar.read_bare("bang").expect("bare bang");
+        assert_eq!(bare.get("type").and_then(Datum::as_str), Some("Bang"));
+        assert_eq!(StdSugar.write_spec("Bang", &bare).as_deref(), Some("bang"));
+    }
+
+    #[test]
+    fn number_config_round_trips() {
+        let s = StdSugar;
+
+        // A bare (default) number stays bare, whether read as a keyword or spec.
+        let bare = s.read_bare("number").expect("bare number");
+        assert_eq!(s.write_spec("Number", &bare).as_deref(), Some("number"));
+        let empty = read_spec("(number)").expect("empty spec");
+        assert_eq!(s.write_spec("Number", &empty).as_deref(), Some("number"));
+
+        // Min/max bounds.
+        let mm = read_spec("(number #:min 0 #:max 100)").expect("min/max");
+        assert_eq!(mm.get("min").and_then(Datum::as_f64), Some(0.0));
+        assert_eq!(mm.get("max").and_then(Datum::as_f64), Some(100.0));
+        assert_eq!(
+            s.write_spec("Number", &mm).as_deref(),
+            Some("(number #:min 0 #:max 100)"),
+        );
+
+        // Display precision.
+        let p = read_spec("(number #:precision 2)").expect("precision");
+        assert_eq!(p.get("precision").and_then(Datum::as_i64), Some(2));
+        assert_eq!(
+            s.write_spec("Number", &p).as_deref(),
+            Some("(number #:precision 2)"),
+        );
+
+        // Disabled push-eval.
+        let np = read_spec("(number #:no-push-eval)").expect("no push-eval");
+        assert_eq!(
+            np.get("push_eval_on_edit").and_then(Datum::as_bool),
+            Some(false)
+        );
+        assert_eq!(
+            s.write_spec("Number", &np).as_deref(),
+            Some("(number #:no-push-eval)"),
+        );
+
+        // Everything at once round-trips in canonical order.
+        let all =
+            read_spec("(number #:min -1.5 #:max 1.5 #:precision 3 #:no-push-eval)").expect("all");
+        assert_eq!(
+            s.write_spec("Number", &all).as_deref(),
+            Some("(number #:min -1.5 #:max 1.5 #:precision 3 #:no-push-eval)"),
+        );
+    }
+
+    #[test]
+    fn log_level_round_trips() {
+        let s = StdSugar;
+
+        // A bare `log` and an explicit `(log)` both default to INFO and write bare.
+        let bare = s.read_bare("log").expect("bare log");
+        assert_eq!(bare.get("level").and_then(Datum::as_str), Some("INFO"));
+        assert_eq!(s.write_spec("Log", &bare).as_deref(), Some("(log)"));
+        let info = read_spec("(log info)").expect("info");
+        assert_eq!(s.write_spec("Log", &info).as_deref(), Some("(log)"));
+
+        // A non-default level round-trips lower-cased.
+        let warn = read_spec("(log warn)").expect("warn");
+        assert_eq!(warn.get("level").and_then(Datum::as_str), Some("WARN"));
+        assert_eq!(s.write_spec("Log", &warn).as_deref(), Some("(log warn)"));
+
+        // An unknown level errors.
+        let exprs = sexpr::read("(log bogus)").expect("read");
+        let args = sexpr::list_args(&exprs[0]).expect("list");
+        assert!(
+            s.read_spec("log", SugarArgs::new(&args[1..], "(log bogus)"))
+                .is_err()
+        );
+    }
+}


### PR DESCRIPTION
## Motivation

`gantz_format` sits at the bottom of the stack, but its `DefaultSugar` hardcoded the human-friendly `.gantz` keyword syntax for *every* builtin node - including nodes defined far downstream. Adding the `tick!` node (`TickBang` in `bevy_gantz_egui`) meant editing upstream `gantz_format` to teach it the `(tick-bang #:duration s | #:rate hz)` form: a layering inversion. This makes each crate own the sugar for the nodes it defines.

## What changed

- **`gantz_format`** - made the existing `Sugar` extension surface ergonomic and public:
  - `Sugar::read_spec` now takes a `SugarArgs` reader (keyword/positional/ verbatim-source helpers) instead of the raw steel `ExprKind` - a `Sugar` impl never touches the s-expression AST.
  - Published the `Datum` tag-builder + accessors and a `node_datum` helper. Added `FormatError::malformed`.
  - `DefaultSugar` -> `CoreSugar`, pruned to `gantz_core`'s own nodes (`inlet`/`outlet`/`apply`/`delay`/`id`/`expr`/`branch`).
  - Added a `NodeSugar` trait (`fn sugar() -> Sugars<'static>`) tying a node-set type to its composite. `from_str`/`to_string`/`to_string_named` read it via `N::sugar()`. The `_with` variants stay sugar-explicit.
- **Per-crate sugars** - `gantz_std::StdSugar` (bang/number/log), `gantz_egui::EguiSugar` (comment/inspect), `bevy_gantz_egui::BevySugar` (update-bang/tick-bang, with the `#:duration`/`#:rate` logic living next to the node in `node/tick_bang.rs`).
- **Composition** - `impl NodeSugar for Box<dyn Node>` in the app (core+std+egui+bevy) and the demo (core+std+egui). The `N: NodeSugar` bound propagates through the generic `gantz_egui` format/export/ops fns and the bevy systems/plugin **with no call-site changes and no runtime resource** - the valid sugar set is a static property of the node-type universe, so binding it at the type level is cleaner than threading a value through ~30 sites.

## Sugar is optional

Both levels of sugar are pure opt-in:

- A node needs **no `Sugar`** at all - an unrecognised tag round-trips via the generic `(node "Tag" ...)` form.
- A node-set type needs **no `NodeSugar`** - the `_with` entry points (`from_str_with`/`to_string_with`/...) carry no `NodeSugar` bound. It is required only by the no-argument convenience functions.
