### PR TITLE
feat(compile): debug-log each compile step with its duration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3342,12 +3342,14 @@ dependencies = [
  "env_logger",
  "gantz_ca",
  "gantz_nodetag",
+ "log",
  "petgraph",
  "serde",
  "serde_json",
  "steel-core",
  "steel-derive",
  "thiserror 2.0.17",
+ "web-time",
 ]
 
 [[package]]

--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -656,7 +656,10 @@ fn structural_sync<N>(
 {
     let now = Instant::now();
     let prefix = format!("gantz-head-{}", entity.index());
-    let derived = match derive_synthdefs(graph, out_channels, &prefix) {
+    let derive_start = Instant::now();
+    let derived_result = derive_synthdefs(graph, out_channels, &prefix);
+    log::debug!("Derived synthdef ({:?})", derive_start.elapsed());
+    let derived = match derived_result {
         Ok(regions) => regions,
         // No dsp sink to root any synthdef at: fade every region out. Freeing
         // the defs now is safe - a fading synth holds its own compiled copy.

--- a/crates/gantz_core/Cargo.toml
+++ b/crates/gantz_core/Cargo.toml
@@ -11,10 +11,12 @@ repository.workspace = true
 [dependencies]
 gantz_ca.workspace = true
 gantz_nodetag.workspace = true
+log.workspace = true
 petgraph.workspace = true
 serde.workspace = true
 steel-core.workspace = true
 thiserror.workspace = true
+web-time.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true

--- a/crates/gantz_core/src/vm.rs
+++ b/crates/gantz_core/src/vm.rs
@@ -106,11 +106,18 @@ where
         + Copy,
     G::NodeWeight: Node,
 {
+    let module_start = web_time::Instant::now();
     let exprs = crate::compile::module(get_node, graph, entrypoints, config)?;
+    log::debug!("Generated steel module ({:?})", module_start.elapsed());
+
     let src = fmt_module(&exprs);
     let map = SourceMap::parse(&src);
     let compiled = Compiled { exprs, src, map };
-    match vm.run(compiled.src.clone()) {
+
+    let run_start = web_time::Instant::now();
+    let result = vm.run(compiled.src.clone());
+    log::debug!("Compiled steel ({:?})", run_start.elapsed());
+    match result {
         Ok(_) => Ok(compiled),
         Err(err) => Err(CompileError::Eval {
             err,


### PR DESCRIPTION
`log::debug!` the three compile steps with a debug-formatted `Duration` of how long each took, surfaced by setting
`RUST_LOG=gantz_core=debug,bevy_gantz_plyphon=debug`:

- module generation: `gantz_core::vm::compile` around `compile::module`
- steel compile: `gantz_core::vm::compile` around `vm.run`
- dsp/synthdef derivation: `bevy_gantz_plyphon::structural_sync` around `derive_synthdefs`

`gantz_core` gains `log` (the facade its tests already bridge via `env_logger`) and `web-time` for an `Instant` that does not panic on wasm32, the same shim `bevy_gantz_plyphon` already uses.