### PR TITLE
feat(dsp): support nested graphs via a pre-derivation flattening pass

### DIFF
--- a/crates/bevy_gantz_plyphon/examples/custom_unit.rs
+++ b/crates/bevy_gantz_plyphon/examples/custom_unit.rs
@@ -27,6 +27,7 @@ use gantz_core::Node as GantzNode;
 use gantz_core::edge::Edge;
 use gantz_core::node::graph::Graph;
 use gantz_core::node::{ExprCtx, ExprResult, MetaCtx, RegCtx, parse_expr};
+use gantz_plyphon::flatten::{AsNamedRef, NamedRef};
 use gantz_plyphon::{DspBuilder, NodeDsp, Signal, ToNodeDsp};
 use plyphon::synthdef::{InputRef, UnitSpec};
 use plyphon::{
@@ -190,6 +191,13 @@ impl ToNodeDsp for N {
             N::Saw(n) => Some(n),
             N::Out(n) => n.to_node_dsp(),
         }
+    }
+}
+
+impl AsNamedRef for N {
+    fn as_named_ref(&self) -> Option<&NamedRef> {
+        // No nested-graph refs in this node set: nothing to flatten.
+        None
     }
 }
 

--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -30,7 +30,7 @@ use gantz_ca as ca;
 use gantz_core::node::graph::Graph;
 use gantz_plyphon::{
     AddAction, Backend, Embedded, GainRef, ROOT_GROUP_ID, RegionDerived, ToNodeDsp,
-    derive_synthdefs, structural_sig,
+    derive_synthdefs, flatten::AsNamedRef, flatten_from_registry, structural_sig,
 };
 use plyphon::{Controller, InputRef, Nrt, Options, StreamConsumer, World, engine};
 // `std::time::Instant` panics ("time not implemented") on `wasm32-unknown-unknown`;
@@ -125,7 +125,7 @@ impl<N> PlyphonPlugin<N> {
 
 impl<N> Plugin for PlyphonPlugin<N>
 where
-    N: 'static + ToNodeDsp + Send + Sync,
+    N: 'static + ToNodeDsp + gantz_core::Node + AsNamedRef + Clone + Send + Sync,
 {
     fn build(&self, app: &mut App) {
         // The shared monotonic epoch (set by `GantzPlugin`, added before this) is
@@ -433,7 +433,7 @@ fn drive_synths<N>(
     mut vms: NonSendMut<HeadVms>,
     heads: Query<(Entity, &HeadRef, &WorkingGraph<N>), With<OpenHead>>,
 ) where
-    N: 'static + ToNodeDsp + Send + Sync,
+    N: 'static + ToNodeDsp + gantz_core::Node + AsNamedRef + Clone + Send + Sync,
 {
     let Some(dsp) = dsp else {
         return;
@@ -468,17 +468,31 @@ fn drive_synths<N>(
             continue;
         };
 
-        // Structural sync: only when the committed graph changed.
+        // Structural sync: only when the committed graph changed. Flattening
+        // first splices any nested graphs (resolved through the registry) into
+        // one flat graph whose nodes carry their original nested paths. On a
+        // flatten error (a ref cycle or an unresolvable ref, both forbidden
+        // upstream): keep the previous synths, parking the head at this graph
+        // address so the error logs once per commit rather than every frame.
         if state.heads.get(&entity).map(|h| h.graph) != Some(graph_ca) {
-            structural_sync(
-                &mut dsp.controller,
-                state,
-                entity,
-                graph_ca,
-                &wg.0,
-                out_channels,
-                sample_rate,
-            );
+            match flatten_from_registry(&wg.0, &registry) {
+                Ok(flat) => structural_sync(
+                    &mut dsp.controller,
+                    state,
+                    entity,
+                    graph_ca,
+                    &flat,
+                    out_channels,
+                    sample_rate,
+                ),
+                Err(e) => {
+                    log::error!(
+                        "bevy_gantz_plyphon: flattening nested graphs failed ({e:?}), \
+                         keeping the previous synths"
+                    );
+                    park_head(state, entity, graph_ca);
+                }
+            }
         }
 
         // Param sync: drain each param's queued control updates and schedule
@@ -603,6 +617,24 @@ fn expire_fades(fading: &mut Vec<FadingSynth>, now: Instant) -> Vec<FadingSynth>
 /// channels and fade defaults are all placeholders at that point - so a
 /// re-derive of the same graph never spuriously respawns.
 ///
+/// Park `entity` at `graph_ca` without touching its running synths, so an
+/// unactionable commit (a flatten or derive error) is not retried (and its
+/// error not re-logged) every frame.
+fn park_head(state: &mut HeadSynths, entity: Entity, graph_ca: ca::GraphAddr) {
+    match state.heads.get_mut(&entity) {
+        Some(head) => head.graph = graph_ca,
+        None => {
+            state.heads.insert(
+                entity,
+                HeadRegions {
+                    graph: graph_ca,
+                    regions: Vec::new(),
+                },
+            );
+        }
+    }
+}
+
 /// A replacement spawns *silent* (fade defaults patched to `0.0`. Defaults seed
 /// both the control wire and the lag state) and ramps its fades to unity once
 /// up, while the old synth's fades ramp to zero ahead of a deferred free - the
@@ -655,18 +687,7 @@ fn structural_sync<N>(
             log::error!(
                 "bevy_gantz_plyphon: `~bus` cycle between regions, keeping the previous synths"
             );
-            match state.heads.get_mut(&entity) {
-                Some(head) => head.graph = graph_ca,
-                None => {
-                    state.heads.insert(
-                        entity,
-                        HeadRegions {
-                            graph: graph_ca,
-                            regions: Vec::new(),
-                        },
-                    );
-                }
-            }
+            park_head(state, entity, graph_ca);
             return;
         }
     };

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -477,6 +477,74 @@ mod tests {
         );
     }
 
+    /// A nested graph of DSP nodes sounds through the flattening pass: the
+    /// child's `~lag` splices into the parent's synthdef carrying its nested
+    /// path, and that path reaches the node's live param state in the VM -
+    /// exactly the contract the audio driver's param sync relies on. Guards
+    /// the whole nested-DSP pipeline (registry ref resolution, flattening,
+    /// derivation, VM state bridge) end to end with the app's real node type.
+    #[test]
+    fn nested_dsp_graph_flattens_derives_and_bridges_state() {
+        use gantz_egui::sync::AsNamedRef;
+        use gantz_plyphon::ToNodeDsp;
+        use std::time::Duration;
+        type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
+
+        // child `env:1`: inlet -> ~lag -> outlet, nested into
+        // parent `env`: ~sinosc -> ref -> ~out.
+        let text = "\
+(graph env:1
+  (i inlet) (l ~lag) (o outlet)
+  (-> i (l 0)) (-> l o))
+
+(graph env
+  (s ~sinosc) (sub (ref env:1)) (out ~out)
+  (-> s (sub 0)) (-> sub (out 0)))";
+        let export: gantz_egui::export::Export<G> =
+            gantz_egui::format::from_str(text, Duration::from_secs(0)).expect("from_str");
+        let parent_head = gantz_ca::Head::Branch("env".into());
+        let child_head = gantz_ca::Head::Branch("env:1".into());
+        let parent = export.registry.head_graph(&parent_head).expect("env graph");
+        let child = export
+            .registry
+            .head_graph(&child_head)
+            .expect("env:1 graph");
+
+        // The indices the flattened path must carry: the ref within the parent,
+        // the lag within the child (its only dsp node).
+        let ref_ix = parent
+            .node_indices()
+            .find(|&n| parent[n].as_named_ref().is_some())
+            .expect("ref node")
+            .index();
+        let lag_ix = child
+            .node_indices()
+            .find(|&n| child[n].to_node_dsp().is_some())
+            .expect("lag node")
+            .index();
+
+        let flat = gantz_plyphon::flatten_from_registry(parent, &export.registry).expect("flatten");
+        let derived = gantz_plyphon::derive_synthdef(&flat, 1, "test").expect("derive");
+        let binding = derived
+            .params
+            .iter()
+            .find(|b| b.node_path == [ref_ix, lag_ix])
+            .expect("a param binding keyed by the lag's nested path");
+
+        // The binding's path reaches the nested lag's live param state in a VM
+        // compiled from the same (un-flattened) graph.
+        let builtins = crate::builtin::Builtins::new();
+        let reg_ref = gantz_egui::RegistryRef::new(&export.registry, &builtins, &export.demos);
+        let get_node = |ca: &gantz_ca::ContentAddr| reg_ref.node(ca);
+        let config = gantz_core::compile::Config::default();
+        let (mut vm, _compiled) =
+            gantz_core::vm::init(&get_node, parent, &[], &config).expect("vm init");
+        let (value, pending) = gantz_plyphon::param::drain_param(&mut vm, &binding.node_path)
+            .expect("nested lag param state");
+        assert_eq!(value, f64::from(gantz_plyphon::Lag::DEFAULT_DUR));
+        assert!(pending.is_empty());
+    }
+
     /// `~unpack`'s placeholder expr honours the multi-output contract for any
     /// `count`: a single value for one output, a list of values otherwise. A
     /// wrong shape (e.g. `(list 0)` for count 1) fails `vm::init`'s compile.

--- a/crates/gantz_plyphon/src/compile.rs
+++ b/crates/gantz_plyphon/src/compile.rs
@@ -107,8 +107,13 @@ pub struct Derived {
 /// dead units whose params the driver would drive and whose presence would force
 /// spurious respawns (they'd land in [`structural_sig`]).
 ///
-/// Phase-1 limitations: a single edge per DSP input (no summing), acyclic graphs
-/// only (no feedback), and flat concrete nodes (no nested graphs / refs).
+/// Nested graphs are supported via a pre-derivation pass: [`flatten`](crate::flatten)
+/// resolves graph refs and splices their nodes into a single flat graph (each
+/// carrying its original nested path via [`ToNodeDsp::node_path`]) before
+/// derivation runs.
+///
+/// Phase-1 limitations: a single edge per DSP input (no summing) and acyclic
+/// graphs only (no feedback).
 pub fn derive_synthdef<N>(
     graph: &Graph<N>,
     out_channels: usize,
@@ -146,7 +151,7 @@ where
                     .unwrap_or_else(|| Signal::silent(1))
             })
             .collect();
-        let outs = dsp.ugens(&[n.index()], &inputs, &mut builder);
+        let outs = dsp.ugens(&graph[n].node_path(n.index()), &inputs, &mut builder);
         debug_assert_eq!(
             outs.len(),
             dsp.n_dsp_outputs(),
@@ -477,7 +482,7 @@ where
                                         channels,
                                     ));
                                     bus_reads.push(BusBinding {
-                                        node_path: vec![bus.index()],
+                                        node_path: graph[bus].node_path(bus.index()),
                                         channels,
                                         unit: unit as usize,
                                     });
@@ -497,7 +502,7 @@ where
                     None => Signal::silent(1),
                 })
                 .collect();
-            let outs = dsp.ugens(&[n.index()], &inputs, &mut builder);
+            let outs = dsp.ugens(&graph[n].node_path(n.index()), &inputs, &mut builder);
             debug_assert_eq!(
                 outs.len(),
                 dsp.n_dsp_outputs(),
@@ -516,7 +521,7 @@ where
                 .and_then(|o| o.get(port))
                 .cloned()
                 .unwrap_or_else(|| Signal::silent(1));
-            let fade = builder.push_fade_gain(&[b.index()]);
+            let fade = builder.push_fade_gain(&graph[b].node_path(b.index()));
             let mut out_inputs = vec![InputRef::Constant(0.0)];
             for ch in sig.channels() {
                 let ch = builder.ensure_audio(ch);
@@ -534,7 +539,7 @@ where
             }
             let unit = builder.push_unit(UnitSpec::new("Out", Rate::Audio, out_inputs, 0));
             bus_writes.push(BusBinding {
-                node_path: vec![b.index()],
+                node_path: graph[b].node_path(b.index()),
                 channels: sig.width(),
                 unit: unit as usize,
             });
@@ -544,7 +549,7 @@ where
         // A stable region identity: its sink and boundary roles + node paths.
         let mut h = DefaultHasher::new();
         for s in &region_sinks {
-            (0u8, s.index()).hash(&mut h);
+            (0u8, graph[*s].node_path(s.index())).hash(&mut h);
         }
         for w in &bus_writes {
             (1u8, &w.node_path).hash(&mut h);

--- a/crates/gantz_plyphon/src/compile.rs
+++ b/crates/gantz_plyphon/src/compile.rs
@@ -107,7 +107,7 @@ pub struct Derived {
 /// dead units whose params the driver would drive and whose presence would force
 /// spurious respawns (they'd land in [`structural_sig`]).
 ///
-/// Nested graphs are supported via a pre-derivation pass: [`flatten`](crate::flatten)
+/// Nested graphs are supported via a pre-derivation pass: [`flatten`](crate::flatten())
 /// resolves graph refs and splices their nodes into a single flat graph (each
 /// carrying its original nested path via [`ToNodeDsp::node_path`]) before
 /// derivation runs.

--- a/crates/gantz_plyphon/src/dsp.rs
+++ b/crates/gantz_plyphon/src/dsp.rs
@@ -189,7 +189,7 @@ pub trait ToNodeDsp {
     /// node's index within the graph being derived.
     ///
     /// Defaults to `[ix]`, correct for a flat graph. The flattening pass
-    /// (see [`flatten`](crate::flatten)) overrides this on its
+    /// (see [`flatten`](crate::flatten())) overrides this on its
     /// [`Flat`](crate::flatten::Flat) wrapper to return the node's original
     /// path within the nested structure, so params keep bridging to the
     /// node's VM state and identities stay stable across re-derives.

--- a/crates/gantz_plyphon/src/dsp.rs
+++ b/crates/gantz_plyphon/src/dsp.rs
@@ -183,6 +183,19 @@ pub trait NodeDsp {
 pub trait ToNodeDsp {
     /// This value as a [`NodeDsp`], if it is one.
     fn to_node_dsp(&self) -> Option<&dyn NodeDsp>;
+
+    /// The node's path, used to name control [`Param`]s, key driver bindings
+    /// (see [`ParamBinding::node_path`]) and hash region keys. `ix` is the
+    /// node's index within the graph being derived.
+    ///
+    /// Defaults to `[ix]`, correct for a flat graph. The flattening pass
+    /// (see [`flatten`](crate::flatten)) overrides this on its
+    /// [`Flat`](crate::flatten::Flat) wrapper to return the node's original
+    /// path within the nested structure, so params keep bridging to the
+    /// node's VM state and identities stay stable across re-derives.
+    fn node_path(&self, ix: usize) -> Vec<usize> {
+        vec![ix]
+    }
 }
 
 /// Records which dsp node a synthdef [`Param`] came from, so the audio driver can

--- a/crates/gantz_plyphon/src/flatten.rs
+++ b/crates/gantz_plyphon/src/flatten.rs
@@ -1,0 +1,323 @@
+//! A pre-derivation flattening pass for nested graphs.
+//!
+//! Nesting (committing a subgraph with `Inlet`/`Outlet` boundaries and reusing
+//! it as a single ref node) is gantz's primary abstraction. The control (Steel)
+//! compiler supports it call-based: each nested level becomes a function the
+//! parent calls. A synthdef is a flat unit list with no notion of calling a
+//! sub-synthdef, so the DSP compiler instead *inlines*: [`flatten`] resolves
+//! each graph ref, splices the referenced graph's nodes into one flat graph and
+//! dissolves the `Inlet`/`Outlet` boundary nodes into the surrounding edges.
+//! The result derives via [`derive_synthdef`](crate::derive_synthdef) or
+//! [`derive_synthdefs`](crate::derive_synthdefs) unchanged.
+//!
+//! Every spliced node carries its original path within the nested structure
+//! (a [`Flat`] weight, surfaced through [`ToNodeDsp::node_path`]). Paths are
+//! load-bearing: params are named by path, the audio driver bridges param and
+//! scope state to the VM by path, buses are allocated by path and region keys
+//! hash paths. Keeping original paths means a node's identity survives
+//! re-derivation regardless of where it lands in the flat graph.
+//!
+//! # Edge bridging
+//!
+//! An edge into a ref's input `i` belongs to every consumer of the referenced
+//! graph's `i`-th inlet, and an edge from a ref's output `j` re-sources from
+//! the single edge feeding the referenced graph's `j`-th outlet (inlets and
+//! outlets map positionally by ascending node index, the same "input i to
+//! inlet i" contract the control compiler uses). Bridging resolves through
+//! arbitrarily deep chains of boundaries (a pure `inlet -> outlet` wire
+//! dissolves entirely). At each hop the *oldest* edge whose chain resolves
+//! wins, matching derivation's oldest-edge-wins input resolution, and an
+//! unresolvable chain (an unconnected inlet or outlet along the way) produces
+//! no edge, so the consumer's input falls back to derivation's usual mono
+//! silence.
+
+use std::collections::HashMap;
+
+use petgraph::Direction;
+use petgraph::visit::EdgeRef;
+
+use gantz_ca::ContentAddr;
+use gantz_core::Edge;
+use gantz_core::node::graph::{Graph, NodeIx};
+use gantz_core::node::{GetNode, MetaCtx};
+
+use crate::dsp::{NodeDsp, ToNodeDsp};
+
+pub use gantz_egui::sync::AsNamedRef;
+
+/// A node spliced out of a nested structure into a flat graph, carrying its
+/// original path (e.g. `[3, 2]` for the node at index 2 within the graph
+/// referenced by the root node at index 3).
+#[derive(Clone, Debug)]
+pub struct Flat<N> {
+    /// The node's original path within the nested structure.
+    pub path: Vec<usize>,
+    /// The node itself.
+    pub node: N,
+}
+
+/// An error flattening a nested graph.
+///
+/// Both cases are defensive: the editor refuses to create ref cycles and the
+/// registry holds a committed graph for every ref it hands out, so neither
+/// should be reachable through the application.
+#[derive(Debug)]
+pub enum FlattenError {
+    /// A graph ref (transitively) resolves through itself.
+    RefCycle(ContentAddr),
+    /// A graph ref whose target graph could not be found.
+    Unresolved(ContentAddr),
+}
+
+/// Resolves a node to the committed graph it references, if any.
+///
+/// - `None`: not a graph ref. The node is copied into the flat graph as-is.
+/// - `Some((ca, Some(graph)))`: a graph ref. The referenced graph is spliced
+///   in place of the node, with `ca` keying the ref-cycle guard.
+/// - `Some((ca, None))`: a graph ref whose target is missing, an
+///   [`FlattenError::Unresolved`] error.
+pub type Resolve<'g, N> = dyn Fn(&N) -> Option<(ContentAddr, Option<&'g Graph<N>>)> + 'g;
+
+/// One level of the nested structure: a graph, where it hangs off its parent,
+/// and where each of its nodes went during splicing. Bridging resolves edge
+/// sources through this table.
+struct Level<'g, N> {
+    graph: &'g Graph<N>,
+    /// The parent level's index and the ref node there, `None` at the root.
+    parent: Option<(usize, NodeIx)>,
+    /// Inlet nodes in ascending index order (the "input i to inlet i" contract).
+    inlets: Vec<NodeIx>,
+    /// Outlet nodes in ascending index order.
+    outlets: Vec<NodeIx>,
+    /// Copied nodes: original index to flat-graph index.
+    kept: HashMap<NodeIx, NodeIx>,
+    /// Resolved refs: ref node index to the child's index in the level table.
+    child: HashMap<NodeIx, usize>,
+}
+
+/// An edge-source endpoint (level, node, output port), tracked on a stack
+/// during source resolution to guard against pure boundary wiring cycles.
+type SrcKey = (usize, NodeIx, usize);
+
+impl<N: ToNodeDsp> ToNodeDsp for Flat<N> {
+    fn to_node_dsp(&self) -> Option<&dyn NodeDsp> {
+        self.node.to_node_dsp()
+    }
+
+    fn node_path(&self, _ix: usize) -> Vec<usize> {
+        self.path.clone()
+    }
+}
+
+/// Flatten `graph`, splicing every nested level (per `resolve`) into one flat
+/// graph and dissolving `Inlet`/`Outlet` boundary nodes into the surrounding
+/// edges (see the module docs).
+///
+/// `get_node` backs the [`MetaCtx`] used to identify inlets and outlets via
+/// the [`gantz_core::Node::inlet`]/[`outlet`](gantz_core::Node::outlet)
+/// predicates (so identification agrees with the control compiler, including
+/// through refs). Nodes that are neither graph refs nor boundaries are copied
+/// as-is. Non-DSP nodes ride along harmlessly, derivation ignores them.
+pub fn flatten<'g, N>(
+    get_node: GetNode<'_>,
+    graph: &'g Graph<N>,
+    resolve: &Resolve<'g, N>,
+) -> Result<Graph<Flat<N>>, FlattenError>
+where
+    N: gantz_core::Node + Clone,
+{
+    let ctx = MetaCtx::new(get_node);
+    let mut levels = Vec::new();
+    let mut out = Graph::default();
+    let mut ca_stack = Vec::new();
+    splice(
+        ctx,
+        resolve,
+        graph,
+        None,
+        Vec::new(),
+        &mut levels,
+        &mut out,
+        &mut ca_stack,
+    )?;
+    bridge(&levels, &mut out);
+    Ok(out)
+}
+
+/// [`flatten`] resolving [`AsNamedRef`] nodes through the content-addressed
+/// registry (a `NamedRef`'s content address is the referenced graph's commit
+/// address).
+pub fn flatten_from_registry<'g, N>(
+    graph: &'g Graph<N>,
+    registry: &'g gantz_ca::Registry<Graph<N>>,
+) -> Result<Graph<Flat<N>>, FlattenError>
+where
+    N: gantz_core::Node + AsNamedRef + Clone,
+{
+    let resolve = |n: &N| {
+        n.as_named_ref().map(|nr| {
+            let ca = nr.content_addr();
+            (ca, registry.commit_graph_ref(&ca.into()))
+        })
+    };
+    let get_node = |ca: &ContentAddr| {
+        registry
+            .commit_graph_ref(&(*ca).into())
+            .map(|g| g as &dyn gantz_core::Node)
+    };
+    flatten(&get_node, graph, &resolve)
+}
+
+/// Phase 1: recursively copy `graph`'s concrete nodes into `out` (paths
+/// prefixed by `prefix`), recording each level's boundary nodes and resolved
+/// refs in `levels` for [`bridge`] to resolve edges through. Returns the
+/// level's index within `levels`.
+#[allow(clippy::too_many_arguments)]
+fn splice<'g, N>(
+    ctx: MetaCtx,
+    resolve: &Resolve<'g, N>,
+    graph: &'g Graph<N>,
+    parent: Option<(usize, NodeIx)>,
+    prefix: Vec<usize>,
+    levels: &mut Vec<Level<'g, N>>,
+    out: &mut Graph<Flat<N>>,
+    ca_stack: &mut Vec<ContentAddr>,
+) -> Result<usize, FlattenError>
+where
+    N: gantz_core::Node + Clone,
+{
+    let id = levels.len();
+    levels.push(Level {
+        graph,
+        parent,
+        inlets: Vec::new(),
+        outlets: Vec::new(),
+        kept: HashMap::new(),
+        child: HashMap::new(),
+    });
+    for ix in graph.node_indices() {
+        let node = &graph[ix];
+        let path = || {
+            let mut p = prefix.clone();
+            p.push(ix.index());
+            p
+        };
+        if let Some((ca, child_graph)) = resolve(node) {
+            if ca_stack.contains(&ca) {
+                return Err(FlattenError::RefCycle(ca));
+            }
+            let child_graph = child_graph.ok_or(FlattenError::Unresolved(ca))?;
+            ca_stack.push(ca);
+            let child = splice(
+                ctx,
+                resolve,
+                child_graph,
+                Some((id, ix)),
+                path(),
+                levels,
+                out,
+                ca_stack,
+            )?;
+            ca_stack.pop();
+            levels[id].child.insert(ix, child);
+        } else if node.inlet(ctx) {
+            levels[id].inlets.push(ix);
+        } else if node.outlet(ctx) {
+            levels[id].outlets.push(ix);
+        } else {
+            let flat = out.add_node(Flat {
+                path: path(),
+                node: node.clone(),
+            });
+            levels[id].kept.insert(ix, flat);
+        }
+    }
+    Ok(id)
+}
+
+/// Phase 2: emit the flat edges. Only edges whose target was kept are
+/// considered (each concrete input's feeds are enumerated exactly once, at
+/// the level where the target lives), with each source resolved through the
+/// boundary chain via [`resolve_src`]. Levels are visited in splice order and
+/// edges in creation (age) order, so a kept input's flat edges keep their
+/// original relative age and derivation's oldest-edge-wins resolution behaves
+/// as on an equivalent hand-flattened graph.
+fn bridge<N>(levels: &[Level<'_, N>], out: &mut Graph<Flat<N>>) {
+    for (id, level) in levels.iter().enumerate() {
+        for e in level.graph.edge_references() {
+            let Some(&flat_t) = level.kept.get(&e.target()) else {
+                continue;
+            };
+            let mut stack = Vec::new();
+            let src = e.weight().output.0 as usize;
+            if let Some((flat_s, port)) = resolve_src(levels, id, e.source(), src, &mut stack) {
+                let edge = Edge::new((port as u16).into(), e.weight().input);
+                out.add_edge(flat_s, flat_t, edge);
+            }
+        }
+    }
+}
+
+/// Resolve the source endpoint `(s, sp)` at level `lvl` to a kept flat node's
+/// output, following ref outputs down into their child's outlet and inlet
+/// outputs up into the parent's edges. `None` when the chain dead-ends
+/// (an unconnected boundary) or revisits an endpoint on `stack` (a pure
+/// boundary wiring cycle).
+fn resolve_src<N>(
+    levels: &[Level<'_, N>],
+    lvl: usize,
+    s: NodeIx,
+    sp: usize,
+    stack: &mut Vec<SrcKey>,
+) -> Option<(NodeIx, usize)> {
+    let key = (lvl, s, sp);
+    if stack.contains(&key) {
+        return None;
+    }
+    stack.push(key);
+    let level = &levels[lvl];
+    let resolved = if let Some(&flat) = level.kept.get(&s) {
+        Some((flat, sp))
+    } else if let Some(&child) = level.child.get(&s) {
+        // A ref's output `sp` reads the child's `sp`-th outlet's one input.
+        levels[child]
+            .outlets
+            .get(sp)
+            .copied()
+            .and_then(|outlet| resolve_via_input(levels, child, outlet, 0, stack))
+    } else if let Some(i) = level.inlets.iter().position(|&n| n == s) {
+        // An inlet's output reads the parent ref's input `i`. A root-level
+        // inlet has no parent to read, so it dissolves unconnected.
+        level
+            .parent
+            .and_then(|(p, r)| resolve_via_input(levels, p, r, i, stack))
+    } else {
+        // An outlet as a source (outlets have no outputs) or a node dropped
+        // by an earlier error path: nothing to wire.
+        None
+    };
+    stack.pop();
+    resolved
+}
+
+/// Resolve the winning source feeding `node`'s `input` at level `lvl`: the
+/// oldest edge whose chain resolves (`edges_directed` iterates newest-first,
+/// hence the reversal), matching derivation's input resolution.
+fn resolve_via_input<N>(
+    levels: &[Level<'_, N>],
+    lvl: usize,
+    node: NodeIx,
+    input: usize,
+    stack: &mut Vec<SrcKey>,
+) -> Option<(NodeIx, usize)> {
+    let edges: Vec<_> = levels[lvl]
+        .graph
+        .edges_directed(node, Direction::Incoming)
+        .filter(|e| e.weight().input.0 as usize == input)
+        .map(|e| (e.source(), e.weight().output.0 as usize))
+        .collect();
+    edges
+        .into_iter()
+        .rev()
+        .find_map(|(s, sp)| resolve_src(levels, lvl, s, sp, stack))
+}

--- a/crates/gantz_plyphon/src/flatten.rs
+++ b/crates/gantz_plyphon/src/flatten.rs
@@ -43,6 +43,7 @@ use gantz_core::node::{GetNode, MetaCtx};
 
 use crate::dsp::{NodeDsp, ToNodeDsp};
 
+pub use gantz_egui::node::NamedRef;
 pub use gantz_egui::sync::AsNamedRef;
 
 /// A node spliced out of a nested structure into a flat graph, carrying its

--- a/crates/gantz_plyphon/src/lib.rs
+++ b/crates/gantz_plyphon/src/lib.rs
@@ -25,12 +25,14 @@ pub use dsp::{
     DspBuilder, FADE_LAG, GainRef, NodeDsp, NodeRate, ParamBinding, ScopeOutBinding, Signal,
     ToNodeDsp,
 };
+pub use flatten::{Flat, FlattenError, flatten, flatten_from_registry};
 pub use node::{Bus, Lag, Out, Pack, ScopeOut, SinOsc, Unpack};
 pub use sugar::PlyphonSugar;
 
 pub mod backend;
 pub mod compile;
 pub mod dsp;
+pub mod flatten;
 pub mod monitor;
 pub mod node;
 pub mod param;

--- a/crates/gantz_plyphon/tests/flatten.rs
+++ b/crates/gantz_plyphon/tests/flatten.rs
@@ -1,0 +1,491 @@
+//! Tests that `flatten` splices nested graphs into a flat graph derivation
+//! understands: boundary bridging, original-path preservation, error cases and
+//! an offline render of a nested graph through the real engine.
+
+use std::collections::HashMap;
+
+use gantz_ca::ContentAddr;
+use gantz_core::edge::Edge;
+use gantz_core::node::graph::{Graph, NodeIx};
+use gantz_core::node::{ExprCtx, ExprResult, MetaCtx, parse_expr};
+use gantz_plyphon::flatten::{Flat, FlattenError, flatten};
+use gantz_plyphon::{
+    AddAction, Bus, Lag, NodeDsp, Out, ROOT_GROUP_ID, ScopeOut, SinOsc, ToNodeDsp, derive_synthdef,
+    derive_synthdefs, structural_sig,
+};
+use petgraph::Direction;
+use petgraph::visit::EdgeRef;
+use plyphon::{Options, World, engine};
+
+const SR: f32 = 48_000.0;
+
+/// A minimal erased node enum, standing in for the app's `Box<dyn Node>`:
+/// the DSP nodes plus the nesting machinery (`Inlet`/`Outlet`/`Ref`) and a
+/// non-DSP `Other` stand-in.
+#[derive(Clone)]
+enum N {
+    SinOsc(SinOsc),
+    Lag(Lag),
+    Out(Out),
+    ScopeOut(ScopeOut),
+    Bus(Bus),
+    Inlet,
+    Outlet,
+    Ref(ContentAddr),
+    Other,
+}
+
+impl ToNodeDsp for N {
+    fn to_node_dsp(&self) -> Option<&dyn NodeDsp> {
+        match self {
+            N::SinOsc(s) => Some(s),
+            N::Lag(l) => Some(l),
+            N::Out(o) => Some(o),
+            N::ScopeOut(t) => Some(t),
+            N::Bus(b) => Some(b),
+            N::Inlet | N::Outlet | N::Ref(_) | N::Other => None,
+        }
+    }
+}
+
+impl gantz_core::Node for N {
+    fn expr(&self, _ctx: ExprCtx<'_, '_>) -> ExprResult {
+        parse_expr("'()")
+    }
+
+    fn inlet(&self, _ctx: MetaCtx) -> bool {
+        matches!(self, N::Inlet)
+    }
+
+    fn outlet(&self, _ctx: MetaCtx) -> bool {
+        matches!(self, N::Outlet)
+    }
+}
+
+fn ca(byte: u8) -> ContentAddr {
+    ContentAddr([byte; 32])
+}
+
+/// A `Resolve` closure over a map of committed graphs: `Ref` nodes resolve
+/// (missing entries surface as `Unresolved`), everything else is concrete.
+fn resolver<'g>(
+    map: &'g HashMap<ContentAddr, Graph<N>>,
+) -> impl Fn(&N) -> Option<(ContentAddr, Option<&'g Graph<N>>)> + 'g {
+    move |n| match n {
+        N::Ref(ca) => Some((*ca, map.get(ca))),
+        _ => None,
+    }
+}
+
+fn flatten_with(graph: &Graph<N>, map: &HashMap<ContentAddr, Graph<N>>) -> Graph<Flat<N>> {
+    try_flatten(graph, map).expect("flatten")
+}
+
+fn try_flatten<'g>(
+    graph: &'g Graph<N>,
+    map: &'g HashMap<ContentAddr, Graph<N>>,
+) -> Result<Graph<Flat<N>>, FlattenError> {
+    let resolve = resolver(map);
+    flatten(&|_| None, graph, &resolve)
+}
+
+/// The flat node with the given original path.
+fn at<'a>(flat: &'a Graph<Flat<N>>, path: &[usize]) -> NodeIx {
+    flat.node_indices()
+        .find(|&n| flat[n].path == path)
+        .unwrap_or_else(|| panic!("no flat node at path {path:?}"))
+}
+
+/// The `(source path, output, input)` of every edge into the node at `path`.
+fn edges_into(flat: &Graph<Flat<N>>, path: &[usize]) -> Vec<(Vec<usize>, u16, u16)> {
+    let n = at(flat, path);
+    let mut edges: Vec<_> = flat
+        .edges_directed(n, Direction::Incoming)
+        .map(|e| {
+            let w = e.weight();
+            (flat[e.source()].path.clone(), w.output.0, w.input.0)
+        })
+        .collect();
+    edges.reverse();
+    edges
+}
+
+/// A child graph `inlet -> ~lag -> outlet`.
+fn lag_child() -> Graph<N> {
+    let mut g = Graph::<N>::default();
+    let i = g.add_node(N::Inlet);
+    let l = g.add_node(N::Lag(Lag::default()));
+    let o = g.add_node(N::Outlet);
+    g.add_edge(i, l, Edge::new(0.into(), 0.into()));
+    g.add_edge(l, o, Edge::new(0.into(), 0.into()));
+    g
+}
+
+/// A child graph `inlet -> outlet` (a pure pass-through wire).
+fn wire_child() -> Graph<N> {
+    let mut g = Graph::<N>::default();
+    let i = g.add_node(N::Inlet);
+    let o = g.add_node(N::Outlet);
+    g.add_edge(i, o, Edge::new(0.into(), 0.into()));
+    g
+}
+
+#[test]
+fn flat_graph_flattens_to_identity() {
+    // No refs: every node is copied with its flat path and every edge kept, and
+    // the derived def is structurally identical to deriving the raw graph.
+    let mut g = Graph::<N>::default();
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let other = g.add_node(N::Other);
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s, o, Edge::new(0.into(), 0.into()));
+    g.add_edge(other, o, Edge::new(0.into(), 1.into()));
+
+    let flat = flatten_with(&g, &HashMap::new());
+    assert_eq!(flat.node_count(), 3);
+    assert_eq!(flat.edge_count(), 2);
+    for n in flat.node_indices() {
+        assert_eq!(flat[n].path, vec![n.index()], "flat paths are [ix]");
+    }
+
+    let raw = derive_synthdef(&g, 1, "t").expect("derive raw");
+    let flt = derive_synthdef(&flat, 1, "t").expect("derive flat");
+    assert_eq!(structural_sig(&raw.def), structural_sig(&flt.def));
+}
+
+#[test]
+fn splices_a_nested_child() {
+    // parent: sin -> ref -> out, child: inlet -> lag -> outlet. The lag splices
+    // in carrying its nested path, boundary edges bridge to direct edges, and
+    // its dur param is named and bound by that path.
+    let map = HashMap::from([(ca(1), lag_child())]);
+    let mut g = Graph::<N>::default();
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::Ref(ca(1)));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(r, o, Edge::new(0.into(), 0.into()));
+
+    let flat = flatten_with(&g, &map);
+    assert_eq!(flat.node_count(), 3, "sin + spliced lag + out");
+    assert_eq!(edges_into(&flat, &[1, 1]), vec![(vec![0], 0, 0)]);
+    assert_eq!(edges_into(&flat, &[2]), vec![(vec![1, 1], 0, 0)]);
+
+    let derived = derive_synthdef(&flat, 1, "t").expect("derive");
+    let dur = derived
+        .def
+        .params
+        .iter()
+        .find(|p| p.name.ends_with("/dur"))
+        .expect("lag dur param");
+    assert_eq!(
+        dur.name, "1-1/dur",
+        "param named by the original nested path"
+    );
+    assert!(
+        derived.params.iter().any(|b| b.node_path == vec![1, 1]),
+        "binding keyed by the original nested path",
+    );
+}
+
+#[test]
+fn inlet_fans_out_to_every_consumer() {
+    // child: one inlet feeding two lags. The one parent edge into the ref
+    // becomes an edge to each consumer.
+    let mut child = Graph::<N>::default();
+    let i = child.add_node(N::Inlet);
+    let l0 = child.add_node(N::Lag(Lag::default()));
+    let l1 = child.add_node(N::Lag(Lag::default()));
+    child.add_edge(i, l0, Edge::new(0.into(), 0.into()));
+    child.add_edge(i, l1, Edge::new(0.into(), 0.into()));
+    let map = HashMap::from([(ca(1), child)]);
+
+    let mut g = Graph::<N>::default();
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::Ref(ca(1)));
+    g.add_edge(s, r, Edge::new(0.into(), 0.into()));
+
+    let flat = flatten_with(&g, &map);
+    assert_eq!(edges_into(&flat, &[1, 1]), vec![(vec![0], 0, 0)]);
+    assert_eq!(edges_into(&flat, &[1, 2]), vec![(vec![0], 0, 0)]);
+}
+
+#[test]
+fn pass_through_wire_dissolves() {
+    // child: inlet -> outlet. The ref dissolves into a direct parent edge.
+    let map = HashMap::from([(ca(1), wire_child())]);
+    let mut g = Graph::<N>::default();
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::Ref(ca(1)));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(r, o, Edge::new(0.into(), 0.into()));
+
+    let flat = flatten_with(&g, &map);
+    assert_eq!(flat.node_count(), 2);
+    assert_eq!(edges_into(&flat, &[2]), vec![(vec![0], 0, 0)]);
+}
+
+#[test]
+fn two_levels_splice_and_pass_through() {
+    // grandchild: inlet -> lag -> outlet. child: inlet -> ref(grandchild) ->
+    // outlet. The lag carries its two-level path and the double boundary
+    // bridges to direct edges.
+    let mut child = Graph::<N>::default();
+    let i = child.add_node(N::Inlet);
+    let r = child.add_node(N::Ref(ca(1)));
+    let o = child.add_node(N::Outlet);
+    child.add_edge(i, r, Edge::new(0.into(), 0.into()));
+    child.add_edge(r, o, Edge::new(0.into(), 0.into()));
+    let map = HashMap::from([(ca(1), lag_child()), (ca(2), child)]);
+
+    let mut g = Graph::<N>::default();
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::Ref(ca(2)));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(r, o, Edge::new(0.into(), 0.into()));
+
+    let flat = flatten_with(&g, &map);
+    assert_eq!(flat.node_count(), 3, "sin + doubly nested lag + out");
+    assert_eq!(edges_into(&flat, &[1, 1, 1]), vec![(vec![0], 0, 0)]);
+    assert_eq!(edges_into(&flat, &[2]), vec![(vec![1, 1, 1], 0, 0)]);
+}
+
+#[test]
+fn unconnected_boundaries_dissolve_to_silence() {
+    // The ref's input is unconnected (the child lag's input dissolves to
+    // nothing) and a second ref has no outlet to source the out's input from.
+    // Both sides resolve to no edge, deferring to derivation's silence.
+    let mut no_outlet = Graph::<N>::default();
+    no_outlet.add_node(N::Inlet);
+    let map = HashMap::from([(ca(1), lag_child()), (ca(2), no_outlet)]);
+
+    let mut g = Graph::<N>::default();
+    let r1 = g.add_node(N::Ref(ca(1)));
+    let r2 = g.add_node(N::Ref(ca(2)));
+    let o = g.add_node(N::Out(Out::default()));
+    let o2 = g.add_node(N::Out(Out::default()));
+    g.add_edge(r1, o, Edge::new(0.into(), 0.into()));
+    g.add_edge(r2, o2, Edge::new(0.into(), 0.into()));
+
+    let flat = flatten_with(&g, &map);
+    assert!(edges_into(&flat, &[0, 1]).is_empty(), "unconnected inlet");
+    assert_eq!(edges_into(&flat, &[2]), vec![(vec![0, 1], 0, 0)]);
+    assert!(edges_into(&flat, &[3]).is_empty(), "no outlet to source");
+    derive_synthdef(&flat, 1, "t").expect("still derives");
+}
+
+#[test]
+fn multi_instance_refs_are_independent() {
+    // The same committed child spliced twice: two lags with distinct paths and
+    // independent param bindings.
+    let map = HashMap::from([(ca(1), lag_child())]);
+    let mut g = Graph::<N>::default();
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let r1 = g.add_node(N::Ref(ca(1)));
+    let r2 = g.add_node(N::Ref(ca(1)));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s, r1, Edge::new(0.into(), 0.into()));
+    g.add_edge(r1, r2, Edge::new(0.into(), 0.into()));
+    g.add_edge(r2, o, Edge::new(0.into(), 0.into()));
+
+    let flat = flatten_with(&g, &map);
+    assert_eq!(edges_into(&flat, &[1, 1]), vec![(vec![0], 0, 0)]);
+    assert_eq!(edges_into(&flat, &[2, 1]), vec![(vec![1, 1], 0, 0)]);
+    assert_eq!(edges_into(&flat, &[3]), vec![(vec![2, 1], 0, 0)]);
+
+    let derived = derive_synthdef(&flat, 1, "t").expect("derive");
+    for path in [vec![1, 1], vec![2, 1]] {
+        assert!(
+            derived.params.iter().any(|b| b.node_path == path),
+            "expected an independent binding at {path:?}",
+        );
+    }
+}
+
+#[test]
+fn ref_cycle_and_unresolved_are_errors() {
+    // a refs b refs a: a cycle. A ref to an uncommitted address: unresolved.
+    let mut a = Graph::<N>::default();
+    a.add_node(N::Ref(ca(2)));
+    let mut b = Graph::<N>::default();
+    b.add_node(N::Ref(ca(1)));
+    let map = HashMap::from([(ca(1), a), (ca(2), b)]);
+
+    let mut g = Graph::<N>::default();
+    g.add_node(N::Ref(ca(1)));
+    assert!(matches!(
+        try_flatten(&g, &map),
+        Err(FlattenError::RefCycle(_)),
+    ));
+
+    let mut g = Graph::<N>::default();
+    g.add_node(N::Ref(ca(9)));
+    assert!(matches!(
+        try_flatten(&g, &HashMap::new()),
+        Err(FlattenError::Unresolved(c)) if c == ca(9),
+    ));
+}
+
+#[test]
+fn boundary_wiring_cycle_dissolves() {
+    // Two pass-through refs wired into a loop (sharing one committed child -
+    // no *ref* cycle). Resolution terminates and the consumer dissolves
+    // unconnected rather than looping.
+    let map = HashMap::from([(ca(1), wire_child())]);
+    let mut g = Graph::<N>::default();
+    let r1 = g.add_node(N::Ref(ca(1)));
+    let r2 = g.add_node(N::Ref(ca(1)));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(r1, r2, Edge::new(0.into(), 0.into()));
+    g.add_edge(r2, r1, Edge::new(0.into(), 0.into()));
+    g.add_edge(r2, o, Edge::new(0.into(), 0.into()));
+
+    let flat = flatten_with(&g, &map);
+    assert_eq!(flat.node_count(), 1, "only the out survives");
+    assert!(edges_into(&flat, &[2]).is_empty());
+}
+
+#[test]
+fn oldest_edge_wins_across_a_bridge() {
+    // Two sources race for the ref's one input: the oldest resolving edge wins
+    // at each hop, matching derivation's input resolution.
+    let map = HashMap::from([(ca(1), wire_child())]);
+    let mut g = Graph::<N>::default();
+    let s_old = g.add_node(N::SinOsc(SinOsc::default()));
+    let s_new = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::Ref(ca(1)));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s_old, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(s_new, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(r, o, Edge::new(0.into(), 0.into()));
+
+    let flat = flatten_with(&g, &map);
+    assert_eq!(
+        edges_into(&flat, &[3]),
+        vec![(vec![0], 0, 0)],
+        "the older source feeds the consumer",
+    );
+}
+
+#[test]
+fn nested_sinks_and_buses_derive_with_stable_keys() {
+    // A nested `~bus` cuts regions exactly as a flat one would, with bindings
+    // and keys carrying the full nested path, and an unrelated parent addition
+    // keeps every region key (no spurious respawns).
+    let mut child = Graph::<N>::default();
+    let i = child.add_node(N::Inlet);
+    let b = child.add_node(N::Bus(Bus::default()));
+    let o = child.add_node(N::Outlet);
+    child.add_edge(i, b, Edge::new(0.into(), 0.into()));
+    child.add_edge(b, o, Edge::new(0.into(), 0.into()));
+    let map = HashMap::from([(ca(1), child)]);
+
+    let mut g = Graph::<N>::default();
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::Ref(ca(1)));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(r, o, Edge::new(0.into(), 0.into()));
+
+    let flat = flatten_with(&g, &map);
+    let regions = derive_synthdefs(&flat, 1, "t").expect("derive");
+    assert_eq!(regions.len(), 2, "the nested bus cuts writer from reader");
+    assert_eq!(regions[0].bus_writes[0].node_path, vec![1, 1]);
+    assert_eq!(regions[1].bus_reads[0].node_path, vec![1, 1]);
+
+    // An unrelated appended node re-flattens with every path (hence key) intact.
+    let keys: Vec<u64> = regions.iter().map(|r| r.key).collect();
+    g.add_node(N::Other);
+    let flat = flatten_with(&g, &map);
+    let regions = derive_synthdefs(&flat, 1, "t").expect("re-derive");
+    let keys2: Vec<u64> = regions.iter().map(|r| r.key).collect();
+    assert_eq!(keys, keys2, "unrelated additions keep region keys");
+}
+
+#[test]
+fn nested_scopeout_binds_by_nested_path() {
+    // A monitor inside the child roots a synthdef pull and its binding names
+    // the nested path (where the driver streams the ring state to).
+    let mut child = Graph::<N>::default();
+    let i = child.add_node(N::Inlet);
+    let t = child.add_node(N::ScopeOut(ScopeOut::default()));
+    child.add_edge(i, t, Edge::new(0.into(), 0.into()));
+    let map = HashMap::from([(ca(1), child)]);
+
+    let mut g = Graph::<N>::default();
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::Ref(ca(1)));
+    g.add_edge(s, r, Edge::new(0.into(), 0.into()));
+
+    let flat = flatten_with(&g, &map);
+    let derived = derive_synthdef(&flat, 1, "t").expect("derive");
+    assert_eq!(derived.monitors.len(), 1);
+    assert_eq!(derived.monitors[0].node_path, vec![1, 1]);
+}
+
+#[test]
+fn nested_synth_plays_expected_tone() {
+    // The whole pipeline end to end: a sine committed inside a child graph
+    // sounds through the parent's `~out` when rendered by the real engine.
+    let mut child = Graph::<N>::default();
+    let s = child.add_node(N::SinOsc(SinOsc::default()));
+    let o = child.add_node(N::Outlet);
+    child.add_edge(s, o, Edge::new(0.into(), 0.into()));
+    let map = HashMap::from([(ca(1), child)]);
+
+    let mut g = Graph::<N>::default();
+    let r = g.add_node(N::Ref(ca(1)));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(r, o, Edge::new(0.into(), 0.into()));
+
+    let flat = flatten_with(&g, &map);
+    let def = derive_synthdef(&flat, 1, "test").expect("derive").def;
+
+    let (mut controller, _nrt, mut world) = engine(Options {
+        sample_rate: SR as f64,
+        output_channels: 1,
+        ..Options::default()
+    });
+    controller.add_synthdef(def);
+    controller
+        .synth_new("test", ROOT_GROUP_ID, AddAction::Tail)
+        .expect("synth_new");
+
+    let a = render(&mut world, SR as usize / 2);
+    assert!(a.iter().any(|s| s.abs() > 0.1), "nested synth was silent");
+    let (m220, m440) = (goertzel(&a, 220.0), goertzel(&a, 440.0));
+    assert!(
+        m220 > 5.0 * m440,
+        "expected 220 Hz dominant: m220={m220}, m440={m440}",
+    );
+}
+
+/// Goertzel magnitude estimate at `freq` (Hz) over mono `samples` sampled at [`SR`].
+fn goertzel(samples: &[f32], freq: f32) -> f32 {
+    let n = samples.len();
+    let k = (0.5 + n as f32 * freq / SR).floor();
+    let w = 2.0 * std::f32::consts::PI * k / n as f32;
+    let coeff = 2.0 * w.cos();
+    let (mut s1, mut s2) = (0.0f32, 0.0f32);
+    for &x in samples {
+        let s = x + coeff * s1 - s2;
+        s2 = s1;
+        s1 = s;
+    }
+    let power = s1 * s1 + s2 * s2 - coeff * s1 * s2;
+    power.max(0.0).sqrt() / n as f32
+}
+
+/// Render `frames` of mono audio.
+fn render(world: &mut World, frames: usize) -> Vec<f32> {
+    let mut out = Vec::with_capacity(frames + 512);
+    let mut buf = vec![0.0f32; 512];
+    while out.len() < frames {
+        world.fill(&mut buf, 1);
+        out.extend_from_slice(&buf);
+    }
+    out.truncate(frames);
+    out
+}


### PR DESCRIPTION
Closes #291.

Composing DSP nodes into a nested graph (`Inlet`/`Outlet` boundaries behind a `NamedRef`) previously derived to silence: the synthdef compiler only saw flat top-level nodes, dropped the ref and severed every edge crossing the boundary.

Since a synthdef is a flat unit list with no notion of calling a sub-synthdef, nesting is supported by *inlining* rather than the control layer's call-based approach.

## What this does

- **`gantz_plyphon::flatten`** (new module): resolves graph refs through the content-addressed registry, splices each referenced graph's nodes into one flat graph and dissolves `Inlet`/`Outlet` boundary nodes into the surrounding edges. Bridging resolves through arbitrarily deep boundary chains (a pure `inlet -> outlet` wire dissolves entirely), taking the oldest resolving edge per hop to match derivation's input resolution. Ref cycles and unresolvable refs return `FlattenError` (both are already forbidden upstream by the editor and loader, so these paths are defensive).
- **Original paths are preserved**: every spliced node is wrapped in `Flat { path, node }` carrying its full nested path (e.g. `[3, 2]`), and a new defaulted `ToNodeDsp::node_path` hook lets derivation use it everywhere it previously hardcoded the flat index. Param names, param/scope bindings, bus allocation keys and region keys all stay keyed by original location, so nested params bridge to VM state and re-derives cause no spurious crossfade respawns. Flat graphs derive byte-identically to before.
- **Driver wiring**: `bevy_gantz_plyphon` flattens each head's working graph on committed-graph change before `structural_sync`. A flatten error keeps the previous synths playing and parks the head at that commit so the error logs once (the same treatment as a `~bus` cycle, extracted into a shared `park_head`).

## Follow-ups

- #295 
- Feedback cycles through a delay node: #293.
- Cross-region `~bus` feedback via `InFeedback`-style reads remains the documented follow-up on `DeriveError::BusCycle`.