### PR TITLE
feat: Make all `bevy_gantz_*` plugins order-independent

### DIFF
--- a/crates/bevy_gantz/src/lib.rs
+++ b/crates/bevy_gantz/src/lib.rs
@@ -90,6 +90,14 @@ impl EvalEpoch {
 /// Apps should also:
 /// - Insert a `BuiltinNodes<N>` resource with their builtin nodes
 /// - Add `GantzEguiPlugin` for egui integration (Views, GraphViews, etc.)
+///
+/// # Assembly
+///
+/// Plugin order does not matter: the gantz plugins contribute to shared
+/// collections via `get_resource_or_init` (see [`EntrypointFns`]) and
+/// perform cross-plugin resource reads in `Plugin::finish` (see
+/// `bevy_gantz_plyphon::PlyphonPlugin`, the reference domain plugin), so
+/// they may be added in any order relative to each other.
 pub struct GantzPlugin<N>(std::marker::PhantomData<N>);
 
 impl<N> Default for GantzPlugin<N> {

--- a/crates/bevy_gantz/src/lib.rs
+++ b/crates/bevy_gantz/src/lib.rs
@@ -103,30 +103,36 @@ where
     N: 'static + Node + Clone + gantz_ca::CaHash + Send + Sync,
 {
     fn build(&self, app: &mut App) {
-        app.insert_resource(vm::EntrypointFns::<N>(vec![Box::new(|get_node, graph| {
-            gantz_core::compile::push_pull_entrypoints(get_node, graph)
-        })]))
-        .init_resource::<FocusedHead>()
-        .init_resource::<HeadTabOrder>()
-        .init_resource::<Registry<N>>()
-        .init_resource::<vm::CompileConfig>()
-        .init_resource::<vm::ValidateCommitted>()
-        .insert_resource(EvalEpoch(web_time::Instant::now()))
-        .init_non_send::<HeadVms>()
-        // Register head event handlers.
-        .add_observer(head::on_open::<N>)
-        .add_observer(head::on_replace::<N>)
-        .add_observer(head::on_close::<N>)
-        .add_observer(head::on_branch_head::<N>)
-        .add_observer(head::on_move_branch::<N>)
-        // Register eval entry event handler.
-        .add_observer(vm::on_eval_entry)
-        // Input-addressed VM synchronisation: (re)compiles whenever a head's
-        // compile inputs (committed graph content address + config) change.
-        .add_systems(Update, vm::sync::<N>.in_set(VmSet))
-        // Debug check for the WorkingGraph commit-before-return invariant
-        // (no-op unless `ValidateCommitted` is enabled).
-        .add_systems(Update, vm::validate_committed::<N>.after(VmSet));
+        // Contributed via `get_resource_or_init` + push (never
+        // `insert_resource`) so providers pushed by plugins built earlier
+        // survive - plugin order must not matter.
+        app.world_mut()
+            .get_resource_or_init::<vm::EntrypointFns<N>>()
+            .0
+            .push(Box::new(|get_node, graph| {
+                gantz_core::compile::push_pull_entrypoints(get_node, graph)
+            }));
+        app.init_resource::<FocusedHead>()
+            .init_resource::<HeadTabOrder>()
+            .init_resource::<Registry<N>>()
+            .init_resource::<vm::CompileConfig>()
+            .init_resource::<vm::ValidateCommitted>()
+            .insert_resource(EvalEpoch(web_time::Instant::now()))
+            .init_non_send::<HeadVms>()
+            // Register head event handlers.
+            .add_observer(head::on_open::<N>)
+            .add_observer(head::on_replace::<N>)
+            .add_observer(head::on_close::<N>)
+            .add_observer(head::on_branch_head::<N>)
+            .add_observer(head::on_move_branch::<N>)
+            // Register eval entry event handler.
+            .add_observer(vm::on_eval_entry)
+            // Input-addressed VM synchronisation: (re)compiles whenever a head's
+            // compile inputs (committed graph content address + config) change.
+            .add_systems(Update, vm::sync::<N>.in_set(VmSet))
+            // Debug check for the WorkingGraph commit-before-return invariant
+            // (no-op unless `ValidateCommitted` is enabled).
+            .add_systems(Update, vm::validate_committed::<N>.after(VmSet));
     }
 }
 
@@ -135,4 +141,43 @@ pub fn clone_graph<N: Clone>(
     graph: &gantz_core::node::graph::Graph<N>,
 ) -> gantz_core::node::graph::Graph<N> {
     graph.map(|_, n| n.clone(), |_, e| *e)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone)]
+    struct TestNode;
+
+    impl gantz_core::Node for TestNode {
+        fn expr(&self, _ctx: gantz_core::node::ExprCtx<'_, '_>) -> gantz_core::node::ExprResult {
+            gantz_core::node::parse_expr("'()")
+        }
+    }
+
+    impl gantz_ca::CaHash for TestNode {
+        fn hash(&self, hasher: &mut gantz_ca::Hasher) {
+            hasher.update(b"test.node");
+        }
+    }
+
+    /// Providers pushed into `EntrypointFns` before `GantzPlugin` is added
+    /// must survive its build: plugins contribute to the shared collection,
+    /// they do not insert over it, so plugin order does not matter.
+    #[test]
+    fn entrypoint_fns_survive_plugin_order() {
+        let mut app = bevy_app::App::new();
+        app.world_mut()
+            .get_resource_or_init::<vm::EntrypointFns<TestNode>>()
+            .0
+            .push(Box::new(|_, _| Vec::new()));
+        app.add_plugins(GantzPlugin::<TestNode>::default());
+        let fns = app.world().resource::<vm::EntrypointFns<TestNode>>();
+        assert_eq!(
+            fns.0.len(),
+            2,
+            "both the pre-pushed provider and the plugin's seed must survive",
+        );
+    }
 }

--- a/crates/bevy_gantz/src/vm.rs
+++ b/crates/bevy_gantz/src/vm.rs
@@ -51,6 +51,11 @@ pub type EntrypointFn<N> = Box<
 /// Each provider is called during compilation to collect entrypoints.
 /// `GantzPlugin` registers `push_pull_entrypoints` by default.
 /// Downstream plugins (e.g. `GantzEguiPlugin`) push additional providers.
+///
+/// Contribute via `get_resource_or_init` + push (never `insert_resource`,
+/// which would clobber providers pushed by plugins built earlier) - the
+/// convention every shared provider collection follows so that plugin order
+/// does not matter.
 #[derive(Resource)]
 pub struct EntrypointFns<N: 'static>(pub Vec<EntrypointFn<N>>);
 

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -48,8 +48,6 @@ pub use sugar::BevySugar;
 /// - Registers observers for GUI state management
 /// - Registers node creation/inspection observers
 /// - Runs the main GUI update system
-///
-/// **Note:** This plugin requires `GantzPlugin<N>` to be added first.
 pub struct GantzEguiPlugin<N> {
     base_immutable: bool,
     _marker: PhantomData<N>,
@@ -97,19 +95,17 @@ where
         + 'static,
 {
     fn build(&self, app: &mut App) {
-        // Register update_bang + tick_bang entrypoint providers.
-        app.world_mut()
-            .resource_mut::<bevy_gantz::EntrypointFns<N>>()
-            .0
-            .push(Box::new(|get_node, graph| {
-                node::update_bang::entrypoints(get_node, graph)
-            }));
-        app.world_mut()
-            .resource_mut::<bevy_gantz::EntrypointFns<N>>()
-            .0
-            .push(Box::new(|get_node, graph| {
-                node::tick_bang::entrypoints(get_node, graph)
-            }));
+        // Register update_bang + tick_bang entrypoint providers. Contributed
+        // via `get_resource_or_init` + push so plugin order does not matter.
+        let mut entrypoint_fns = app
+            .world_mut()
+            .get_resource_or_init::<bevy_gantz::EntrypointFns<N>>();
+        entrypoint_fns.0.push(Box::new(|get_node, graph| {
+            node::update_bang::entrypoints(get_node, graph)
+        }));
+        entrypoint_fns.0.push(Box::new(|get_node, graph| {
+            node::tick_bang::entrypoints(get_node, graph)
+        }));
 
         // Builtin GUI response payload dispatchers. Head-scoped payloads
         // arrive at the observers below as `ForHead<T>` events; the rest map

--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -96,11 +96,34 @@ fn osc(secs: f64) -> u64 {
 /// Plugin wiring plyphon DSP into a gantz bevy app.
 ///
 /// Generic over `N`, the graph node type (must expose its DSP nodes via
-/// [`ToNodeDsp`]). Add it *after* [`bevy_gantz::GantzPlugin`].
+/// [`ToNodeDsp`]).
 ///
 /// To use custom UGens, register them with [`with_units`](Self::with_units). A
 /// node's [`NodeDsp::ugens`](gantz_plyphon::NodeDsp::ugens) can then name them in a
 /// [`UnitSpec`](plyphon::UnitSpec).
+///
+/// # The domain plugin shape
+///
+/// This plugin is the reference for wiring a domain into a gantz app: a
+/// plain bevy `Plugin` (deliberately no `GantzDomain` umbrella trait or
+/// plugin group - the plugin IS the domain's bevy-side assembly point),
+/// addable in ANY order relative to the other gantz plugins:
+///
+/// - Cross-plugin resource reads (here the shared [`EvalEpoch`] clock)
+///   happen in [`Plugin::finish`], which bevy runs after every plugin's
+///   `build`, before the schedule first ticks.
+/// - Contributions to shared collections go through
+///   `get_resource_or_init` + push (see
+///   [`bevy_gantz::EntrypointFns`],
+///   [`RegisterResponseExt::register_response_with`]) - never
+///   `insert_resource`, which would clobber earlier contributions.
+/// - GUI surfaces are provided by per-frame systems in `PreUpdate`
+///   (here `sync_dsp_settings` and `provide_dsp_ref_ext`) pushing into the
+///   `First`-cleared collections ([`SettingsTabs`], [`RefExtUis`]), whose
+///   `init_resource` calls are idempotent on purpose so the plugin works
+///   with or without `GantzEguiPlugin`.
+/// - The domain's own extension points (here
+///   [`with_units`](Self::with_units)) hang off the plugin itself.
 pub struct PlyphonPlugin<N> {
     unit_registrars: Vec<UnitRegistrar>,
     _marker: std::marker::PhantomData<N>,
@@ -145,12 +168,35 @@ where
     N: 'static + ToNodeDsp + gantz_core::Node + AsNamedRef + Clone + Send + Sync,
 {
     fn build(&self, app: &mut App) {
-        // The shared monotonic epoch (set by `GantzPlugin`, added before this) is
-        // the dsp clock's time base. The cpal callback anchors the engine clock
-        // to it via `fill_at`, matching the firing times queued into `%args`.
-        let epoch = *app.world().resource::<EvalEpoch>();
-        // DSP settings (the Settings -> DSP tab) + the status it reports.
+        // DSP settings (the Settings -> DSP tab).
         app.init_resource::<DspConfig>();
+        // The Settings -> DSP tab: the tab's emitted `Config` payloads dispatch
+        // into a buffered message, applied (and re-snapshotted into the tab)
+        // by `sync_dsp_settings`. The `NamedRef` inspector's DSP `inline`
+        // toggle is provided per frame by `provide_dsp_ref_ext`. The
+        // `init_resource` calls are idempotent and keep the providers valid
+        // without the egui plugin.
+        app.init_resource::<SettingsTabs>()
+            .init_resource::<RefExtUis>()
+            .add_message::<DspSettingsChanged>()
+            .register_response_with::<Config>(dispatch_dsp_settings)
+            .add_systems(PreUpdate, (sync_dsp_settings, provide_dsp_ref_ext::<N>));
+        // `.after(EntrypointSet)`: run once the `tick!`/`update!` drivers' triggered
+        // evaluations have flushed, so the control values they queue are visible to
+        // the param drain below in the same frame.
+        app.add_systems(Update, drive_synths::<N>.after(VmSet).after(EntrypointSet));
+    }
+
+    // Engine construction lives in `finish` rather than `build`: it reads the
+    // shared `EvalEpoch` clock, which another plugin (`GantzPlugin`) inserts
+    // at build time. `finish` runs after every plugin's `build` and before
+    // the schedule first ticks, so plugin order does not matter and the
+    // systems registered above find their resources on the first frame.
+    fn finish(&self, app: &mut App) {
+        // The shared monotonic epoch is the dsp clock's time base. The cpal
+        // callback anchors the engine clock to it via `fill_at`, matching
+        // the firing times queued into `%args`.
+        let epoch = *app.world().resource::<EvalEpoch>();
         let mut head_synths = HeadSynths::default();
         let status = match build_dsp_engine(epoch, &self.unit_registrars) {
             Some(engine) => {
@@ -171,23 +217,9 @@ where
             }
         };
         app.insert_resource(DspStatus(status));
-        // The Settings -> DSP tab: the tab's emitted `Config` payloads dispatch
-        // into a buffered message, applied (and re-snapshotted into the tab)
-        // by `sync_dsp_settings`. The `NamedRef` inspector's DSP `inline`
-        // toggle is provided per frame by `provide_dsp_ref_ext`. The
-        // `init_resource` calls are idempotent and keep the providers valid
-        // without the egui plugin.
-        app.init_resource::<SettingsTabs>()
-            .init_resource::<RefExtUis>()
-            .add_message::<DspSettingsChanged>()
-            .register_response_with::<Config>(dispatch_dsp_settings)
-            .add_systems(PreUpdate, (sync_dsp_settings, provide_dsp_ref_ext::<N>));
-        // `.after(EntrypointSet)`: run once the `tick!`/`update!` drivers' triggered
-        // evaluations have flushed, so the control values they queue are visible to
-        // the param drain below in the same frame. `HeadSynths` is a NonSend resource:
-        // it holds each `~scopeout`'s scope `StreamConsumer` (a `!Sync` SPSC handle).
-        app.insert_non_send(head_synths)
-            .add_systems(Update, drive_synths::<N>.after(VmSet).after(EntrypointSet));
+        // `HeadSynths` is a NonSend resource: it holds each `~scopeout`'s
+        // scope `StreamConsumer` (a `!Sync` SPSC handle).
+        app.insert_non_send(head_synths);
     }
 }
 

--- a/crates/bevy_gantz_plyphon/tests/plugin_order.rs
+++ b/crates/bevy_gantz_plyphon/tests/plugin_order.rs
@@ -1,0 +1,63 @@
+//! Plugin assembly must be order-insensitive: `PlyphonPlugin` reads the
+//! shared `EvalEpoch` in `Plugin::finish`, so adding it BEFORE `GantzPlugin`
+//! must work identically.
+
+use bevy::MinimalPlugins;
+use bevy::app::App;
+use bevy_gantz::GantzPlugin;
+use bevy_gantz_plyphon::{DspConfig, DspStatus, PlyphonPlugin};
+use gantz_egui::node::NamedRef;
+use gantz_egui::sync::AsNamedRef;
+use gantz_plyphon::{NodeDsp, ToNodeDsp};
+
+#[derive(Clone)]
+struct TestNode;
+
+impl gantz_core::Node for TestNode {
+    fn expr(&self, _ctx: gantz_core::node::ExprCtx<'_, '_>) -> gantz_core::node::ExprResult {
+        gantz_core::node::parse_expr("'()")
+    }
+}
+
+impl ToNodeDsp for TestNode {
+    fn to_node_dsp(&self) -> Option<&dyn NodeDsp> {
+        None
+    }
+}
+
+impl AsNamedRef for TestNode {
+    fn as_named_ref(&self) -> Option<&NamedRef> {
+        None
+    }
+}
+
+impl gantz_ca::CaHash for TestNode {
+    fn hash(&self, hasher: &mut gantz_ca::Hasher) {
+        hasher.update(b"test.node");
+    }
+}
+
+/// A headless app with the gantz plugins added in REVERSED order builds,
+/// finishes and ticks without panicking, with the DSP resources present.
+#[test]
+fn plugin_order_is_insensitive() {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    // Deliberately reversed: the DSP runtime before the core plugin.
+    app.add_plugins(PlyphonPlugin::<TestNode>::new());
+    app.add_plugins(GantzPlugin::<TestNode>::default());
+    // The builtin set is the app's responsibility (see `GantzPlugin` docs).
+    app.insert_resource(bevy_gantz::BuiltinNodes::<TestNode>(Box::new(
+        gantz_core::BuiltinSet::from_specs([]),
+    )));
+    app.finish();
+    app.cleanup();
+    for _ in 0..3 {
+        app.update();
+    }
+    assert!(app.world().contains_resource::<DspConfig>());
+    assert!(
+        app.world().contains_resource::<DspStatus>(),
+        "DspStatus is inserted at finish regardless of device presence",
+    );
+}

--- a/crates/gantz/src/main.rs
+++ b/crates/gantz/src/main.rs
@@ -74,7 +74,10 @@ fn main() {
 fn log_plugin() -> bevy::log::LogPlugin {
     bevy::log::LogPlugin {
         custom_layer: move |app| {
-            let capture = app.world().resource_ref::<TraceCapture>();
+            // `get_resource_or_init`: this closure runs while `DefaultPlugins`
+            // builds, and `GantzEguiPlugin`s later idempotent `init_resource`
+            // shares the instance - so plugin order does not matter.
+            let capture = app.world_mut().get_resource_or_init::<TraceCapture>();
             Some(Box::new(capture.0.clone().layer()))
         },
         ..Default::default()

--- a/crates/gantz/src/main_update_base.rs
+++ b/crates/gantz/src/main_update_base.rs
@@ -65,7 +65,10 @@ fn main() {
 fn log_plugin() -> bevy::log::LogPlugin {
     bevy::log::LogPlugin {
         custom_layer: move |app| {
-            let capture = app.world().resource_ref::<TraceCapture>();
+            // `get_resource_or_init`: this closure runs while `DefaultPlugins`
+            // builds, and `GantzEguiPlugin`s later idempotent `init_resource`
+            // shares the instance - so plugin order does not matter.
+            let capture = app.world_mut().get_resource_or_init::<TraceCapture>();
             Some(Box::new(capture.0.clone().layer()))
         },
         ..Default::default()


### PR DESCRIPTION
Part of #304

This makes every gantz plugin safe to add in any order.

Previously, `GantzEguiPlugin` had to be added before `GantzPlugin`, and `PlyphonPlugin` had to be added after both, due to hidden resource-seed ordering requirements.

## Changes

### bevy_gantz (GantzPlugin & EntrypointFns)
- Both GantzPlugin and GantzEguiPlugin now contribute to `EntrypointFns` via `get_resource_or_init` + push instead of clobbering with `insert`. This matches the existing `ResponseDispatchers` pattern.

### bevy_gantz_egui (GantzEguiPlugin)
- Same idiom: uses `get_resource_or_init` + push for its provider. No longer panics if GantzPlugin hasn't been added first.

### bevy_gantz_plyphon (PlyphonPlugin)
- DSP engine construction (epoch read, cpal stream, DspEngine, HeadSynths) moved from `build` to `finish`. Bevy calls `finish` on all plugins after every `build` phase and before the first schedule tick, so cross-plugin reads are safe regardless of order. *Note: A `lazy_get_resource_or_init` would have been wrong here because it would fork the DSP clock from a default epoch created by whichever plugin ran first.*

### gantz (log layer)
- The log plugin's custom layer now uses `get_resource_or_init` for `TraceCapture`, so it captures the same traces as GantzEguiPlugin regardless of which is added first.

### Docs
- `GantzPlugin` doc now documents the order-independent assembly convention and points users at `EntrypointFns` for the contribution idiom and `PlyphonPlugin` as the reference domain-plugin shape.
- `PlyphonPlugin` doc describes the domain-plugin shape it serves as a reference for (plain `Plugin`, order-independent, `finish` for cross-plugin reads, provider systems, contribution idiom, extension points, no `GantzDomain` umbrella trait).