### PR TITLE
Assorted GUI polish nits

### DIFF
--- a/crates/gantz_egui/src/impls/inlet.rs
+++ b/crates/gantz_egui/src/impls/inlet.rs
@@ -1,6 +1,6 @@
 use crate::{
-    InspectorRowsResponse, InspectorUiResponse, NodeCtx, NodeUi, NodeUiResponse, Registry,
-    SocketDoc, SocketKind, widget::node_inspector,
+    InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind,
+    widget::node_inspector,
 };
 use gantz_core::node;
 
@@ -38,15 +38,9 @@ impl NodeUi for gantz_core::node::graph::Inlet {
                 ui.label(format!("{ix}"));
             });
         });
-        InspectorRowsResponse::default()
-    }
-
-    fn inspector_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> InspectorUiResponse {
-        ui.separator();
-        let (resp, changed) =
-            node_inspector::socket_doc_editor(ui, ctx.path(), &mut self.ty, &mut self.description);
-        InspectorUiResponse {
-            inner: Some(resp),
+        let changed =
+            node_inspector::socket_doc_rows(body, ctx.path(), &mut self.ty, &mut self.description);
+        InspectorRowsResponse {
             changed,
             payloads: Vec::new(),
         }

--- a/crates/gantz_egui/src/impls/outlet.rs
+++ b/crates/gantz_egui/src/impls/outlet.rs
@@ -1,6 +1,6 @@
 use crate::{
-    InspectorRowsResponse, InspectorUiResponse, NodeCtx, NodeUi, NodeUiResponse, Registry,
-    SocketDoc, SocketKind, widget::node_inspector,
+    InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind,
+    widget::node_inspector,
 };
 use gantz_core::node;
 
@@ -38,15 +38,9 @@ impl NodeUi for gantz_core::node::graph::Outlet {
                 ui.label(format!("{ix}"));
             });
         });
-        InspectorRowsResponse::default()
-    }
-
-    fn inspector_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> InspectorUiResponse {
-        ui.separator();
-        let (resp, changed) =
-            node_inspector::socket_doc_editor(ui, ctx.path(), &mut self.ty, &mut self.description);
-        InspectorUiResponse {
-            inner: Some(resp),
+        let changed =
+            node_inspector::socket_doc_rows(body, ctx.path(), &mut self.ty, &mut self.description);
+        InspectorRowsResponse {
             changed,
             payloads: Vec::new(),
         }

--- a/crates/gantz_egui/src/keybind.rs
+++ b/crates/gantz_egui/src/keybind.rs
@@ -36,8 +36,9 @@ pub enum Action {
     Undo,
     /// Redo the last undone change to the focused graph.
     Redo,
-    /// Show or hide the command palette.
-    ToggleCommandPalette,
+    /// Show or hide the node palette.
+    #[serde(alias = "ToggleCommandPalette")]
+    ToggleNodePalette,
     /// Select every node in the focused graph.
     SelectAll,
     /// Copy the selected nodes to the clipboard, then remove them.
@@ -84,7 +85,7 @@ const REDO: &[KeyboardShortcut] = &[
     KeyboardShortcut::new(CMD_SHIFT, Key::Z),
     KeyboardShortcut::new(CMD, Key::Y),
 ];
-const TOGGLE_COMMAND_PALETTE: &[KeyboardShortcut] =
+const TOGGLE_NODE_PALETTE: &[KeyboardShortcut] =
     &[KeyboardShortcut::new(Modifiers::NONE, Key::Space)];
 const SELECT_ALL: &[KeyboardShortcut] = &[KeyboardShortcut::new(CMD, Key::A)];
 const CUT: &[KeyboardShortcut] = &[KeyboardShortcut::new(CMD, Key::X)];
@@ -98,7 +99,7 @@ impl Action {
         Action::NewGraph,
         Action::Undo,
         Action::Redo,
-        Action::ToggleCommandPalette,
+        Action::ToggleNodePalette,
         Action::SelectAll,
         Action::Cut,
         Action::Duplicate,
@@ -112,7 +113,7 @@ impl Action {
             Action::NewGraph => "New graph",
             Action::Undo => "Undo",
             Action::Redo => "Redo",
-            Action::ToggleCommandPalette => "Node palette",
+            Action::ToggleNodePalette => "Node palette",
             Action::SelectAll => "Select all",
             Action::Cut => "Cut",
             Action::Duplicate => "Duplicate",
@@ -127,7 +128,7 @@ impl Action {
             Action::NewGraph => "Open a new graph in a new tab.",
             Action::Undo => "Undo the last change to the focused graph.",
             Action::Redo => "Redo the last undone change to the focused graph.",
-            Action::ToggleCommandPalette => "Show or hide the command palette for creating nodes.",
+            Action::ToggleNodePalette => "Show or hide the node palette for creating nodes.",
             Action::SelectAll => "Select every node in the focused graph.",
             Action::Cut => "Copy the selected nodes to the clipboard, then remove them.",
             Action::Duplicate => "Duplicate the selected nodes in place.",
@@ -147,7 +148,7 @@ impl Action {
             // Two defaults; `Cmd+Shift+Z` is the more specific, so dispatch Redo
             // before Undo (see [`Keymap::consume`]).
             Action::Redo => REDO,
-            Action::ToggleCommandPalette => TOGGLE_COMMAND_PALETTE,
+            Action::ToggleNodePalette => TOGGLE_NODE_PALETTE,
             Action::SelectAll => SELECT_ALL,
             Action::Cut => CUT,
             Action::Duplicate => DUPLICATE,

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -52,7 +52,7 @@ pub use widget::graph_select::GraphRegistry;
 ///   Required by [`node::FnNamedRef`]'s UI dropdown.
 ///
 /// - [`NodeTypeRegistry`] (`widget/gantz.rs`) — enumerates all creatable node
-///   types. Required by the command palette for node creation.
+///   types. Required by the node palette for node creation.
 ///
 /// - [`GraphRegistry`] (`widget/graph_select.rs`) — provides access to commits
 ///   and branch names. Required by the graph selector and history view.
@@ -70,7 +70,7 @@ pub trait Registry: NameRegistry + FnNodeNames + NodeTypeRegistry + GraphRegistr
     /// Whether referencing the graph named `target` from the graph named
     /// `editing` would create a reference cycle (see [`cycle::would_cycle`]).
     ///
-    /// Used by the command palette to hide node types that would form a cycle.
+    /// Used by the node palette to hide node types that would form a cycle.
     /// The default is conservative (never a cycle); the standard [`RegistryRef`]
     /// implementation walks the registry.
     fn would_ref_cycle(&self, target: &str, editing: &str) -> bool {
@@ -103,7 +103,7 @@ pub trait Registry: NameRegistry + FnNodeNames + NodeTypeRegistry + GraphRegistr
     /// Display-ready documentation for the creatable node type named `name`.
     ///
     /// Combines the node's description with its derived input/output
-    /// [`SocketDoc`]s. Shown beside the highlighted entry in the command palette
+    /// [`SocketDoc`]s. Shown beside the highlighted entry in the node palette
     /// and as hover documentation in the "Graphs" select widget. The standard
     /// [`RegistryRef`] impl introspects a builtin instance or resolves a named
     /// graph; the default returns just the name.
@@ -125,7 +125,7 @@ pub trait Registry: NameRegistry + FnNodeNames + NodeTypeRegistry + GraphRegistr
     }
 
     /// A concise description of the creatable node type `name`, for inline
-    /// display in the command palette. Lighter than [`command_info`](Self::command_info)
+    /// display in the node palette. Lighter than [`command_info`](Self::command_info)
     /// (it derives no input/output docs); the default has none.
     fn node_description(&self, name: &str) -> Option<Cow<'static, str>> {
         let _ = name;
@@ -171,7 +171,7 @@ impl SocketDoc {
 ///
 /// Built by [`Registry::command_info`] from a node's [`description`] and its
 /// derived per-socket [`SocketDoc`]s, and rendered by [`node_info_ui`] in the
-/// command palette and the "Graphs" select hover.
+/// node palette and the "Graphs" select hover.
 ///
 /// [`description`]: NodeUi::description
 #[derive(Clone, Debug, Default)]
@@ -189,7 +189,7 @@ pub struct CommandInfo {
 /// Render a [`CommandInfo`] as a name heading, description, and labelled
 /// input/output lists.
 ///
-/// Used both for the command palette's side panel and as the body of the
+/// Used both for the node palette's side panel and as the body of the
 /// per-item / graph-select hover tooltips. Callers that render inside a tooltip
 /// should set a max width first (see the tooltip-width note in `socket_hover`).
 pub fn node_info_ui(info: &CommandInfo, ui: &mut egui::Ui) {
@@ -392,7 +392,7 @@ pub trait NodeUi {
 
     /// A concise, free-form description of what the node does.
     ///
-    /// Shown alongside the node's inputs/outputs in the command palette and as
+    /// Shown alongside the node's inputs/outputs in the node palette and as
     /// hover documentation in the "Graphs" select widget. Builtins hardcode a
     /// short string; nodes that reference a named graph resolve the graph's
     /// stored description via [`Registry::command_info`].
@@ -491,7 +491,7 @@ pub fn resolve_paste_offset(pos: &PastePos, copied_positions: &egui_graph::Layou
 //
 // Typed payloads emitted from within the widget tree via the dynamic
 // [`response::Responses`] channel and returned from `Gantz::show`. With the
-// exception of [`OpenCommandPalette`] (which `Gantz::show` handles itself),
+// exception of [`OpenNodePalette`] (which `Gantz::show` handles itself),
 // applications drain and handle these after the GUI pass.
 // Unhandled payloads should be reported via [`response::Responses::type_names`].
 // ----------------------------------------------------------------------------
@@ -562,11 +562,11 @@ pub struct InspectEdge {
     pub pos: egui::Pos2,
 }
 
-/// Open the command palette for node creation.
+/// Open the node palette for node creation.
 ///
 /// Handled by `Gantz::show` itself - applications never see this payload.
 #[derive(Clone, Copy, Debug)]
-pub struct OpenCommandPalette;
+pub struct OpenNodePalette;
 
 /// Reset the top-level tile layout to its default arrangement.
 ///

--- a/crates/gantz_egui/src/widget.rs
+++ b/crates/gantz_egui/src/widget.rs
@@ -57,15 +57,28 @@ pub(crate) fn to_local_datetime(datetime: OffsetDateTime) -> OffsetDateTime {
         .unwrap_or(datetime)
 }
 
-/// Format a SystemTime as a local datetime string.
-pub(crate) fn format_local_datetime(system_time: std::time::SystemTime) -> String {
+/// The glyph for a widget's options/settings button (swap if it doesn't render).
+pub(crate) const OPTIONS_GLYPH: &str = "⛭";
+
+/// Format a SystemTime as a local string using the given `time` format
+/// description.
+fn format_local(system_time: std::time::SystemTime, desc: &str) -> String {
     let datetime = OffsetDateTime::from(system_time);
     let local_datetime = to_local_datetime(datetime);
-    let format = format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second]")
-        .expect("invalid format");
+    let format = format_description::parse(desc).expect("invalid format");
     local_datetime
         .format(&format)
         .unwrap_or_else(|_| "<invalid-timestamp>".to_string())
+}
+
+/// Format a SystemTime as a local `YYYY-MM-DD HH:MM:SS` datetime string.
+pub(crate) fn format_local_datetime(system_time: std::time::SystemTime) -> String {
+    format_local(system_time, "[year]-[month]-[day] [hour]:[minute]:[second]")
+}
+
+/// Format a SystemTime as a local `HH:MM:SS` time-of-day string (no date).
+pub(crate) fn format_local_time(system_time: std::time::SystemTime) -> String {
+    format_local(system_time, "[hour]:[minute]:[second]")
 }
 
 /// Group consecutive slice elements considered equal by `eq` into runs,

--- a/crates/gantz_egui/src/widget.rs
+++ b/crates/gantz_egui/src/widget.rs
@@ -2,7 +2,6 @@
 use time::{OffsetDateTime, UtcOffset, format_description};
 
 pub use checkbox_enabled::CheckboxEnabled;
-pub use command_palette::CommandPalette;
 pub use gantz::{
     AlignConfig, Gantz, GantzState, GridConfig, LayoutConfig, SceneConfig, SnapConfig, SnapMode,
     update_graph_pane_head,
@@ -19,6 +18,7 @@ pub use label_button::LabelButton;
 pub use label_toggle::LabelToggle;
 pub use log_view::LogView;
 pub use node_inspector::NodeInspector;
+pub use node_palette::NodePalette;
 pub use panes_config::{panes_config, reset_layout_button};
 pub use perf_view::{PerfCapture, PerfView};
 pub use settings::{SettingsResponse, settings};
@@ -27,7 +27,6 @@ pub use style_config::style_config;
 pub use tab::{Tab, TabResponse};
 
 pub mod checkbox_enabled;
-pub mod command_palette;
 pub mod gantz;
 pub mod global_config;
 pub mod graph_config;
@@ -41,6 +40,7 @@ pub mod label_button;
 pub mod label_toggle;
 pub mod log_view;
 pub mod node_inspector;
+pub mod node_palette;
 pub mod panes_config;
 pub mod perf_view;
 pub mod settings;

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -753,9 +753,9 @@ impl<'a> Gantz<'a> {
         }
 
         // The persisted outer tree. The version suffix invalidates any tree
-        // persisted before the sidebar overhaul (which lacks the new panes and
-        // tab containers), forcing a rebuild via `create_tree`.
-        let tree_id = egui::Id::new("gantz-tiles-tree-storage-v3");
+        // persisted before the latest default-layout change (v4: perf panes
+        // side by side at half height), forcing a rebuild via `create_tree`.
+        let tree_id = egui::Id::new("gantz-tiles-tree-storage-v4");
 
         // Retrieve the tree from persistent storage, or load the default.
         let mut tree: egui_tiles::Tree<Pane> =
@@ -1891,12 +1891,14 @@ fn create_tree() -> egui_tiles::Tree<Pane> {
 
     // Sidebar tab containers (first child is the default-active tab).
     let graphs_history_settings = tiles.insert_tab_tile(vec![graphs, history, settings]);
-    let perf = tiles.insert_tab_tile(vec![vm_perf, gui_perf]);
+    // VM Perf and GUI Perf sit side by side rather than as tabs, so both plots
+    // are visible at once.
+    let perf = tiles.insert_horizontal_tile(vec![vm_perf, gui_perf]);
 
     // The left column (sidebar).
     let mut shares = egui_tiles::Shares::default();
     shares.set_share(graphs_history_settings, 0.30);
-    shares.set_share(perf, 0.10);
+    shares.set_share(perf, 0.05);
     shares.set_share(graph_config, 0.13);
     shares.set_share(node_inspector, 0.25);
     let left_column = tiles.insert_container(egui_tiles::Linear {

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -1,6 +1,6 @@
 use crate::{
     Action, CopyNodes, CreateNestedGraph, CreateNode, CutNodes, DuplicateNodes, ExportAllNamed,
-    ExportHead, HeadAccess, Keymap, NodeCtx, NodeUi, OpenCommandPalette, OpenLogs, OpenNodeView,
+    ExportHead, HeadAccess, Keymap, NodeCtx, NodeUi, OpenLogs, OpenNodePalette, OpenNodeView,
     Paste, Redo, Registry, ReplaceHead, ResetTilesLayout, Undo, export,
     response::{DynResponse, Responses},
     widget::{self, GraphScene, GraphSceneState, graph_scene},
@@ -28,7 +28,7 @@ pub enum FileDropTarget {
 
 /// The reserved node-type name that creates a new nested graph.
 ///
-/// Selecting this entry in the command palette emits a
+/// Selecting this entry in the node palette emits a
 /// [`CreateNestedGraph`] rather than a [`CreateNode`], so a nested graph is
 /// created like any other node but routed through the registry-aware op.
 pub const NESTED_GRAPH_TYPE: &str = "graph";
@@ -41,7 +41,7 @@ pub trait NodeTypeRegistry {
     /// The unique name of each node available.
     fn node_types(&self) -> Vec<&str>;
 
-    /// The formatted keyboard shortcut for the command palette.
+    /// The formatted keyboard shortcut for the node palette.
     fn command_formatted_kb_shortcut(
         &self,
         _ctx: &egui::Context,
@@ -80,7 +80,8 @@ pub struct GantzState {
     #[serde(serialize_with = "gantz_ca::serde_sorted::serialize_map")]
     pub open_heads: OpenHeadStates,
     pub view_toggles: ViewToggles,
-    pub command_palette: widget::CommandPalette,
+    #[serde(default, alias = "command_palette")]
+    pub node_palette: widget::NodePalette,
     /// Global auto-layout parameters (the non-flow `egui_graph` layout params;
     /// flow stays per-head in [`OpenHeadState::layout_flow`]).
     #[serde(default)]
@@ -815,10 +816,10 @@ impl<'a> Gantz<'a> {
         response.file_drops = collect_gantz_file_drops(ui.ctx());
 
         // Apply payloads that only affect the widget's own state, so
-        // applications never see them: command palette toggling and resetting
+        // applications never see them: node palette toggling and resetting
         // the tile layout to its default arrangement.
-        for _ in response.responses.take::<OpenCommandPalette>() {
-            state.command_palette.toggle();
+        for _ in response.responses.take::<OpenNodePalette>() {
+            state.node_palette.toggle();
         }
         for _ in response.responses.take::<ResetTilesLayout>() {
             tree = create_tree();
@@ -866,7 +867,7 @@ impl GantzState {
     pub fn from_open_heads(open_heads: OpenHeadStates) -> Self {
         Self {
             open_heads,
-            command_palette: widget::CommandPalette::default(),
+            node_palette: widget::NodePalette::default(),
             view_toggles: ViewToggles::default(),
             layout_config: LayoutConfig::default(),
             scene_config: SceneConfig::default(),
@@ -1153,7 +1154,7 @@ where
                 // Persist the inner tree.
                 store_tree(ui.ctx(), graph_tree_id, &graph_tree);
 
-                // Show the command palette once (not per-pane), operating on the focused head.
+                // Show the node palette once (not per-pane), operating on the focused head.
                 if let Some(fh) = access.heads().get(*focused_head).cloned() {
                     let focused_immutable = head_immutable(&fh, gantz.base_immutable, base_names);
 
@@ -1221,7 +1222,7 @@ where
                         }
                     }
 
-                    // Skip command palette when immutable.
+                    // Skip node palette when immutable.
                     if !focused_immutable {
                         let editing = match &fh {
                             gantz_ca::Head::Branch(name) => Some(name.as_str()),
@@ -1231,10 +1232,10 @@ where
                         // (graph coords) recorded this frame; new nodes are placed
                         // here. `Copy`, so no borrow is held across the call.
                         let pointer_pos = head_state.scene.interaction.last_pointer_pos;
-                        let created = command_palette(
+                        let created = node_palette(
                             gantz.env,
                             editing,
-                            &mut state.command_palette,
+                            &mut state.node_palette,
                             &state.keymap,
                             ui,
                         );
@@ -1820,7 +1821,7 @@ fn node_view_title(pane: &NodeViewPane) -> String {
     s
 }
 
-impl widget::command_palette::Command for NodeTyCmd<'_> {
+impl widget::node_palette::Command for NodeTyCmd<'_> {
     fn text(&self) -> &str {
         self.name
     }
@@ -2573,7 +2574,7 @@ fn name_breadcrumb(
     responses
 }
 
-/// A node-creation choice made in the command palette.
+/// A node-creation choice made in the node palette.
 enum PaletteChoice {
     /// Create an ordinary node of the given type.
     Node(CreateNode),
@@ -2585,19 +2586,19 @@ enum PaletteChoice {
 ///
 /// `editing` is the focused head's name (when it is a branch), used to hide node
 /// types whose reference would cycle back to the graph being edited.
-fn command_palette(
+fn node_palette(
     env: &dyn Registry,
     editing: Option<&str>,
-    cmd_palette: &mut widget::CommandPalette,
+    node_palette: &mut widget::NodePalette,
     keymap: &Keymap,
     ui: &mut egui::Ui,
 ) -> Option<PaletteChoice> {
-    // Toggle command palette visibility via its keymap binding.
-    if !ui.ctx().egui_wants_keyboard_input() && keymap.consume(ui, Action::ToggleCommandPalette) {
-        cmd_palette.toggle();
+    // Toggle node palette visibility via its keymap binding.
+    if !ui.ctx().egui_wants_keyboard_input() && keymap.consume(ui, Action::ToggleNodePalette) {
+        node_palette.toggle();
     }
 
-    // Map the node types to commands for the command palette, dropping any type
+    // Map the node types to commands for the node palette, dropping any type
     // whose reference would form a cycle back to the editing graph. The reserved
     // nested-graph entry always mints a fresh child, so it is never cyclic.
     let types: Vec<&str> = env
@@ -2611,7 +2612,7 @@ fn command_palette(
     // `NESTED_GRAPH_TYPE` routes to the registry-aware nested-graph op. The
     // palette is centered over the graph scene (this `ui`'s rect).
     let scene_rect = ui.max_rect();
-    cmd_palette.show(ui.ctx(), scene_rect, cmds).map(|cmd| {
+    node_palette.show(ui.ctx(), scene_rect, cmds).map(|cmd| {
         // The placement position is filled in by the caller, which has access to
         // the focused head's last pointer position.
         if cmd.name == NESTED_GRAPH_TYPE {

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -1352,8 +1352,10 @@ where
                     let immutable = head_immutable(&fh, gantz.base_immutable, base_names);
                     let head_state = state.open_heads.entry(fh.clone()).or_default();
                     let result = access.with_head_mut(&fh, |data| {
-                        node_inspector(gantz.env, data.graph, data.vm, head_state, immutable, ui)
-                            .inner
+                        node_inspector(
+                            gantz.env, data.graph, data.vm, head_state, &fh, immutable, ui,
+                        )
+                        .inner
                     });
                     if let Some((changed, payloads)) = result {
                         if changed {
@@ -2671,6 +2673,7 @@ fn node_inspector<N>(
     root: &mut gantz_core::node::graph::Graph<N>,
     vm: &mut Engine,
     head_state: &mut OpenHeadState,
+    head: &gantz_ca::Head,
     immutable: bool,
     ui: &mut egui::Ui,
 ) -> egui::InnerResponse<(bool, Vec<DynResponse>)>
@@ -2687,12 +2690,15 @@ where
                 let ids: Vec<_> = graph.node_references().map(|n_ref| n_ref.id()).collect();
                 // Collect the inlets and outlets.
                 let (inlets, outlets) = crate::inlet_outlet_ids(registry, graph);
+                // The rect of the first selected node, used to scroll to it.
+                let mut selected_rect: Option<egui::Rect> = None;
                 for id in ids {
                     let mut frame = egui::Frame::group(ui.style());
-                    if head_state.scene.interaction.selection.nodes.contains(&id) {
+                    let is_selected = head_state.scene.interaction.selection.nodes.contains(&id);
+                    if is_selected {
                         frame.stroke.color = ui.visuals().selection.stroke.color;
                     }
-                    frame.show(ui, |ui| {
+                    let frame_resp = frame.show(ui, |ui| {
                         let Some(node) = graph.node_weight_mut(id) else {
                             return;
                         };
@@ -2714,6 +2720,30 @@ where
                             }
                         }
                     });
+                    if is_selected && selected_rect.is_none() {
+                        selected_rect = Some(frame_resp.response.rect);
+                    }
+                }
+
+                // Scroll to the first selected node when the selection changes,
+                // mirroring the Steel view's scroll-to-span on selection.
+                let state_id = egui::Id::new("node_inspector_selection");
+                let mut selected: Vec<node::Id> = head_state
+                    .scene
+                    .interaction
+                    .selection
+                    .nodes
+                    .iter()
+                    .map(|n| n.index())
+                    .collect();
+                selected.sort_unstable();
+                let current = egui::Id::new(("inspector_sel", head, &selected));
+                let prev: Option<egui::Id> = ui.ctx().data(|d| d.get_temp(state_id));
+                if prev != Some(current) {
+                    ui.ctx().data_mut(|d| d.insert_temp(state_id, current));
+                    if let Some(rect) = selected_rect {
+                        ui.scroll_to_rect(rect, Some(egui::Align::Center));
+                    }
                 }
             });
         (changed, responses)

--- a/crates/gantz_egui/src/widget/graph_config.rs
+++ b/crates/gantz_egui/src/widget/graph_config.rs
@@ -86,127 +86,184 @@ impl<'a> GraphConfig<'a> {
     }
 
     pub fn show(self, ui: &mut egui::Ui) -> GraphConfigResponse {
-        // Name editing TextEdit with per-head temp state.
-        let edit_id = egui::Id::new("graph_config_name_edit").with(self.head);
-        let mut name = ui
-            .memory_mut(|m| m.data.get_temp::<String>(edit_id))
-            .unwrap_or_else(|| head_name(self.head));
-        let name_res = head_name_edit(self.head, &mut name, self.names, ui);
-        ui.memory_mut(|m| m.data.insert_temp(edit_id, name));
-        let new_branch = name_res.new_branch;
-
         let is_named = matches!(self.head, gantz_ca::Head::Branch(_));
         let is_demo =
             matches!(&self.head, gantz_ca::Head::Branch(name) if name.starts_with("demo-"));
 
-        // Description editor (per-head temp state), for named graphs. The edit
-        // is committed when the field loses focus to avoid a commit per keypress.
-        let mut description_changed = None;
-        if is_named {
-            let desc_id = egui::Id::new("graph_config_desc_edit").with(self.head);
+        // Per-head temp state for the name editor.
+        let edit_id = egui::Id::new("graph_config_name_edit").with(self.head);
+        let mut name = ui
+            .memory_mut(|m| m.data.get_temp::<String>(edit_id))
+            .unwrap_or_else(|| head_name(self.head));
+
+        // Per-head temp state for the description editor (named graphs only).
+        // The edit is committed on focus loss to avoid a commit per keypress.
+        let desc_id = egui::Id::new("graph_config_desc_edit").with(self.head);
+        let mut desc = is_named.then(|| {
             let current = self.current_description.unwrap_or("");
-            let mut desc = ui
-                .memory_mut(|m| m.data.get_temp::<String>(desc_id))
-                .unwrap_or_else(|| current.to_string());
-            let resp = ui.add_enabled(
-                !self.immutable,
-                egui::TextEdit::multiline(&mut desc)
-                    .hint_text("Description")
-                    .desired_rows(2)
-                    .desired_width(f32::INFINITY),
-            );
-            if resp.lost_focus() && desc != current {
-                description_changed = Some(desc.clone());
-            }
+            ui.memory_mut(|m| m.data.get_temp::<String>(desc_id))
+                .unwrap_or_else(|| current.to_string())
+        });
+
+        // Outputs collected from within the grid.
+        let mut new_branch = None;
+        let mut description_changed = None;
+        let mut demo_changed = None;
+        let mut reset_base_graph = false;
+        let mut export = false;
+
+        // Reserve room for the label column so the value column's text fields
+        // don't expand to fill the entire pane.
+        let control_w = (ui.available_width() - 64.0).max(64.0);
+
+        egui::Grid::new(egui::Id::new("graph_config_grid").with(self.head))
+            .num_columns(2)
+            .spacing([8.0, 6.0])
+            .striped(true)
+            .show(ui, |ui| {
+                // name
+                ui.label("name");
+                new_branch = ui
+                    .scope(|ui| {
+                        ui.set_max_width(control_w);
+                        head_name_edit(self.head, &mut name, self.names, ui)
+                    })
+                    .inner
+                    .new_branch;
+                ui.end_row();
+
+                // desc.
+                if let Some(desc) = desc.as_mut() {
+                    ui.label("desc.");
+                    let current = self.current_description.unwrap_or("");
+                    // Multiline + word-wrap; the grid row auto-fits its height
+                    // to the (wrapped) text, growing from a single row.
+                    let resp = ui.add_enabled(
+                        !self.immutable,
+                        egui::TextEdit::multiline(desc)
+                            .hint_text("Description")
+                            .desired_rows(1)
+                            .desired_width(control_w),
+                    );
+                    if resp.lost_focus() && desc.as_str() != current {
+                        description_changed = Some(desc.clone());
+                    }
+                    ui.end_row();
+                }
+
+                // demo (named, non-demo graphs only)
+                if is_named && !is_demo && !self.demo_names.is_empty() {
+                    ui.label("demo");
+                    ui.add_enabled_ui(!self.immutable, |ui| {
+                        let selected_text = self.current_demo.unwrap_or("none");
+                        egui::ComboBox::from_id_salt("demo_graph_select")
+                            .selected_text(selected_text)
+                            .show_ui(ui, |ui| {
+                                if ui
+                                    .selectable_label(self.current_demo.is_none(), "none")
+                                    .clicked()
+                                {
+                                    demo_changed = Some(None);
+                                }
+                                for &demo_name in self.demo_names {
+                                    if ui
+                                        .selectable_label(
+                                            self.current_demo == Some(demo_name),
+                                            demo_name,
+                                        )
+                                        .clicked()
+                                    {
+                                        demo_changed = Some(Some(demo_name.to_string()));
+                                    }
+                                }
+                            });
+                    });
+                    ui.end_row();
+                }
+
+                // reset (base demo graphs only)
+                if self.is_base && is_demo {
+                    ui.label("reset");
+                    if ui
+                        .button("Reset")
+                        .on_hover_text("reset demo to initial state")
+                        .clicked()
+                    {
+                        reset_base_graph = true;
+                    }
+                    ui.end_row();
+                }
+
+                // base note
+                if self.is_base {
+                    ui.label("");
+                    ui.label(
+                        egui::RichText::new("\"base\" node, included with gantz")
+                            .italics()
+                            .weak(),
+                    );
+                    ui.end_row();
+                }
+
+                // layout - center-view and auto-layout side by side. Both are
+                // one-shot: they apply once when clicked (consumed by the graph
+                // scene next pass), so hand-arranged nodes are never disturbed.
+                ui.label("layout");
+                ui.horizontal(|ui| {
+                    if ui
+                        .button("center view")
+                        .on_hover_text("center the view over the graph")
+                        .clicked()
+                    {
+                        self.head_state.scene.pending_center_view = true;
+                    }
+                    ui.add_enabled_ui(!self.immutable, |ui| {
+                        if ui
+                            .button("auto-layout")
+                            .on_hover_text(
+                                "lay out the selection, or the whole graph when nothing is selected",
+                            )
+                            .clicked()
+                        {
+                            self.head_state.scene.pending_auto_layout = true;
+                        }
+                    });
+                });
+                ui.end_row();
+
+                // flow
+                ui.label("flow");
+                ui.add_enabled_ui(!self.immutable, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.radio_value(
+                            &mut self.head_state.layout_flow,
+                            egui::Direction::LeftToRight,
+                            "Right",
+                        );
+                        ui.radio_value(
+                            &mut self.head_state.layout_flow,
+                            egui::Direction::TopDown,
+                            "Down",
+                        );
+                    });
+                });
+                ui.end_row();
+
+                // export
+                ui.label("export");
+                export = ui
+                    .button("export")
+                    .on_hover_text("export this graph and its dependencies to a .gantz file")
+                    .clicked();
+                ui.end_row();
+            });
+
+        // Persist the per-head editor buffers.
+        ui.memory_mut(|m| m.data.insert_temp(edit_id, name));
+        if let Some(desc) = desc {
             ui.memory_mut(|m| m.data.insert_temp(desc_id, desc));
         }
 
-        // Demo graph selector (only for named, non-demo graphs).
-        let mut demo_changed = None;
-        if is_named && !is_demo && !self.demo_names.is_empty() {
-            ui.add_enabled_ui(!self.immutable, |ui| {
-                ui.horizontal(|ui| {
-                    ui.label("Demo:");
-                    let selected_text = self.current_demo.unwrap_or("none");
-                    egui::ComboBox::from_id_salt("demo_graph_select")
-                        .selected_text(selected_text)
-                        .show_ui(ui, |ui| {
-                            if ui
-                                .selectable_label(self.current_demo.is_none(), "none")
-                                .clicked()
-                            {
-                                demo_changed = Some(None);
-                            }
-                            for &demo_name in self.demo_names {
-                                if ui
-                                    .selectable_label(
-                                        self.current_demo == Some(demo_name),
-                                        demo_name,
-                                    )
-                                    .clicked()
-                                {
-                                    demo_changed = Some(Some(demo_name.to_string()));
-                                }
-                            }
-                        });
-                });
-            });
-        }
-
-        // Reset button for demo base graphs.
-        let mut reset_base_graph = false;
-        if self.is_base && is_demo {
-            if ui
-                .button("Reset")
-                .on_hover_text("reset demo to initial state")
-                .clicked()
-            {
-                reset_base_graph = true;
-            }
-        }
-
-        if self.is_base {
-            ui.label(
-                egui::RichText::new("\"base\" node, included with gantz")
-                    .italics()
-                    .weak(),
-            );
-        }
-
-        // Layout actions. Auto-layout and center-view are one-shot: they apply
-        // once when clicked (consumed by the graph scene on the next pass), so
-        // arranging nodes by hand is never disturbed.
-        if ui
-            .button("center view")
-            .on_hover_text("center the view over the graph")
-            .clicked()
-        {
-            self.head_state.scene.pending_center_view = true;
-        }
-        ui.add_enabled_ui(!self.immutable, |ui| {
-            if ui
-                .button("auto-layout")
-                .on_hover_text("lay out the selection, or the whole graph when nothing is selected")
-                .clicked()
-            {
-                self.head_state.scene.pending_auto_layout = true;
-            }
-            ui.horizontal(|ui| {
-                ui.label("Flow:");
-                ui.radio_value(
-                    &mut self.head_state.layout_flow,
-                    egui::Direction::LeftToRight,
-                    "Right",
-                );
-                ui.radio_value(
-                    &mut self.head_state.layout_flow,
-                    egui::Direction::TopDown,
-                    "Down",
-                );
-            });
-        });
-
-        let export = ui.button("Export").clicked();
         GraphConfigResponse {
             new_branch,
             export,

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -1,5 +1,5 @@
 use crate::{
-    CopyNodes, InspectEdge, NodeUi, OpenCommandPalette, OpenHead, OpenNodeView, Paste, PastePos,
+    CopyNodes, InspectEdge, NodeUi, OpenHead, OpenNodePalette, OpenNodeView, Paste, PastePos,
     Registry, ResetTilesLayout, SocketDoc, response::DynResponse,
 };
 use egui::emath::GuiRounding;
@@ -293,7 +293,7 @@ where
         }
 
         // Track the latest pointer position over the scene (in graph space) so a
-        // node added via the command palette lands under the pointer. While the
+        // node added via the node palette lands under the pointer. While the
         // palette window covers the scene, `contains_pointer` is false, so this
         // retains the pre-open position.
         if graph_response.response.contains_pointer() {
@@ -323,7 +323,7 @@ where
                     // positioning.
                     let menu_screen_pos = ui.min_rect().left_top();
                     if ui.button("add node").clicked() {
-                        responses.push(DynResponse::new(OpenCommandPalette));
+                        responses.push(DynResponse::new(OpenNodePalette));
                         ui.close();
                     }
                     if ui.button("paste").clicked() {

--- a/crates/gantz_egui/src/widget/log_view.rs
+++ b/crates/gantz_egui/src/widget/log_view.rs
@@ -27,8 +27,17 @@ pub struct LogViewResponse {
 #[derive(Clone)]
 struct LogViewState {
     level_filter: log::LevelFilter,
-    target_filter: String,
+    /// Substring filter over each entry's message and target (space-separated
+    /// terms, all must match).
+    text_filter: String,
     auto_scroll: bool,
+    /// Whether the Time, Level and Target columns are shown. Target defaults
+    /// off as it's the least useful column for most entries.
+    show_time: bool,
+    /// Whether the Time column includes the date (vs time-of-day only).
+    show_date: bool,
+    show_level: bool,
+    show_target: bool,
 }
 
 #[derive(Clone)]
@@ -40,9 +49,13 @@ pub struct LogEntry {
 }
 
 impl LogEntry {
-    fn format_timestamp(&self) -> String {
+    fn format_timestamp(&self, show_date: bool) -> String {
         let system_time = crate::system_time_from_web(self.timestamp).expect("failed to convert");
-        crate::widget::format_local_datetime(system_time)
+        if show_date {
+            crate::widget::format_local_datetime(system_time)
+        } else {
+            crate::widget::format_local_time(system_time)
+        }
     }
 
     fn freshness(&self) -> f32 {
@@ -136,40 +149,65 @@ impl<'a> LogView<'a> {
             .memory_mut(|mem| mem.data.get_temp::<LogViewState>(state_id))
             .unwrap_or_else(|| LogViewState {
                 level_filter: log::max_level(),
-                target_filter: String::new(),
+                text_filter: String::new(),
                 auto_scroll: true,
+                show_time: true,
+                show_date: true,
+                show_level: true,
+                show_target: false,
             });
 
-        // Controls
+        // A text filter, with an options button on the right that opens a popup
+        // menu of view settings (level, auto-scroll, columns, clear).
         ui.horizontal(|ui| {
-            ui.label("Level:");
-            let init_filter = state.level_filter.clone();
-            egui::ComboBox::from_id_salt(self.id.with("level_filter"))
-                .selected_text(format!("{}", state.level_filter))
-                .show_ui(ui, |ui| {
-                    ui.selectable_value(&mut state.level_filter, log::LevelFilter::Off, "Off");
-                    ui.selectable_value(&mut state.level_filter, log::LevelFilter::Error, "Error");
-                    ui.selectable_value(&mut state.level_filter, log::LevelFilter::Warn, "Warn");
-                    ui.selectable_value(&mut state.level_filter, log::LevelFilter::Info, "Info");
-                    ui.selectable_value(&mut state.level_filter, log::LevelFilter::Debug, "Debug");
-                    ui.selectable_value(&mut state.level_filter, log::LevelFilter::Trace, "Trace");
-                });
-            if init_filter != state.level_filter {
-                log::set_max_level(state.level_filter);
-            }
-
-            ui.separator();
-            ui.checkbox(&mut state.auto_scroll, "Auto-scroll");
-
-            ui.separator();
-            if ui.button("Clear").clicked() {
-                self.logger.clear();
-            }
-        });
-        ui.separator();
-        ui.horizontal(|ui| {
-            ui.label("Target:");
-            ui.text_edit_singleline(&mut state.target_filter);
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                let h = ui.spacing().interact_size.y;
+                let btn = ui
+                    .add_sized([h, h], egui::Button::new(crate::widget::OPTIONS_GLYPH))
+                    .on_hover_text("log options");
+                egui::Popup::menu(&btn)
+                    .close_behavior(egui::PopupCloseBehavior::CloseOnClickOutside)
+                    .show(|ui| {
+                        ui.horizontal(|ui| {
+                            ui.label("Level:");
+                            let init = state.level_filter;
+                            egui::ComboBox::from_id_salt(self.id.with("level_filter"))
+                                .selected_text(format!("{}", state.level_filter))
+                                .show_ui(ui, |ui| {
+                                    use log::LevelFilter as L;
+                                    ui.selectable_value(&mut state.level_filter, L::Off, "Off");
+                                    ui.selectable_value(&mut state.level_filter, L::Error, "Error");
+                                    ui.selectable_value(&mut state.level_filter, L::Warn, "Warn");
+                                    ui.selectable_value(&mut state.level_filter, L::Info, "Info");
+                                    ui.selectable_value(&mut state.level_filter, L::Debug, "Debug");
+                                    ui.selectable_value(&mut state.level_filter, L::Trace, "Trace");
+                                });
+                            if init != state.level_filter {
+                                log::set_max_level(state.level_filter);
+                            }
+                        });
+                        ui.checkbox(&mut state.auto_scroll, "Auto-scroll");
+                        ui.separator();
+                        ui.label("Columns:");
+                        ui.checkbox(&mut state.show_time, "Time");
+                        ui.add_enabled(
+                            state.show_time,
+                            egui::Checkbox::new(&mut state.show_date, "Date"),
+                        )
+                        .on_hover_text("include the date in the Time column");
+                        ui.checkbox(&mut state.show_level, "Level");
+                        ui.checkbox(&mut state.show_target, "Target");
+                        ui.separator();
+                        if ui.button("Clear").clicked() {
+                            self.logger.clear();
+                        }
+                    });
+                // The filter fills the remaining width.
+                egui::TextEdit::singleline(&mut state.text_filter)
+                    .desired_width(ui.available_width())
+                    .hint_text("🔎 Filter")
+                    .show(ui);
+            });
         });
 
         ui.separator();
@@ -179,9 +217,12 @@ impl<'a> LogView<'a> {
 
         entries.retain(|entry| entry.level <= state.level_filter);
 
-        if !state.target_filter.is_empty() {
-            let filter = state.target_filter.to_lowercase();
-            entries.retain(|entry| entry.target.to_lowercase().contains(&filter));
+        if !state.text_filter.is_empty() {
+            let filter = state.text_filter.to_lowercase();
+            entries.retain(|entry| {
+                let hay = format!("{} {}", entry.message, entry.target).to_lowercase();
+                filter.split_whitespace().all(|term| hay.contains(term))
+            });
         }
 
         entries.reverse();
@@ -192,24 +233,42 @@ impl<'a> LogView<'a> {
             a.level == b.level && a.message == b.message && a.target == b.target
         });
 
-        // Create table
-        TableBuilder::new(ui)
-            .striped(true)
-            .resizable(true)
-            .column(Column::auto().at_least(80.0)) // Timestamp
-            .column(Column::auto().at_least(50.0)) // Level
-            .column(Column::auto().at_least(80.0)) // Target
+        // Create table. The Time/Level/Target columns are optional; Message is
+        // always the trailing remainder column.
+        let (show_time, show_date, show_level, show_target) = (
+            state.show_time,
+            state.show_date,
+            state.show_level,
+            state.show_target,
+        );
+        let mut table = TableBuilder::new(ui).striped(true).resizable(true);
+        if show_time {
+            table = table.column(Column::auto().at_least(80.0)); // Timestamp
+        }
+        if show_level {
+            table = table.column(Column::auto().at_least(50.0)); // Level
+        }
+        if show_target {
+            table = table.column(Column::auto().at_least(80.0)); // Target
+        }
+        table
             .column(Column::remainder().at_least(100.0)) // Message
             .header(20.0, |mut header| {
-                header.col(|ui| {
-                    ui.strong("Time");
-                });
-                header.col(|ui| {
-                    ui.strong("Level");
-                });
-                header.col(|ui| {
-                    ui.strong("Target");
-                });
+                if show_time {
+                    header.col(|ui| {
+                        ui.strong("Time");
+                    });
+                }
+                if show_level {
+                    header.col(|ui| {
+                        ui.strong("Level");
+                    });
+                }
+                if show_target {
+                    header.col(|ui| {
+                        ui.strong("Target");
+                    });
+                }
                 header.col(|ui| {
                     ui.strong("Message");
                 });
@@ -230,45 +289,51 @@ impl<'a> LogView<'a> {
                         text_color
                     };
 
-                    row.col(|ui| {
-                        let text = entry.format_timestamp();
-                        ui.colored_label(text_color, text);
-                    });
+                    if show_time {
+                        row.col(|ui| {
+                            let text = entry.format_timestamp(show_date);
+                            ui.colored_label(text_color, text);
+                        });
+                    }
 
-                    row.col(|ui| {
-                        let (color, text) = match entry.level {
-                            Level::Error => (egui::Color32::from_rgb(255, 100, 100), "ERROR"),
-                            Level::Warn => (egui::Color32::from_rgb(255, 200, 100), "WARN"),
-                            Level::Info => (egui::Color32::from_rgb(100, 200, 255), "INFO"),
-                            Level::Debug => (egui::Color32::GRAY, "DEBUG"),
-                            Level::Trace => (egui::Color32::DARK_GRAY, "TRACE"),
-                        };
-                        ui.colored_label(color, text);
-                    });
+                    if show_level {
+                        row.col(|ui| {
+                            let (color, text) = match entry.level {
+                                Level::Error => (egui::Color32::from_rgb(255, 100, 100), "ERROR"),
+                                Level::Warn => (egui::Color32::from_rgb(255, 200, 100), "WARN"),
+                                Level::Info => (egui::Color32::from_rgb(100, 200, 255), "INFO"),
+                                Level::Debug => (egui::Color32::GRAY, "DEBUG"),
+                                Level::Trace => (egui::Color32::DARK_GRAY, "TRACE"),
+                            };
+                            ui.colored_label(color, text);
+                        });
+                    }
 
-                    row.col(|ui| {
-                        let node_path = gantz_std::log::parse_log_target(&entry.target);
-                        match node_path {
-                            Some(path) => {
-                                let label = self
-                                    .node_labels
-                                    .and_then(|labels| labels.get(&path))
-                                    .map(String::as_str);
-                                let ids: Vec<String> =
-                                    path.iter().map(ToString::to_string).collect();
-                                let text = match label {
-                                    Some(label) => format!("{label} ({})", ids.join(":")),
-                                    None => ids.join(":"),
-                                };
-                                if ui.link(text).on_hover_text("select node").clicked() {
-                                    response.clicked_path = Some(path);
+                    if show_target {
+                        row.col(|ui| {
+                            let node_path = gantz_std::log::parse_log_target(&entry.target);
+                            match node_path {
+                                Some(path) => {
+                                    let label = self
+                                        .node_labels
+                                        .and_then(|labels| labels.get(&path))
+                                        .map(String::as_str);
+                                    let ids: Vec<String> =
+                                        path.iter().map(ToString::to_string).collect();
+                                    let text = match label {
+                                        Some(label) => format!("{label} ({})", ids.join(":")),
+                                        None => ids.join(":"),
+                                    };
+                                    if ui.link(text).on_hover_text("select node").clicked() {
+                                        response.clicked_path = Some(path);
+                                    }
+                                }
+                                None => {
+                                    ui.colored_label(text_color, &entry.target);
                                 }
                             }
-                            None => {
-                                ui.colored_label(text_color, &entry.target);
-                            }
-                        }
-                    });
+                        });
+                    }
 
                     row.col(|ui| {
                         ui.horizontal(|ui| {

--- a/crates/gantz_egui/src/widget/node_inspector.rs
+++ b/crates/gantz_egui/src/widget/node_inspector.rs
@@ -225,7 +225,7 @@ pub fn path_string(path: &[node::Id]) -> String {
         .join(" ")
 }
 
-/// Working state for the [`socket_doc_editor`], persisted in egui memory so
+/// Working state for the [`socket_doc_rows`] editor, persisted in egui memory so
 /// in-progress text isn't clobbered by re-seeding every frame.
 #[derive(Clone, Default)]
 struct SocketDocEditState {
@@ -237,26 +237,31 @@ struct SocketDocEditState {
     seeded: (String, String),
 }
 
-/// A small editor for an inlet/outlet marker's stored `ty`/`description`
-/// fields (a type label and a longer note).
+/// Append `type` and `desc.` editor rows for an inlet/outlet marker's stored
+/// `ty`/`description` fields (a type label and a note) to the inspector table
+/// `body`.
 ///
-/// Edits are buffered in egui memory and written back into `ty`/`description`
-/// (trimmed) only when a field loses focus or the user presses Enter in the
-/// description (Ctrl/Cmd+Enter inserts a newline). Buffering avoids re-seeding
-/// (and trimming trailing whitespace) on every keystroke, and means the node -
-/// and thus the working graph - only changes on commit, so editing produces a
-/// single graph edit rather than one per keystroke. `id_salt` scopes the edit
-/// state to the node. Returns the combined field response together with whether
-/// a commit actually changed `ty`/`description` (so the caller can report the
-/// CA-affecting edit), `true` only on the flush frame that writes a new value.
-pub(crate) fn socket_doc_editor(
-    ui: &mut egui::Ui,
+/// `type` is a short single-line field; `desc.` is multiline and word-wraps,
+/// with its row sized to fit the wrapped text. Edits are buffered in egui memory
+/// and written back into `ty`/`description` (trimmed) only on commit (focus loss,
+/// or Enter - in the description, Cmd/Ctrl+Enter inserts a newline). Buffering
+/// avoids re-seeding (and trimming trailing whitespace) on every keystroke, and
+/// means the node - and thus the working graph - only changes on commit, so
+/// editing produces a single graph edit rather than one per keystroke. `id_salt`
+/// scopes the edit state to the node. Returns whether a commit actually changed
+/// `ty`/`description` (so the caller can report the CA-affecting edit), `true`
+/// only on the flush frame that writes a new value.
+pub(crate) fn socket_doc_rows(
+    body: &mut egui_extras::TableBody,
     id_salt: impl std::hash::Hash,
     ty: &mut String,
     description: &mut String,
-) -> (egui::Response, bool) {
+) -> bool {
     let id = egui::Id::new("socket-doc-editor").with(&id_salt);
-    let mut st: SocketDocEditState = ui.memory(|m| m.data.get_temp(id)).unwrap_or_default();
+    let mut st: SocketDocEditState = body
+        .ui_mut()
+        .memory(|m| m.data.get_temp(id))
+        .unwrap_or_default();
 
     // Re-seed the buffer only when the stored fields changed externally (never
     // mid-edit, since our own edits aren't written back until committed).
@@ -267,34 +272,66 @@ pub(crate) fn socket_doc_editor(
         st.seeded = cur;
     }
 
-    let ty_resp = ui.add(
-        egui::TextEdit::singleline(&mut st.ty)
-            .id(id.with("ty"))
-            .hint_text("type")
-            .desired_width(f32::INFINITY),
-    );
-    // Plain Enter commits; Ctrl/Cmd+Enter inserts a newline.
-    let desc_resp = ui.add(
-        egui::TextEdit::multiline(&mut st.desc)
-            .id(id.with("desc"))
-            .hint_text("description")
-            .desired_rows(2)
-            .desired_width(f32::INFINITY)
-            .return_key(egui::KeyboardShortcut::new(
-                egui::Modifiers::COMMAND,
-                egui::Key::Enter,
-            )),
-    );
+    // `type` is a short single-line label at the default row height.
+    let row_h = table_row_h(body.ui_mut());
+    let mut ty_resp = None;
+    body.row(row_h, |mut row| {
+        row.col(|ui| {
+            ui.label("type");
+        });
+        row.col(|ui| {
+            ty_resp = Some(
+                ui.add(
+                    egui::TextEdit::singleline(&mut st.ty)
+                        .id(id.with("ty"))
+                        .hint_text("type")
+                        .desired_width(f32::INFINITY),
+                ),
+            );
+        });
+    });
+
+    // `desc.` is multiline and word-wraps; the value column is the table's
+    // remainder, so estimate its width conservatively to wrap within the cell
+    // and size the row to the wrapped text.
+    let wrap_w = (body.ui_mut().available_width() - 64.0).max(64.0);
+    let desc_h = doc_field_height(body.ui_mut(), &st.desc, wrap_w);
+    let mut desc_resp = None;
+    body.row(desc_h, |mut row| {
+        row.col(|ui| {
+            ui.label("desc.");
+        });
+        row.col(|ui| {
+            // Plain Enter commits: the return key is Cmd/Ctrl+Enter, so a bare
+            // Enter surrenders focus instead of inserting a newline.
+            desc_resp = Some(
+                ui.add(
+                    egui::TextEdit::multiline(&mut st.desc)
+                        .id(id.with("desc"))
+                        .hint_text("description")
+                        .desired_rows(1)
+                        .desired_width(wrap_w)
+                        .return_key(egui::KeyboardShortcut::new(
+                            egui::Modifiers::COMMAND,
+                            egui::Key::Enter,
+                        )),
+                ),
+            );
+        });
+    });
+
+    let ty_resp = ty_resp.expect("value column always rendered");
+    let desc_resp = desc_resp.expect("value column always rendered");
+    // The single-line `type` commits on Enter via focus loss. For the multiline
+    // `desc.`, a plain Enter surrenders focus (see the field above) to commit.
     let desc_enter = desc_resp.has_focus()
-        && ui.input(|i| i.key_pressed(egui::Key::Enter) && !i.modifiers.any());
-    // Drop focus on commit so the description behaves like the single-line type
-    // field (whose default return-key handling already surrenders focus).
+        && body
+            .ui_mut()
+            .input(|i| i.key_pressed(egui::Key::Enter) && !i.modifiers.any());
     if desc_enter {
         desc_resp.surrender_focus();
     }
     let commit = ty_resp.lost_focus() || desc_resp.lost_focus() || desc_enter;
-
-    let resp = ty_resp.union(desc_resp);
 
     let mut changed = false;
     if commit {
@@ -311,6 +348,21 @@ pub(crate) fn socket_doc_editor(
         st.seeded = new;
     }
 
-    ui.memory_mut(|m| m.data.insert_temp(id, st));
-    (resp, changed)
+    body.ui_mut().memory_mut(|m| m.data.insert_temp(id, st));
+    changed
+}
+
+/// A table-row height that fits `text` wrapped at `wrap_width` (at least one
+/// line), including the multiline `TextEdit`'s vertical margin.
+fn doc_field_height(ui: &egui::Ui, text: &str, wrap_width: f32) -> f32 {
+    let font_id = egui::TextStyle::Body.resolve(ui.style());
+    let line_h = ui.text_style_height(&egui::TextStyle::Body);
+    let color = ui.visuals().text_color();
+    // Lay out a touch narrower than the field so the measured line count is
+    // never below the field's (which would clip); the small extra height is
+    // harmless.
+    let galley = ui
+        .painter()
+        .layout(text.to_owned(), font_id, color, (wrap_width - 8.0).max(1.0));
+    galley.size().y.max(line_h) + 10.0
 }

--- a/crates/gantz_egui/src/widget/node_palette.rs
+++ b/crates/gantz_egui/src/widget/node_palette.rs
@@ -1,4 +1,4 @@
-//! A generic command palette widget adapted from rerun's command palette.
+//! A generic node palette widget adapted from rerun's command palette.
 
 use egui::{Align2, Key, NumExt as _};
 use std::borrow::Cow;
@@ -22,7 +22,7 @@ pub trait Command: Copy + Sized {
 }
 
 #[derive(Default, serde::Deserialize, serde::Serialize)]
-pub struct CommandPalette {
+pub struct NodePalette {
     visible: bool,
     query: String,
     /// The highlighted entry, or `None` when nothing is highlighted (the
@@ -30,7 +30,7 @@ pub struct CommandPalette {
     selected_alternative: Option<usize>,
 }
 
-impl CommandPalette {
+impl NodePalette {
     pub fn new() -> Self {
         Self::default()
     }
@@ -39,7 +39,7 @@ impl CommandPalette {
         self.visible ^= true;
     }
 
-    /// Show the command palette, if it is visible.
+    /// Show the node palette, if it is visible.
     ///
     /// `area` is the rect the palette is centered over (e.g. the graph scene).
     #[must_use = "Returns the command that was selected"]
@@ -67,7 +67,7 @@ impl CommandPalette {
         let width = 400.0.at_most(area.width());
         let max_height = 320.0.at_most(area.height());
 
-        let window_response = egui::Window::new("Command Palette")
+        let window_response = egui::Window::new("Node Palette")
             .fixed_pos(area.center() - 0.5 * max_height * egui::Vec2::Y)
             .fixed_size([width, max_height])
             .pivot(egui::Align2::CENTER_TOP)

--- a/crates/gantz_egui/src/widget/trace_view.rs
+++ b/crates/gantz_egui/src/widget/trace_view.rs
@@ -17,8 +17,17 @@ pub struct TraceView {
 // State that needs to persist between frames.
 #[derive(Clone)]
 struct TraceViewState {
-    target_filter: String,
+    /// Substring filter over each entry's message and target (space-separated
+    /// terms, all must match).
+    text_filter: String,
     auto_scroll: bool,
+    /// Whether the Time, Level and Target columns are shown. Target defaults
+    /// off as it's the least useful column for most entries.
+    show_time: bool,
+    /// Whether the Time column includes the date (vs time-of-day only).
+    show_date: bool,
+    show_level: bool,
+    show_target: bool,
 }
 
 #[derive(Clone)]
@@ -46,9 +55,13 @@ struct MessageVisitor {
 }
 
 impl TraceEntry {
-    fn format_timestamp(&self) -> String {
+    fn format_timestamp(&self, show_date: bool) -> String {
         let system_time = crate::system_time_from_web(self.timestamp).expect("failed to convert");
-        crate::widget::format_local_datetime(system_time)
+        if show_date {
+            crate::widget::format_local_datetime(system_time)
+        } else {
+            crate::widget::format_local_time(system_time)
+        }
     }
 
     fn freshness(&self) -> f32 {
@@ -113,31 +126,52 @@ impl TraceView {
         let mut state = ui
             .memory_mut(|mem| mem.data.get_temp::<TraceViewState>(state_id))
             .unwrap_or_else(|| TraceViewState {
-                target_filter: String::new(),
+                text_filter: String::new(),
                 auto_scroll: true,
+                show_time: true,
+                show_date: true,
+                show_level: true,
+                show_target: false,
             });
 
-        // Controls
+        // A text filter, with an options button on the right that opens a popup
+        // menu of view settings (level, auto-scroll, columns, clear).
         ui.horizontal(|ui| {
-            ui.label("Level:");
-            let level_label = egui::Label::new(format!("{}", self.level)).selectable(false);
-            #[allow(unused_variables)]
-            let level_response = ui.add(level_label);
-            #[cfg(not(target_arch = "wasm32"))]
-            level_response.on_hover_text("adjust with RUST_LOG env var at startup");
-
-            ui.separator();
-            ui.checkbox(&mut state.auto_scroll, "Auto-scroll");
-
-            ui.separator();
-            if ui.button("Clear").clicked() {
-                self.capture.clear();
-            }
-        });
-        ui.separator();
-        ui.horizontal(|ui| {
-            ui.label("Target:");
-            ui.text_edit_singleline(&mut state.target_filter);
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                let h = ui.spacing().interact_size.y;
+                let btn = ui
+                    .add_sized([h, h], egui::Button::new(crate::widget::OPTIONS_GLYPH))
+                    .on_hover_text("trace options");
+                egui::Popup::menu(&btn)
+                    .close_behavior(egui::PopupCloseBehavior::CloseOnClickOutside)
+                    .show(|ui| {
+                        // The level is fixed at startup by the `RUST_LOG` filter.
+                        #[allow(unused_variables)]
+                        let level_response = ui.label(format!("Level: {}", self.level));
+                        #[cfg(not(target_arch = "wasm32"))]
+                        level_response.on_hover_text("adjust with RUST_LOG env var at startup");
+                        ui.checkbox(&mut state.auto_scroll, "Auto-scroll");
+                        ui.separator();
+                        ui.label("Columns:");
+                        ui.checkbox(&mut state.show_time, "Time");
+                        ui.add_enabled(
+                            state.show_time,
+                            egui::Checkbox::new(&mut state.show_date, "Date"),
+                        )
+                        .on_hover_text("include the date in the Time column");
+                        ui.checkbox(&mut state.show_level, "Level");
+                        ui.checkbox(&mut state.show_target, "Target");
+                        ui.separator();
+                        if ui.button("Clear").clicked() {
+                            self.capture.clear();
+                        }
+                    });
+                // The filter fills the remaining width.
+                egui::TextEdit::singleline(&mut state.text_filter)
+                    .desired_width(ui.available_width())
+                    .hint_text("🔎 Filter")
+                    .show(ui);
+            });
         });
 
         ui.separator();
@@ -155,9 +189,12 @@ impl TraceView {
             LevelFilter::TRACE => true,
         });
 
-        if !state.target_filter.is_empty() {
-            let filter = state.target_filter.to_lowercase();
-            entries.retain(|entry| entry.target.to_lowercase().contains(&filter));
+        if !state.text_filter.is_empty() {
+            let filter = state.text_filter.to_lowercase();
+            entries.retain(|entry| {
+                let hay = format!("{} {}", entry.message, entry.target).to_lowercase();
+                filter.split_whitespace().all(|term| hay.contains(term))
+            });
         }
 
         entries.reverse();
@@ -168,24 +205,42 @@ impl TraceView {
             a.level == b.level && a.message == b.message && a.target == b.target
         });
 
-        // Create table
-        TableBuilder::new(ui)
-            .striped(true)
-            .resizable(true)
-            .column(Column::auto().at_least(80.0)) // Timestamp
-            .column(Column::auto().at_least(50.0)) // Level
-            .column(Column::auto().at_least(80.0)) // Target
+        // Create table. The Time/Level/Target columns are optional; Message is
+        // always the trailing remainder column.
+        let (show_time, show_date, show_level, show_target) = (
+            state.show_time,
+            state.show_date,
+            state.show_level,
+            state.show_target,
+        );
+        let mut table = TableBuilder::new(ui).striped(true).resizable(true);
+        if show_time {
+            table = table.column(Column::auto().at_least(80.0)); // Timestamp
+        }
+        if show_level {
+            table = table.column(Column::auto().at_least(50.0)); // Level
+        }
+        if show_target {
+            table = table.column(Column::auto().at_least(80.0)); // Target
+        }
+        table
             .column(Column::remainder().at_least(100.0)) // Message
             .header(20.0, |mut header| {
-                header.col(|ui| {
-                    ui.strong("Time");
-                });
-                header.col(|ui| {
-                    ui.strong("Level");
-                });
-                header.col(|ui| {
-                    ui.strong("Target");
-                });
+                if show_time {
+                    header.col(|ui| {
+                        ui.strong("Time");
+                    });
+                }
+                if show_level {
+                    header.col(|ui| {
+                        ui.strong("Level");
+                    });
+                }
+                if show_target {
+                    header.col(|ui| {
+                        ui.strong("Target");
+                    });
+                }
                 header.col(|ui| {
                     ui.strong("Message");
                 });
@@ -206,25 +261,31 @@ impl TraceView {
                         text_color
                     };
 
-                    row.col(|ui| {
-                        let text = entry.format_timestamp();
-                        ui.colored_label(text_color, text);
-                    });
+                    if show_time {
+                        row.col(|ui| {
+                            let text = entry.format_timestamp(show_date);
+                            ui.colored_label(text_color, text);
+                        });
+                    }
 
-                    row.col(|ui| {
-                        let (color, text) = match entry.level {
-                            Level::ERROR => (egui::Color32::from_rgb(255, 100, 100), "ERROR"),
-                            Level::WARN => (egui::Color32::from_rgb(255, 200, 100), "WARN"),
-                            Level::INFO => (egui::Color32::from_rgb(100, 200, 255), "INFO"),
-                            Level::DEBUG => (egui::Color32::GRAY, "DEBUG"),
-                            Level::TRACE => (egui::Color32::DARK_GRAY, "TRACE"),
-                        };
-                        ui.colored_label(color, text);
-                    });
+                    if show_level {
+                        row.col(|ui| {
+                            let (color, text) = match entry.level {
+                                Level::ERROR => (egui::Color32::from_rgb(255, 100, 100), "ERROR"),
+                                Level::WARN => (egui::Color32::from_rgb(255, 200, 100), "WARN"),
+                                Level::INFO => (egui::Color32::from_rgb(100, 200, 255), "INFO"),
+                                Level::DEBUG => (egui::Color32::GRAY, "DEBUG"),
+                                Level::TRACE => (egui::Color32::DARK_GRAY, "TRACE"),
+                            };
+                            ui.colored_label(color, text);
+                        });
+                    }
 
-                    row.col(|ui| {
-                        ui.colored_label(text_color, &entry.target);
-                    });
+                    if show_target {
+                        row.col(|ui| {
+                            ui.colored_label(text_color, &entry.target);
+                        });
+                    }
 
                     row.col(|ui| {
                         ui.horizontal(|ui| {


### PR DESCRIPTION
A batch of small, independent UI-polish nits for the editor.

## Changes

- **Rename `CommandPalette` -> `NodePalette`.** The node-creation palette widget and its identifiers (`OpenNodePalette` payload, `GantzState.node_palette`, `Action::ToggleNodePalette`) are renamed to reflect their purpose. Persisted state is preserved via `#[serde(alias = ...)]` on the renamed field and keymap action.

- **Log/Trace view rework.** A text filter at the top (matches each entry's message + target), a `⛭` options button opening a popup that holds the view settings (log level, auto-scroll, per-column toggles, Clear), and an optional **Date** in the Time column (off -> time-of-day only). Mirrors the Graphs-select widget's filter/options pattern.

- **Graph Config pane -> grid.** The pane is laid out as a two-column grid (name / desc. / demo / reset / layout / flow / export). The description field is multiline, word-wrapping and auto-fits its height. The Export button is lowercased to `export` with hover text.

- **Inlet/outlet socket editor -> inspector rows.** The `type` and `desc.` fields are now regular rows in the node-inspector table (no standalone grid / separator). `type` is single-line. `desc.` is multiline, word-wrapping, with its row height sized to fit the wrapped text.

- **Scroll the node inspector to the selected node** on selection change, mirroring how the Steel view scrolls to a node's code span.

- **Perf tiles side-by-side.** VM Perf and GUI Perf sit next to each other (was tabs) at half the previous height. The persisted-tree version is bumped so existing users pick up the new default.
