### PR TITLE
feat: Merge support for graphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3226,6 +3226,7 @@ dependencies = [
  "gantz_ca_derive",
  "hex",
  "petgraph",
+ "ron 0.10.1",
  "serde",
 ]
 

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -1506,17 +1506,11 @@ where
             return;
         }
     };
-    // Extract just the commits reachable from the target name.
+    // Extract just the commits reachable from the target name (all parents,
+    // so merge ancestry survives a reset).
     if let Some(&base_commit_ca) = export.registry.names().get(name) {
-        let mut required = std::collections::HashSet::new();
-        let mut ca = base_commit_ca;
-        loop {
-            required.insert(ca);
-            match export.registry.commits().get(&ca).and_then(|c| c.parent) {
-                Some(parent) => ca = parent,
-                None => break,
-            }
-        }
+        let required: std::collections::HashSet<_> =
+            ca::ancestors(export.registry.commits(), base_commit_ca).collect();
         let mut subset = export.registry.export(&required);
         subset.insert_name(name.clone(), base_commit_ca);
         registry.merge(subset);

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -1221,6 +1221,7 @@ pub fn on_merge_head<N>(
         &mut gv,
         &mut head_state.scene.interaction.selection,
         &event.data.source,
+        event.data.resolutions,
         event.data.auto_resolve,
     );
 

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -120,6 +120,7 @@ where
             .register_head_response::<gantz_egui::CreateNode>()
             .register_head_response::<gantz_egui::CreateNestedGraph>()
             .register_head_response::<gantz_egui::InspectEdge>()
+            .register_head_response::<gantz_egui::MergeHead>()
             .register_head_response::<gantz_egui::Paste>()
             .register_head_response::<gantz_egui::Redo>()
             .register_head_response::<gantz_egui::Undo>()
@@ -155,6 +156,7 @@ where
             .add_observer(on_copy_nodes::<N>)
             .add_observer(on_cut_nodes::<N>)
             .add_observer(on_duplicate_nodes::<N>)
+            .add_observer(on_merge_head::<N>)
             .add_observer(on_paste::<N>)
             .add_observer(on_undo::<N>)
             .add_observer(on_redo)
@@ -1164,6 +1166,98 @@ pub fn on_duplicate_nodes<N>(
 
     // Uphold the `WorkingGraph` invariant: commit the in-place edit.
     bevy_gantz::commit_working_graph(&mut registry, &mut cmds, event.head, &mut head_ref.0, &wg.0);
+}
+
+/// Handle merge payloads: merge the named source branch into the head.
+///
+/// A fast-forward navigates the head to the source's tip (reloading the
+/// working graph, VM and views); a true merge is applied to the working graph
+/// and committed with two parents by [`gantz_egui::ops::merge_head`] itself,
+/// so this triggers [`head::CommittedEvent`] directly rather than calling
+/// `commit_working_graph` (which would see the already-committed graph and
+/// skip the event).
+pub fn on_merge_head<N>(
+    trigger: On<ForHead<gantz_egui::MergeHead>>,
+    mut registry: ResMut<Registry<N>>,
+    builtins: Res<BuiltinNodes<N>>,
+    views: Res<Views>,
+    demos: Res<Demos>,
+    mut gui_state: ResMut<GuiState>,
+    mut vms: NonSendMut<head::HeadVms>,
+    mut cmds: Commands,
+    mut heads: Query<
+        (
+            &mut head::HeadRef,
+            &mut head::WorkingGraph<N>,
+            &mut GraphView,
+        ),
+        With<head::OpenHead>,
+    >,
+) where
+    N: 'static + Node + Clone + ca::CaHash + gantz_egui::sync::AsNamedRef + Send + Sync,
+{
+    let event = trigger.event();
+    let Ok((mut head_ref, mut wg, mut gv)) = heads.get_mut(event.head) else {
+        log::error!("MergeHead: head not found for entity {:?}", event.head);
+        return;
+    };
+    let Some(head_state) = gui_state.open_heads.get_mut(&**head_ref) else {
+        log::error!("MergeHead: GUI state not found for head");
+        return;
+    };
+    let Some(vm) = vms.get_mut(&event.head) else {
+        log::error!("MergeHead: VM not found for head");
+        return;
+    };
+
+    let old_head = head_ref.0.clone();
+    let outcome = gantz_egui::ops::merge_head(
+        &mut registry,
+        &views,
+        bevy_gantz::reg::timestamp(),
+        &mut head_ref.0,
+        &mut wg,
+        vm,
+        &mut gv,
+        &mut head_state.scene.interaction.selection,
+        &event.data.source,
+        event.data.auto_resolve,
+    );
+
+    match outcome {
+        gantz_egui::ops::MergeHeadOutcome::FastForward(target) => {
+            navigate_head(&mut cmds, event.head, &old_head, target);
+        }
+        gantz_egui::ops::MergeHeadOutcome::Merged { new_commit, .. } => {
+            log::debug!(
+                "Merged '{}' -> {}",
+                event.data.source,
+                new_commit.display_short()
+            );
+            // Re-register the root graph so merged-in nodes get their state
+            // initialized. Idempotent for existing nodes.
+            let node_reg = registry_ref(&registry, &builtins, &demos);
+            let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
+            gantz_core::graph::register(&get_node, &**wg, &[], vm);
+            // The op already committed (with both parents), so fire the
+            // committed machinery (GUI-state migration, redo-stack clear,
+            // NamedRef resync, `vm::sync` recompile) directly.
+            cmds.trigger(head::CommittedEvent {
+                entity: event.head,
+                old_head,
+                new_head: head_ref.0.clone(),
+            });
+        }
+        gantz_egui::ops::MergeHeadOutcome::Refused(reasons) => {
+            // Defensive: the UI disables conflicted/blocked candidates.
+            log::warn!(
+                "MergeHead: refused to merge '{}': {}",
+                event.data.source,
+                reasons.join("; ")
+            );
+        }
+        gantz_egui::ops::MergeHeadOutcome::Noop => (),
+    }
 }
 
 /// Handle undo payloads: move the head back to its parent commit.

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -1061,15 +1061,8 @@ mod tests {
         let mut registry = startup.registry;
         let name = "demo-arithmetic";
         let &demo_commit = reparse.registry.names().get(name).expect("demo name");
-        let mut required = HashSet::new();
-        let mut ca = demo_commit;
-        loop {
-            required.insert(ca);
-            match reparse.registry.commits().get(&ca).and_then(|c| c.parent) {
-                Some(parent) => ca = parent,
-                None => break,
-            }
-        }
+        let required: HashSet<_> =
+            gantz_ca::ancestors(reparse.registry.commits(), demo_commit).collect();
         let mut subset = reparse.registry.export(&required);
         subset.insert_name(name.to_string(), demo_commit);
         registry.merge(subset);

--- a/crates/gantz_ca/Cargo.toml
+++ b/crates/gantz_ca/Cargo.toml
@@ -14,3 +14,6 @@ gantz_ca_derive.workspace = true
 hex.workspace = true
 petgraph.workspace = true
 serde.workspace = true
+
+[dev-dependencies]
+ron.workspace = true

--- a/crates/gantz_ca/src/commit.rs
+++ b/crates/gantz_ca/src/commit.rs
@@ -8,10 +8,18 @@ pub struct Commit {
     /// The timestamp of the commit, represented as the duration since
     /// `UNIX_EPOCH`.
     pub timestamp: Timestamp,
-    /// The parent of this commit.
+    /// The first parent of this commit: the commit the head was on when the
+    /// commit was made.
     pub parent: Option<CommitAddr>,
     /// The address of the graph pointed to by this commit.
     pub graph: GraphAddr,
+    /// Extra parents, present only on merge commits (the merged-in tips).
+    ///
+    /// Empty on ordinary commits and omitted from both the content hash and
+    /// the serialized form, so existing commit addresses and persisted
+    /// registries are unchanged.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub merge_parents: Vec<CommitAddr>,
 }
 
 /// The timestamp of a commit, represented as the duration since `UNIX_EPOCH`.
@@ -52,17 +60,50 @@ impl Commit {
             timestamp,
             parent,
             graph,
+            merge_parents: vec![],
         }
+    }
+
+    /// Create a merge commit joining `theirs` into `ours`.
+    ///
+    /// `ours` becomes the first parent (the commit the head was on), `theirs`
+    /// the merge parent.
+    pub fn new_merge(
+        timestamp: Duration,
+        ours: CommitAddr,
+        theirs: CommitAddr,
+        graph: GraphAddr,
+    ) -> Self {
+        Self {
+            timestamp,
+            parent: Some(ours),
+            graph,
+            merge_parents: vec![theirs],
+        }
+    }
+
+    /// All parents of this commit: the first parent (if any), then any merge
+    /// parents.
+    pub fn parents(&self) -> impl Iterator<Item = CommitAddr> + '_ {
+        self.parent
+            .into_iter()
+            .chain(self.merge_parents.iter().copied())
     }
 }
 
-/// Commits addressed by timestamp, parent and graph CA.
+/// Commits addressed by timestamp, parent(s) and graph CA.
 impl CaHash for Commit {
     fn hash(&self, hasher: &mut Hasher) {
         self.timestamp.as_secs().hash(hasher);
         self.timestamp.subsec_nanos().hash(hasher);
         self.parent.hash(hasher);
         self.graph.hash(hasher);
+        // Folded in only when non-empty so ordinary commits hash byte-for-byte
+        // as they did before merge support existed.
+        if !self.merge_parents.is_empty() {
+            hasher.update(b"merge-parents");
+            self.merge_parents.hash(hasher);
+        }
     }
 }
 
@@ -100,4 +141,97 @@ impl fmt::Display for CommitAddr {
 /// Shorthand for producing the address of a [`Commit`].
 pub fn addr(commit: &Commit) -> CommitAddr {
     CommitAddr(crate::content_addr(commit))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn graph_addr(n: u8) -> GraphAddr {
+        GraphAddr::from(ContentAddr::from([n; 32]))
+    }
+
+    fn commit_addr_raw(n: u8) -> CommitAddr {
+        CommitAddr::from(ContentAddr::from([n; 32]))
+    }
+
+    /// The commit hash as it was before `merge_parents` existed. Ordinary
+    /// commits must keep hashing byte-for-byte like this so that existing
+    /// registries' commit addresses are unchanged.
+    fn pre_merge_addr(commit: &Commit) -> CommitAddr {
+        let mut hasher = Hasher::new();
+        commit.timestamp.as_secs().hash(&mut hasher);
+        commit.timestamp.subsec_nanos().hash(&mut hasher);
+        commit.parent.hash(&mut hasher);
+        commit.graph.hash(&mut hasher);
+        let bytes: [u8; 32] = hasher.finalize().into();
+        CommitAddr::from(ContentAddr::from(bytes))
+    }
+
+    #[test]
+    fn ordinary_commit_addr_unchanged_by_merge_parents_field() {
+        let root = Commit::new(Duration::from_secs(1), None, graph_addr(1));
+        assert_eq!(addr(&root), pre_merge_addr(&root));
+        let child = Commit::new(Duration::from_secs(2), Some(addr(&root)), graph_addr(2));
+        assert_eq!(addr(&child), pre_merge_addr(&child));
+    }
+
+    #[test]
+    fn merge_commit_addr_differs_from_ordinary() {
+        let ours = commit_addr_raw(10);
+        let theirs = commit_addr_raw(20);
+        let merge = Commit::new_merge(Duration::from_secs(3), ours, theirs, graph_addr(1));
+        let ordinary = Commit::new(Duration::from_secs(3), Some(ours), graph_addr(1));
+        assert_ne!(addr(&merge), addr(&ordinary));
+    }
+
+    #[test]
+    fn parents_yields_first_parent_then_merge_parents() {
+        let ours = commit_addr_raw(10);
+        let theirs = commit_addr_raw(20);
+        let merge = Commit::new_merge(Duration::from_secs(3), ours, theirs, graph_addr(1));
+        assert_eq!(merge.parents().collect::<Vec<_>>(), vec![ours, theirs]);
+        let root = Commit::new(Duration::from_secs(1), None, graph_addr(1));
+        assert_eq!(root.parents().count(), 0);
+    }
+
+    #[test]
+    fn legacy_commit_ron_deserializes() {
+        // A commit serialized before `merge_parents` existed.
+        let commit = Commit::new(Duration::from_secs(1), None, graph_addr(1));
+        let legacy = {
+            #[derive(serde::Serialize)]
+            struct OldCommit {
+                timestamp: Timestamp,
+                parent: Option<CommitAddr>,
+                graph: GraphAddr,
+            }
+            ron::to_string(&OldCommit {
+                timestamp: commit.timestamp,
+                parent: commit.parent,
+                graph: commit.graph,
+            })
+            .unwrap()
+        };
+        let de: Commit = ron::de::from_str(&legacy).unwrap();
+        assert_eq!(de, commit);
+    }
+
+    #[test]
+    fn ordinary_commit_ron_omits_merge_parents() {
+        let commit = Commit::new(Duration::from_secs(1), None, graph_addr(1));
+        let s = ron::to_string(&commit).unwrap();
+        assert!(!s.contains("merge_parents"));
+        // A merge commit round-trips its merge parents.
+        let merge = Commit::new_merge(
+            Duration::from_secs(2),
+            commit_addr_raw(10),
+            commit_addr_raw(20),
+            graph_addr(1),
+        );
+        let s = ron::to_string(&merge).unwrap();
+        assert!(s.contains("merge_parents"));
+        let de: Commit = ron::de::from_str(&s).unwrap();
+        assert_eq!(de, merge);
+    }
 }

--- a/crates/gantz_ca/src/diff.rs
+++ b/crates/gantz_ca/src/diff.rs
@@ -20,7 +20,7 @@
 //!   the results tracks a node's identity through content edits, so an edit
 //!   diffs as a *modification* rather than a remove + add.
 
-use crate::{CaHash, CommitAddr, Registry, content_addr, history, node_addrs};
+use crate::{CaHash, CommitAddr, Registry, Timestamp, content_addr, history};
 use petgraph::{Directed, graph::IndexType};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
@@ -89,6 +89,34 @@ impl<E> Diff<E> {
     }
 }
 
+/// The content address of every node, indexed by node index (contiguous for
+/// a plain `petgraph::Graph`).
+fn node_cas<N, E, Ix>(g: &Graph<N, E, Ix>) -> Vec<crate::ContentAddr>
+where
+    N: CaHash,
+    Ix: IndexType,
+{
+    g.node_weights().map(crate::content_addr).collect()
+}
+
+/// The [`match_nodes`] grouping over precomputed node content addresses.
+fn match_cas(a: &[crate::ContentAddr], b: &[crate::ContentAddr]) -> Matching {
+    let mut groups: BTreeMap<crate::ContentAddr, (Vec<usize>, Vec<usize>)> = BTreeMap::new();
+    for (ix, ca) in a.iter().enumerate() {
+        groups.entry(*ca).or_default().0.push(ix);
+    }
+    for (ix, ca) in b.iter().enumerate() {
+        groups.entry(*ca).or_default().1.push(ix);
+    }
+    // Indices are pushed in ascending order, so the per-group zips pair by
+    // canonical rank without sorting.
+    let mut matching = Matching::new();
+    for (a_ixs, b_ixs) in groups.into_values() {
+        matching.extend(a_ixs.into_iter().zip(b_ixs));
+    }
+    matching
+}
+
 /// Directly match nodes between two graphs by content.
 ///
 /// Nodes are grouped by content address and paired within each group in
@@ -99,37 +127,21 @@ where
     N: CaHash,
     Ix: IndexType,
 {
-    let mut groups: BTreeMap<crate::ContentAddr, (Vec<usize>, Vec<usize>)> = BTreeMap::new();
-    for (id, ca) in node_addrs(a) {
-        groups.entry(ca).or_default().0.push(id.index());
-    }
-    for (id, ca) in node_addrs(b) {
-        groups.entry(ca).or_default().1.push(id.index());
-    }
-    let mut matching = Matching::new();
-    for (mut a_ixs, mut b_ixs) in groups.into_values() {
-        a_ixs.sort_unstable();
-        b_ixs.sort_unstable();
-        matching.extend(a_ixs.into_iter().zip(b_ixs));
-    }
-    matching
+    match_cas(&node_cas(a), &node_cas(b))
 }
 
-/// Match nodes between two *consecutive* commits' graphs.
+/// Match nodes between two *consecutive* commits' graphs (by their node
+/// content addresses).
 ///
-/// [`match_nodes`] pairs everything whose content is unchanged; the leftover
+/// [`match_cas`] pairs everything whose content is unchanged; the leftover
 /// nodes on both sides are then paired when they share an index. A single
 /// edit step justifies this: an in-place content edit preserves the node's
 /// index, while a swap-removal never leaves an equal-index leftover pair.
-fn match_step<N, E, Ix>(prev: &Graph<N, E, Ix>, next: &Graph<N, E, Ix>) -> Matching
-where
-    N: CaHash,
-    Ix: IndexType,
-{
-    let mut matching = match_nodes(prev, next);
+fn match_step_cas(prev: &[crate::ContentAddr], next: &[crate::ContentAddr]) -> Matching {
+    let mut matching = match_cas(prev, next);
     let matched_next: HashSet<usize> = matching.values().copied().collect();
-    for ix in 0..prev.node_count() {
-        if !matching.contains_key(&ix) && ix < next.node_count() && !matched_next.contains(&ix) {
+    for ix in 0..prev.len() {
+        if !matching.contains_key(&ix) && ix < next.len() && !matched_next.contains(&ix) {
             matching.insert(ix, ix);
         }
     }
@@ -153,20 +165,45 @@ where
     N: CaHash,
     Ix: IndexType,
 {
+    matching_with_times(reg, base, tip).map(|(matching, _)| matching)
+}
+
+/// [`matching`], also returning each tracked node's *last-edit time*: for
+/// every base node still present at the tip, the timestamp of the last commit
+/// along the chain that changed its content (no entry = content untouched).
+///
+/// Feeds per-node "last edit wins" conflict resolution (see
+/// [`crate::merge::BothModified::KeepNewest`]). The direct-matching fallback
+/// has no chain to read times from, so it returns them empty; callers fall
+/// back to the tips' own timestamps.
+pub fn matching_with_times<N, E, Ix>(
+    reg: &Registry<Graph<N, E, Ix>>,
+    base: CommitAddr,
+    tip: CommitAddr,
+) -> Option<(Matching, BTreeMap<usize, Timestamp>)>
+where
+    N: CaHash,
+    Ix: IndexType,
+{
     let commits = reg.commits();
     let graphs = reg.graphs();
     let base_graph = graphs.get(&commits.get(&base)?.graph)?;
     let tip_graph = graphs.get(&commits.get(&tip)?.graph)?;
     let identity = |g: &Graph<N, E, Ix>| (0..g.node_count()).map(|ix| (ix, ix)).collect();
+    let direct = || (match_nodes(base_graph, tip_graph), BTreeMap::new());
 
     let Some(chain) = history::first_parent_chain_to(commits, tip, base) else {
-        return Some(match_nodes(base_graph, tip_graph));
+        return Some(direct());
     };
 
-    // Walk the chain oldest-first, composing the per-step matchings.
+    // Walk the chain oldest-first, composing the per-step matchings and
+    // stamping tracked nodes whose content changed at a step. Each step's
+    // node addresses are computed once and carried into the next iteration.
     let mut matching: Matching = identity(base_graph);
+    let mut times: BTreeMap<usize, Timestamp> = BTreeMap::new();
     let mut steps = chain.iter().rev();
     let mut prev = steps.next()?;
+    let mut prev_cas: Option<Vec<crate::ContentAddr>> = None;
     for next in steps {
         // Same graph (e.g. a layout-only commit): identity step.
         if prev.graph == next.graph {
@@ -175,16 +212,25 @@ where
         }
         let (Some(pg), Some(ng)) = (graphs.get(&prev.graph), graphs.get(&next.graph)) else {
             // An intermediate graph is unavailable: fall back to direct.
-            return Some(match_nodes(base_graph, tip_graph));
+            return Some(direct());
         };
-        let step = match_step(pg, ng);
+        let pc = prev_cas.take().unwrap_or_else(|| node_cas(pg));
+        let nc = node_cas(ng);
+        let step = match_step_cas(&pc, &nc);
         matching = matching
             .into_iter()
-            .filter_map(|(b, cur)| step.get(&cur).map(|&n| (b, n)))
+            .filter_map(|(b, cur)| {
+                let &n = step.get(&cur)?;
+                if pc[cur] != nc[n] {
+                    times.insert(b, next.timestamp);
+                }
+                Some((b, n))
+            })
             .collect();
+        prev_cas = Some(nc);
         prev = next;
     }
-    Some(matching)
+    Some((matching, times))
 }
 
 /// The structural diff of `other` relative to `base` under the given node
@@ -289,6 +335,11 @@ mod tests {
         })
     }
 
+    /// [`match_step_cas`] over whole graphs, for test brevity.
+    fn match_step(prev: &G, next: &G) -> Matching {
+        match_step_cas(&node_cas(prev), &node_cas(next))
+    }
+
     #[test]
     fn match_nodes_pairs_duplicate_content_by_rank() {
         // [A, B, A] with B removed via swap-remove -> [A, A].
@@ -345,6 +396,23 @@ mod tests {
         );
         // Through the removal: base ix 0 is gone, ix 1 tracked at ix 1.
         assert_eq!(matching(&reg, base, c3).unwrap(), Matching::from([(1, 1)]));
+    }
+
+    #[test]
+    fn matching_with_times_stamps_the_last_content_change() {
+        let mut reg = Registry::<G>::default();
+        let g0 = graph(&["a", "b"], &[]);
+        let g1 = graph(&["a", "b2"], &[]); // edit ix 1 @ t=2
+        let g2 = graph(&["a", "b2", "c"], &[]); // add ix 2 @ t=3
+        let g3 = graph(&["a", "b3", "c"], &[]); // edit ix 1 again @ t=4
+        let base = commit(&mut reg, 1, None, &g0);
+        let c1 = commit(&mut reg, 2, Some(base), &g1);
+        let c2 = commit(&mut reg, 3, Some(c1), &g2);
+        let c3 = commit(&mut reg, 4, Some(c2), &g3);
+        let (m, times) = matching_with_times(&reg, base, c3).unwrap();
+        assert_eq!(m, Matching::from([(0, 0), (1, 1)]));
+        // Node 1's last content change was the t=4 commit; node 0 untouched.
+        assert_eq!(times, BTreeMap::from([(1, Timestamp::from_secs(4))]),);
     }
 
     #[test]

--- a/crates/gantz_ca/src/diff.rs
+++ b/crates/gantz_ca/src/diff.rs
@@ -1,0 +1,407 @@
+//! Node identity matching and structural diffing between graph versions.
+//!
+//! Nodes have no persistent identity of their own - only an index and a
+//! content address - so diffing two versions of a graph first requires a
+//! [`Matching`]: an injective mapping pairing "the same node" across the two
+//! versions.
+//!
+//! Two strategies are provided:
+//!
+//! - [`match_nodes`]: direct content matching. Nodes are grouped by content
+//!   address and paired within each group in ascending-index order. This is
+//!   conservative: a node whose content was edited appears as a removal plus
+//!   an addition.
+//! - [`matching`]: chain-tracked matching. The registry retains every commit
+//!   and graph, and gantz's commit-on-change model means consecutive commits
+//!   differ by a single logical edit, during which a node's *index* is its
+//!   identity (an in-place edit keeps the node's index; a removal swap-moves
+//!   exactly one other node, which content-matching pairs). Matching each
+//!   consecutive pair of commits along the first-parent chain and composing
+//!   the results tracks a node's identity through content edits, so an edit
+//!   diffs as a *modification* rather than a remove + add.
+
+use crate::{CaHash, CommitAddr, Registry, content_addr, history, node_addrs};
+use petgraph::{Directed, graph::IndexType};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+type Graph<N, E, Ix> = petgraph::graph::Graph<N, E, Directed, Ix>;
+
+/// A node identity mapping between two versions of a graph: left node index
+/// to right node index. Injective: no two left nodes map to the same right
+/// node.
+pub type Matching = BTreeMap<usize, usize>;
+
+/// A structural diff of `other` relative to `base`, under a node [`Matching`].
+///
+/// Node entries are expressed in the coordinates of the graph they exist in:
+/// removals in `base` indices, additions in `other` indices. Edges are
+/// treated as sets of `(source, target, weight)` triples; parallel edges with
+/// identical weights are not distinguished.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Diff<E> {
+    /// Base node index to other node index, for nodes present in both.
+    pub matched: Matching,
+    /// The subset of `matched` (base indices) whose node content changed.
+    pub modified: BTreeSet<usize>,
+    /// Base indices with no counterpart in `other`.
+    pub removed_nodes: BTreeSet<usize>,
+    /// Other indices with no counterpart in `base`.
+    pub added_nodes: BTreeSet<usize>,
+    /// Edges present in `base` but not `other`, in *base* coordinates.
+    ///
+    /// Only edges whose endpoints both survive into `other`: edges lost as a
+    /// consequence of node removal are implied by `removed_nodes`.
+    pub removed_edges: BTreeSet<(usize, usize, E)>,
+    /// Edges present in `other` but not `base`, in *other* coordinates
+    /// (endpoints may be added nodes).
+    pub added_edges: BTreeSet<(usize, usize, E)>,
+}
+
+/// Change counts for a [`Diff`], e.g. for GUI hover summaries.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct DiffSummary {
+    pub nodes_added: usize,
+    pub nodes_removed: usize,
+    pub nodes_modified: usize,
+    pub edges_added: usize,
+    pub edges_removed: usize,
+}
+
+impl<E> Diff<E> {
+    /// Change counts for this diff.
+    pub fn summary(&self) -> DiffSummary {
+        DiffSummary {
+            nodes_added: self.added_nodes.len(),
+            nodes_removed: self.removed_nodes.len(),
+            nodes_modified: self.modified.len(),
+            edges_added: self.added_edges.len(),
+            edges_removed: self.removed_edges.len(),
+        }
+    }
+
+    /// Whether the diff records no changes.
+    pub fn is_empty(&self) -> bool {
+        self.modified.is_empty()
+            && self.removed_nodes.is_empty()
+            && self.added_nodes.is_empty()
+            && self.removed_edges.is_empty()
+            && self.added_edges.is_empty()
+    }
+}
+
+/// Directly match nodes between two graphs by content.
+///
+/// Nodes are grouped by content address and paired within each group in
+/// ascending-index order (canonical rank). Conservative: a node whose content
+/// was edited is left unmatched on both sides.
+pub fn match_nodes<N, E, Ix>(a: &Graph<N, E, Ix>, b: &Graph<N, E, Ix>) -> Matching
+where
+    N: CaHash,
+    Ix: IndexType,
+{
+    let mut groups: BTreeMap<crate::ContentAddr, (Vec<usize>, Vec<usize>)> = BTreeMap::new();
+    for (id, ca) in node_addrs(a) {
+        groups.entry(ca).or_default().0.push(id.index());
+    }
+    for (id, ca) in node_addrs(b) {
+        groups.entry(ca).or_default().1.push(id.index());
+    }
+    let mut matching = Matching::new();
+    for (mut a_ixs, mut b_ixs) in groups.into_values() {
+        a_ixs.sort_unstable();
+        b_ixs.sort_unstable();
+        matching.extend(a_ixs.into_iter().zip(b_ixs));
+    }
+    matching
+}
+
+/// Match nodes between two *consecutive* commits' graphs.
+///
+/// [`match_nodes`] pairs everything whose content is unchanged; the leftover
+/// nodes on both sides are then paired when they share an index. A single
+/// edit step justifies this: an in-place content edit preserves the node's
+/// index, while a swap-removal never leaves an equal-index leftover pair.
+fn match_step<N, E, Ix>(prev: &Graph<N, E, Ix>, next: &Graph<N, E, Ix>) -> Matching
+where
+    N: CaHash,
+    Ix: IndexType,
+{
+    let mut matching = match_nodes(prev, next);
+    let matched_next: HashSet<usize> = matching.values().copied().collect();
+    for ix in 0..prev.node_count() {
+        if !matching.contains_key(&ix) && ix < next.node_count() && !matched_next.contains(&ix) {
+            matching.insert(ix, ix);
+        }
+    }
+    matching
+}
+
+/// Node identity between `base`'s graph and `tip`'s graph, tracked step-wise
+/// along `tip`'s first-parent chain (see the module docs).
+///
+/// Steps whose graph address is unchanged (e.g. layout-only commits) are
+/// identity. Falls back to direct [`match_nodes`] between the endpoint graphs
+/// when `base` is not on the chain or an intermediate graph is unavailable.
+/// Returns `None` only when an endpoint commit or graph is missing from the
+/// registry.
+pub fn matching<N, E, Ix>(
+    reg: &Registry<Graph<N, E, Ix>>,
+    base: CommitAddr,
+    tip: CommitAddr,
+) -> Option<Matching>
+where
+    N: CaHash,
+    Ix: IndexType,
+{
+    let commits = reg.commits();
+    let graphs = reg.graphs();
+    let base_graph = graphs.get(&commits.get(&base)?.graph)?;
+    let tip_graph = graphs.get(&commits.get(&tip)?.graph)?;
+    let identity = |g: &Graph<N, E, Ix>| (0..g.node_count()).map(|ix| (ix, ix)).collect();
+
+    let Some(chain) = history::first_parent_chain_to(commits, tip, base) else {
+        return Some(match_nodes(base_graph, tip_graph));
+    };
+
+    // Walk the chain oldest-first, composing the per-step matchings.
+    let mut matching: Matching = identity(base_graph);
+    let mut steps = chain.iter().rev();
+    let mut prev = steps.next()?;
+    for next in steps {
+        // Same graph (e.g. a layout-only commit): identity step.
+        if prev.graph == next.graph {
+            prev = next;
+            continue;
+        }
+        let (Some(pg), Some(ng)) = (graphs.get(&prev.graph), graphs.get(&next.graph)) else {
+            // An intermediate graph is unavailable: fall back to direct.
+            return Some(match_nodes(base_graph, tip_graph));
+        };
+        let step = match_step(pg, ng);
+        matching = matching
+            .into_iter()
+            .filter_map(|(b, cur)| step.get(&cur).map(|&n| (b, n)))
+            .collect();
+        prev = next;
+    }
+    Some(matching)
+}
+
+/// The structural diff of `other` relative to `base` under the given node
+/// [`Matching`] (see [`Diff`]).
+pub fn diff<N, E, Ix>(
+    base: &Graph<N, E, Ix>,
+    other: &Graph<N, E, Ix>,
+    matching: &Matching,
+) -> Diff<E>
+where
+    N: CaHash,
+    E: Clone + Ord,
+    Ix: IndexType,
+{
+    let matched_other: HashSet<usize> = matching.values().copied().collect();
+    let modified = matching
+        .iter()
+        .filter(|&(&b, &o)| {
+            let b_ca = content_addr(&base[petgraph::graph::NodeIndex::new(b)]);
+            let o_ca = content_addr(&other[petgraph::graph::NodeIndex::new(o)]);
+            b_ca != o_ca
+        })
+        .map(|(&b, _)| b)
+        .collect();
+    let removed_nodes: BTreeSet<usize> = (0..base.node_count())
+        .filter(|ix| !matching.contains_key(ix))
+        .collect();
+    let added_nodes: BTreeSet<usize> = (0..other.node_count())
+        .filter(|ix| !matched_other.contains(ix))
+        .collect();
+
+    let edge_set = |g: &Graph<N, E, Ix>| -> BTreeSet<(usize, usize, E)> {
+        g.edge_indices()
+            .map(|e| {
+                let (s, d) = g.edge_endpoints(e).expect("edge must have endpoints");
+                (s.index(), d.index(), g[e].clone())
+            })
+            .collect()
+    };
+    let base_edges = edge_set(base);
+    let other_edges = edge_set(other);
+
+    // Map base edges into other coordinates where both endpoints survive.
+    let removed_edges = base_edges
+        .iter()
+        .filter(|(s, d, w)| {
+            let (Some(&os), Some(&od)) = (matching.get(s), matching.get(d)) else {
+                // An endpoint was removed: implied by `removed_nodes`.
+                return false;
+            };
+            !other_edges.contains(&(os, od, w.clone()))
+        })
+        .cloned()
+        .collect();
+    // Map other edges back into base coordinates to detect additions.
+    let inverse: BTreeMap<usize, usize> = matching.iter().map(|(&b, &o)| (o, b)).collect();
+    let added_edges = other_edges
+        .iter()
+        .filter(|(s, d, w)| {
+            let (Some(&bs), Some(&bd)) = (inverse.get(s), inverse.get(d)) else {
+                // An endpoint is an added node: the edge is necessarily new.
+                return true;
+            };
+            !base_edges.contains(&(bs, bd, w.clone()))
+        })
+        .cloned()
+        .collect();
+
+    Diff {
+        matched: matching.clone(),
+        modified,
+        removed_nodes,
+        added_nodes,
+        removed_edges,
+        added_edges,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Commit, Timestamp, commit_addr, graph_addr};
+    use std::time::Duration;
+
+    type G = petgraph::graph::Graph<String, u32, Directed, usize>;
+
+    fn graph(nodes: &[&str], edges: &[(usize, usize, u32)]) -> G {
+        let mut g = G::default();
+        for n in nodes {
+            g.add_node(n.to_string());
+        }
+        for &(s, d, w) in edges {
+            g.add_edge(s.into(), d.into(), w);
+        }
+        g
+    }
+
+    /// Commit `g` on top of `parent` in `reg`, returning the commit addr.
+    fn commit(reg: &mut Registry<G>, secs: u64, parent: Option<CommitAddr>, g: &G) -> CommitAddr {
+        reg.commit_graph(Duration::from_secs(secs), parent, graph_addr(g), || {
+            g.clone()
+        })
+    }
+
+    #[test]
+    fn match_nodes_pairs_duplicate_content_by_rank() {
+        // [A, B, A] with B removed via swap-remove -> [A, A].
+        let a = graph(&["a", "b", "a"], &[]);
+        let b = graph(&["a", "a"], &[]);
+        let m = match_nodes(&a, &b);
+        assert_eq!(m, Matching::from([(0, 0), (2, 1)]));
+    }
+
+    #[test]
+    fn match_step_pairs_edited_node_by_index() {
+        let prev = graph(&["a", "b", "c"], &[]);
+        let next = graph(&["a", "b2", "c"], &[]);
+        let m = match_step(&prev, &next);
+        assert_eq!(m, Matching::from([(0, 0), (1, 1), (2, 2)]));
+    }
+
+    #[test]
+    fn match_step_swap_removal_leaves_no_false_pair() {
+        // Removing ix 1 swap-moves the last node into its slot.
+        let prev = graph(&["a", "b", "c"], &[]);
+        let next = graph(&["a", "c"], &[]);
+        let m = match_step(&prev, &next);
+        assert_eq!(m, Matching::from([(0, 0), (2, 1)]));
+    }
+
+    #[test]
+    fn match_step_edit_to_duplicate_content() {
+        // Editing ix 1 to duplicate ix 0's content must not steal its match.
+        let prev = graph(&["a", "b"], &[]);
+        let next = graph(&["a", "a"], &[]);
+        let m = match_step(&prev, &next);
+        assert_eq!(m, Matching::from([(0, 0), (1, 1)]));
+    }
+
+    #[test]
+    fn matching_composes_along_the_chain() {
+        let mut reg = Registry::<G>::default();
+        let g0 = graph(&["a", "b"], &[]);
+        let g1 = graph(&["a", "b2"], &[]); // edit ix 1
+        let g2 = graph(&["a", "b2", "c"], &[]); // add ix 2
+        let g3 = graph(&["c", "b2"], &[]); // remove ix 0 (c swaps in)
+        let base = commit(&mut reg, 1, None, &g0);
+        let c1 = commit(&mut reg, 2, Some(base), &g1);
+        // A layout-only commit: same graph, new commit.
+        let c1b = commit(&mut reg, 3, Some(c1), &g1);
+        let c2 = commit(&mut reg, 4, Some(c1b), &g2);
+        let c3 = commit(&mut reg, 5, Some(c2), &g3);
+
+        // Through the edit: identity is preserved.
+        assert_eq!(
+            matching(&reg, base, c2).unwrap(),
+            Matching::from([(0, 0), (1, 1)]),
+        );
+        // Through the removal: base ix 0 is gone, ix 1 tracked at ix 1.
+        assert_eq!(matching(&reg, base, c3).unwrap(), Matching::from([(1, 1)]));
+    }
+
+    #[test]
+    fn matching_falls_back_to_direct_when_chain_unavailable() {
+        // Hand-build a registry whose intermediate graph is absent.
+        let g0 = graph(&["a", "b"], &[]);
+        let g1 = graph(&["a", "b2"], &[]);
+        let g2 = graph(&["a", "b3"], &[]);
+        let c0 = Commit::new(Timestamp::from_secs(1), None, graph_addr(&g0));
+        let ca0 = commit_addr(&c0);
+        let c1 = Commit::new(Timestamp::from_secs(2), Some(ca0), graph_addr(&g1));
+        let ca1 = commit_addr(&c1);
+        let c2 = Commit::new(Timestamp::from_secs(3), Some(ca1), graph_addr(&g2));
+        let ca2 = commit_addr(&c2);
+        let graphs = [(graph_addr(&g0), g0.clone()), (graph_addr(&g2), g2.clone())]
+            .into_iter()
+            .collect();
+        let commits = [(ca0, c0), (ca1, c1), (ca2, c2)].into_iter().collect();
+        let reg = Registry::new(graphs, commits, Default::default());
+        // Direct matching pairs only the content-identical node.
+        assert_eq!(matching(&reg, ca0, ca2).unwrap(), Matching::from([(0, 0)]));
+    }
+
+    #[test]
+    fn diff_reports_node_and_edge_changes() {
+        let base = graph(&["a", "b"], &[(0, 1, 0)]);
+        let other = graph(&["a", "b2", "c"], &[(0, 2, 1)]);
+        let m = Matching::from([(0, 0), (1, 1)]);
+        let d = diff(&base, &other, &m);
+        assert_eq!(d.modified, BTreeSet::from([1]));
+        assert!(d.removed_nodes.is_empty());
+        assert_eq!(d.added_nodes, BTreeSet::from([2]));
+        assert_eq!(d.removed_edges, BTreeSet::from([(0, 1, 0)]));
+        assert_eq!(d.added_edges, BTreeSet::from([(0, 2, 1)]));
+        let s = d.summary();
+        assert_eq!(
+            (s.nodes_added, s.nodes_removed, s.nodes_modified),
+            (1, 0, 1)
+        );
+        assert_eq!((s.edges_added, s.edges_removed), (1, 1));
+    }
+
+    #[test]
+    fn diff_excludes_edges_implied_by_node_removal() {
+        let base = graph(&["a", "b"], &[(0, 1, 0)]);
+        let other = graph(&["a"], &[]);
+        let m = Matching::from([(0, 0)]);
+        let d = diff(&base, &other, &m);
+        assert_eq!(d.removed_nodes, BTreeSet::from([1]));
+        assert!(d.removed_edges.is_empty());
+        assert!(!d.is_empty());
+    }
+
+    #[test]
+    fn diff_of_identical_graphs_is_empty() {
+        let g = graph(&["a", "b"], &[(0, 1, 0)]);
+        let m = match_nodes(&g, &g);
+        assert!(diff(&g, &g, &m).is_empty());
+    }
+}

--- a/crates/gantz_ca/src/history.rs
+++ b/crates/gantz_ca/src/history.rs
@@ -1,0 +1,262 @@
+//! Utilities for walking commit ancestry.
+//!
+//! Commits form a DAG: every commit has an optional first parent and, for
+//! merge commits, one or more merge parents (see [`Commit::parents`]). These
+//! free fns provide the ancestry queries needed for merging diverged heads.
+
+use crate::{Commit, CommitAddr, registry::Commits};
+use std::collections::{HashSet, VecDeque};
+
+/// The relationship between two commit tips, from the perspective of merging
+/// `theirs` into `ours`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MergeAnalysis {
+    /// The tips share no common ancestor.
+    Unrelated,
+    /// `theirs` is an ancestor of `ours`: there is nothing to merge.
+    AlreadyUpToDate,
+    /// `ours` is an ancestor of `theirs`: the head can simply move to
+    /// `theirs` without a merge commit.
+    FastForward,
+    /// The tips have diverged; a true merge is required. Carries the merge
+    /// base (best common ancestor).
+    Diverged(CommitAddr),
+}
+
+/// All ancestors of `tip` (inclusive of `tip` itself), in breadth-first order
+/// over all parents (first parent and merge parents).
+///
+/// Commits absent from `commits` terminate their branch of the walk.
+pub fn ancestors(commits: &Commits, tip: CommitAddr) -> impl Iterator<Item = CommitAddr> + '_ {
+    let mut queue: VecDeque<CommitAddr> = VecDeque::from([tip]);
+    let mut visited: HashSet<CommitAddr> = HashSet::from([tip]);
+    std::iter::from_fn(move || {
+        let ca = queue.pop_front()?;
+        if let Some(commit) = commits.get(&ca) {
+            for parent in commit.parents() {
+                if visited.insert(parent) {
+                    queue.push_back(parent);
+                }
+            }
+        }
+        Some(ca)
+    })
+}
+
+/// The first-parent chain from `tip` back to the root (inclusive of `tip`).
+///
+/// This is the "main line" of a head's history: merge parents are not
+/// followed, matching how undo walks back through commits.
+pub fn first_parent_chain(
+    commits: &Commits,
+    tip: CommitAddr,
+) -> impl Iterator<Item = CommitAddr> + '_ {
+    let mut next = Some(tip);
+    std::iter::from_fn(move || {
+        let ca = next?;
+        next = commits.get(&ca).and_then(|commit| commit.parent);
+        Some(ca)
+    })
+}
+
+/// The best common ancestor of `a` and `b`, or `None` when their histories
+/// are unrelated.
+///
+/// A common ancestor is "best" when it is not itself an ancestor of another
+/// common ancestor. When several such candidates exist (criss-cross
+/// histories), one is chosen deterministically by max `(timestamp, addr)`;
+/// recursively merging the candidates is out of scope.
+pub fn merge_base(commits: &Commits, a: CommitAddr, b: CommitAddr) -> Option<CommitAddr> {
+    let a_ancestors: HashSet<CommitAddr> = ancestors(commits, a).collect();
+    let mut common: HashSet<CommitAddr> = ancestors(commits, b)
+        .filter(|ca| a_ancestors.contains(ca))
+        .collect();
+    // Drop candidates that are proper ancestors of another candidate.
+    for ca in common.clone() {
+        if !common.contains(&ca) {
+            continue;
+        }
+        for ancestor in ancestors(commits, ca).skip(1) {
+            common.remove(&ancestor);
+        }
+    }
+    common
+        .into_iter()
+        .max_by_key(|&ca| (commits.get(&ca).map(|c| c.timestamp), ca))
+}
+
+/// Analyze the relationship between two tips, from the perspective of merging
+/// `theirs` into `ours`.
+pub fn analyze(commits: &Commits, ours: CommitAddr, theirs: CommitAddr) -> MergeAnalysis {
+    match merge_base(commits, ours, theirs) {
+        None => MergeAnalysis::Unrelated,
+        Some(base) if base == theirs => MergeAnalysis::AlreadyUpToDate,
+        Some(base) if base == ours => MergeAnalysis::FastForward,
+        Some(base) => MergeAnalysis::Diverged(base),
+    }
+}
+
+/// The graph addresses along `tip`'s first-parent chain from `tip` back to
+/// `base` (inclusive of both), or `None` if `base` is not on the chain.
+pub fn first_parent_chain_to(
+    commits: &Commits,
+    tip: CommitAddr,
+    base: CommitAddr,
+) -> Option<Vec<&Commit>> {
+    let mut chain = Vec::new();
+    for ca in first_parent_chain(commits, tip) {
+        chain.push(commits.get(&ca)?);
+        if ca == base {
+            return Some(chain);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Commit, ContentAddr, GraphAddr, commit_addr};
+    use std::time::Duration;
+
+    fn graph_addr(n: u8) -> GraphAddr {
+        GraphAddr::from(ContentAddr::from([n; 32]))
+    }
+
+    /// Add a commit to the map, returning its address.
+    fn add(commits: &mut Commits, secs: u64, parent: Option<CommitAddr>, g: u8) -> CommitAddr {
+        let commit = Commit::new(Duration::from_secs(secs), parent, graph_addr(g));
+        let ca = commit_addr(&commit);
+        commits.insert(ca, commit);
+        ca
+    }
+
+    /// Add a merge commit to the map, returning its address.
+    fn add_merge(
+        commits: &mut Commits,
+        secs: u64,
+        ours: CommitAddr,
+        theirs: CommitAddr,
+        g: u8,
+    ) -> CommitAddr {
+        let commit = Commit::new_merge(Duration::from_secs(secs), ours, theirs, graph_addr(g));
+        let ca = commit_addr(&commit);
+        commits.insert(ca, commit);
+        ca
+    }
+
+    #[test]
+    fn ancestors_of_linear_chain() {
+        let mut commits = Commits::default();
+        let a = add(&mut commits, 1, None, 1);
+        let b = add(&mut commits, 2, Some(a), 2);
+        let c = add(&mut commits, 3, Some(b), 3);
+        assert_eq!(ancestors(&commits, c).collect::<Vec<_>>(), vec![c, b, a]);
+    }
+
+    #[test]
+    fn ancestors_follow_merge_parents() {
+        let mut commits = Commits::default();
+        let root = add(&mut commits, 1, None, 1);
+        let ours = add(&mut commits, 2, Some(root), 2);
+        let theirs = add(&mut commits, 3, Some(root), 3);
+        let merge = add_merge(&mut commits, 4, ours, theirs, 4);
+        let all: HashSet<_> = ancestors(&commits, merge).collect();
+        assert_eq!(all, [merge, ours, theirs, root].into_iter().collect());
+    }
+
+    #[test]
+    fn first_parent_chain_skips_merge_parents() {
+        let mut commits = Commits::default();
+        let root = add(&mut commits, 1, None, 1);
+        let ours = add(&mut commits, 2, Some(root), 2);
+        let theirs = add(&mut commits, 3, Some(root), 3);
+        let merge = add_merge(&mut commits, 4, ours, theirs, 4);
+        assert_eq!(
+            first_parent_chain(&commits, merge).collect::<Vec<_>>(),
+            vec![merge, ours, root],
+        );
+    }
+
+    #[test]
+    fn merge_base_of_diverged_tips() {
+        let mut commits = Commits::default();
+        let root = add(&mut commits, 1, None, 1);
+        let base = add(&mut commits, 2, Some(root), 2);
+        let ours = add(&mut commits, 3, Some(base), 3);
+        let theirs = add(&mut commits, 4, Some(base), 4);
+        assert_eq!(merge_base(&commits, ours, theirs), Some(base));
+        assert_eq!(
+            analyze(&commits, ours, theirs),
+            MergeAnalysis::Diverged(base)
+        );
+    }
+
+    #[test]
+    fn merge_base_of_unrelated_roots() {
+        let mut commits = Commits::default();
+        let a = add(&mut commits, 1, None, 1);
+        let b = add(&mut commits, 2, None, 2);
+        assert_eq!(merge_base(&commits, a, b), None);
+        assert_eq!(analyze(&commits, a, b), MergeAnalysis::Unrelated);
+    }
+
+    #[test]
+    fn analyze_fast_forward_and_up_to_date() {
+        let mut commits = Commits::default();
+        let root = add(&mut commits, 1, None, 1);
+        let tip = add(&mut commits, 2, Some(root), 2);
+        assert_eq!(analyze(&commits, root, tip), MergeAnalysis::FastForward);
+        assert_eq!(analyze(&commits, tip, root), MergeAnalysis::AlreadyUpToDate);
+        assert_eq!(analyze(&commits, tip, tip), MergeAnalysis::AlreadyUpToDate);
+    }
+
+    #[test]
+    fn merge_base_after_a_merge_commit() {
+        let mut commits = Commits::default();
+        let root = add(&mut commits, 1, None, 1);
+        let ours = add(&mut commits, 2, Some(root), 2);
+        let theirs = add(&mut commits, 3, Some(root), 3);
+        let merge = add_merge(&mut commits, 4, ours, theirs, 4);
+        let after = add(&mut commits, 5, Some(merge), 5);
+        // Theirs' tip is now an ancestor of the merged line.
+        assert_eq!(
+            analyze(&commits, after, theirs),
+            MergeAnalysis::AlreadyUpToDate
+        );
+        // A new commit on theirs' line diverges at theirs.
+        let theirs2 = add(&mut commits, 6, Some(theirs), 6);
+        assert_eq!(
+            analyze(&commits, after, theirs2),
+            MergeAnalysis::Diverged(theirs)
+        );
+    }
+
+    #[test]
+    fn criss_cross_tie_break_is_deterministic() {
+        let mut commits = Commits::default();
+        let root = add(&mut commits, 1, None, 1);
+        let a = add(&mut commits, 2, Some(root), 2);
+        let b = add(&mut commits, 3, Some(root), 3);
+        // Criss-cross: each side merges the other's tip.
+        let ma = add_merge(&mut commits, 4, a, b, 4);
+        let mb = add_merge(&mut commits, 5, b, a, 5);
+        // Both a and b are best common ancestors; the later timestamp wins.
+        assert_eq!(merge_base(&commits, ma, mb), Some(b));
+    }
+
+    #[test]
+    fn first_parent_chain_to_reaches_base_or_none() {
+        let mut commits = Commits::default();
+        let root = add(&mut commits, 1, None, 1);
+        let base = add(&mut commits, 2, Some(root), 2);
+        let tip = add(&mut commits, 3, Some(base), 3);
+        let chain = first_parent_chain_to(&commits, tip, base).unwrap();
+        assert_eq!(chain.len(), 2);
+        assert_eq!(crate::commit_addr(chain[0]), tip);
+        assert_eq!(crate::commit_addr(chain[1]), base);
+        // A base not on the chain yields None.
+        let other = add(&mut commits, 4, None, 4);
+        assert!(first_parent_chain_to(&commits, tip, other).is_none());
+    }
+}

--- a/crates/gantz_ca/src/lib.rs
+++ b/crates/gantz_ca/src/lib.rs
@@ -4,6 +4,8 @@
 pub use ca::{ContentAddr, ContentAddrShort, content_addr};
 #[doc(inline)]
 pub use commit::{Branch, Commit, CommitAddr, Head, Timestamp, addr as commit_addr};
+#[doc(inline)]
+pub use diff::{Diff, DiffSummary, Matching};
 /// Re-export the derive macro.
 pub use gantz_ca_derive::CaHash;
 #[doc(inline)]
@@ -20,6 +22,7 @@ pub use registry::Registry;
 
 mod ca;
 mod commit;
+pub mod diff;
 mod graph;
 mod hash;
 pub mod history;

--- a/crates/gantz_ca/src/lib.rs
+++ b/crates/gantz_ca/src/lib.rs
@@ -14,11 +14,14 @@ pub use graph::{
 #[doc(inline)]
 pub use hash::{CaHash, Hasher};
 #[doc(inline)]
+pub use history::{MergeAnalysis, analyze, ancestors, first_parent_chain, merge_base};
+#[doc(inline)]
 pub use registry::Registry;
 
 mod ca;
 mod commit;
 mod graph;
 mod hash;
+pub mod history;
 pub mod registry;
 pub mod serde_sorted;

--- a/crates/gantz_ca/src/lib.rs
+++ b/crates/gantz_ca/src/lib.rs
@@ -18,6 +18,10 @@ pub use hash::{CaHash, Hasher};
 #[doc(inline)]
 pub use history::{MergeAnalysis, analyze, ancestors, first_parent_chain, merge_base};
 #[doc(inline)]
+pub use merge::{
+    Conflict, MergeError, MergeOutcome, MergeResolution, NodeSrc, Side, merge_commits,
+};
+#[doc(inline)]
 pub use registry::Registry;
 
 mod ca;
@@ -26,5 +30,6 @@ pub mod diff;
 mod graph;
 mod hash;
 pub mod history;
+pub mod merge;
 pub mod registry;
 pub mod serde_sorted;

--- a/crates/gantz_ca/src/lib.rs
+++ b/crates/gantz_ca/src/lib.rs
@@ -19,8 +19,8 @@ pub use hash::{CaHash, Hasher};
 pub use history::{MergeAnalysis, analyze, ancestors, first_parent_chain, merge_base};
 #[doc(inline)]
 pub use merge::{
-    Conflict, EditOrDelete, MergeError, MergeOutcome, MergeResolution, NodeSrc, Resolutions, Side,
-    merge_commits,
+    BothModified, Conflict, EditOrDelete, MergeError, MergeOutcome, MergeResolution, NodeSrc,
+    Resolutions, Side, merge_commits,
 };
 #[doc(inline)]
 pub use registry::Registry;

--- a/crates/gantz_ca/src/lib.rs
+++ b/crates/gantz_ca/src/lib.rs
@@ -19,7 +19,8 @@ pub use hash::{CaHash, Hasher};
 pub use history::{MergeAnalysis, analyze, ancestors, first_parent_chain, merge_base};
 #[doc(inline)]
 pub use merge::{
-    Conflict, MergeError, MergeOutcome, MergeResolution, NodeSrc, Side, merge_commits,
+    Conflict, EditOrDelete, MergeError, MergeOutcome, MergeResolution, NodeSrc, Resolutions, Side,
+    merge_commits,
 };
 #[doc(inline)]
 pub use registry::Registry;

--- a/crates/gantz_ca/src/merge.rs
+++ b/crates/gantz_ca/src/merge.rs
@@ -1,0 +1,704 @@
+//! Three-way merging of diverged graph heads.
+//!
+//! [`merge_commits`] resolves the relationship between two commit tips (see
+//! [`history::analyze`]) and, when they have truly diverged, performs a
+//! three-way merge of their graphs against the merge base via
+//! [`merge_graphs`].
+//!
+//! The merge is *total*: it always produces a merged graph. Situations with
+//! no single obvious resolution are recorded as [`Conflict`]s, each carrying
+//! the default resolution that was applied, so callers can refuse the result,
+//! surface the conflicts, or accept the defaults.
+
+use crate::{
+    CaHash, CommitAddr, Diff, GraphAddr, Matching, MergeAnalysis, Registry, content_addr, diff,
+    history,
+};
+use petgraph::{
+    Directed,
+    graph::{IndexType, NodeIndex},
+};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+type Graph<N, E, Ix> = petgraph::graph::Graph<N, E, Directed, Ix>;
+
+/// One side of a merge.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Side {
+    Ours,
+    Theirs,
+}
+
+/// A conflict encountered during a three-way merge.
+///
+/// Conflicts are flagged, not fatal: each records the default resolution the
+/// merge applied so that the result remains usable and callers can decide
+/// whether to accept it.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Conflict<E> {
+    /// Both sides modified the same base node with different results.
+    ///
+    /// Applied resolution: ours' content is kept. `ours`/`theirs` are the
+    /// node's indices in the respective graphs.
+    BothModified {
+        base: usize,
+        ours: usize,
+        theirs: usize,
+    },
+    /// One side deleted the node, the other modified it.
+    ///
+    /// Applied resolution: the modified node is kept (an edit wins over a
+    /// delete).
+    DeleteModify { base: usize, modified: Side },
+    /// `side` added an edge to a node the other side deleted (and which
+    /// stayed deleted).
+    ///
+    /// Applied resolution: the edge is dropped. `src`/`dst` are indices in
+    /// `side`'s graph.
+    EdgeToDeleted {
+        side: Side,
+        src: usize,
+        dst: usize,
+        edge: E,
+    },
+}
+
+/// The provenance of one merged node: its index in each of the three input
+/// graphs it appears in.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NodeSrc {
+    pub base: Option<usize>,
+    pub ours: Option<usize>,
+    pub theirs: Option<usize>,
+}
+
+/// The result of a three-way graph merge.
+#[derive(Clone, Debug)]
+pub struct MergeOutcome<N, E, Ix: IndexType> {
+    /// The merged graph: ours' surviving nodes in ours' order, followed by
+    /// theirs-only nodes in ascending theirs order. When theirs removed no
+    /// nodes, ours' indices are preserved exactly.
+    pub graph: Graph<N, E, Ix>,
+    /// The provenance of each merged node, indexed by merged node index.
+    pub node_srcs: Vec<NodeSrc>,
+    /// The conflicts encountered, each already resolved by its documented
+    /// default.
+    pub conflicts: Vec<Conflict<E>>,
+}
+
+/// The resolution of merging one commit tip into another.
+#[derive(Clone, Debug)]
+pub enum MergeResolution<N, E, Ix: IndexType> {
+    /// Theirs is an ancestor of ours: there is nothing to merge.
+    AlreadyUpToDate,
+    /// Ours is an ancestor of theirs: the head can simply move to theirs'
+    /// tip; no merge commit is required.
+    FastForward,
+    /// The tips have diverged and a three-way merge was performed.
+    Diverged {
+        /// The merge base the diffs are relative to.
+        base: CommitAddr,
+        /// Ours' changes relative to the base.
+        ours_diff: Diff<E>,
+        /// Theirs' changes relative to the base.
+        theirs_diff: Diff<E>,
+        /// The merged graph, provenance and conflicts.
+        outcome: MergeOutcome<N, E, Ix>,
+    },
+}
+
+/// An error preventing a merge from being attempted.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MergeError {
+    /// The tips share no common ancestor.
+    Unrelated,
+    /// A required commit is missing from the registry.
+    MissingCommit(CommitAddr),
+    /// A required graph is missing from the registry.
+    MissingGraph(GraphAddr),
+}
+
+impl fmt::Display for MergeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unrelated => write!(f, "the commits share no common ancestor"),
+            Self::MissingCommit(ca) => write!(f, "missing commit {ca}"),
+            Self::MissingGraph(ca) => write!(f, "missing graph {ca}"),
+        }
+    }
+}
+
+impl std::error::Error for MergeError {}
+
+/// The fate of a base node in the merged graph.
+#[derive(Clone, Copy)]
+enum Fate {
+    /// The node is absent from the merged graph.
+    Delete,
+    /// The node survives with ours' content.
+    KeepOurs,
+    /// The node survives with theirs' content.
+    KeepTheirs,
+}
+
+/// Merge two tips of a registry's commit DAG.
+///
+/// Pure: the registry is not mutated, so this doubles as a dry run for
+/// previews. On [`MergeResolution::Diverged`], committing the result is the
+/// caller's job (see [`Registry::commit_merge_to_head`]).
+pub fn merge_commits<N, E, Ix>(
+    reg: &Registry<Graph<N, E, Ix>>,
+    ours: CommitAddr,
+    theirs: CommitAddr,
+) -> Result<MergeResolution<N, E, Ix>, MergeError>
+where
+    N: Clone + CaHash,
+    E: Clone + Ord,
+    Ix: IndexType,
+{
+    let commits = reg.commits();
+    let base = match history::analyze(commits, ours, theirs) {
+        MergeAnalysis::Unrelated => return Err(MergeError::Unrelated),
+        MergeAnalysis::AlreadyUpToDate => return Ok(MergeResolution::AlreadyUpToDate),
+        MergeAnalysis::FastForward => return Ok(MergeResolution::FastForward),
+        MergeAnalysis::Diverged(base) => base,
+    };
+    let graph_of = |ca: CommitAddr| {
+        let commit = commits.get(&ca).ok_or(MergeError::MissingCommit(ca))?;
+        reg.graphs()
+            .get(&commit.graph)
+            .ok_or(MergeError::MissingGraph(commit.graph))
+    };
+    let base_g = graph_of(base)?;
+    let ours_g = graph_of(ours)?;
+    let theirs_g = graph_of(theirs)?;
+    // Endpoints are verified above, so `matching` cannot fail; degrade to
+    // direct matching rather than panicking should that ever change.
+    let mo = diff::matching(reg, base, ours).unwrap_or_else(|| diff::match_nodes(base_g, ours_g));
+    let mt =
+        diff::matching(reg, base, theirs).unwrap_or_else(|| diff::match_nodes(base_g, theirs_g));
+    let ours_diff = diff::diff(base_g, ours_g, &mo);
+    let theirs_diff = diff::diff(base_g, theirs_g, &mt);
+    let outcome = merge_graphs(base_g, ours_g, theirs_g, &ours_diff, &theirs_diff);
+    Ok(MergeResolution::Diverged {
+        base,
+        ours_diff,
+        theirs_diff,
+        outcome,
+    })
+}
+
+/// Three-way merge of `ours` and `theirs` against their common `base`, under
+/// the diffs produced by [`diff::diff`] (which carry the node matchings).
+///
+/// Node rules, per base node:
+///
+/// - present on both sides, modified by at most one: the modified side's
+///   content is kept (change beats no-change).
+/// - modified by both to the same content: kept, no conflict.
+/// - modified by both to different content: ours' content is kept and
+///   [`Conflict::BothModified`] is flagged.
+/// - deleted by one side, untouched by the other: deleted.
+/// - deleted by one side, modified by the other: the modified node is kept
+///   and [`Conflict::DeleteModify`] is flagged.
+///
+/// Nodes added by a side are always included. Ours' surviving nodes come
+/// first in ours' order, then theirs-only nodes in ascending theirs order, so
+/// ours' indices are preserved exactly whenever theirs removed nothing.
+///
+/// Edge rules, on `(source, target, weight)` sets:
+///
+/// - a base edge survives unless a side removed it or an endpoint is absent
+///   from the merged graph.
+/// - added edges from both sides are unioned; identical additions collapse.
+/// - an edge added to a node that is absent from the merged graph is dropped
+///   and [`Conflict::EdgeToDeleted`] is flagged.
+///
+/// Construction order is deterministic, so merging the same inputs always
+/// yields the same graph address.
+pub fn merge_graphs<N, E, Ix>(
+    base: &Graph<N, E, Ix>,
+    ours: &Graph<N, E, Ix>,
+    theirs: &Graph<N, E, Ix>,
+    ours_diff: &Diff<E>,
+    theirs_diff: &Diff<E>,
+) -> MergeOutcome<N, E, Ix>
+where
+    N: Clone + CaHash,
+    E: Clone + Ord,
+    Ix: IndexType,
+{
+    let node_ix = |i: usize| NodeIndex::<Ix>::new(i);
+    let mut conflicts = Vec::new();
+
+    // Decide each base node's fate.
+    let mut fates: BTreeMap<usize, Fate> = BTreeMap::new();
+    for b in 0..base.node_count() {
+        let o = ours_diff.matched.get(&b).copied();
+        let t = theirs_diff.matched.get(&b).copied();
+        let mod_o = ours_diff.modified.contains(&b);
+        let mod_t = theirs_diff.modified.contains(&b);
+        let fate = match (o, t) {
+            (Some(o), Some(t)) => match (mod_o, mod_t) {
+                (_, false) => Fate::KeepOurs,
+                (false, true) => Fate::KeepTheirs,
+                (true, true) => {
+                    if content_addr(&ours[node_ix(o)]) != content_addr(&theirs[node_ix(t)]) {
+                        conflicts.push(Conflict::BothModified {
+                            base: b,
+                            ours: o,
+                            theirs: t,
+                        });
+                    }
+                    Fate::KeepOurs
+                }
+            },
+            (Some(_), None) if mod_o => {
+                conflicts.push(Conflict::DeleteModify {
+                    base: b,
+                    modified: Side::Ours,
+                });
+                Fate::KeepOurs
+            }
+            (None, Some(_)) if mod_t => {
+                conflicts.push(Conflict::DeleteModify {
+                    base: b,
+                    modified: Side::Theirs,
+                });
+                Fate::KeepTheirs
+            }
+            _ => Fate::Delete,
+        };
+        fates.insert(b, fate);
+    }
+
+    // Ours' surviving nodes, in ours' order.
+    let inv_ours: Matching = ours_diff.matched.iter().map(|(&b, &o)| (o, b)).collect();
+    let inv_theirs: Matching = theirs_diff.matched.iter().map(|(&b, &t)| (t, b)).collect();
+    let mut graph = Graph::default();
+    let mut node_srcs: Vec<NodeSrc> = Vec::new();
+    let mut merged_of_ours: BTreeMap<usize, usize> = BTreeMap::new();
+    let mut merged_of_theirs: BTreeMap<usize, usize> = BTreeMap::new();
+    for o in 0..ours.node_count() {
+        let (weight, src) = match inv_ours.get(&o) {
+            // A node matched from base: its fate decides.
+            Some(&b) => {
+                let t = theirs_diff.matched.get(&b).copied();
+                let src = NodeSrc {
+                    base: Some(b),
+                    ours: Some(o),
+                    theirs: t,
+                };
+                match fates[&b] {
+                    Fate::Delete => continue,
+                    Fate::KeepOurs => (ours[node_ix(o)].clone(), src),
+                    Fate::KeepTheirs => {
+                        let t = t.expect("`KeepTheirs` fate requires a theirs match");
+                        (theirs[node_ix(t)].clone(), src)
+                    }
+                }
+            }
+            // A node added by ours.
+            None => {
+                let src = NodeSrc {
+                    base: None,
+                    ours: Some(o),
+                    theirs: None,
+                };
+                (ours[node_ix(o)].clone(), src)
+            }
+        };
+        let m = graph.add_node(weight).index();
+        node_srcs.push(src);
+        merged_of_ours.insert(o, m);
+        if let Some(t) = src.theirs {
+            merged_of_theirs.insert(t, m);
+        }
+    }
+    // Theirs-only survivors, in theirs' order: nodes added by theirs, and
+    // nodes theirs modified but ours deleted (kept by `DeleteModify`).
+    for t in 0..theirs.node_count() {
+        if merged_of_theirs.contains_key(&t) {
+            continue;
+        }
+        let src = match inv_theirs.get(&t) {
+            Some(&b) => match fates[&b] {
+                Fate::KeepTheirs => NodeSrc {
+                    base: Some(b),
+                    ours: None,
+                    theirs: Some(t),
+                },
+                // Deleted, or already added via ours above.
+                _ => continue,
+            },
+            None => NodeSrc {
+                base: None,
+                ours: None,
+                theirs: Some(t),
+            },
+        };
+        let m = graph.add_node(theirs[node_ix(t)].clone()).index();
+        node_srcs.push(src);
+        merged_of_theirs.insert(t, m);
+    }
+
+    // The merged index of a base node, if it survived (via either side).
+    let base_merged = |b: usize| -> Option<usize> {
+        let via_ours = ours_diff
+            .matched
+            .get(&b)
+            .and_then(|o| merged_of_ours.get(o));
+        let via_theirs = theirs_diff
+            .matched
+            .get(&b)
+            .and_then(|t| merged_of_theirs.get(t));
+        via_ours.or(via_theirs).copied()
+    };
+
+    // Base edges survive unless a side removed them or an endpoint is gone.
+    let edge_triples = |g: &Graph<N, E, Ix>| -> BTreeSet<(usize, usize, E)> {
+        g.edge_indices()
+            .map(|e| {
+                let (s, d) = g.edge_endpoints(e).expect("edge must have endpoints");
+                (s.index(), d.index(), g[e].clone())
+            })
+            .collect()
+    };
+    let mut merged_edges: BTreeSet<(usize, usize, E)> = BTreeSet::new();
+    for (s, d, w) in edge_triples(base) {
+        let removed = ours_diff.removed_edges.contains(&(s, d, w.clone()))
+            || theirs_diff.removed_edges.contains(&(s, d, w.clone()));
+        if removed {
+            continue;
+        }
+        // An absent endpoint means the edge is implied-removed with its node.
+        let (Some(ms), Some(md)) = (base_merged(s), base_merged(d)) else {
+            continue;
+        };
+        merged_edges.insert((ms, md, w));
+    }
+    // Union in each side's added edges; identical additions collapse.
+    let mut add_edges =
+        |added: &BTreeSet<(usize, usize, E)>, merged_of: &BTreeMap<usize, usize>, side: Side| {
+            for (s, d, w) in added {
+                match (merged_of.get(s), merged_of.get(d)) {
+                    (Some(&ms), Some(&md)) => {
+                        merged_edges.insert((ms, md, w.clone()));
+                    }
+                    _ => conflicts.push(Conflict::EdgeToDeleted {
+                        side,
+                        src: *s,
+                        dst: *d,
+                        edge: w.clone(),
+                    }),
+                }
+            }
+        };
+    add_edges(&ours_diff.added_edges, &merged_of_ours, Side::Ours);
+    add_edges(&theirs_diff.added_edges, &merged_of_theirs, Side::Theirs);
+    for (s, d, w) in merged_edges {
+        graph.add_edge(node_ix(s), node_ix(d), w);
+    }
+
+    MergeOutcome {
+        graph,
+        node_srcs,
+        conflicts,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Head, graph_addr};
+    use std::time::Duration;
+
+    type G = petgraph::graph::Graph<String, u32, Directed, usize>;
+
+    fn graph(nodes: &[&str], edges: &[(usize, usize, u32)]) -> G {
+        let mut g = G::default();
+        for n in nodes {
+            g.add_node(n.to_string());
+        }
+        for &(s, d, w) in edges {
+            g.add_edge(s.into(), d.into(), w);
+        }
+        g
+    }
+
+    fn commit(reg: &mut Registry<G>, secs: u64, parent: Option<CommitAddr>, g: &G) -> CommitAddr {
+        reg.commit_graph(Duration::from_secs(secs), parent, graph_addr(g), || {
+            g.clone()
+        })
+    }
+
+    fn nodes(g: &G) -> Vec<&str> {
+        g.node_weights().map(|s| s.as_str()).collect()
+    }
+
+    fn edges(g: &G) -> BTreeSet<(usize, usize, u32)> {
+        g.edge_indices()
+            .map(|e| {
+                let (s, d) = g.edge_endpoints(e).unwrap();
+                (s.index(), d.index(), g[e])
+            })
+            .collect()
+    }
+
+    /// Merge two graphs that diverged from `base` by one commit each.
+    fn merge_two(
+        base: &G,
+        ours: &G,
+        theirs: &G,
+    ) -> (
+        Registry<G>,
+        CommitAddr,
+        CommitAddr,
+        MergeResolution<String, u32, usize>,
+    ) {
+        let mut reg = Registry::<G>::default();
+        let b = commit(&mut reg, 1, None, base);
+        let o = commit(&mut reg, 2, Some(b), ours);
+        let t = commit(&mut reg, 3, Some(b), theirs);
+        let res = merge_commits(&reg, o, t).unwrap();
+        (reg, o, t, res)
+    }
+
+    fn diverged(res: MergeResolution<String, u32, usize>) -> MergeOutcome<String, u32, usize> {
+        match res {
+            MergeResolution::Diverged { outcome, .. } => outcome,
+            other => panic!("expected Diverged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disjoint_additions_union() {
+        let base = graph(&["a"], &[]);
+        let ours = graph(&["a", "x"], &[]);
+        let theirs = graph(&["a", "y"], &[]);
+        let (_, _, _, res) = merge_two(&base, &ours, &theirs);
+        let out = diverged(res);
+        assert!(out.conflicts.is_empty());
+        assert_eq!(nodes(&out.graph), vec!["a", "x", "y"]);
+        assert_eq!(
+            out.node_srcs,
+            vec![
+                NodeSrc {
+                    base: Some(0),
+                    ours: Some(0),
+                    theirs: Some(0)
+                },
+                NodeSrc {
+                    base: None,
+                    ours: Some(1),
+                    theirs: None
+                },
+                NodeSrc {
+                    base: None,
+                    ours: None,
+                    theirs: Some(1)
+                },
+            ],
+        );
+    }
+
+    /// The collaborative-editing driver scenario: one side edits a node's
+    /// content while the other connects an edge to it. Chain-tracked identity
+    /// makes this a clean merge.
+    #[test]
+    fn content_edit_and_edge_add_merge_cleanly() {
+        let base = graph(&["a", "b"], &[]);
+        let ours = graph(&["a", "b2"], &[]);
+        let theirs = graph(&["a", "b"], &[(0, 1, 0)]);
+        let (_, _, _, res) = merge_two(&base, &ours, &theirs);
+        let out = diverged(res);
+        assert!(out.conflicts.is_empty());
+        assert_eq!(nodes(&out.graph), vec!["a", "b2"]);
+        assert_eq!(edges(&out.graph), BTreeSet::from([(0, 1, 0)]));
+    }
+
+    #[test]
+    fn both_modified_differently_keeps_ours_and_flags() {
+        let base = graph(&["a", "b"], &[]);
+        let ours = graph(&["a", "b2"], &[]);
+        let theirs = graph(&["a", "b3"], &[]);
+        let (_, _, _, res) = merge_two(&base, &ours, &theirs);
+        let out = diverged(res);
+        assert_eq!(nodes(&out.graph), vec!["a", "b2"]);
+        assert_eq!(
+            out.conflicts,
+            vec![Conflict::BothModified {
+                base: 1,
+                ours: 1,
+                theirs: 1
+            }],
+        );
+    }
+
+    #[test]
+    fn both_modified_identically_is_clean() {
+        let base = graph(&["a", "b"], &[]);
+        let ours = graph(&["a", "b2"], &[]);
+        let theirs = graph(&["a", "b2"], &[]);
+        let (_, _, _, res) = merge_two(&base, &ours, &theirs);
+        let out = diverged(res);
+        assert!(out.conflicts.is_empty());
+        assert_eq!(nodes(&out.graph), vec!["a", "b2"]);
+    }
+
+    #[test]
+    fn delete_vs_modify_keeps_the_modified_node() {
+        let base = graph(&["a", "b"], &[]);
+        // Ours deletes ix 1; theirs modifies it.
+        let ours = graph(&["a"], &[]);
+        let theirs = graph(&["a", "b2"], &[]);
+        let (_, _, _, res) = merge_two(&base, &ours, &theirs);
+        let out = diverged(res);
+        assert_eq!(nodes(&out.graph), vec!["a", "b2"]);
+        assert_eq!(
+            out.conflicts,
+            vec![Conflict::DeleteModify {
+                base: 1,
+                modified: Side::Theirs
+            }],
+        );
+        assert_eq!(
+            out.node_srcs[1],
+            NodeSrc {
+                base: Some(1),
+                ours: None,
+                theirs: Some(1)
+            },
+        );
+    }
+
+    #[test]
+    fn delete_vs_untouched_deletes() {
+        let base = graph(&["a", "b"], &[]);
+        let ours = graph(&["a"], &[]);
+        let theirs = graph(&["a", "b"], &[]);
+        let (_, _, _, res) = merge_two(&base, &ours, &theirs);
+        let out = diverged(res);
+        assert!(out.conflicts.is_empty());
+        assert_eq!(nodes(&out.graph), vec!["a"]);
+    }
+
+    #[test]
+    fn edge_to_deleted_node_is_dropped_and_flagged() {
+        let base = graph(&["a", "b"], &[]);
+        // Ours deletes ix 1 (untouched by theirs); theirs wires into it.
+        let ours = graph(&["a"], &[]);
+        let theirs = graph(&["a", "b"], &[(0, 1, 0)]);
+        let (_, _, _, res) = merge_two(&base, &ours, &theirs);
+        let out = diverged(res);
+        assert_eq!(nodes(&out.graph), vec!["a"]);
+        assert!(edges(&out.graph).is_empty());
+        assert_eq!(
+            out.conflicts,
+            vec![Conflict::EdgeToDeleted {
+                side: Side::Theirs,
+                src: 0,
+                dst: 1,
+                edge: 0
+            }],
+        );
+    }
+
+    #[test]
+    fn identical_edge_additions_collapse() {
+        let base = graph(&["a", "b"], &[]);
+        let ours = graph(&["a", "b"], &[(0, 1, 0)]);
+        let theirs = graph(&["a", "b"], &[(0, 1, 0)]);
+        let (_, _, _, res) = merge_two(&base, &ours, &theirs);
+        let out = diverged(res);
+        assert!(out.conflicts.is_empty());
+        assert_eq!(edges(&out.graph), BTreeSet::from([(0, 1, 0)]));
+        assert_eq!(out.graph.edge_count(), 1);
+    }
+
+    #[test]
+    fn distinct_parallel_edge_additions_are_both_kept() {
+        let base = graph(&["a", "b"], &[]);
+        let ours = graph(&["a", "b"], &[(0, 1, 0)]);
+        let theirs = graph(&["a", "b"], &[(0, 1, 1)]);
+        let (_, _, _, res) = merge_two(&base, &ours, &theirs);
+        let out = diverged(res);
+        assert!(out.conflicts.is_empty());
+        assert_eq!(edges(&out.graph), BTreeSet::from([(0, 1, 0), (0, 1, 1)]));
+    }
+
+    #[test]
+    fn edge_removed_by_one_side_stays_removed() {
+        let base = graph(&["a", "b"], &[(0, 1, 0)]);
+        let ours = graph(&["a", "b"], &[]);
+        let theirs = graph(&["a", "b", "c"], &[(0, 1, 0)]);
+        let (_, _, _, res) = merge_two(&base, &ours, &theirs);
+        let out = diverged(res);
+        assert!(out.conflicts.is_empty());
+        assert_eq!(nodes(&out.graph), vec!["a", "b", "c"]);
+        assert!(edges(&out.graph).is_empty());
+    }
+
+    #[test]
+    fn merge_is_deterministic() {
+        let base = graph(&["a", "b"], &[(0, 1, 0)]);
+        let ours = graph(&["a", "b", "x"], &[(0, 1, 0), (0, 2, 1)]);
+        let theirs = graph(&["a", "b2", "y"], &[(0, 1, 0), (2, 1, 2)]);
+        let (_, o, t, res) = merge_two(&base, &ours, &theirs);
+        let out = diverged(res);
+        let (reg2, _, _, _) = merge_two(&base, &ours, &theirs);
+        let res2 = merge_commits(&reg2, o, t).unwrap();
+        let out2 = diverged(res2);
+        assert_eq!(graph_addr(&out.graph), graph_addr(&out2.graph));
+    }
+
+    #[test]
+    fn fast_forward_and_up_to_date_and_unrelated() {
+        let mut reg = Registry::<G>::default();
+        let g0 = graph(&["a"], &[]);
+        let g1 = graph(&["a", "b"], &[]);
+        let root = commit(&mut reg, 1, None, &g0);
+        let tip = commit(&mut reg, 2, Some(root), &g1);
+        assert!(matches!(
+            merge_commits(&reg, root, tip),
+            Ok(MergeResolution::FastForward)
+        ));
+        assert!(matches!(
+            merge_commits(&reg, tip, root),
+            Ok(MergeResolution::AlreadyUpToDate)
+        ));
+        let stray = commit(&mut reg, 3, None, &g1);
+        assert!(matches!(
+            merge_commits(&reg, tip, stray),
+            Err(MergeError::Unrelated)
+        ));
+    }
+
+    /// End-to-end: merge two diverged branches and commit the result; the
+    /// merge commit's ancestry spans both sides while undo's first-parent
+    /// walk lands on ours' pre-merge tip.
+    #[test]
+    fn merge_commit_end_to_end() {
+        let base = graph(&["a"], &[]);
+        let ours = graph(&["a", "x"], &[]);
+        let theirs = graph(&["a", "y"], &[]);
+        let (mut reg, o, t, res) = merge_two(&base, &ours, &theirs);
+        let out = diverged(res);
+        assert!(out.conflicts.is_empty());
+        reg.insert_name("alpha".to_string(), o);
+        let mut head = Head::Branch("alpha".to_string());
+        let merge_ca = reg.commit_merge_to_head(
+            Duration::from_secs(4),
+            graph_addr(&out.graph),
+            || out.graph.clone(),
+            t,
+            &mut head,
+        );
+        let ancestors: BTreeSet<_> = history::ancestors(reg.commits(), merge_ca).collect();
+        assert!(ancestors.contains(&o) && ancestors.contains(&t));
+        assert_eq!(reg.commits()[&merge_ca].parent, Some(o));
+        // The merged graph is now reachable via the head.
+        assert_eq!(nodes(reg.head_graph(&head).unwrap()), vec!["a", "x", "y"]);
+    }
+}

--- a/crates/gantz_ca/src/merge.rs
+++ b/crates/gantz_ca/src/merge.rs
@@ -24,33 +24,69 @@ use std::fmt;
 type Graph<N, E, Ix> = petgraph::graph::Graph<N, E, Directed, Ix>;
 
 /// One side of a merge.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize,
+)]
 pub enum Side {
+    #[default]
     Ours,
     Theirs,
 }
 
+/// How a merge resolves each class of conflict (see [`Conflict`]).
+///
+/// An edge added to a node absent from the merged graph is always dropped -
+/// that is a consequence of the node's absence, not a choice.
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize,
+)]
+pub struct Resolutions {
+    /// Which side's content is kept when both sides modified the same base
+    /// node with different results.
+    pub both_modified: Side,
+    /// Whether the edit or the delete wins when one side deleted a node the
+    /// other modified.
+    pub delete_modify: EditOrDelete,
+}
+
+/// Whether an edit or a delete wins a [`Conflict::DeleteModify`].
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize,
+)]
+pub enum EditOrDelete {
+    /// The modified node is kept (don't lose work).
+    #[default]
+    KeepEdit,
+    /// The node stays deleted.
+    KeepDelete,
+}
+
 /// A conflict encountered during a three-way merge.
 ///
-/// Conflicts are flagged, not fatal: each records the default resolution the
-/// merge applied so that the result remains usable and callers can decide
-/// whether to accept it.
+/// Conflicts are flagged, not fatal: each records the resolution the merge
+/// applied (per the caller's [`Resolutions`]) so that the result remains
+/// usable and callers can decide whether to accept it.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Conflict<E> {
     /// Both sides modified the same base node with different results.
     ///
-    /// Applied resolution: ours' content is kept. `ours`/`theirs` are the
+    /// Applied resolution: `kept`'s content is kept. `ours`/`theirs` are the
     /// node's indices in the respective graphs.
     BothModified {
         base: usize,
         ours: usize,
         theirs: usize,
+        kept: Side,
     },
-    /// One side deleted the node, the other modified it.
+    /// One side deleted the node, the other (`modified`) modified it.
     ///
-    /// Applied resolution: the modified node is kept (an edit wins over a
-    /// delete).
-    DeleteModify { base: usize, modified: Side },
+    /// Applied resolution: the modified node is kept when `kept`, else it
+    /// stays deleted.
+    DeleteModify {
+        base: usize,
+        modified: Side,
+        kept: bool,
+    },
     /// `side` added an edge to a node the other side deleted (and which
     /// stayed deleted).
     ///
@@ -151,6 +187,7 @@ pub fn merge_commits<N, E, Ix>(
     reg: &Registry<Graph<N, E, Ix>>,
     ours: CommitAddr,
     theirs: CommitAddr,
+    resolutions: Resolutions,
 ) -> Result<MergeResolution<N, E, Ix>, MergeError>
 where
     N: Clone + CaHash,
@@ -180,7 +217,14 @@ where
         diff::matching(reg, base, theirs).unwrap_or_else(|| diff::match_nodes(base_g, theirs_g));
     let ours_diff = diff::diff(base_g, ours_g, &mo);
     let theirs_diff = diff::diff(base_g, theirs_g, &mt);
-    let outcome = merge_graphs(base_g, ours_g, theirs_g, &ours_diff, &theirs_diff);
+    let outcome = merge_graphs(
+        base_g,
+        ours_g,
+        theirs_g,
+        &ours_diff,
+        &theirs_diff,
+        resolutions,
+    );
     Ok(MergeResolution::Diverged {
         base,
         ours_diff,
@@ -197,11 +241,13 @@ where
 /// - present on both sides, modified by at most one: the modified side's
 ///   content is kept (change beats no-change).
 /// - modified by both to the same content: kept, no conflict.
-/// - modified by both to different content: ours' content is kept and
-///   [`Conflict::BothModified`] is flagged.
+/// - modified by both to different content:
+///   [`resolutions.both_modified`](Resolutions::both_modified)'s content is
+///   kept and [`Conflict::BothModified`] is flagged.
 /// - deleted by one side, untouched by the other: deleted.
-/// - deleted by one side, modified by the other: the modified node is kept
-///   and [`Conflict::DeleteModify`] is flagged.
+/// - deleted by one side, modified by the other: resolved per
+///   [`resolutions.delete_modify`](Resolutions::delete_modify) and
+///   [`Conflict::DeleteModify`] is flagged.
 ///
 /// Nodes added by a side are always included. Ours' surviving nodes come
 /// first in ours' order, then theirs-only nodes in ascending theirs order, so
@@ -223,6 +269,7 @@ pub fn merge_graphs<N, E, Ix>(
     theirs: &Graph<N, E, Ix>,
     ours_diff: &Diff<E>,
     theirs_diff: &Diff<E>,
+    resolutions: Resolutions,
 ) -> MergeOutcome<N, E, Ix>
 where
     N: Clone + CaHash,
@@ -231,6 +278,7 @@ where
 {
     let node_ix = |i: usize| NodeIndex::<Ix>::new(i);
     let mut conflicts = Vec::new();
+    let keep_edit = resolutions.delete_modify == EditOrDelete::KeepEdit;
 
     // Decide each base node's fate.
     let mut fates: BTreeMap<usize, Fate> = BTreeMap::new();
@@ -244,29 +292,44 @@ where
                 (_, false) => Fate::KeepOurs,
                 (false, true) => Fate::KeepTheirs,
                 (true, true) => {
+                    let kept = resolutions.both_modified;
                     if content_addr(&ours[node_ix(o)]) != content_addr(&theirs[node_ix(t)]) {
                         conflicts.push(Conflict::BothModified {
                             base: b,
                             ours: o,
                             theirs: t,
+                            kept,
                         });
                     }
-                    Fate::KeepOurs
+                    match kept {
+                        Side::Ours => Fate::KeepOurs,
+                        Side::Theirs => Fate::KeepTheirs,
+                    }
                 }
             },
             (Some(_), None) if mod_o => {
                 conflicts.push(Conflict::DeleteModify {
                     base: b,
                     modified: Side::Ours,
+                    kept: keep_edit,
                 });
-                Fate::KeepOurs
+                if keep_edit {
+                    Fate::KeepOurs
+                } else {
+                    Fate::Delete
+                }
             }
             (None, Some(_)) if mod_t => {
                 conflicts.push(Conflict::DeleteModify {
                     base: b,
                     modified: Side::Theirs,
+                    kept: keep_edit,
                 });
-                Fate::KeepTheirs
+                if keep_edit {
+                    Fate::KeepTheirs
+                } else {
+                    Fate::Delete
+                }
             }
             _ => Fate::Delete,
         };
@@ -446,7 +509,8 @@ mod tests {
             .collect()
     }
 
-    /// Merge two graphs that diverged from `base` by one commit each.
+    /// Merge two graphs that diverged from `base` by one commit each, using
+    /// the default [`Resolutions`].
     fn merge_two(
         base: &G,
         ours: &G,
@@ -457,11 +521,26 @@ mod tests {
         CommitAddr,
         MergeResolution<String, u32, usize>,
     ) {
+        merge_two_with(base, ours, theirs, Resolutions::default())
+    }
+
+    /// [`merge_two`] with explicit [`Resolutions`].
+    fn merge_two_with(
+        base: &G,
+        ours: &G,
+        theirs: &G,
+        resolutions: Resolutions,
+    ) -> (
+        Registry<G>,
+        CommitAddr,
+        CommitAddr,
+        MergeResolution<String, u32, usize>,
+    ) {
         let mut reg = Registry::<G>::default();
         let b = commit(&mut reg, 1, None, base);
         let o = commit(&mut reg, 2, Some(b), ours);
         let t = commit(&mut reg, 3, Some(b), theirs);
-        let res = merge_commits(&reg, o, t).unwrap();
+        let res = merge_commits(&reg, o, t, resolutions).unwrap();
         (reg, o, t, res)
     }
 
@@ -531,7 +610,31 @@ mod tests {
             vec![Conflict::BothModified {
                 base: 1,
                 ours: 1,
-                theirs: 1
+                theirs: 1,
+                kept: Side::Ours,
+            }],
+        );
+    }
+
+    #[test]
+    fn both_modified_resolves_to_theirs_when_asked() {
+        let base = graph(&["a", "b"], &[]);
+        let ours = graph(&["a", "b2"], &[]);
+        let theirs = graph(&["a", "b3"], &[]);
+        let resolutions = Resolutions {
+            both_modified: Side::Theirs,
+            ..Default::default()
+        };
+        let (_, _, _, res) = merge_two_with(&base, &ours, &theirs, resolutions);
+        let out = diverged(res);
+        assert_eq!(nodes(&out.graph), vec!["a", "b3"]);
+        assert_eq!(
+            out.conflicts,
+            vec![Conflict::BothModified {
+                base: 1,
+                ours: 1,
+                theirs: 1,
+                kept: Side::Theirs,
             }],
         );
     }
@@ -560,7 +663,8 @@ mod tests {
             out.conflicts,
             vec![Conflict::DeleteModify {
                 base: 1,
-                modified: Side::Theirs
+                modified: Side::Theirs,
+                kept: true,
             }],
         );
         assert_eq!(
@@ -570,6 +674,39 @@ mod tests {
                 ours: None,
                 theirs: Some(1)
             },
+        );
+    }
+
+    #[test]
+    fn delete_vs_modify_deletes_when_asked() {
+        let base = graph(&["a", "b"], &[]);
+        // Ours deletes ix 1; theirs modifies it *and* wires into it.
+        let ours = graph(&["a"], &[]);
+        let theirs = graph(&["a", "b2"], &[(0, 1, 0)]);
+        let resolutions = Resolutions {
+            delete_modify: EditOrDelete::KeepDelete,
+            ..Default::default()
+        };
+        let (_, _, _, res) = merge_two_with(&base, &ours, &theirs, resolutions);
+        let out = diverged(res);
+        // The delete wins; theirs' edge into the node dangles and drops.
+        assert_eq!(nodes(&out.graph), vec!["a"]);
+        assert!(edges(&out.graph).is_empty());
+        assert_eq!(
+            out.conflicts,
+            vec![
+                Conflict::DeleteModify {
+                    base: 1,
+                    modified: Side::Theirs,
+                    kept: false,
+                },
+                Conflict::EdgeToDeleted {
+                    side: Side::Theirs,
+                    src: 0,
+                    dst: 1,
+                    edge: 0,
+                },
+            ],
         );
     }
 
@@ -648,7 +785,7 @@ mod tests {
         let (_, o, t, res) = merge_two(&base, &ours, &theirs);
         let out = diverged(res);
         let (reg2, _, _, _) = merge_two(&base, &ours, &theirs);
-        let res2 = merge_commits(&reg2, o, t).unwrap();
+        let res2 = merge_commits(&reg2, o, t, Resolutions::default()).unwrap();
         let out2 = diverged(res2);
         assert_eq!(graph_addr(&out.graph), graph_addr(&out2.graph));
     }
@@ -660,17 +797,18 @@ mod tests {
         let g1 = graph(&["a", "b"], &[]);
         let root = commit(&mut reg, 1, None, &g0);
         let tip = commit(&mut reg, 2, Some(root), &g1);
+        let rs = Resolutions::default();
         assert!(matches!(
-            merge_commits(&reg, root, tip),
+            merge_commits(&reg, root, tip, rs),
             Ok(MergeResolution::FastForward)
         ));
         assert!(matches!(
-            merge_commits(&reg, tip, root),
+            merge_commits(&reg, tip, root, rs),
             Ok(MergeResolution::AlreadyUpToDate)
         ));
         let stray = commit(&mut reg, 3, None, &g1);
         assert!(matches!(
-            merge_commits(&reg, tip, stray),
+            merge_commits(&reg, tip, stray, rs),
             Err(MergeError::Unrelated)
         ));
     }

--- a/crates/gantz_ca/src/merge.rs
+++ b/crates/gantz_ca/src/merge.rs
@@ -11,8 +11,8 @@
 //! surface the conflicts, or accept the defaults.
 
 use crate::{
-    CaHash, CommitAddr, Diff, GraphAddr, Matching, MergeAnalysis, Registry, content_addr, diff,
-    history,
+    CaHash, CommitAddr, Diff, GraphAddr, Matching, MergeAnalysis, Registry, Timestamp,
+    content_addr, diff, history,
 };
 use petgraph::{
     Directed,
@@ -41,12 +41,35 @@ pub enum Side {
     Clone, Copy, Debug, Default, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize,
 )]
 pub struct Resolutions {
-    /// Which side's content is kept when both sides modified the same base
-    /// node with different results.
-    pub both_modified: Side,
+    /// Which content is kept when both sides modified the same base node with
+    /// different results.
+    pub both_modified: BothModified,
     /// Whether the edit or the delete wins when one side deleted a node the
     /// other modified.
     pub delete_modify: EditOrDelete,
+}
+
+/// Which content wins a [`Conflict::BothModified`].
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize,
+)]
+pub enum BothModified {
+    /// Ours' content is kept.
+    #[default]
+    #[serde(alias = "Ours")]
+    KeepOurs,
+    /// Theirs' content is kept.
+    #[serde(alias = "Theirs")]
+    KeepTheirs,
+    /// Last edit wins, per node: the side whose last content-changing commit
+    /// for that node is newer keeps its version (see [`EditTimes`]).
+    ///
+    /// Unlike the sided options this resolution is *symmetric*: merging A
+    /// into B picks the same content as merging B into A, so two peers
+    /// resolving the same conflict independently converge (the basis for a
+    /// shared-session "last edit wins" mode). Exact time ties break to the
+    /// greater content address - arbitrary, but side-independent.
+    KeepNewest,
 }
 
 /// Whether an edit or a delete wins a [`Conflict::DeleteModify`].
@@ -59,6 +82,25 @@ pub enum EditOrDelete {
     KeepEdit,
     /// The node stays deleted.
     KeepDelete,
+}
+
+/// Per-node last-edit timestamps consulted by [`BothModified::KeepNewest`].
+///
+/// [`merge_commits`] fills this from each side's commit chain (see
+/// [`diff::matching_with_times`]); a node without an entry falls back to its
+/// side's tip timestamp. The `Default` (empty, zero tips) makes every
+/// comparison a tie, so `KeepNewest` degrades to the content-address
+/// tie-break.
+#[derive(Clone, Debug, Default)]
+pub struct EditTimes {
+    /// Base node index -> the last time ours' chain changed the node.
+    pub ours: BTreeMap<usize, Timestamp>,
+    /// Base node index -> the last time theirs' chain changed the node.
+    pub theirs: BTreeMap<usize, Timestamp>,
+    /// Ours' tip commit timestamp (the fallback edit time).
+    pub ours_tip: Timestamp,
+    /// Theirs' tip commit timestamp (the fallback edit time).
+    pub theirs_tip: Timestamp,
 }
 
 /// A conflict encountered during a three-way merge.
@@ -210,13 +252,22 @@ where
     let base_g = graph_of(base)?;
     let ours_g = graph_of(ours)?;
     let theirs_g = graph_of(theirs)?;
-    // Endpoints are verified above, so `matching` cannot fail; degrade to
-    // direct matching rather than panicking should that ever change.
-    let mo = diff::matching(reg, base, ours).unwrap_or_else(|| diff::match_nodes(base_g, ours_g));
-    let mt =
-        diff::matching(reg, base, theirs).unwrap_or_else(|| diff::match_nodes(base_g, theirs_g));
+    // Endpoints are verified above, so `matching_with_times` cannot fail;
+    // degrade to direct matching rather than panicking should that ever
+    // change.
+    let (mo, ours_times) = diff::matching_with_times(reg, base, ours)
+        .unwrap_or_else(|| (diff::match_nodes(base_g, ours_g), Default::default()));
+    let (mt, theirs_times) = diff::matching_with_times(reg, base, theirs)
+        .unwrap_or_else(|| (diff::match_nodes(base_g, theirs_g), Default::default()));
     let ours_diff = diff::diff(base_g, ours_g, &mo);
     let theirs_diff = diff::diff(base_g, theirs_g, &mt);
+    let tip_time = |ca: CommitAddr| commits.get(&ca).map(|c| c.timestamp).unwrap_or_default();
+    let edit_times = EditTimes {
+        ours: ours_times,
+        theirs: theirs_times,
+        ours_tip: tip_time(ours),
+        theirs_tip: tip_time(theirs),
+    };
     let outcome = merge_graphs(
         base_g,
         ours_g,
@@ -224,6 +275,7 @@ where
         &ours_diff,
         &theirs_diff,
         resolutions,
+        &edit_times,
     );
     Ok(MergeResolution::Diverged {
         base,
@@ -270,6 +322,7 @@ pub fn merge_graphs<N, E, Ix>(
     ours_diff: &Diff<E>,
     theirs_diff: &Diff<E>,
     resolutions: Resolutions,
+    edit_times: &EditTimes,
 ) -> MergeOutcome<N, E, Ix>
 where
     N: Clone + CaHash,
@@ -292,8 +345,35 @@ where
                 (_, false) => Fate::KeepOurs,
                 (false, true) => Fate::KeepTheirs,
                 (true, true) => {
-                    let kept = resolutions.both_modified;
-                    if content_addr(&ours[node_ix(o)]) != content_addr(&theirs[node_ix(t)]) {
+                    let o_ca = content_addr(&ours[node_ix(o)]);
+                    let t_ca = content_addr(&theirs[node_ix(t)]);
+                    let kept = match resolutions.both_modified {
+                        BothModified::KeepOurs => Side::Ours,
+                        BothModified::KeepTheirs => Side::Theirs,
+                        // Per-node last edit wins. Both orderings of the same
+                        // merge compare identical values (the time maps swap
+                        // sides but keep their entries, and the tie-break is
+                        // on content), so independent peers converge.
+                        BothModified::KeepNewest => {
+                            let ot = edit_times
+                                .ours
+                                .get(&b)
+                                .copied()
+                                .unwrap_or(edit_times.ours_tip);
+                            let tt = edit_times
+                                .theirs
+                                .get(&b)
+                                .copied()
+                                .unwrap_or(edit_times.theirs_tip);
+                            match (tt.cmp(&ot), t_ca > o_ca) {
+                                (std::cmp::Ordering::Greater, _) => Side::Theirs,
+                                (std::cmp::Ordering::Less, _) => Side::Ours,
+                                (std::cmp::Ordering::Equal, true) => Side::Theirs,
+                                (std::cmp::Ordering::Equal, false) => Side::Ours,
+                            }
+                        }
+                    };
+                    if o_ca != t_ca {
                         conflicts.push(Conflict::BothModified {
                             base: b,
                             ours: o,
@@ -622,7 +702,7 @@ mod tests {
         let ours = graph(&["a", "b2"], &[]);
         let theirs = graph(&["a", "b3"], &[]);
         let resolutions = Resolutions {
-            both_modified: Side::Theirs,
+            both_modified: BothModified::KeepTheirs,
             ..Default::default()
         };
         let (_, _, _, res) = merge_two_with(&base, &ours, &theirs, resolutions);
@@ -637,6 +717,55 @@ mod tests {
                 kept: Side::Theirs,
             }],
         );
+    }
+
+    /// Per-node last edit wins: ours edited node 0 at t=2 then node 1 at
+    /// t=5 (a newer *tip*), while theirs edited node 0 at t=3. Node 0's
+    /// conflict resolves to theirs - the side whose last edit to *that node*
+    /// is newer - even though ours' tip is newer overall.
+    #[test]
+    fn keep_newest_resolves_per_node_not_per_tip() {
+        let resolutions = Resolutions {
+            both_modified: BothModified::KeepNewest,
+            ..Default::default()
+        };
+        let mut reg = Registry::<G>::default();
+        let base = commit(&mut reg, 1, None, &graph(&["x", "y"], &[]));
+        let o1 = commit(&mut reg, 2, Some(base), &graph(&["x2", "y"], &[]));
+        let ours = commit(&mut reg, 5, Some(o1), &graph(&["x2", "y2"], &[]));
+        let theirs = commit(&mut reg, 3, Some(base), &graph(&["x3", "y"], &[]));
+        let out = diverged(merge_commits(&reg, ours, theirs, resolutions).unwrap());
+        assert_eq!(nodes(&out.graph), vec!["x3", "y2"]);
+        assert_eq!(
+            out.conflicts,
+            vec![Conflict::BothModified {
+                base: 0,
+                ours: 0,
+                theirs: 0,
+                kept: Side::Theirs,
+            }],
+        );
+    }
+
+    /// `KeepNewest` is symmetric: merging in either direction keeps the same
+    /// content, including on exact time ties (content-address tie-break), so
+    /// independent peers converge on the same merged graph.
+    #[test]
+    fn keep_newest_is_symmetric() {
+        let resolutions = Resolutions {
+            both_modified: BothModified::KeepNewest,
+            ..Default::default()
+        };
+        let mut reg = Registry::<G>::default();
+        let base = commit(&mut reg, 1, None, &graph(&["x"], &[]));
+        // Both sides edit the node at the same timestamp.
+        let a = commit(&mut reg, 2, Some(base), &graph(&["x-a"], &[]));
+        let b = commit(&mut reg, 2, Some(base), &graph(&["x-b"], &[]));
+        let ab = diverged(merge_commits(&reg, a, b, resolutions).unwrap());
+        let ba = diverged(merge_commits(&reg, b, a, resolutions).unwrap());
+        assert_eq!(graph_addr(&ab.graph), graph_addr(&ba.graph));
+        assert_eq!(ab.conflicts.len(), 1);
+        assert_eq!(ba.conflicts.len(), 1);
     }
 
     #[test]

--- a/crates/gantz_ca/src/registry.rs
+++ b/crates/gantz_ca/src/registry.rs
@@ -167,6 +167,28 @@ impl<G> Registry<G> {
         commit_graph_to_head(self, timestamp, graph_ca, graph, head)
     }
 
+    /// Commit the graph at the given address as a merge of `theirs` into the
+    /// current head commit, and update `head` to the new merge commit.
+    ///
+    /// The head's current commit becomes the first parent, `theirs` the merge
+    /// parent.
+    ///
+    /// Only calls `graph` if no graph exists within the registry for the given
+    /// address.
+    ///
+    /// NOTE: Assumes `graph_ca` is a correct address for the graph resulting
+    /// from `graph()`.
+    pub fn commit_merge_to_head(
+        &mut self,
+        timestamp: Timestamp,
+        graph_ca: GraphAddr,
+        graph: impl FnOnce() -> G,
+        theirs: CommitAddr,
+        head: &mut Head,
+    ) -> CommitAddr {
+        commit_merge_to_head(self, timestamp, graph_ca, graph, theirs, head)
+    }
+
     /// Insert the given name mapping into the registry.
     ///
     /// Returns the previous mapping if one exists.
@@ -177,10 +199,11 @@ impl<G> Registry<G> {
     /// Insert a commit, computing its address from the commit's contents.
     ///
     /// A commit must not reference a parent that is not in the registry, so a
-    /// parent that is absent is cleared to `None` *before* the address is
-    /// computed. Because the parent is part of the hashed content, the returned
-    /// address reflects the cleared parent: to preserve a chain's addresses,
-    /// insert its commits oldest-first so each parent is already present.
+    /// parent that is absent is cleared to `None` (and absent merge parents
+    /// are dropped) *before* the address is computed. Because parents are part
+    /// of the hashed content, the returned address reflects the cleared
+    /// parents: to preserve a chain's addresses, insert its commits
+    /// oldest-first so each parent is already present.
     ///
     /// Returns the computed [`CommitAddr`], which always matches the stored
     /// commit.
@@ -190,6 +213,9 @@ impl<G> Registry<G> {
                 commit.parent = None;
             }
         }
+        commit
+            .merge_parents
+            .retain(|p| self.commits.contains_key(p));
         let ca = commit_addr(&commit);
         self.commits.insert(ca, commit);
         ca
@@ -388,28 +414,55 @@ fn commit_graph_to_head<G>(
 ) -> CommitAddr {
     let parent_ca = *head_commit_ca(&reg.names, head).unwrap();
     let commit_ca = commit_graph(reg, timestamp, Some(parent_ca), graph_ca, graph);
+    point_head_at(reg, head, commit_ca);
+    commit_ca
+}
+
+/// Commit the given graph to the given head as a merge of `theirs` into the
+/// head's current commit.
+///
+/// If the graph doesn't exist, calls `graph()` to retrieve the graph for the
+/// registry.
+fn commit_merge_to_head<G>(
+    reg: &mut Registry<G>,
+    timestamp: Timestamp,
+    graph_ca: GraphAddr,
+    graph: impl FnOnce() -> G,
+    theirs: CommitAddr,
+    head: &mut Head,
+) -> CommitAddr {
+    let ours = *head_commit_ca(&reg.names, head).unwrap();
+    reg.graphs.entry(graph_ca).or_insert_with(graph);
+    let commit = Commit::new_merge(timestamp, ours, theirs, graph_ca);
+    let commit_ca = commit_addr(&commit);
+    reg.commits.insert(commit_ca, commit);
+    point_head_at(reg, head, commit_ca);
+    commit_ca
+}
+
+/// Point the head at the given commit: a branch head updates the name mapping,
+/// a detached head is reassigned directly.
+fn point_head_at<G>(reg: &mut Registry<G>, head: &mut Head, commit_ca: CommitAddr) {
     match *head {
         Head::Commit(ref mut ca) => *ca = commit_ca,
         Head::Branch(ref name) => {
             reg.names.insert(name.to_string(), commit_ca);
         }
     }
-    commit_ca
 }
 
 /// For all `parent` commits that are invalid (i.e. don't point to an existing
-/// commit), set them to `None`.
+/// commit), set them to `None`. Invalid merge parents are dropped likewise.
 fn detach_invalid_parents(commits: &mut Commits) {
-    let mut has_invalid_parent = HashSet::new();
-    for (&ca, commit) in commits.iter() {
-        if let Some(parent_ca) = commit.parent {
-            if !commits.contains_key(&parent_ca) {
-                has_invalid_parent.insert(ca);
-            }
+    let present: HashSet<CommitAddr> = commits.keys().copied().collect();
+    for commit in commits.values_mut() {
+        if commit
+            .parent
+            .is_some_and(|parent_ca| !present.contains(&parent_ca))
+        {
+            commit.parent = None;
         }
-    }
-    for ca in has_invalid_parent {
-        commits.get_mut(&ca).unwrap().parent = None;
+        commit.merge_parents.retain(|p| present.contains(p));
     }
 }
 
@@ -615,5 +668,73 @@ mod tests {
             graph_addr(2),
         ));
         assert_eq!(reg.commits()[&child].parent, Some(root));
+    }
+
+    #[test]
+    fn add_commit_drops_absent_merge_parents() {
+        let mut reg: Registry<String> =
+            Registry::new(HashMap::new(), HashMap::new(), BTreeMap::new());
+        let root = reg.add_commit(Commit::new(Duration::from_secs(1), None, graph_addr(1)));
+        let absent = commit_addr_raw(99);
+        let merge = reg.add_commit(Commit::new_merge(
+            Duration::from_secs(2),
+            root,
+            absent,
+            graph_addr(2),
+        ));
+        assert!(reg.commits()[&merge].merge_parents.is_empty());
+        // Its address is that of the equivalent non-merge commit.
+        let ordinary = Commit::new(Duration::from_secs(2), Some(root), graph_addr(2));
+        assert_eq!(merge, crate::commit_addr(&ordinary));
+    }
+
+    #[test]
+    fn commit_merge_to_head_mints_two_parent_commit_and_advances_head() {
+        let mut reg: Registry<String> = Registry::default();
+        let ours = reg.commit_graph_to_name(
+            Duration::from_secs(1),
+            graph_addr(1),
+            || "ours".to_string(),
+            "alpha",
+        );
+        let theirs = reg.commit_graph(Duration::from_secs(2), None, graph_addr(2), || {
+            "theirs".to_string()
+        });
+        let mut head = Head::Branch("alpha".to_string());
+        let merge = reg.commit_merge_to_head(
+            Duration::from_secs(3),
+            graph_addr(3),
+            || "merged".to_string(),
+            theirs,
+            &mut head,
+        );
+        let commit = &reg.commits()[&merge];
+        assert_eq!(commit.parent, Some(ours));
+        assert_eq!(commit.merge_parents, vec![theirs]);
+        assert_eq!(reg.names().get("alpha"), Some(&merge));
+        assert_eq!(reg.head_commit_ca(&head), Some(&merge));
+    }
+
+    #[test]
+    fn prune_unreachable_detaches_pruned_merge_parents() {
+        let mut reg: Registry<String> = Registry::default();
+        let ours = reg.commit_graph(Duration::from_secs(1), None, graph_addr(1), || {
+            "ours".to_string()
+        });
+        let theirs = reg.commit_graph(Duration::from_secs(2), None, graph_addr(2), || {
+            "theirs".to_string()
+        });
+        let mut head = Head::Commit(ours);
+        let merge = reg.commit_merge_to_head(
+            Duration::from_secs(3),
+            graph_addr(3),
+            || "merged".to_string(),
+            theirs,
+            &mut head,
+        );
+        // Prune theirs' side of history.
+        reg.prune_unreachable(&[ours, merge].into_iter().collect());
+        assert_eq!(reg.commits()[&merge].parent, Some(ours));
+        assert!(reg.commits()[&merge].merge_parents.is_empty());
     }
 }

--- a/crates/gantz_core/src/node/state.rs
+++ b/crates/gantz_core/src/node/state.rs
@@ -267,6 +267,46 @@ pub fn move_value(vm: &mut Engine, from: &[usize], to: &[usize]) -> Result<(), S
     Ok(())
 }
 
+/// Re-key the root graph's per-node state through `mapping` (old node index to
+/// new node index) in a single pass.
+///
+/// Each moved value carries its nested subtree with it. State for indices
+/// absent from the mapping is dropped. Unlike repeated [`move_value`] calls,
+/// an arbitrary permutation cannot collide with itself here. Used when a whole
+/// graph is rebuilt with a known node correspondence (e.g. merging a diverged
+/// branch). A no-op if `ROOT_STATE` hasn't been initialized.
+pub fn remap_root(
+    vm: &mut Engine,
+    mapping: &std::collections::BTreeMap<usize, usize>,
+) -> Result<(), SteelErr> {
+    let root_val = match vm.extract_value(ROOT_STATE) {
+        Ok(val) => val,
+        // No root state initialized yet, nothing to remap.
+        Err(_) => return Ok(()),
+    };
+    let SteelVal::HashMapV(root_state) = root_val else {
+        return Err(SteelErr::new(
+            ErrorKind::Generic,
+            "`ROOT_STATE` was not a hashmap".to_string(),
+        ));
+    };
+    let mut remapped = steel::HashMap::new();
+    for (key, val) in root_state.iter() {
+        let &SteelVal::IntV(old) = key else {
+            // Non-index keys shouldn't exist at the root; keep them as-is.
+            remapped = remapped.update(key.clone(), val.clone());
+            continue;
+        };
+        let old: usize = old.try_into().expect("node index out of range");
+        if let Some(&new) = mapping.get(&old) {
+            let new = new.try_into().expect("node index out of range");
+            remapped = remapped.update(SteelVal::IntV(new), val.clone());
+        }
+    }
+    vm.update_value(ROOT_STATE, SteelVal::HashMapV(Gc::new(remapped).into()));
+    Ok(())
+}
+
 /// Extract the value for the node with the given ID.
 pub fn extract_value(vm: &Engine, node_path: &[usize]) -> Result<Option<SteelVal>, SteelErr> {
     let SteelVal::HashMapV(root_state) = vm.extract_value(ROOT_STATE)? else {

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -251,6 +251,18 @@ impl gantz_egui::Registry for Environment {
             .and_then(|n| n.description())
             .map(Cow::Borrowed)
     }
+
+    fn merge_candidates(&self, ours: &gantz_ca::Head) -> Vec<gantz_egui::merge::MergeCandidate> {
+        gantz_egui::merge::merge_candidates(&self.registry, ours)
+    }
+
+    fn merge_preview(
+        &self,
+        ours: &gantz_ca::Head,
+        source: &str,
+    ) -> Option<gantz_egui::merge::MergePreview> {
+        gantz_egui::merge::merge_preview(&self.registry, ours, source)
+    }
 }
 
 /// The set of all known node types accessible to gantz.
@@ -1248,6 +1260,57 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
             let vm = &mut state.vms[ix];
             let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
             gantz_core::graph::register(&get_node, &*graph, &[], vm);
+        }
+    }
+
+    for (
+        head,
+        gantz_egui::MergeHead {
+            source,
+            auto_resolve,
+        },
+    ) in responses.take()
+    {
+        let Some((head, ix)) = tagged_head(state, head) else {
+            continue;
+        };
+        let outcome = {
+            let head_state = state.gantz.open_heads.entry(head.clone()).or_default();
+            let (h, graph, view) = &mut state.heads[ix];
+            gantz_egui::ops::merge_head(
+                &mut state.env.registry,
+                &HashMap::new(),
+                timestamp(),
+                h,
+                graph,
+                &mut state.vms[ix],
+                view,
+                &mut head_state.scene.interaction.selection,
+                &source,
+                auto_resolve,
+            )
+        };
+        match outcome {
+            gantz_egui::ops::MergeHeadOutcome::FastForward(target) => {
+                navigate_head(ctx, state, &head, target);
+            }
+            gantz_egui::ops::MergeHeadOutcome::Merged { .. } => {
+                // The op already committed (with both parents), so the commit
+                // loop sees a clean graph; do its bookkeeping here: clear the
+                // redo stack, recompile (this also re-registers, initializing
+                // merged-in nodes' state), and bring referrers up to date.
+                state.gantz.migrate_head(&head, &head, true);
+                recompile_heads(state);
+                resync_and_refresh(state);
+            }
+            gantz_egui::ops::MergeHeadOutcome::Refused(reasons) => {
+                // Defensive: the UI disables conflicted/blocked candidates.
+                log::warn!(
+                    "MergeHead: refused to merge '{source}': {}",
+                    reasons.join("; ")
+                );
+            }
+            gantz_egui::ops::MergeHeadOutcome::Noop => (),
         }
     }
 

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -260,8 +260,9 @@ impl gantz_egui::Registry for Environment {
         &self,
         ours: &gantz_ca::Head,
         source: &str,
+        resolutions: gantz_ca::Resolutions,
     ) -> Option<gantz_egui::merge::MergePreview> {
-        gantz_egui::merge::merge_preview(&self.registry, ours, source)
+        gantz_egui::merge::merge_preview(&self.registry, ours, source, resolutions)
     }
 }
 
@@ -1267,6 +1268,7 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
         head,
         gantz_egui::MergeHead {
             source,
+            resolutions,
             auto_resolve,
         },
     ) in responses.take()
@@ -1287,6 +1289,7 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
                 view,
                 &mut head_state.scene.interaction.selection,
                 &source,
+                resolutions,
                 auto_resolve,
             )
         };

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -14,6 +14,7 @@ pub mod export;
 pub mod format;
 mod impls;
 pub mod keybind;
+pub mod merge;
 pub mod node;
 pub mod ops;
 pub mod reg;
@@ -129,6 +130,24 @@ pub trait Registry: NameRegistry + FnNodeNames + NodeTypeRegistry + GraphRegistr
     /// (it derives no input/output docs); the default has none.
     fn node_description(&self, name: &str) -> Option<Cow<'static, str>> {
         let _ = name;
+        None
+    }
+
+    /// The named graphs that can be merged into `ours` (see
+    /// [`merge::merge_candidates`]).
+    ///
+    /// Drives the graph config pane's merge row. The default has none (hiding
+    /// the row's candidates); the standard [`RegistryRef`] impl queries the
+    /// content-addressed registry.
+    fn merge_candidates(&self, ours: &gantz_ca::Head) -> Vec<merge::MergeCandidate> {
+        let _ = ours;
+        vec![]
+    }
+
+    /// Dry-run the merge of the branch named `source` into `ours` (see
+    /// [`merge::merge_preview`]), for hover previews in the merge row.
+    fn merge_preview(&self, ours: &gantz_ca::Head, source: &str) -> Option<merge::MergePreview> {
+        let _ = (ours, source);
         None
     }
 }
@@ -614,6 +633,18 @@ pub struct ReplaceHead(pub gantz_ca::Head);
 pub struct Paste {
     pub text: Option<String>,
     pub pos: PastePos,
+}
+
+/// Merge the named source branch into the emitting head (see
+/// [`ops::merge_head`]).
+#[derive(Clone, Debug)]
+pub struct MergeHead {
+    /// The name of the branch to merge in.
+    pub source: String,
+    /// Merge despite conflicts, applying the default resolutions (see
+    /// [`gantz_ca::merge::Conflict`]). Hard blockers (e.g. reference cycles)
+    /// still refuse the merge.
+    pub auto_resolve: bool,
 }
 
 /// Redo a previously undone edit (move head forward).

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -144,10 +144,16 @@ pub trait Registry: NameRegistry + FnNodeNames + NodeTypeRegistry + GraphRegistr
         vec![]
     }
 
-    /// Dry-run the merge of the branch named `source` into `ours` (see
-    /// [`merge::merge_preview`]), for hover previews in the merge row.
-    fn merge_preview(&self, ours: &gantz_ca::Head, source: &str) -> Option<merge::MergePreview> {
-        let _ = (ours, source);
+    /// Dry-run the merge of the branch named `source` into `ours` under the
+    /// given conflict resolutions (see [`merge::merge_preview`]), for hover
+    /// previews in the merge row.
+    fn merge_preview(
+        &self,
+        ours: &gantz_ca::Head,
+        source: &str,
+        resolutions: gantz_ca::Resolutions,
+    ) -> Option<merge::MergePreview> {
+        let _ = (ours, source, resolutions);
         None
     }
 }
@@ -641,7 +647,9 @@ pub struct Paste {
 pub struct MergeHead {
     /// The name of the branch to merge in.
     pub source: String,
-    /// Merge despite conflicts, applying the default resolutions (see
+    /// How conflicts resolve when the merge proceeds despite them.
+    pub resolutions: gantz_ca::Resolutions,
+    /// Merge despite conflicts, applying `resolutions` (see
     /// [`gantz_ca::merge::Conflict`]). Hard blockers (e.g. reference cycles)
     /// still refuse the merge.
     pub auto_resolve: bool,

--- a/crates/gantz_egui/src/merge.rs
+++ b/crates/gantz_egui/src/merge.rs
@@ -1,0 +1,183 @@
+//! Merge-candidate detection and dry-run previews for the graph config pane.
+//!
+//! The core three-way merge lives in [`gantz_ca::merge`]; this module wraps it
+//! with the GUI-facing queries: which named graphs *can* be merged into the
+//! current head ([`merge_candidates`]), and what a given merge would do
+//! ([`merge_preview`]). Both are pure reads, so the config pane can call them
+//! while rendering; the mutating op is [`crate::ops::merge_head`].
+
+use crate::sync::AsNamedRef;
+use gantz_ca as ca;
+use gantz_core::node::graph::Graph;
+
+/// A named graph that can be merged into the current head.
+#[derive(Clone, Debug)]
+pub struct MergeCandidate {
+    /// The source branch name.
+    pub name: String,
+    /// The source branch's tip commit.
+    pub theirs: ca::CommitAddr,
+    /// The merge base shared with the current head's tip.
+    pub base: ca::CommitAddr,
+    /// The current head has no changes since the base: merging just moves the
+    /// head to `theirs`, with no merge commit.
+    pub fast_forward: bool,
+}
+
+/// A dry-run summary of merging one candidate, for hover previews.
+///
+/// Cached by the config pane in egui temp memory keyed by the two tips, which
+/// are content addresses - a pair's preview can never go stale.
+#[derive(Clone, Debug)]
+pub struct MergePreview {
+    /// The changes the merge would bring in (the source branch's changes
+    /// relative to the merge base; for a fast-forward, relative to ours' tip).
+    pub summary: ca::DiffSummary,
+    /// Conflicts, rendered for display. Merging despite these applies the
+    /// default resolutions (see [`gantz_ca::merge::Conflict`]).
+    pub conflicts: Vec<String>,
+    /// Hard blockers, rendered for display: problems (e.g. reference cycles)
+    /// that prevent the merge entirely.
+    pub blockers: Vec<String>,
+}
+
+impl MergePreview {
+    /// Whether the merge can proceed as-is (no conflicts, no blockers).
+    pub fn is_clean(&self) -> bool {
+        self.conflicts.is_empty() && self.blockers.is_empty()
+    }
+}
+
+/// The named graphs that can be merged into `ours`: those whose tip shares an
+/// ancestor with ours' tip and has changes ours lacks.
+///
+/// Skips ours' own name and nested (`parent:child`) graphs. Candidates are
+/// ordered by name (the registry's name order).
+pub fn merge_candidates<N>(reg: &ca::Registry<Graph<N>>, ours: &ca::Head) -> Vec<MergeCandidate> {
+    let Some(&ours_tip) = reg.head_commit_ca(ours) else {
+        return vec![];
+    };
+    let our_name = match ours {
+        ca::Head::Branch(name) => Some(name.as_str()),
+        ca::Head::Commit(_) => None,
+    };
+    let commits = reg.commits();
+    reg.names()
+        .iter()
+        .filter(|(name, _)| Some(name.as_str()) != our_name)
+        .filter(|(name, _)| !name.contains(crate::node::NESTED_SEP))
+        .filter_map(|(name, &theirs)| {
+            let (base, fast_forward) = match ca::analyze(commits, ours_tip, theirs) {
+                ca::MergeAnalysis::Diverged(base) => (base, false),
+                ca::MergeAnalysis::FastForward => (ours_tip, true),
+                ca::MergeAnalysis::AlreadyUpToDate | ca::MergeAnalysis::Unrelated => return None,
+            };
+            Some(MergeCandidate {
+                name: name.clone(),
+                theirs,
+                base,
+                fast_forward,
+            })
+        })
+        .collect()
+}
+
+/// Dry-run the merge of the branch named `source` into `ours` (see
+/// [`gantz_ca::merge_commits`]).
+///
+/// Returns `None` when there is nothing to merge (unknown source, unrelated or
+/// already-up-to-date histories, or missing registry data).
+pub fn merge_preview<N>(
+    reg: &ca::Registry<Graph<N>>,
+    ours: &ca::Head,
+    source: &str,
+) -> Option<MergePreview>
+where
+    N: Clone + ca::CaHash + AsNamedRef,
+{
+    let ours_tip = *reg.head_commit_ca(ours)?;
+    let theirs_tip = *reg.names().get(source)?;
+    match ca::merge_commits(reg, ours_tip, theirs_tip).ok()? {
+        ca::MergeResolution::Diverged {
+            theirs_diff,
+            outcome,
+            ..
+        } => Some(MergePreview {
+            summary: theirs_diff.summary(),
+            conflicts: conflict_strings(&outcome.conflicts),
+            blockers: merge_blockers(reg, ours, &outcome.graph),
+        }),
+        // A fast-forward brings in exactly theirs' changes since ours' tip.
+        ca::MergeResolution::FastForward => {
+            let matching = ca::diff::matching(reg, ours_tip, theirs_tip)?;
+            let ours_g = reg.commit_graph_ref(&ours_tip)?;
+            let theirs_g = reg.commit_graph_ref(&theirs_tip)?;
+            let diff = ca::diff::diff(ours_g, theirs_g, &matching);
+            Some(MergePreview {
+                summary: diff.summary(),
+                conflicts: vec![],
+                blockers: merge_blockers(reg, ours, theirs_g),
+            })
+        }
+        ca::MergeResolution::AlreadyUpToDate => None,
+    }
+}
+
+/// Render merge conflicts for display, phrased from the current head's
+/// perspective ("here" = ours, "the branch" = theirs).
+pub fn conflict_strings(conflicts: &[ca::Conflict<gantz_core::Edge>]) -> Vec<String> {
+    conflicts
+        .iter()
+        .map(|conflict| match conflict {
+            ca::Conflict::BothModified { ours, .. } => {
+                format!("node {ours}: modified on both sides (keeps this graph's version)")
+            }
+            ca::Conflict::DeleteModify {
+                modified: ca::Side::Ours,
+                ..
+            } => "a node modified here was deleted in the branch (kept)".to_string(),
+            ca::Conflict::DeleteModify {
+                modified: ca::Side::Theirs,
+                ..
+            } => "a node deleted here was modified in the branch (kept)".to_string(),
+            ca::Conflict::EdgeToDeleted {
+                side: ca::Side::Ours,
+                src,
+                dst,
+                ..
+            } => format!("edge {src}\u{2192}{dst} targets a node deleted in the branch (dropped)"),
+            ca::Conflict::EdgeToDeleted {
+                side: ca::Side::Theirs,
+                src,
+                dst,
+                ..
+            } => format!("branch edge {src}\u{2192}{dst} targets a node deleted here (dropped)"),
+        })
+        .collect()
+}
+
+/// Hard blockers preventing a merge of `merged` into `ours` entirely,
+/// regardless of conflict resolution.
+///
+/// Currently one class: a merged-in [`crate::node::NamedRef`] that would form
+/// a reference cycle back to the edited graph (mirroring the guard in
+/// [`crate::ops::paste`]; with sync enabled such a cycle recommits endlessly).
+pub fn merge_blockers<N>(
+    reg: &ca::Registry<Graph<N>>,
+    ours: &ca::Head,
+    merged: &Graph<N>,
+) -> Vec<String>
+where
+    N: AsNamedRef,
+{
+    let ca::Head::Branch(editing) = ours else {
+        // A nameless (detached commit) head can't be a name-based cycle target.
+        return vec![];
+    };
+    merged
+        .node_weights()
+        .filter_map(|n| n.as_named_ref())
+        .filter(|nr| crate::cycle::would_cycle(reg, nr.name(), editing))
+        .map(|nr| format!("'{}' would create a reference cycle", nr.name()))
+        .collect()
+}

--- a/crates/gantz_egui/src/merge.rs
+++ b/crates/gantz_egui/src/merge.rs
@@ -123,6 +123,37 @@ where
     }
 }
 
+/// Render a [`ca::DiffSummary`] as a compact one-line change summary, e.g.
+/// `"+2 nodes  -1 node  ~1 modified  +3/-1 edges"`.
+pub fn summary_text(s: &ca::DiffSummary) -> String {
+    let plural = |n: usize| if n == 1 { "" } else { "s" };
+    let mut parts = Vec::new();
+    if s.nodes_added > 0 {
+        parts.push(format!("+{} node{}", s.nodes_added, plural(s.nodes_added)));
+    }
+    if s.nodes_removed > 0 {
+        parts.push(format!(
+            "-{} node{}",
+            s.nodes_removed,
+            plural(s.nodes_removed)
+        ));
+    }
+    if s.nodes_modified > 0 {
+        parts.push(format!("~{} modified", s.nodes_modified));
+    }
+    match (s.edges_added, s.edges_removed) {
+        (0, 0) => (),
+        (a, 0) => parts.push(format!("+{a} edge{}", plural(a))),
+        (0, r) => parts.push(format!("-{r} edge{}", plural(r))),
+        (a, r) => parts.push(format!("+{a}/-{r} edges")),
+    }
+    if parts.is_empty() {
+        "no structural changes".to_string()
+    } else {
+        parts.join("  ")
+    }
+}
+
 /// Render merge conflicts for display, phrased from the current head's
 /// perspective ("here" = ours, "the branch" = theirs).
 pub fn conflict_strings(conflicts: &[ca::Conflict<gantz_core::Edge>]) -> Vec<String> {

--- a/crates/gantz_egui/src/merge.rs
+++ b/crates/gantz_egui/src/merge.rs
@@ -91,13 +91,14 @@ pub fn merge_preview<N>(
     reg: &ca::Registry<Graph<N>>,
     ours: &ca::Head,
     source: &str,
+    resolutions: ca::Resolutions,
 ) -> Option<MergePreview>
 where
     N: Clone + ca::CaHash + AsNamedRef,
 {
     let ours_tip = *reg.head_commit_ca(ours)?;
     let theirs_tip = *reg.names().get(source)?;
-    match ca::merge_commits(reg, ours_tip, theirs_tip).ok()? {
+    match ca::merge_commits(reg, ours_tip, theirs_tip, resolutions).ok()? {
         ca::MergeResolution::Diverged {
             theirs_diff,
             outcome,
@@ -155,22 +156,27 @@ pub fn summary_text(s: &ca::DiffSummary) -> String {
 }
 
 /// Render merge conflicts for display, phrased from the current head's
-/// perspective ("here" = ours, "the branch" = theirs).
+/// perspective ("here" = ours, "the branch" = theirs). Each line names the
+/// resolution the merge applied (per the selected [`ca::Resolutions`]).
 pub fn conflict_strings(conflicts: &[ca::Conflict<gantz_core::Edge>]) -> Vec<String> {
     conflicts
         .iter()
         .map(|conflict| match conflict {
-            ca::Conflict::BothModified { ours, .. } => {
-                format!("node {ours}: modified on both sides (keeps this graph's version)")
+            ca::Conflict::BothModified { ours, kept, .. } => {
+                let kept = match kept {
+                    ca::Side::Ours => "keeps this graph's version",
+                    ca::Side::Theirs => "keeps the branch's version",
+                };
+                format!("node {ours}: modified on both sides ({kept})")
             }
-            ca::Conflict::DeleteModify {
-                modified: ca::Side::Ours,
-                ..
-            } => "a node modified here was deleted in the branch (kept)".to_string(),
-            ca::Conflict::DeleteModify {
-                modified: ca::Side::Theirs,
-                ..
-            } => "a node deleted here was modified in the branch (kept)".to_string(),
+            &ca::Conflict::DeleteModify { modified, kept, .. } => {
+                let what = match modified {
+                    ca::Side::Ours => "a node modified here was deleted in the branch",
+                    ca::Side::Theirs => "a node deleted here was modified in the branch",
+                };
+                let kept = if kept { "kept" } else { "stays deleted" };
+                format!("{what} ({kept})")
+            }
             ca::Conflict::EdgeToDeleted {
                 side: ca::Side::Ours,
                 src,

--- a/crates/gantz_egui/src/ops.rs
+++ b/crates/gantz_egui/src/ops.rs
@@ -562,8 +562,8 @@ pub enum MergeHeadOutcome {
 /// parents via [`gantz_ca::Registry::commit_merge_to_head`] - upholding the
 /// committed-working-graph invariant, so callers must not commit again.
 ///
-/// Conflicts refuse the merge unless `auto_resolve` accepts the default
-/// resolutions; hard blockers (a merged-in reference cycle) always refuse.
+/// Conflicts refuse the merge unless `auto_resolve` accepts the given
+/// `resolutions`; hard blockers (a merged-in reference cycle) always refuse.
 /// Fast-forwards mutate nothing - the caller navigates the head instead.
 #[allow(clippy::too_many_arguments)]
 pub fn merge_head<N>(
@@ -576,6 +576,7 @@ pub fn merge_head<N>(
     head_view: &mut crate::SceneView,
     selection: &mut crate::widget::graph_scene::Selection,
     source: &str,
+    resolutions: gantz_ca::Resolutions,
     auto_resolve: bool,
 ) -> MergeHeadOutcome
 where
@@ -590,7 +591,7 @@ where
         log::error!("MergeHead: unknown source branch '{source}'");
         return MergeHeadOutcome::Noop;
     };
-    let outcome = match gantz_ca::merge_commits(registry, ours_tip, theirs_tip) {
+    let outcome = match gantz_ca::merge_commits(registry, ours_tip, theirs_tip, resolutions) {
         Err(e) => {
             log::warn!("MergeHead: cannot merge '{source}': {e}");
             return MergeHeadOutcome::Noop;
@@ -603,7 +604,7 @@ where
     };
 
     // Refuse on hard blockers, and on conflicts unless the caller opted into
-    // the default resolutions.
+    // the selected resolutions.
     let blockers = crate::merge::merge_blockers(registry, head, &outcome.graph);
     if !blockers.is_empty() {
         return MergeHeadOutcome::Refused(blockers);
@@ -834,6 +835,7 @@ mod tests {
             view,
             selection,
             "beta",
+            gantz_ca::Resolutions::default(),
             auto_resolve,
         )
     }

--- a/crates/gantz_egui/src/ops.rs
+++ b/crates/gantz_egui/src/ops.rs
@@ -526,6 +526,152 @@ pub fn redo(
     redo_stacks.get_mut(head)?.pop()
 }
 
+/// The result of a [`merge_head`] call.
+#[derive(Debug)]
+pub enum MergeHeadOutcome {
+    /// Ours had no changes since the merge base: nothing was mutated and no
+    /// commit was made. The caller navigates the head to this commit, which
+    /// reloads the working graph and views.
+    FastForward(CommitAddr),
+    /// The merge was applied to the working graph and committed with two
+    /// parents; `head` has been advanced. `mapping` records where each of the
+    /// pre-merge graph's nodes ended up (old index to new index; absent =
+    /// removed), for any remaining index-keyed data of the caller's. The
+    /// caller re-registers the graph with the VM (merged-in nodes need their
+    /// state initialized) and fires its committed/resync machinery.
+    Merged {
+        new_commit: CommitAddr,
+        mapping: gantz_ca::Matching,
+    },
+    /// Conflicts (without `auto_resolve`) or hard blockers refused the merge;
+    /// nothing was mutated. Carries the rendered reasons.
+    Refused(Vec<String>),
+    /// Nothing to do: unknown source, unrelated histories, or already up to
+    /// date.
+    Noop,
+}
+
+/// Merge the branch named `source` into `head`, applying the result to the
+/// head's working `graph` in place (see [`gantz_ca::merge_commits`]).
+///
+/// On a true merge this migrates the index-keyed VM state, layout and
+/// selection through the merged graph's node mapping (an identity mapping
+/// whenever the source branch removed no nodes), seeds layout for merged-in
+/// nodes from the source branch's persisted view in `all_views` (falling back
+/// to placement near the view centre), and commits the result with two
+/// parents via [`gantz_ca::Registry::commit_merge_to_head`] - upholding the
+/// committed-working-graph invariant, so callers must not commit again.
+///
+/// Conflicts refuse the merge unless `auto_resolve` accepts the default
+/// resolutions; hard blockers (a merged-in reference cycle) always refuse.
+/// Fast-forwards mutate nothing - the caller navigates the head instead.
+#[allow(clippy::too_many_arguments)]
+pub fn merge_head<N>(
+    registry: &mut gantz_ca::Registry<Graph<N>>,
+    all_views: &HashMap<CommitAddr, crate::SceneView>,
+    timestamp: gantz_ca::Timestamp,
+    head: &mut gantz_ca::Head,
+    graph: &mut Graph<N>,
+    vm: &mut Engine,
+    head_view: &mut crate::SceneView,
+    selection: &mut crate::widget::graph_scene::Selection,
+    source: &str,
+    auto_resolve: bool,
+) -> MergeHeadOutcome
+where
+    N: Clone + CaHash + AsNamedRef,
+{
+    let node_id = |ix: usize| egui_graph::NodeId::from_u64(ix as u64);
+    let Some(&ours_tip) = registry.head_commit_ca(head) else {
+        log::error!("MergeHead: no commit for head {head}");
+        return MergeHeadOutcome::Noop;
+    };
+    let Some(&theirs_tip) = registry.names().get(source) else {
+        log::error!("MergeHead: unknown source branch '{source}'");
+        return MergeHeadOutcome::Noop;
+    };
+    let outcome = match gantz_ca::merge_commits(registry, ours_tip, theirs_tip) {
+        Err(e) => {
+            log::warn!("MergeHead: cannot merge '{source}': {e}");
+            return MergeHeadOutcome::Noop;
+        }
+        Ok(gantz_ca::MergeResolution::AlreadyUpToDate) => return MergeHeadOutcome::Noop,
+        Ok(gantz_ca::MergeResolution::FastForward) => {
+            return MergeHeadOutcome::FastForward(theirs_tip);
+        }
+        Ok(gantz_ca::MergeResolution::Diverged { outcome, .. }) => outcome,
+    };
+
+    // Refuse on hard blockers, and on conflicts unless the caller opted into
+    // the default resolutions.
+    let blockers = crate::merge::merge_blockers(registry, head, &outcome.graph);
+    if !blockers.is_empty() {
+        return MergeHeadOutcome::Refused(blockers);
+    }
+    if !outcome.conflicts.is_empty() && !auto_resolve {
+        return MergeHeadOutcome::Refused(crate::merge::conflict_strings(&outcome.conflicts));
+    }
+
+    // Where each pre-merge (ours) node ended up, and where each source
+    // (theirs) node ended up. By the committed-working-graph invariant the
+    // working graph *is* ours' tip graph, so "ours" indices are the working
+    // graph's.
+    let mut ours_map = gantz_ca::Matching::new();
+    let mut theirs_only = Vec::new();
+    for (m, src) in outcome.node_srcs.iter().enumerate() {
+        match (src.ours, src.theirs) {
+            (Some(o), _) => {
+                ours_map.insert(o, m);
+            }
+            (None, Some(t)) => theirs_only.push((m, t)),
+            (None, None) => unreachable!("a merged node comes from somewhere"),
+        }
+    }
+
+    // Migrate the index-keyed VM state, layout and selection. When the source
+    // branch removed no nodes the mapping is identity and this is a no-op.
+    if let Err(e) = node::state::remap_root(vm, &ours_map) {
+        log::error!("MergeHead: failed to remap node state: {e}");
+    }
+    let old_layout = std::mem::take(&mut head_view.layout);
+    for (&o, &m) in &ours_map {
+        if let Some(pos) = old_layout.get(&node_id(o)) {
+            head_view.layout.insert(node_id(m), *pos);
+        }
+    }
+    selection.nodes = selection
+        .nodes
+        .iter()
+        .filter_map(|n| ours_map.get(&n.index()).map(|&m| NodeIndex::new(m)))
+        .collect();
+    selection.edges.clear();
+
+    // Seed layout for merged-in nodes from the source branch's persisted view
+    // (positions are compatible: both branches share the base's coordinates),
+    // falling back to placement near the view centre.
+    let theirs_view = all_views.get(&theirs_tip);
+    for (i, &(m, t)) in theirs_only.iter().enumerate() {
+        let pos = theirs_view
+            .and_then(|v| v.layout.get(&node_id(t)).copied())
+            .unwrap_or_else(|| head_view.camera.center + egui::vec2(20.0, 20.0) * i as f32);
+        head_view.layout.insert(node_id(m), pos);
+    }
+
+    // Swap in the merged graph and commit it with both parents.
+    *graph = outcome.graph;
+    let new_commit = registry.commit_merge_to_head(
+        timestamp,
+        gantz_ca::graph_addr(&*graph),
+        || graph.clone(),
+        theirs_tip,
+        head,
+    );
+    MergeHeadOutcome::Merged {
+        new_commit,
+        mapping: ours_map,
+    }
+}
+
 /// Commit the current layout as a new commit on the head's *existing* graph
 /// when node positions have changed since the head commit's frozen baseline
 /// view, advancing `head` to the new commit.
@@ -566,7 +712,9 @@ pub fn commit_layout<G>(
 mod tests {
     use super::*;
     use crate::widget::graph_scene::Selection;
+    use gantz_core::ROOT_STATE;
     use gantz_core::node::graph::NodeIx;
+    use steel::SteelVal;
 
     // Deleting a node swap-removes the former-last node into its slot; the
     // swapped node's layout entry and selection must follow it to the new index.
@@ -616,5 +764,247 @@ mod tests {
             selection.nodes.iter().copied().collect::<Vec<_>>(),
             vec![NodeIx::new(1)],
         );
+    }
+
+    /// A minimal node type satisfying [`merge_head`]'s bounds.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct TestNode(u32);
+
+    impl CaHash for TestNode {
+        fn hash(&self, hasher: &mut gantz_ca::Hasher) {
+            CaHash::hash(&self.0, hasher);
+        }
+    }
+
+    impl AsNamedRef for TestNode {
+        fn as_named_ref(&self) -> Option<&NamedRef> {
+            None
+        }
+    }
+
+    fn test_graph(nodes: &[u32]) -> Graph<TestNode> {
+        let mut g = Graph::default();
+        for &n in nodes {
+            g.add_node(TestNode(n));
+        }
+        g
+    }
+
+    fn node_id(ix: usize) -> egui_graph::NodeId {
+        egui_graph::NodeId::from_u64(ix as u64)
+    }
+
+    /// A registry where the branch `alpha` (returned as the head) and the
+    /// branch `beta` diverge from a shared base.
+    fn diverged_registry(
+        base: &[u32],
+        ours: &[u32],
+        theirs: &[u32],
+    ) -> (gantz_ca::Registry<Graph<TestNode>>, gantz_ca::Head) {
+        let secs = |s| std::time::Duration::from_secs(s);
+        let mut reg = gantz_ca::Registry::default();
+        let g = test_graph(base);
+        let base_ca = reg.commit_graph(secs(1), None, gantz_ca::graph_addr(&g), || g);
+        let g = test_graph(ours);
+        let ours_ca = reg.commit_graph(secs(2), Some(base_ca), gantz_ca::graph_addr(&g), || g);
+        let g = test_graph(theirs);
+        let theirs_ca = reg.commit_graph(secs(3), Some(base_ca), gantz_ca::graph_addr(&g), || g);
+        reg.insert_name("alpha".to_string(), ours_ca);
+        reg.insert_name("beta".to_string(), theirs_ca);
+        (reg, gantz_ca::Head::Branch("alpha".to_string()))
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn run_merge(
+        reg: &mut gantz_ca::Registry<Graph<TestNode>>,
+        head: &mut gantz_ca::Head,
+        graph: &mut Graph<TestNode>,
+        vm: &mut Engine,
+        view: &mut crate::SceneView,
+        selection: &mut Selection,
+        auto_resolve: bool,
+    ) -> MergeHeadOutcome {
+        merge_head(
+            reg,
+            &HashMap::new(),
+            std::time::Duration::from_secs(9),
+            head,
+            graph,
+            vm,
+            view,
+            selection,
+            "beta",
+            auto_resolve,
+        )
+    }
+
+    // Ours edited a node while theirs added one: the merge keeps ours' indices
+    // (identity mapping), applies theirs' addition, and commits two parents.
+    #[test]
+    fn merge_head_applies_theirs_and_commits_two_parents() {
+        let (mut reg, mut head) = diverged_registry(&[1, 2], &[1, 20], &[1, 2, 3]);
+        let ours_tip = *reg.head_commit_ca(&head).unwrap();
+        let theirs_tip = reg.names()["beta"];
+        let mut graph = test_graph(&[1, 20]);
+        let mut vm = Engine::new_base();
+        let mut view = crate::SceneView::default();
+        view.layout.insert(node_id(0), egui::pos2(0.0, 0.0));
+        view.layout.insert(node_id(1), egui::pos2(1.0, 0.0));
+        let mut selection = Selection::default();
+        selection.nodes.insert(NodeIx::new(1));
+
+        let outcome = run_merge(
+            &mut reg,
+            &mut head,
+            &mut graph,
+            &mut vm,
+            &mut view,
+            &mut selection,
+            false,
+        );
+        let MergeHeadOutcome::Merged { new_commit, .. } = outcome else {
+            panic!("expected Merged, got {outcome:?}");
+        };
+
+        // The merged graph keeps ours' nodes in place and appends theirs' add.
+        let weights: Vec<u32> = graph.node_weights().map(|n| n.0).collect();
+        assert_eq!(weights, vec![1, 20, 3]);
+        // Ours' layout and selection are untouched; the merged-in node has a
+        // (fallback) layout entry.
+        assert_eq!(view.layout.get(&node_id(1)), Some(&egui::pos2(1.0, 0.0)));
+        assert!(view.layout.contains_key(&node_id(2)));
+        assert!(selection.nodes.contains(&NodeIx::new(1)));
+        // The commit joins both parents and the head advanced to it.
+        let commit = &reg.commits()[&new_commit];
+        assert_eq!(commit.parent, Some(ours_tip));
+        assert_eq!(commit.merge_parents, vec![theirs_tip]);
+        assert_eq!(reg.head_commit_ca(&head), Some(&new_commit));
+    }
+
+    // Theirs removed a node: ours' surviving state/layout/selection migrate
+    // through the returned mapping.
+    #[test]
+    fn merge_head_migrates_state_layout_selection_on_removal() {
+        let (mut reg, mut head) = diverged_registry(&[1, 2], &[1, 2], &[2]);
+        let mut graph = test_graph(&[1, 2]);
+        let mut vm = Engine::new_base();
+        vm.register_value(ROOT_STATE, SteelVal::empty_hashmap());
+        node::state::update_value(&mut vm, &[1], SteelVal::IntV(42)).unwrap();
+        let mut view = crate::SceneView::default();
+        view.layout.insert(node_id(0), egui::pos2(0.0, 0.0));
+        view.layout.insert(node_id(1), egui::pos2(1.0, 0.0));
+        let mut selection = Selection::default();
+        selection.nodes.insert(NodeIx::new(1));
+
+        let outcome = run_merge(
+            &mut reg,
+            &mut head,
+            &mut graph,
+            &mut vm,
+            &mut view,
+            &mut selection,
+            false,
+        );
+        let MergeHeadOutcome::Merged { mapping, .. } = outcome else {
+            panic!("expected Merged, got {outcome:?}");
+        };
+
+        // Node 2 (ours ix 1) survives at merged ix 0.
+        assert_eq!(mapping, gantz_ca::Matching::from([(1, 0)]));
+        let weights: Vec<u32> = graph.node_weights().map(|n| n.0).collect();
+        assert_eq!(weights, vec![2]);
+        // Its state, layout and selection followed.
+        let state = node::state::extract_value(&vm, &[0]).unwrap();
+        assert_eq!(state, Some(SteelVal::IntV(42)));
+        assert_eq!(view.layout.len(), 1);
+        assert_eq!(view.layout.get(&node_id(0)), Some(&egui::pos2(1.0, 0.0)));
+        assert_eq!(
+            selection.nodes.iter().copied().collect::<Vec<_>>(),
+            vec![NodeIx::new(0)],
+        );
+    }
+
+    // Conflicting edits refuse the merge (mutating nothing) unless the caller
+    // opts into the default resolutions.
+    #[test]
+    fn merge_head_refuses_conflicts_unless_auto_resolve() {
+        let (mut reg, mut head) = diverged_registry(&[1, 2], &[1, 20], &[1, 30]);
+        let ours_tip = *reg.head_commit_ca(&head).unwrap();
+        let mut graph = test_graph(&[1, 20]);
+        let mut vm = Engine::new_base();
+        let mut view = crate::SceneView::default();
+        let mut selection = Selection::default();
+
+        let outcome = run_merge(
+            &mut reg,
+            &mut head,
+            &mut graph,
+            &mut vm,
+            &mut view,
+            &mut selection,
+            false,
+        );
+        let MergeHeadOutcome::Refused(reasons) = outcome else {
+            panic!("expected Refused, got {outcome:?}");
+        };
+        assert!(!reasons.is_empty());
+        // Nothing moved.
+        assert_eq!(reg.head_commit_ca(&head), Some(&ours_tip));
+        assert_eq!(
+            graph.node_weights().map(|n| n.0).collect::<Vec<_>>(),
+            [1, 20]
+        );
+
+        // Opting in applies the default resolution (ours wins).
+        let outcome = run_merge(
+            &mut reg,
+            &mut head,
+            &mut graph,
+            &mut vm,
+            &mut view,
+            &mut selection,
+            true,
+        );
+        assert!(matches!(outcome, MergeHeadOutcome::Merged { .. }));
+        assert_eq!(
+            graph.node_weights().map(|n| n.0).collect::<Vec<_>>(),
+            [1, 20]
+        );
+        assert_ne!(reg.head_commit_ca(&head), Some(&ours_tip));
+    }
+
+    // A source branch that is strictly ahead fast-forwards without a commit.
+    #[test]
+    fn merge_head_fast_forwards() {
+        let secs = |s| std::time::Duration::from_secs(s);
+        let mut reg = gantz_ca::Registry::default();
+        let g = test_graph(&[1]);
+        let base_ca = reg.commit_graph(secs(1), None, gantz_ca::graph_addr(&g), || g);
+        let g = test_graph(&[1, 2]);
+        let theirs_ca = reg.commit_graph(secs(2), Some(base_ca), gantz_ca::graph_addr(&g), || g);
+        reg.insert_name("alpha".to_string(), base_ca);
+        reg.insert_name("beta".to_string(), theirs_ca);
+        let mut head = gantz_ca::Head::Branch("alpha".to_string());
+        let mut graph = test_graph(&[1]);
+        let mut vm = Engine::new_base();
+        let mut view = crate::SceneView::default();
+        let mut selection = Selection::default();
+
+        let outcome = run_merge(
+            &mut reg,
+            &mut head,
+            &mut graph,
+            &mut vm,
+            &mut view,
+            &mut selection,
+            false,
+        );
+        let MergeHeadOutcome::FastForward(target) = outcome else {
+            panic!("expected FastForward, got {outcome:?}");
+        };
+        assert_eq!(target, theirs_ca);
+        // Nothing mutated: navigation is the caller's job.
+        assert_eq!(reg.names()["alpha"], base_ca);
+        assert_eq!(graph.node_count(), 1);
     }
 }

--- a/crates/gantz_egui/src/reg.rs
+++ b/crates/gantz_egui/src/reg.rs
@@ -264,8 +264,13 @@ where
         crate::merge::merge_candidates(self.ca_registry, ours)
     }
 
-    fn merge_preview(&self, ours: &ca::Head, source: &str) -> Option<crate::merge::MergePreview> {
-        crate::merge::merge_preview(self.ca_registry, ours, source)
+    fn merge_preview(
+        &self,
+        ours: &ca::Head,
+        source: &str,
+        resolutions: ca::Resolutions,
+    ) -> Option<crate::merge::MergePreview> {
+        crate::merge::merge_preview(self.ca_registry, ours, source, resolutions)
     }
 
     fn node_description(&self, name: &str) -> Option<Cow<'static, str>> {

--- a/crates/gantz_egui/src/reg.rs
+++ b/crates/gantz_egui/src/reg.rs
@@ -162,8 +162,9 @@ impl<N: 'static + Node + Send + Sync> FnNodeNames for RegistryRef<'_, N> {
     }
 }
 
-impl<N: 'static + Node + crate::NodeUi + crate::sync::AsNamedRef + Send + Sync> Registry
-    for RegistryRef<'_, N>
+impl<N> Registry for RegistryRef<'_, N>
+where
+    N: 'static + Node + crate::NodeUi + crate::sync::AsNamedRef + Clone + ca::CaHash + Send + Sync,
 {
     fn node(&self, ca: &ca::ContentAddr) -> Option<&dyn Node> {
         RegistryRef::node(self, ca)
@@ -257,6 +258,14 @@ impl<N: 'static + Node + crate::NodeUi + crate::sync::AsNamedRef + Send + Sync> 
 
     fn graph_description(&self, name: &str) -> Option<&str> {
         self.ca_registry.description(name)
+    }
+
+    fn merge_candidates(&self, ours: &ca::Head) -> Vec<crate::merge::MergeCandidate> {
+        crate::merge::merge_candidates(self.ca_registry, ours)
+    }
+
+    fn merge_preview(&self, ours: &ca::Head, source: &str) -> Option<crate::merge::MergePreview> {
+        crate::merge::merge_preview(self.ca_registry, ours, source)
     }
 
     fn node_description(&self, name: &str) -> Option<Cow<'static, str>> {

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -1088,10 +1088,14 @@ where
                             .demo_names(&demo_names_vec)
                             .current_demo(current_demo)
                             .current_description(current_description)
+                            .merge_env(gantz.env)
                             .show(ui)
                     });
                     if res.inner.new_branch.is_some() {
                         gantz_response.new_branch = res.inner.new_branch;
+                    }
+                    if let Some(merge) = res.inner.merge {
+                        gantz_response.responses.push(Some(head.clone()), merge);
                     }
                     if let Some(demo_val) = res.inner.demo_changed {
                         gantz_response.demo_changed = Some((head.clone(), demo_val));

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -95,6 +95,10 @@ pub struct GantzState {
     /// command bindings (see [`crate::keybind`]); edited in Settings -> Keybinds.
     #[serde(default)]
     pub keymap: Keymap,
+    /// How graph merges resolve conflicts; edited via the merge row's "⛭"
+    /// menu in the Graph Config pane.
+    #[serde(default)]
+    pub merge_resolutions: gantz_ca::merge::Resolutions,
     /// Per-head redo stacks for undo/redo support.
     #[serde(default, serialize_with = "gantz_ca::serde_sorted::serialize_map")]
     pub redo_stacks: HashMap<gantz_ca::Head, Vec<gantz_ca::CommitAddr>>,
@@ -872,6 +876,7 @@ impl GantzState {
             layout_config: LayoutConfig::default(),
             scene_config: SceneConfig::default(),
             keymap: Keymap::default(),
+            merge_resolutions: Default::default(),
             redo_stacks: HashMap::new(),
             sidebar_width: default_sidebar_width(),
             tray_height: default_tray_height(),
@@ -1052,6 +1057,7 @@ where
         match pane {
             Pane::GraphConfig => match access.heads().get(*focused_head).cloned() {
                 Some(head) => {
+                    let merge_resolutions = &mut state.merge_resolutions;
                     let head_state = state.open_heads.entry(head.clone()).or_default();
                     let names = gantz.env.names();
                     let is_base = match &head {
@@ -1088,7 +1094,7 @@ where
                             .demo_names(&demo_names_vec)
                             .current_demo(current_demo)
                             .current_description(current_description)
-                            .merge_env(gantz.env)
+                            .merge_env(gantz.env, merge_resolutions)
                             .show(ui)
                     });
                     if res.inner.new_branch.is_some() {

--- a/crates/gantz_egui/src/widget/graph_config.rs
+++ b/crates/gantz_egui/src/widget/graph_config.rs
@@ -17,7 +17,10 @@ pub struct GraphConfig<'a> {
     demo_names: &'a [&'a str],
     current_demo: Option<&'a str>,
     current_description: Option<&'a str>,
-    env: Option<&'a dyn crate::Registry>,
+    env: Option<(
+        &'a dyn crate::Registry,
+        &'a mut gantz_ca::merge::Resolutions,
+    )>,
 }
 
 /// Response from the [`GraphConfig`] widget.
@@ -89,10 +92,15 @@ impl<'a> GraphConfig<'a> {
         self
     }
 
-    /// Registry access for the merge row's candidates and previews. Without
-    /// it, the merge row is hidden.
-    pub fn merge_env(mut self, env: &'a dyn crate::Registry) -> Self {
-        self.env = Some(env);
+    /// Registry access for the merge row's candidates and previews, plus the
+    /// conflict-resolution strategy its "⛭" menu edits. Without these, the
+    /// merge row is hidden.
+    pub fn merge_env(
+        mut self,
+        env: &'a dyn crate::Registry,
+        resolutions: &'a mut gantz_ca::merge::Resolutions,
+    ) -> Self {
+        self.env = Some((env, resolutions));
         self
     }
 
@@ -263,9 +271,16 @@ impl<'a> GraphConfig<'a> {
 
                 // merge (named, mutable, non-base graphs only)
                 if is_named && !self.immutable && !self.is_base {
-                    if let Some(env) = self.env {
+                    if let Some((env, resolutions)) = self.env {
                         ui.label("merge");
-                        merge = merge_select(env, self.head, ui);
+                        ui.horizontal(|ui| {
+                            merge = merge_select(env, self.head, *resolutions, ui);
+                            ui.menu_button("\u{26ED}", |ui| {
+                                resolutions_menu(resolutions, ui);
+                            })
+                            .response
+                            .on_hover_text("conflict resolution strategy");
+                        });
                         ui.end_row();
                     }
                 }
@@ -300,15 +315,18 @@ impl<'a> GraphConfig<'a> {
 /// a dry-run hover summary. Picking a candidate *is* the action (one-shot,
 /// like the layout buttons): a clean candidate merges on click; a conflicted
 /// one is disabled, its tooltip listing the conflicts, with a separate opt-in
-/// button applying the default resolutions. Hard-blocked candidates (e.g. a
-/// reference cycle) can only be inspected.
+/// button applying the selected [`Resolutions`]. Hard-blocked candidates
+/// (e.g. a reference cycle) can only be inspected.
 ///
 /// Candidates and previews are only computed while the popup is open, and each
-/// preview is cached keyed by the two branch tips - content addresses, so a
-/// cached preview can never go stale.
+/// preview is cached keyed by the two branch tips (content addresses) plus the
+/// resolution strategy, so a cached preview can never go stale.
+///
+/// [`Resolutions`]: gantz_ca::merge::Resolutions
 fn merge_select(
     env: &dyn crate::Registry,
     head: &gantz_ca::Head,
+    resolutions: gantz_ca::merge::Resolutions,
     ui: &mut egui::Ui,
 ) -> Option<crate::MergeHead> {
     let mut merge = None;
@@ -326,11 +344,12 @@ fn merge_select(
             };
             for candidate in candidates {
                 // Fetch (or compute and cache) the candidate's dry-run preview.
-                let preview_id = egui::Id::new("merge_preview").with((ours_tip, candidate.theirs));
+                let preview_id =
+                    egui::Id::new("merge_preview").with((ours_tip, candidate.theirs, resolutions));
                 let preview = ui
                     .memory_mut(|m| m.data.get_temp::<crate::merge::MergePreview>(preview_id))
                     .or_else(|| {
-                        let preview = env.merge_preview(head, &candidate.name);
+                        let preview = env.merge_preview(head, &candidate.name, resolutions);
                         if let Some(preview) = &preview {
                             ui.memory_mut(|m| m.data.insert_temp(preview_id, preview.clone()));
                         }
@@ -358,6 +377,7 @@ fn merge_select(
                     {
                         merge = Some(crate::MergeHead {
                             source: candidate.name.clone(),
+                            resolutions,
                             auto_resolve: false,
                         });
                     }
@@ -366,7 +386,7 @@ fn merge_select(
 
                 // Conflicted or blocked: not directly selectable. Conflicts
                 // (but not blockers) offer an explicit opt-in that applies the
-                // default resolutions.
+                // selected resolutions.
                 let preview = preview.expect("`!clean` requires a preview");
                 let warn = crate::node::named_ref::outdated_color();
                 ui.horizontal(|ui| {
@@ -389,13 +409,14 @@ fn merge_select(
                         && ui
                             .small_button("merge anyway")
                             .on_hover_text(
-                                "merge despite the conflicts, applying the default \
-                                 resolutions (this graph's version wins conflicting edits)",
+                                "merge despite the conflicts, applying the selected \
+                                 resolutions (see \u{26ED})",
                             )
                             .clicked()
                     {
                         merge = Some(crate::MergeHead {
                             source: candidate.name.clone(),
+                            resolutions,
                             auto_resolve: true,
                         });
                     }
@@ -403,4 +424,33 @@ fn merge_select(
             }
         });
     merge
+}
+
+/// The "⛭" menu beside the merge dropdown: how conflicts resolve when merging
+/// despite them. Edits the persisted, GUI-global strategy in place.
+fn resolutions_menu(resolutions: &mut gantz_ca::merge::Resolutions, ui: &mut egui::Ui) {
+    use gantz_ca::merge::{EditOrDelete, Side};
+    ui.label("when both sides modified a node");
+    ui.radio_value(
+        &mut resolutions.both_modified,
+        Side::Ours,
+        "keep this graph's version",
+    );
+    ui.radio_value(
+        &mut resolutions.both_modified,
+        Side::Theirs,
+        "keep the branch's version",
+    );
+    ui.separator();
+    ui.label("when a delete meets an edit");
+    ui.radio_value(
+        &mut resolutions.delete_modify,
+        EditOrDelete::KeepEdit,
+        "keep the edited node",
+    );
+    ui.radio_value(
+        &mut resolutions.delete_modify,
+        EditOrDelete::KeepDelete,
+        "keep the delete",
+    );
 }

--- a/crates/gantz_egui/src/widget/graph_config.rs
+++ b/crates/gantz_egui/src/widget/graph_config.rs
@@ -429,17 +429,26 @@ fn merge_select(
 /// The "⛭" menu beside the merge dropdown: how conflicts resolve when merging
 /// despite them. Edits the persisted, GUI-global strategy in place.
 fn resolutions_menu(resolutions: &mut gantz_ca::merge::Resolutions, ui: &mut egui::Ui) {
-    use gantz_ca::merge::{EditOrDelete, Side};
+    use gantz_ca::merge::{BothModified, EditOrDelete};
     ui.label("when both sides modified a node");
     ui.radio_value(
         &mut resolutions.both_modified,
-        Side::Ours,
+        BothModified::KeepOurs,
         "keep this graph's version",
     );
     ui.radio_value(
         &mut resolutions.both_modified,
-        Side::Theirs,
+        BothModified::KeepTheirs,
         "keep the branch's version",
+    );
+    ui.radio_value(
+        &mut resolutions.both_modified,
+        BothModified::KeepNewest,
+        "keep the most recent edit",
+    )
+    .on_hover_text(
+        "per node: whichever side edited the node last wins \
+         (ties resolve deterministically)",
     );
     ui.separator();
     ui.label("when a delete meets an edit");

--- a/crates/gantz_egui/src/widget/graph_config.rs
+++ b/crates/gantz_egui/src/widget/graph_config.rs
@@ -17,6 +17,7 @@ pub struct GraphConfig<'a> {
     demo_names: &'a [&'a str],
     current_demo: Option<&'a str>,
     current_description: Option<&'a str>,
+    env: Option<&'a dyn crate::Registry>,
 }
 
 /// Response from the [`GraphConfig`] widget.
@@ -32,6 +33,8 @@ pub struct GraphConfigResponse {
     /// The graph's description was edited (committed on focus loss). An empty
     /// string clears the description.
     pub description_changed: Option<String>,
+    /// A merge candidate was chosen from the merge row.
+    pub merge: Option<crate::MergeHead>,
 }
 
 impl<'a> GraphConfig<'a> {
@@ -49,6 +52,7 @@ impl<'a> GraphConfig<'a> {
             demo_names: &[],
             current_demo: None,
             current_description: None,
+            env: None,
         }
     }
 
@@ -85,6 +89,13 @@ impl<'a> GraphConfig<'a> {
         self
     }
 
+    /// Registry access for the merge row's candidates and previews. Without
+    /// it, the merge row is hidden.
+    pub fn merge_env(mut self, env: &'a dyn crate::Registry) -> Self {
+        self.env = Some(env);
+        self
+    }
+
     pub fn show(self, ui: &mut egui::Ui) -> GraphConfigResponse {
         let is_named = matches!(self.head, gantz_ca::Head::Branch(_));
         let is_demo =
@@ -111,6 +122,7 @@ impl<'a> GraphConfig<'a> {
         let mut demo_changed = None;
         let mut reset_base_graph = false;
         let mut export = false;
+        let mut merge = None;
 
         // Reserve room for the label column so the value column's text fields
         // don't expand to fill the entire pane.
@@ -249,6 +261,15 @@ impl<'a> GraphConfig<'a> {
                 });
                 ui.end_row();
 
+                // merge (named, mutable, non-base graphs only)
+                if is_named && !self.immutable && !self.is_base {
+                    if let Some(env) = self.env {
+                        ui.label("merge");
+                        merge = merge_select(env, self.head, ui);
+                        ui.end_row();
+                    }
+                }
+
                 // export
                 ui.label("export");
                 export = ui
@@ -270,6 +291,116 @@ impl<'a> GraphConfig<'a> {
             demo_changed,
             reset_base_graph,
             description_changed,
+            merge,
         }
     }
+}
+
+/// The merge row's branch selector: a dropdown of merge candidates, each with
+/// a dry-run hover summary. Picking a candidate *is* the action (one-shot,
+/// like the layout buttons): a clean candidate merges on click; a conflicted
+/// one is disabled, its tooltip listing the conflicts, with a separate opt-in
+/// button applying the default resolutions. Hard-blocked candidates (e.g. a
+/// reference cycle) can only be inspected.
+///
+/// Candidates and previews are only computed while the popup is open, and each
+/// preview is cached keyed by the two branch tips - content addresses, so a
+/// cached preview can never go stale.
+fn merge_select(
+    env: &dyn crate::Registry,
+    head: &gantz_ca::Head,
+    ui: &mut egui::Ui,
+) -> Option<crate::MergeHead> {
+    let mut merge = None;
+    egui::ComboBox::from_id_salt("merge_select")
+        .selected_text("select branch\u{2026}")
+        .show_ui(ui, |ui| {
+            let candidates = env.merge_candidates(head);
+            if candidates.is_empty() {
+                ui.weak("no mergeable graphs");
+                return;
+            }
+            let ours_tip = match head {
+                gantz_ca::Head::Branch(name) => env.names().get(name).copied(),
+                gantz_ca::Head::Commit(ca) => Some(*ca),
+            };
+            for candidate in candidates {
+                // Fetch (or compute and cache) the candidate's dry-run preview.
+                let preview_id = egui::Id::new("merge_preview").with((ours_tip, candidate.theirs));
+                let preview = ui
+                    .memory_mut(|m| m.data.get_temp::<crate::merge::MergePreview>(preview_id))
+                    .or_else(|| {
+                        let preview = env.merge_preview(head, &candidate.name);
+                        if let Some(preview) = &preview {
+                            ui.memory_mut(|m| m.data.insert_temp(preview_id, preview.clone()));
+                        }
+                        preview
+                    });
+
+                let mut summary = preview
+                    .as_ref()
+                    .map(|p| crate::merge::summary_text(&p.summary))
+                    .unwrap_or_default();
+                if candidate.fast_forward {
+                    summary =
+                        format!("fast-forward: moves this graph to the branch tip\n{summary}");
+                }
+                let clean = preview.as_ref().is_none_or(|p| p.is_clean());
+                if clean {
+                    let mut text = candidate.name.clone();
+                    if candidate.fast_forward {
+                        text.push_str(" (fast-forward)");
+                    }
+                    if ui
+                        .selectable_label(false, text)
+                        .on_hover_text(summary)
+                        .clicked()
+                    {
+                        merge = Some(crate::MergeHead {
+                            source: candidate.name.clone(),
+                            auto_resolve: false,
+                        });
+                    }
+                    continue;
+                }
+
+                // Conflicted or blocked: not directly selectable. Conflicts
+                // (but not blockers) offer an explicit opt-in that applies the
+                // default resolutions.
+                let preview = preview.expect("`!clean` requires a preview");
+                let warn = crate::node::named_ref::outdated_color();
+                ui.horizontal(|ui| {
+                    let text = egui::RichText::new(format!("{} !", candidate.name)).color(warn);
+                    ui.add_enabled(false, egui::Button::selectable(false, text))
+                        .on_disabled_hover_ui(|ui| {
+                            ui.set_max_width(320.0);
+                            ui.label(summary);
+                            for conflict in &preview.conflicts {
+                                ui.colored_label(warn, format!("! {conflict}"));
+                            }
+                            for blocker in &preview.blockers {
+                                ui.colored_label(
+                                    crate::node::named_ref::missing_color(),
+                                    format!("\u{2715} {blocker}"),
+                                );
+                            }
+                        });
+                    if preview.blockers.is_empty()
+                        && ui
+                            .small_button("merge anyway")
+                            .on_hover_text(
+                                "merge despite the conflicts, applying the default \
+                                 resolutions (this graph's version wins conflicting edits)",
+                            )
+                            .clicked()
+                    {
+                        merge = Some(crate::MergeHead {
+                            source: candidate.name.clone(),
+                            auto_resolve: true,
+                        });
+                    }
+                });
+            }
+        });
+    merge
 }

--- a/crates/gantz_format/src/lib.rs
+++ b/crates/gantz_format/src/lib.rs
@@ -178,4 +178,44 @@ mod tests {
             dumped.text,
         );
     }
+
+    /// Merge commits round-trip their extra parents via the additive
+    /// `(merge-parents ...)` clause; ordinary commits are written without it.
+    #[test]
+    fn merge_parents_round_trip() {
+        let text = "\
+            (graph g1 (k (node \"Knob\" (value 1))))\n\
+            (graph g2 (k (node \"Knob\" (value 2))))\n\
+            (graph g3 (k (node \"Knob\" (value 3))))\n\
+            (commits\n\
+              (c1 (time 1 0) (graph g1))\n\
+              (c2 (time 2 0) (graph g2))\n\
+              (c3 (time 3 0) (parent c1) (merge-parents c2) (graph g3)))";
+        let loaded = from_str_with::<Box<dyn Widget>>(text, std::time::Duration::ZERO, &CoreSugar)
+            .expect("parse merge commit");
+        let merge = loaded
+            .registry
+            .commits()
+            .values()
+            .find(|c| !c.merge_parents.is_empty())
+            .expect("merge commit survives the parse");
+        assert!(merge.parent.is_some());
+        assert_eq!(merge.merge_parents.len(), 1);
+        assert_ne!(merge.parent, Some(merge.merge_parents[0]));
+
+        // The merge parent survives a write + reparse; non-merge commits carry
+        // no `merge-parents` clause.
+        let dumped = to_string_with(&loaded.registry, &CoreSugar).expect("write merge commit");
+        assert_eq!(dumped.text.matches("(merge-parents").count(), 1);
+        let reloaded =
+            from_str_with::<Box<dyn Widget>>(&dumped.text, std::time::Duration::ZERO, &CoreSugar)
+                .expect("reparse");
+        let re_merge = reloaded
+            .registry
+            .commits()
+            .values()
+            .find(|c| !c.merge_parents.is_empty())
+            .expect("merge commit survives the round-trip");
+        assert_eq!(re_merge.merge_parents.len(), 1);
+    }
 }

--- a/crates/gantz_format/src/lower.rs
+++ b/crates/gantz_format/src/lower.rs
@@ -269,7 +269,15 @@ fn build_commit<N>(
 ) -> CommitAddr {
     let parent = resolve_parent(&decl.parent, commit_ids, known);
     let timestamp = Duration::new(decl.secs, decl.nanos);
-    let commit_ca = registry.add_commit(Commit::new(timestamp, parent, g_addr));
+    let mut commit = Commit::new(timestamp, parent, g_addr);
+    // Merge parents resolve like the first parent; an absent one is dropped
+    // (`resolve_parent` re-roots, which for an *extra* parent means dropping).
+    commit.merge_parents = decl
+        .merge_parents
+        .iter()
+        .filter_map(|addr| resolve_parent(&Some(addr.clone()), commit_ids, known))
+        .collect();
+    let commit_ca = registry.add_commit(commit);
     // A declared id may not match the recomputed address - e.g. the format
     // keeps only the head commit per graph, so a dropped parent re-roots the
     // commit and changes its hash. This is routine (refs recover by name in

--- a/crates/gantz_format/src/model.rs
+++ b/crates/gantz_format/src/model.rs
@@ -127,6 +127,10 @@ pub struct CommitDecl {
     pub nanos: u32,
     /// The parent commit, or `None` for a root commit.
     pub parent: Option<Addr>,
+    /// Extra parents, present only on merge commits (the merged-in tips).
+    /// Written as a `(merge-parents ...)` clause only when non-empty, so
+    /// ordinary commits serialize exactly as before.
+    pub merge_parents: Vec<Addr>,
     /// The id of the graph this commit points at.
     pub graph: Addr,
 }

--- a/crates/gantz_format/src/parse.rs
+++ b/crates/gantz_format/src/parse.rs
@@ -362,6 +362,7 @@ fn parse_commit_entry(
     let mut secs = 0u64;
     let mut nanos = 0u32;
     let mut parent = None;
+    let mut merge_parents = Vec::new();
     let mut graph = None;
     for field in &args[1..] {
         let fargs = list_args(field).ok_or_else(|| {
@@ -391,6 +392,12 @@ fn parse_commit_entry(
                     None => None,
                 };
             }
+            Some("merge-parents") => {
+                merge_parents = fargs[1..]
+                    .iter()
+                    .map(|e| parse_addr(e, src))
+                    .collect::<Result<_, _>>()?;
+            }
             Some("graph") => {
                 graph = fargs.get(1).map(|e| parse_addr(e, src)).transpose()?;
             }
@@ -415,6 +422,7 @@ fn parse_commit_entry(
         secs,
         nanos,
         parent,
+        merge_parents,
         graph,
     })
 }

--- a/crates/gantz_format/src/raise.rs
+++ b/crates/gantz_format/src/raise.rs
@@ -47,7 +47,23 @@ where
     let mut doc = Document::default();
     let mut graphs = HashMap::new();
 
-    for (g_addr, graph) in registry.graphs() {
+    // Write commits ascending by (timestamp, addr) and graphs by the newest
+    // commit pointing at them. The registry maps are unordered, but document
+    // order matters on load: a commit's parents (incl. merge parents) resolve
+    // only against already-built commits, and the last commit declared per
+    // graph wins as its head (see `lower`). Time order keeps ancestry intact
+    // across a round-trip and the output stable.
+    let mut commits: Vec<_> = registry.commits().iter().collect();
+    commits.sort_by_key(|&(ca, c)| (c.timestamp, *ca));
+    let mut newest: HashMap<gantz_ca::GraphAddr, gantz_ca::Timestamp> = HashMap::new();
+    for &(_, c) in &commits {
+        // Ascending order, so a later entry is never older.
+        newest.insert(c.graph, c.timestamp);
+    }
+    let mut graph_entries: Vec<_> = registry.graphs().iter().collect();
+    graph_entries.sort_by_key(|&(ga, _)| (newest.get(ga).copied(), *ga));
+
+    for (g_addr, graph) in graph_entries {
         let (body, labels) = graph_to_body::<N>(graph, sugar, true)?;
         let id = short_hex(*g_addr);
         doc.graphs.push(GraphDef {
@@ -57,12 +73,17 @@ where
         graphs.insert(*g_addr, GraphLabels { id, labels });
     }
 
-    for (c_addr, commit) in registry.commits() {
+    for (c_addr, commit) in commits {
         doc.commits.push(CommitDecl {
             id: Addr::Concrete(short_hex(*c_addr)),
             secs: commit.timestamp.as_secs(),
             nanos: commit.timestamp.subsec_nanos(),
             parent: commit.parent.map(|p| Addr::Concrete(short_hex(p))),
+            merge_parents: commit
+                .merge_parents
+                .iter()
+                .map(|&p| Addr::Concrete(short_hex(p)))
+                .collect(),
             graph: Addr::Concrete(short_hex(commit.graph)),
         });
     }

--- a/crates/gantz_format/src/writer.rs
+++ b/crates/gantz_format/src/writer.rs
@@ -146,6 +146,10 @@ fn commit_text(c: &CommitDecl) -> String {
     if let Some(addr) = &c.parent {
         s.push_str(&format!(" (parent {})", addr_text(addr)));
     }
+    if !c.merge_parents.is_empty() {
+        let addrs: Vec<String> = c.merge_parents.iter().map(addr_text).collect();
+        s.push_str(&format!(" (merge-parents {})", addrs.join(" ")));
+    }
     s.push_str(&format!(" (graph {}))", addr_text(&c.graph)));
     s
 }


### PR DESCRIPTION
Closes #287.

Adds git-inspired merging of diverged graph heads, as groundwork for collaborative editing (#286).

## What

A new `merge` row in the Graph Config pane lists the named graphs that can be merged into the current one (those sharing an ancestor with changes the current graph lacks). Hovering a candidate shows a dry-run summary of what it would bring in (`+2 nodes  ~1 modified  +1 edge`). Fast-forwards are labelled and skip the merge commit entirely. Clean candidates merge on click. Conflicted candidates are disabled and marked `!`, with a tooltip listing each conflict and a separate "merge anyway" opt-in. A "⛭" menu selects the conflict resolution strategy. Undo from a merge lands back on the pre-merge tip.

## How

- **Merge commits**: `Commit` gains an additive `merge_parents` field, hashed and serialized only when non-empty - all existing commit addresses and persisted registries are byte-for-byte unchanged (guarded by compat regression tests).
- **History utilities** (`gantz_ca::history`): DAG-aware `ancestors`, `merge_base` (best common ancestor with a deterministic criss-cross tie-break) and `analyze` (unrelated / up-to-date / fast-forward / diverged).
- **Node identity** (`gantz_ca::diff`): nodes have no persistent id, so "the same node" across branches is recovered by walking each side's commit chain from the merge base and composing per-step content matchings. Since consecutive commits differ by one logical edit, an edit keeps its node's identity - so one user editing a node while another wires into it merges cleanly instead of producing a false delete-conflict (the common collaborative case).
- **Three-way merge** (`gantz_ca::merge`): pure and *total* - it always produces a merged graph, flagging conflicts alongside the resolution that was applied so the GUI can refuse, surface, or accept them. Change beats no-change per node. Additions union. Edge sets union with removals winning. Construction is deterministic (equal inputs yield equal graph addresses). The result preserves the current graph's node indices whenever the source removed nothing, and per-node provenance drives VM-state/layout/selection migration plus layout seeding for merged-in nodes from the source branch's view.
- **Resolutions**: two independent knobs, persisted and editable from the "⛭" menu: *both modified*: keep this graph's version (default), the branch's version, or
    **the most recent edit** - arbitrated per node from the commit chain's timestamps. The last option is symmetric (ties break on content, not side), so two peers merging in opposite directions converge on the same graph - the intended basis for #286's "last edit wins" session mode.
  - *delete vs modify*: keep the edit (default) or keep the delete.

  Dangling edges (into a node that stayed deleted) are always dropped - a consequence, not a choice.
- **Format**: an additive `(merge-parents ...)` clause round-trips merge ancestry. old `.gantz` files parse unchanged.

## Also fixed

`gantz_format::raise` wrote graphs/commits in `HashMap` iteration order, which dropped commit ancestry nondeterministically on round-trip (parents only resolve against already-built commits on load) and made full-export output unstable. It now writes in timestamp order.

## Out of scope (follow-ups)

- Per-conflict manual resolution editor (conflicts are surfaced, with bulk strategies only).
- Merging nested (`parent:child`) graphs recursively - nested names are excluded from candidates. Merged-in `NamedRef`s resolve via the existing sync/fork machinery.
- Graph-scene preview on hover (textual summary only).
- Detached (unnamed commit) heads as merge targets.