### PR TITLE
feat: instanced DSP `Ref`s (share defs, spawn per instance)

### DIFF
--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -1479,11 +1479,13 @@ mod tests {
     fn structural_sync_keeps_sound_with_inlets() {
         use gantz_core::edge::Edge;
         use gantz_core::node::graph::Graph;
-        use gantz_plyphon::flatten::{Flat, flatten};
+        use gantz_plyphon::flatten::{Flat, RefKind, flatten};
 
         let flatten_no_refs = |g: &Graph<TestN>| -> Graph<Flat<TestN>> {
             let resolve =
-                |_: &TestN| -> Option<(gantz_ca::ContentAddr, Option<&Graph<TestN>>)> { None };
+                |_: &TestN| -> Option<(gantz_ca::ContentAddr, RefKind, Option<&Graph<TestN>>)> {
+                    None
+                };
             flatten(&|_| None, g, &resolve).expect("flatten")
         };
 
@@ -1555,11 +1557,13 @@ mod tests {
     fn structural_edit_in_stable_region_reinstalls_def() {
         use gantz_core::edge::Edge;
         use gantz_core::node::graph::Graph;
-        use gantz_plyphon::flatten::{Flat, flatten};
+        use gantz_plyphon::flatten::{Flat, RefKind, flatten};
 
         let flatten_no_refs = |g: &Graph<TestN>| -> Graph<Flat<TestN>> {
             let resolve =
-                |_: &TestN| -> Option<(gantz_ca::ContentAddr, Option<&Graph<TestN>>)> { None };
+                |_: &TestN| -> Option<(gantz_ca::ContentAddr, RefKind, Option<&Graph<TestN>>)> {
+                    None
+                };
             flatten(&|_| None, g, &resolve).expect("flatten")
         };
 

--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -29,8 +29,9 @@ use cpal::{FromSample, SizedSample};
 use gantz_ca as ca;
 use gantz_core::node::graph::Graph;
 use gantz_plyphon::{
-    AddAction, AsRefNode, Backend, BusKey, Embedded, GainRef, ROOT_GROUP_ID, RegionDerived,
-    ToNodeDsp, derive_synthdefs, flatten_from_registry, structural_sig,
+    AddAction, AsRefNode, Backend, BusKey, DefCache, Embedded, GainRef, ROOT_GROUP_ID,
+    ResolvedPart, ToNodeDsp, derive_template, flatten_from_registry, flatten_instance_children,
+    instantiate,
 };
 use plyphon::{Controller, Nrt, Options, StreamConsumer, World, engine};
 // `std::time::Instant` panics ("time not implemented") on `wasm32-unknown-unknown`;
@@ -273,6 +274,9 @@ struct HeadSynths {
     /// re-cued while the old `ScopeOut` (bufnum baked into its def) can still
     /// write it.
     fading: Vec<FadingSynth>,
+    /// Memoised child templates, shared across heads and frames (content
+    /// addressed, so entries stay valid for as long as their variant recurs).
+    def_cache: DefCache,
 }
 
 /// One open head's running synths: one per boundary-cut region, in region-DAG
@@ -436,9 +440,10 @@ impl ScopeAlloc {
     }
 }
 
-/// The installed synthdef + running synth for one region of a head.
+/// The installed synthdef + running synth for one resolved part of a head
+/// (a top-level region, or one instance's spawn of a shared child region).
 struct PartSynth {
-    /// The region's identity across re-derives (`RegionDerived::key`), the
+    /// The part's identity across re-derives (`ResolvedPart::key`), the
     /// driver's match for the keep/replace decision.
     key: u64,
     def_name: String,
@@ -446,6 +451,11 @@ struct PartSynth {
     /// Structural signature of the running synth's def (excludes param values) -
     /// unchanged across a structural-graph edit means the synth need not respawn.
     sig: u64,
+    /// Hash of the part's bus wiring (keys + widths + params). A wiring change
+    /// with an unchanged def (e.g. an inlet re-routed to another source)
+    /// crossfade-respawns rather than live-switching the bus param - an abrupt
+    /// bus switch clicks, while the respawn reuses the trusted fade machinery.
+    wiring: u64,
     /// One slot per control param, binding a dsp node's state value to its synth
     /// param index, with the last value pushed via `set_control`.
     params: Vec<ParamSlot>,
@@ -606,13 +616,18 @@ fn drive_synths<N>(
         // upstream): keep the previous synths, parking the head at this graph
         // address so the error logs once per commit rather than every frame.
         if state.heads.get(&entity).map(|h| h.graph) != Some(graph_ca) {
-            match flatten_from_registry(&wg.0, &registry) {
-                Ok(flat) => structural_sync(
+            let flat_children = flatten_from_registry(&wg.0, &registry).and_then(|flat| {
+                let children = flatten_instance_children(&flat, &registry)?;
+                Ok((flat, children))
+            });
+            match flat_children {
+                Ok((flat, children)) => structural_sync(
                     &mut dsp.controller,
                     state,
                     entity,
                     graph_ca,
                     &flat,
+                    &children,
                     out_channels,
                     sample_rate,
                 ),
@@ -780,19 +795,20 @@ fn structural_sync<N>(
     state: &mut HeadSynths,
     entity: Entity,
     graph_ca: ca::GraphAddr,
-    graph: &Graph<N>,
+    graph: &Graph<gantz_plyphon::Flat<N>>,
+    children: &HashMap<gantz_ca::ContentAddr, Graph<gantz_plyphon::Flat<N>>>,
     out_channels: usize,
     sample_rate: f64,
 ) where
     N: ToNodeDsp,
 {
     let now = Instant::now();
-    let prefix = format!("gantz-head-{}", entity.index());
     let derive_start = Instant::now();
-    let derived_result = derive_synthdefs(graph, out_channels, &prefix);
-    log::debug!("Derived synthdef ({:?})", derive_start.elapsed());
-    let derived = match derived_result {
-        Ok(regions) => regions,
+    let resolve = |ca: &gantz_ca::ContentAddr| children.get(ca);
+    let template_result = derive_template(graph, out_channels, &resolve, &mut state.def_cache);
+    log::debug!("Derived synthdef template ({:?})", derive_start.elapsed());
+    let derived: Vec<ResolvedPart> = match template_result {
+        Ok(template) => instantiate(&template, &state.def_cache),
         // No dsp sink to root any synthdef at: fade every region out. Freeing
         // the defs now is safe - a fading synth holds its own compiled copy.
         Err(gantz_plyphon::DeriveError::NoSink) => {
@@ -815,13 +831,12 @@ fn structural_sync<N>(
             );
             return;
         }
-        // A bus cycle has no runnable writer-before-reader order: keep the
-        // previous synths, recording the graph address so the error logs once
-        // per commit rather than every frame.
+        // A cycle between parts (`~bus` regions or instances) has no runnable
+        // writer-before-reader order: keep the previous synths, recording the
+        // graph address so the error logs once per commit rather than every
+        // frame.
         Err(gantz_plyphon::DeriveError::BusCycle) => {
-            log::error!(
-                "bevy_gantz_plyphon: `~bus` cycle between regions, keeping the previous synths"
-            );
+            log::error!("bevy_gantz_plyphon: bus cycle between parts, keeping the previous synths");
             park_head(state, entity, graph_ca);
             return;
         }
@@ -835,11 +850,11 @@ fn structural_sync<N>(
         }
     };
 
-    // Release bus runs whose boundary nodes are gone from the derivation.
+    // Release bus runs whose keys are gone from the derivation.
     let live_buses: HashSet<BusKey> = derived
         .iter()
         .flat_map(|r| r.bus_writes.iter().chain(&r.bus_reads))
-        .map(|b| BusKey::Bus(b.node_path.clone()))
+        .map(|b| b.key.clone())
         .collect();
     let dead_buses: Vec<_> = state
         .bus_alloc
@@ -852,11 +867,12 @@ fn structural_sync<N>(
         state.bus_alloc.release(&key, now);
     }
 
-    // Plan each region: keep the running synth when key + sig match, else spawn
-    // a replacement (fading any predecessor once the replacement is up).
+    // Plan each part: keep the running synth when key + sig + wiring match,
+    // else spawn a replacement (fading any predecessor once the replacement
+    // is up).
     enum Plan {
         Keep(PartSynth),
-        Spawn(RegionDerived, u64, Option<PartSynth>),
+        Spawn(ResolvedPart, u64, Option<PartSynth>),
     }
     let mut prev = state
         .heads
@@ -865,16 +881,16 @@ fn structural_sync<N>(
         .unwrap_or_default();
     let mut plans: Vec<Plan> = Vec::with_capacity(derived.len());
     for r in derived {
-        let sig = structural_sig(&r.derived.def);
+        let wiring = wiring_hash(&r);
         match prev.iter().position(|p| p.key == r.key) {
             Some(ix) => {
                 let mut p = prev.remove(ix);
-                if p.sig == sig {
-                    // Structure unchanged (e.g. a non-dsp edit, or a ring-size
-                    // edit that is not in the def): keep the synth + its param
-                    // slots + its cued scope streams. Refresh each tap's ring
-                    // `size` in case a size edit changed it.
-                    for m in &r.derived.monitors {
+                if p.sig == r.sig && p.wiring == wiring {
+                    // Structure + wiring unchanged (e.g. a non-dsp edit, or a
+                    // ring-size edit that is not in the def): keep the synth +
+                    // its param slots + its cued scope streams. Refresh each
+                    // tap's ring `size` in case a size edit changed it.
+                    for m in &r.monitors {
                         if let Some(slot) = p.scopes.iter_mut().find(|s| s.node_path == m.node_path)
                         {
                             slot.size = m.size;
@@ -888,13 +904,13 @@ fn structural_sync<N>(
                     }
                     plans.push(Plan::Keep(p));
                 } else {
-                    plans.push(Plan::Spawn(r, sig, Some(p)));
+                    plans.push(Plan::Spawn(r, wiring, Some(p)));
                 }
             }
-            None => plans.push(Plan::Spawn(r, sig, None)),
+            None => plans.push(Plan::Spawn(r, wiring, None)),
         }
     }
-    // Regions that disappeared entirely: fade out + free their defs.
+    // Parts that disappeared entirely: fade out + free their defs.
     for old in prev {
         let def_name = old.def_name.clone();
         fade_out(controller, state, entity, old);
@@ -917,13 +933,13 @@ fn structural_sync<N>(
     for (plan, anchor) in plans.into_iter().zip(anchors) {
         match plan {
             Plan::Keep(k) => parts.push(k),
-            Plan::Spawn(r, sig, old) => {
-                match spawn_region(controller, state, entity, r, sig, sample_rate, anchor) {
+            Plan::Spawn(r, wiring, old) => {
+                match spawn_part(controller, state, entity, r, wiring, sample_rate, anchor) {
                     Some(synth) => {
                         // The replacement is live: fade the old out (the gain
                         // overlap is the crossfade) and release its def
                         // refcount. If the new synth shares the name (stable
-                        // key), the refcount was bumped by `spawn_region`, so
+                        // key), the refcount was bumped by `spawn_part`, so
                         // this just drops the old's reference (the def stays
                         // installed for the new synth); if the name differs,
                         // the old def frees now (the old synth keeps its own
@@ -951,45 +967,62 @@ fn structural_sync<N>(
     );
 }
 
+/// Hash of a part's bus wiring - every read/write's key, width and param.
+/// Combined with the def's structural sig for the keep/replace decision: a
+/// re-route that keeps the def (e.g. an instance inlet fed from a different
+/// source) still respawns, crossfading onto the new buses.
+fn wiring_hash(part: &ResolvedPart) -> u64 {
+    use std::hash::{DefaultHasher, Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    for b in &part.bus_reads {
+        (0u8, &b.key, b.channels, b.param).hash(&mut h);
+    }
+    for b in &part.bus_writes {
+        (1u8, &b.key, b.channels, b.param).hash(&mut h);
+    }
+    h.finish()
+}
+
 /// Cue scope streams and allocate buses (so their indices are known), then
-/// install and spawn one region's def - `Before` the given anchor when present,
+/// install and spawn one part's def - `Before` the given anchor when present,
 /// else at the root group's tail. The synth spawns silent behind its fade
 /// gains' baked `0.0` defaults; bus indices, scope bufnums and unbound
 /// fade-to-unity are then set via `set_control` in one command-ring drain
 /// (landing before the first audible block). Bound params re-send from node
 /// state via the same-frame param sync. Returns `None` on failure, having
 /// cleaned up after itself.
-fn spawn_region(
+fn spawn_part(
     controller: &mut Controller,
     state: &mut HeadSynths,
     entity: Entity,
-    region: RegionDerived,
-    sig: u64,
+    part: ResolvedPart,
+    wiring: u64,
     sample_rate: f64,
     anchor: Option<i32>,
 ) -> Option<PartSynth> {
     let now = Instant::now();
-    let RegionDerived {
+    let ResolvedPart {
         key,
-        derived,
-        bus_writes,
-        bus_reads,
-    } = region;
-    let gantz_plyphon::Derived {
+        sig,
         def,
         params,
         monitors,
         gains,
-    } = derived;
+        bus_writes,
+        bus_reads,
+    } = part;
 
     // Allocate buses and cue scope streams up front so their indices are known
     // for the post-spawn `set_control` drain below (no def mutation: the bus
     // indices and bufnums are no-lag control params, set live per block).
+    // Whichever side of a bus spawns first allocates; the counterpart (spawned
+    // later in topo order, or kept from a previous sync) looks the run up by
+    // the same key.
     let mut set_after_spawn: Vec<(usize, f32)> = Vec::new();
     for binding in bus_writes.iter().chain(&bus_reads) {
-        let bus_key = (entity, BusKey::Bus(binding.node_path.clone()));
+        let bus_key = (entity, binding.key.clone());
         let Some(run) = state.bus_alloc.get_or_alloc(bus_key, binding.channels, now) else {
-            log::error!("bevy_gantz_plyphon: private audio buses exhausted; region not spawned");
+            log::error!("bevy_gantz_plyphon: private audio buses exhausted; part not spawned");
             return None;
         };
         set_after_spawn.push((binding.param, run.start as f32));
@@ -1028,7 +1061,7 @@ fn spawn_region(
         .get(&def_name)
         .is_some_and(|&(_, s)| s == sig);
     if !sig_matches {
-        if let Err(e) = backend.install_synthdef(def) {
+        if let Err(e) = backend.install_synthdef((*def).clone()) {
             log::error!("bevy_gantz_plyphon: synthdef install failed: {e:?}");
             drop(backend);
             free_scopes(controller, &mut state.scope_alloc, scopes);
@@ -1078,6 +1111,7 @@ fn spawn_region(
                 def_name,
                 node_id,
                 sig,
+                wiring,
                 params,
                 scopes,
                 gains,
@@ -1429,24 +1463,28 @@ mod tests {
         );
     }
 
-    /// A `~sinosc -> ~out` graph spawns through `spawn_region` and sounds: the
+    /// A `~sinosc -> ~out` graph spawns through `spawn_part` and sounds: the
     /// fade gain (baked at `0.0`) is ramped to unity via `set_control`, and the
     /// tone is audible after the fade lag. Guards the driver's runtime spawn
     /// path (the GUI's path) end to end with an offline engine.
     #[test]
-    fn spawn_region_sounds_sin_out() {
+    fn spawn_part_sounds_sin_out() {
         use gantz_core::edge::Edge;
         use gantz_core::node::graph::Graph;
-        use gantz_plyphon::{NodeDsp, ToNodeDsp, derive_synthdefs};
+        use gantz_plyphon::flatten::{Flat, RefKind, flatten};
 
         let mut g = Graph::<TestN>::default();
         let s = g.add_node(TestN::SinOsc(gantz_plyphon::SinOsc::default()));
         let o = g.add_node(TestN::Out(gantz_plyphon::Out::default()));
         g.add_edge(s, o, Edge::new(0.into(), 0.into()));
+        let resolve =
+            |_: &TestN| -> Option<(gantz_ca::ContentAddr, RefKind, Option<&Graph<TestN>>)> { None };
+        let flat: Graph<Flat<TestN>> = flatten(&|_| None, &g, &resolve).expect("flatten");
 
-        let regions = derive_synthdefs(&g, 1, "head").expect("derive");
-        let region = regions.into_iter().next().unwrap();
-        let sig = gantz_plyphon::structural_sig(&region.derived.def);
+        let mut cache = DefCache::new();
+        let template = derive_template(&flat, 1, &|_| None, &mut cache).expect("derive");
+        let part = instantiate(&template, &cache).into_iter().next().unwrap();
+        let wiring = wiring_hash(&part);
 
         let (mut controller, _nrt, mut world) = plyphon::engine(plyphon::Options {
             sample_rate: 48_000.0,
@@ -1455,16 +1493,16 @@ mod tests {
         });
         let mut state = HeadSynths::default();
         let entity = entities(1)[0];
-        let synth = spawn_region(
+        let synth = spawn_part(
             &mut controller,
             &mut state,
             entity,
-            region,
-            sig,
+            part,
+            wiring,
             48_000.0,
             None,
         )
-        .expect("spawn_region");
+        .expect("spawn_part");
         assert_eq!(synth.gains.len(), 1, "the out carries a fade gain");
 
         let mut out = vec![0.0f32; 48_000 / 2];
@@ -1474,7 +1512,7 @@ mod tests {
         let rms = (out.iter().map(|v| v * v).sum::<f32>() / out.len() as f32).sqrt();
         assert!(
             rms > 0.05,
-            "sin -> out must sound via spawn_region: rms={rms}"
+            "sin -> out must sound via spawn_part: rms={rms}"
         );
     }
 
@@ -1518,6 +1556,7 @@ mod tests {
             entity,
             ca1,
             &flat1,
+            &HashMap::new(),
             1,
             48_000.0,
         );
@@ -1544,6 +1583,7 @@ mod tests {
             entity,
             ca2,
             &flat2,
+            &HashMap::new(),
             1,
             48_000.0,
         );
@@ -1597,6 +1637,7 @@ mod tests {
             entity,
             ca1,
             &flatten_no_refs(&g1),
+            &HashMap::new(),
             1,
             48_000.0,
         );
@@ -1622,6 +1663,7 @@ mod tests {
             entity,
             ca2,
             &flatten_no_refs(&g2),
+            &HashMap::new(),
             1,
             48_000.0,
         );

--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -282,11 +282,16 @@ struct HeadSynths {
     def_cache: DefCache,
 }
 
-/// One open head's running synths: one per boundary-cut region, in region-DAG
+/// One open head's running synths: one per resolved part, in part-DAG
 /// topological order (bus writers before their readers - also their node-tree
 /// order). Empty when the head's graph has no dsp sink.
 struct HeadParts {
     graph: ca::GraphAddr,
+    /// Re-run the structural sync next frame even though `graph` is current:
+    /// a spawn failed transiently (command ring full). The ring drains within
+    /// a block and the re-run is convergent - already-spawned parts match by
+    /// key + sig + wiring and are kept.
+    retry: bool,
     parts: Vec<PartSynth>,
 }
 
@@ -618,7 +623,11 @@ fn drive_synths<N>(
         // flatten error (a ref cycle or an unresolvable ref, both forbidden
         // upstream): keep the previous synths, parking the head at this graph
         // address so the error logs once per commit rather than every frame.
-        if state.heads.get(&entity).map(|h| h.graph) != Some(graph_ca) {
+        let stale = state
+            .heads
+            .get(&entity)
+            .is_none_or(|h| h.graph != graph_ca || h.retry);
+        if stale {
             let flat_children = flatten_from_registry(&wg.0, &registry).and_then(|flat| {
                 let children = flatten_instance_children(&flat, &registry)?;
                 Ok((flat, children))
@@ -778,6 +787,7 @@ fn park_head(state: &mut HeadSynths, entity: Entity, graph_ca: ca::GraphAddr) {
                 entity,
                 HeadParts {
                     graph: graph_ca,
+                    retry: false,
                     parts: Vec::new(),
                 },
             );
@@ -829,6 +839,7 @@ fn structural_sync<N>(
                 entity,
                 HeadParts {
                     graph: graph_ca,
+                    retry: false,
                     parts: Vec::new(),
                 },
             );
@@ -933,12 +944,13 @@ fn structural_sync<N>(
         .collect();
 
     let mut parts: Vec<PartSynth> = Vec::with_capacity(plans.len());
+    let mut transient_failure = false;
     for (plan, anchor) in plans.into_iter().zip(anchors) {
         match plan {
             Plan::Keep(k) => parts.push(k),
             Plan::Spawn(r, wiring, old) => {
                 match spawn_part(controller, state, entity, r, wiring, sample_rate, anchor) {
-                    Some(synth) => {
+                    Ok(synth) => {
                         // The replacement is live: fade the old out (the gain
                         // overlap is the crossfade) and release its def
                         // refcount. If the new synth shares the name (stable
@@ -956,7 +968,12 @@ fn structural_sync<N>(
                     }
                     // Keep the old synth playing untouched on failure -
                     // strictly better than the silence a teardown would leave.
-                    None => parts.extend(old),
+                    // A transient failure (full command ring) marks the head
+                    // for a convergent re-sync next frame.
+                    Err(e) => {
+                        transient_failure |= matches!(e, SpawnError::Transient);
+                        parts.extend(old);
+                    }
                 }
             }
         }
@@ -965,9 +982,20 @@ fn structural_sync<N>(
         entity,
         HeadParts {
             graph: graph_ca,
+            retry: transient_failure,
             parts,
         },
     );
+}
+
+/// Why a part failed to spawn.
+#[derive(Debug)]
+enum SpawnError {
+    /// The command ring was momentarily full; retrying next frame converges.
+    Transient,
+    /// Anything else (bus exhaustion, install or build failure) - retrying
+    /// without an edit would fail identically, so the head parks as usual.
+    Permanent,
 }
 
 /// Hash of a part's bus wiring - every read/write's key, width and param.
@@ -992,8 +1020,8 @@ fn wiring_hash(part: &ResolvedPart) -> u64 {
 /// gains' baked `0.0` defaults; bus indices, scope bufnums and unbound
 /// fade-to-unity are then set via `set_control` in one command-ring drain
 /// (landing before the first audible block). Bound params re-send from node
-/// state via the same-frame param sync. Returns `None` on failure, having
-/// cleaned up after itself.
+/// state via the same-frame param sync. On failure, cleans up after itself
+/// and reports whether retrying next frame can converge ([`SpawnError`]).
 fn spawn_part(
     controller: &mut Controller,
     state: &mut HeadSynths,
@@ -1002,7 +1030,7 @@ fn spawn_part(
     wiring: u64,
     sample_rate: f64,
     anchor: Option<i32>,
-) -> Option<PartSynth> {
+) -> Result<PartSynth, SpawnError> {
     let now = Instant::now();
     let ResolvedPart {
         key,
@@ -1026,7 +1054,7 @@ fn spawn_part(
         let bus_key = (entity, binding.key.clone());
         let Some(run) = state.bus_alloc.get_or_alloc(bus_key, binding.channels, now) else {
             log::error!("bevy_gantz_plyphon: private audio buses exhausted; part not spawned");
-            return None;
+            return Err(SpawnError::Permanent);
         };
         set_after_spawn.push((binding.param, run.start as f32));
     }
@@ -1068,7 +1096,7 @@ fn spawn_part(
             log::error!("bevy_gantz_plyphon: synthdef install failed: {e:?}");
             drop(backend);
             free_scopes(controller, &mut state.scope_alloc, scopes);
-            return None;
+            return Err(SpawnError::Permanent);
         }
     }
     state
@@ -1109,7 +1137,7 @@ fn spawn_part(
                     last: None,
                 })
                 .collect();
-            Some(PartSynth {
+            Ok(PartSynth {
                 key,
                 def_name,
                 node_id,
@@ -1122,10 +1150,14 @@ fn spawn_part(
         }
         Err(e) => {
             log::error!("bevy_gantz_plyphon: synth spawn failed: {e:?}");
+            let spawn_err = match e {
+                gantz_plyphon::BackendError::QueueFull => SpawnError::Transient,
+                _ => SpawnError::Permanent,
+            };
             drop(backend);
             release_def(controller, &mut state.shared_defs, &def_name);
             free_scopes(controller, &mut state.scope_alloc, scopes);
-            None
+            Err(spawn_err)
         }
     }
 }

--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -260,6 +260,13 @@ struct HeadSynths {
     heads: HashMap<Entity, HeadRegions>,
     scope_alloc: ScopeAlloc,
     bus_alloc: BusAlloc,
+    /// Installed synthdef names -> `(refcount, structural_sig)`. A def is
+    /// installed once per name and reused while its structure is unchanged;
+    /// a structural edit (same name, different sig) re-installs (retiring the
+    /// old compiled def, which running synths keep via their own `Arc`). The
+    /// refcount frees the def only when its last synth is retired. Per-head
+    /// region defs (unique names per region) refcount 0 -> 1 -> 0 as before.
+    shared_defs: HashMap<String, (usize, u64)>,
     /// Crossfade-retired synths still ramping their gains to zero, freed once
     /// their deadline passes (oldest first - entries are pushed in replacement
     /// order). Their scope streams ride along: a stream index must not be
@@ -578,6 +585,9 @@ fn drive_synths<N>(
     // Tick NRT cleanup off the audio thread (drops freed synths, surfaces events).
     dsp.nrt.process();
     while dsp.nrt.poll().is_some() {}
+    // Drop retired compiled defs once the audio thread is done with them.
+    // Frees without a follow-up install would otherwise linger in `retiring`.
+    dsp.controller.reap_retired_defs();
 
     let out_channels = dsp.out_channels;
     let sample_rate = dsp.sample_rate;
@@ -692,7 +702,7 @@ fn drive_synths<N>(
             for synth in head.regions {
                 let def_name = synth.def_name.clone();
                 fade_out(&mut dsp.controller, state, e, synth);
-                let _ = Embedded::new(&mut dsp.controller).free_synthdef(&def_name);
+                release_def(&mut dsp.controller, &mut state.shared_defs, &def_name);
             }
         }
         state.bus_alloc.release_head(e, Instant::now());
@@ -790,7 +800,7 @@ fn structural_sync<N>(
                 for synth in head.regions {
                     let def_name = synth.def_name.clone();
                     fade_out(controller, state, entity, synth);
-                    let _ = Embedded::new(controller).free_synthdef(&def_name);
+                    release_def(controller, &mut state.shared_defs, &def_name);
                 }
             }
             state.bus_alloc.release_head(entity, now);
@@ -880,7 +890,7 @@ fn structural_sync<N>(
     for old in prev {
         let def_name = old.def_name.clone();
         fade_out(controller, state, entity, old);
-        let _ = Embedded::new(controller).free_synthdef(&def_name);
+        release_def(controller, &mut state.shared_defs, &def_name);
     }
 
     // Each spawn's node-tree anchor: the first KEPT synth later in topo order
@@ -903,10 +913,17 @@ fn structural_sync<N>(
                 match spawn_region(controller, state, entity, r, sig, sample_rate, anchor) {
                     Some(synth) => {
                         // The replacement is live: fade the old out (the gain
-                        // overlap is the crossfade). The def name was just
-                        // re-installed, so the old def is already retired.
+                        // overlap is the crossfade) and release its def
+                        // refcount. If the new synth shares the name (stable
+                        // key), the refcount was bumped by `spawn_region`, so
+                        // this just drops the old's reference (the def stays
+                        // installed for the new synth); if the name differs,
+                        // the old def frees now (the old synth keeps its own
+                        // `Arc` while it fades out).
                         if let Some(old) = old {
+                            let old_def_name = old.def_name.clone();
                             fade_out(controller, state, entity, old);
+                            release_def(controller, &mut state.shared_defs, &old_def_name);
                         }
                         regions.push(synth);
                     }
@@ -994,12 +1011,30 @@ fn spawn_region(
 
     let def_name = def.name.clone();
     let mut backend = Embedded::new(controller);
-    if let Err(e) = backend.install_synthdef(def) {
-        log::error!("bevy_gantz_plyphon: synthdef install failed: {e:?}");
-        drop(backend);
-        free_scopes(controller, &mut state.scope_alloc, scopes);
-        return None;
+    // Install the def unless an identical one (same name AND structural sig) is
+    // already installed. A structural edit to a stable-key region changes the
+    // def while keeping the name, so the sig differs and we re-install
+    // (retiring the old compiled def; running synths keep their own `Arc`).
+    let sig_matches = state
+        .shared_defs
+        .get(&def_name)
+        .is_some_and(|&(_, s)| s == sig);
+    if !sig_matches {
+        if let Err(e) = backend.install_synthdef(def) {
+            log::error!("bevy_gantz_plyphon: synthdef install failed: {e:?}");
+            drop(backend);
+            free_scopes(controller, &mut state.scope_alloc, scopes);
+            return None;
+        }
     }
+    state
+        .shared_defs
+        .entry(def_name.clone())
+        .and_modify(|(rc, s)| {
+            *rc += 1;
+            *s = sig;
+        })
+        .or_insert((1, sig));
     let (target, action) = match anchor {
         Some(node) => (node, AddAction::Before),
         None => (ROOT_GROUP_ID, AddAction::Tail),
@@ -1042,8 +1077,8 @@ fn spawn_region(
         }
         Err(e) => {
             log::error!("bevy_gantz_plyphon: synth spawn failed: {e:?}");
-            let _ = backend.free_synthdef(&def_name);
             drop(backend);
+            release_def(controller, &mut state.shared_defs, &def_name);
             free_scopes(controller, &mut state.scope_alloc, scopes);
             None
         }
@@ -1087,6 +1122,22 @@ fn free_scopes(controller: &mut Controller, scope_alloc: &mut ScopeAlloc, scopes
     for scope in scopes {
         let _ = controller.close_recording(scope.index);
         scope_alloc.free(scope.index);
+    }
+}
+
+/// Decrement the refcount of `def_name`, freeing the def (retiring it on the
+/// audio thread) only when the last reference drops. A shared variant def is
+/// thus installed once and freed once its last instance is retired.
+fn release_def(
+    controller: &mut Controller,
+    shared_defs: &mut HashMap<String, (usize, u64)>,
+    def_name: &str,
+) {
+    let entry = shared_defs.entry(def_name.to_string()).or_insert((0, 0));
+    entry.0 = entry.0.saturating_sub(1);
+    if entry.0 == 0 {
+        shared_defs.remove(def_name);
+        let _ = Embedded::new(controller).free_synthdef(def_name);
     }
 }
 
@@ -1360,5 +1411,261 @@ mod tests {
             alloc.get_or_alloc((e[0], vec![3]), 4, base),
             Some(Run { start: 0, len: 4 }),
         );
+    }
+
+    /// A `~sinosc -> ~out` graph spawns through `spawn_region` and sounds: the
+    /// fade gain (baked at `0.0`) is ramped to unity via `set_control`, and the
+    /// tone is audible after the fade lag. Guards the driver's runtime spawn
+    /// path (the GUI's path) end to end with an offline engine.
+    #[test]
+    fn spawn_region_sounds_sin_out() {
+        use gantz_core::edge::Edge;
+        use gantz_core::node::graph::Graph;
+        use gantz_plyphon::{NodeDsp, ToNodeDsp, derive_synthdefs};
+
+        let mut g = Graph::<TestN>::default();
+        let s = g.add_node(TestN::SinOsc(gantz_plyphon::SinOsc::default()));
+        let o = g.add_node(TestN::Out(gantz_plyphon::Out::default()));
+        g.add_edge(s, o, Edge::new(0.into(), 0.into()));
+
+        let regions = derive_synthdefs(&g, 1, "head").expect("derive");
+        let region = regions.into_iter().next().unwrap();
+        let sig = gantz_plyphon::structural_sig(&region.derived.def);
+
+        let (mut controller, _nrt, mut world) = plyphon::engine(plyphon::Options {
+            sample_rate: 48_000.0,
+            output_channels: 1,
+            ..plyphon::Options::default()
+        });
+        let mut state = HeadSynths::default();
+        let entity = entities(1)[0];
+        let synth = spawn_region(
+            &mut controller,
+            &mut state,
+            entity,
+            region,
+            sig,
+            48_000.0,
+            None,
+        )
+        .expect("spawn_region");
+        assert_eq!(synth.gains.len(), 1, "the out carries a fade gain");
+
+        let mut out = vec![0.0f32; 48_000 / 2];
+        for block in out.chunks_mut(64) {
+            world.fill(block, 1);
+        }
+        let rms = (out.iter().map(|v| v * v).sum::<f32>() / out.len() as f32).sqrt();
+        assert!(
+            rms > 0.05,
+            "sin -> out must sound via spawn_region: rms={rms}"
+        );
+    }
+
+    /// Multi-frame `structural_sync`: a `~sinosc -> ~out` head graph sounds,
+    /// and adding unconnected `inlet`/`outlet` nodes (which dissolve in the
+    /// flattener) keeps the tone audible (the region is kept or respawned with
+    /// the fade ramped in). Regression guard for the GUI's reported "no sound
+    /// with inlet/outlet" issue. Mimics the GUI exactly: flatten, then sync.
+    #[test]
+    fn structural_sync_keeps_sound_with_inlets() {
+        use gantz_core::edge::Edge;
+        use gantz_core::node::graph::Graph;
+        use gantz_plyphon::flatten::{Flat, flatten};
+
+        let flatten_no_refs = |g: &Graph<TestN>| -> Graph<Flat<TestN>> {
+            let resolve =
+                |_: &TestN| -> Option<(gantz_ca::ContentAddr, Option<&Graph<TestN>>)> { None };
+            flatten(&|_| None, g, &resolve).expect("flatten")
+        };
+
+        let (mut controller, _nrt, mut world) = plyphon::engine(plyphon::Options {
+            sample_rate: 48_000.0,
+            output_channels: 1,
+            ..plyphon::Options::default()
+        });
+        let mut state = HeadSynths::default();
+        let entity = entities(1)[0];
+
+        // Frame 1: `~sinosc -> ~out`.
+        let mut g1 = Graph::<TestN>::default();
+        let s = g1.add_node(TestN::SinOsc(gantz_plyphon::SinOsc::default()));
+        let o = g1.add_node(TestN::Out(gantz_plyphon::Out::default()));
+        g1.add_edge(s, o, Edge::new(0.into(), 0.into()));
+        let ca1 = gantz_ca::graph_addr(&g1);
+        let flat1 = flatten_no_refs(&g1);
+        structural_sync(
+            &mut controller,
+            &mut state,
+            entity,
+            ca1,
+            &flat1,
+            1,
+            48_000.0,
+        );
+        let mut out = vec![0.0f32; 48_000 / 4];
+        for block in out.chunks_mut(64) {
+            world.fill(block, 1);
+        }
+        let rms1 = (out.iter().map(|v| v * v).sum::<f32>() / out.len() as f32).sqrt();
+        assert!(rms1 > 0.05, "frame 1 must sound: rms={rms1}");
+
+        // Frame 2: add unconnected `inlet`/`outlet` (different graph address).
+        let mut g2 = Graph::<TestN>::default();
+        let s = g2.add_node(TestN::SinOsc(gantz_plyphon::SinOsc::default()));
+        let o = g2.add_node(TestN::Out(gantz_plyphon::Out::default()));
+        let _i = g2.add_node(TestN::Inlet);
+        let _o2 = g2.add_node(TestN::Outlet);
+        g2.add_edge(s, o, Edge::new(0.into(), 0.into()));
+        let ca2 = gantz_ca::graph_addr(&g2);
+        assert_ne!(ca1, ca2, "adding nodes changes the graph address");
+        let flat2 = flatten_no_refs(&g2);
+        structural_sync(
+            &mut controller,
+            &mut state,
+            entity,
+            ca2,
+            &flat2,
+            1,
+            48_000.0,
+        );
+        // Render past the crossfade (the respawn fades in over FADE_LAG).
+        let mut out = vec![0.0f32; 48_000 / 2];
+        for block in out.chunks_mut(64) {
+            world.fill(block, 1);
+        }
+        let rms2 = (out.iter().map(|v| v * v).sum::<f32>() / out.len() as f32).sqrt();
+        assert!(rms2 > 0.05, "frame 2 (with inlets) must sound: rms={rms2}");
+    }
+
+    /// A structural edit within a stable-key region (connecting `~sinosc` into
+    /// an existing `~pack -> ~unpack -> ~out` chain) re-installs the def and
+    /// the synth plays the NEW (sounding) def. Regression guard for the GUI's
+    /// reported "~pack/~unpack no longer work" issue: the Phase-4 refcounting
+    /// must not skip `install_synthdef` when the def changed (same name, new sig).
+    #[test]
+    fn structural_edit_in_stable_region_reinstalls_def() {
+        use gantz_core::edge::Edge;
+        use gantz_core::node::graph::Graph;
+        use gantz_plyphon::flatten::{Flat, flatten};
+
+        let flatten_no_refs = |g: &Graph<TestN>| -> Graph<Flat<TestN>> {
+            let resolve =
+                |_: &TestN| -> Option<(gantz_ca::ContentAddr, Option<&Graph<TestN>>)> { None };
+            flatten(&|_| None, g, &resolve).expect("flatten")
+        };
+
+        let (mut controller, _nrt, mut world) = plyphon::engine(plyphon::Options {
+            sample_rate: 48_000.0,
+            output_channels: 1,
+            ..plyphon::Options::default()
+        });
+        let mut state = HeadSynths::default();
+        let entity = entities(1)[0];
+
+        // Frame 1: `~pack -> ~unpack -> ~out` (pack input unconnected -> silence).
+        let mut g1 = Graph::<TestN>::default();
+        let pk = g1.add_node(TestN::Pack(gantz_plyphon::Pack::default()));
+        let up = g1.add_node(TestN::Unpack(gantz_plyphon::Unpack::default()));
+        let o = g1.add_node(TestN::Out(gantz_plyphon::Out::default()));
+        g1.add_edge(pk, up, Edge::new(0.into(), 0.into()));
+        g1.add_edge(up, o, Edge::new(0.into(), 0.into()));
+        let ca1 = gantz_ca::graph_addr(&g1);
+        structural_sync(
+            &mut controller,
+            &mut state,
+            entity,
+            ca1,
+            &flatten_no_refs(&g1),
+            1,
+            48_000.0,
+        );
+        let mut out = vec![0.0f32; 48_000 / 8];
+        for block in out.chunks_mut(64) {
+            world.fill(block, 1);
+        }
+        let rms1 = (out.iter().map(|v| v * v).sum::<f32>() / out.len() as f32).sqrt();
+        assert!(
+            rms1 < 1e-3,
+            "frame 1 (unconnected pack) must be silent: rms={rms1}"
+        );
+
+        // Frame 2: connect `~sinosc -> ~pack` (same `~out` path -> stable key,
+        // same name, but the def CHANGED: now carries a SinOsc). Must re-install.
+        let mut g2 = g1.clone();
+        let s = g2.add_node(TestN::SinOsc(gantz_plyphon::SinOsc::default()));
+        g2.add_edge(s, pk, Edge::new(0.into(), 0.into()));
+        let ca2 = gantz_ca::graph_addr(&g2);
+        structural_sync(
+            &mut controller,
+            &mut state,
+            entity,
+            ca2,
+            &flatten_no_refs(&g2),
+            1,
+            48_000.0,
+        );
+        let mut out = vec![0.0f32; 48_000 / 2];
+        for block in out.chunks_mut(64) {
+            world.fill(block, 1);
+        }
+        let rms2 = (out.iter().map(|v| v * v).sum::<f32>() / out.len() as f32).sqrt();
+        assert!(
+            rms2 > 0.05,
+            "frame 2 (sinosc connected) must sound: rms={rms2}"
+        );
+    }
+
+    /// A minimal node enum for driver tests: DSP sinks/sources plus the nesting
+    /// markers (`Inlet`/`Outlet`).
+    #[derive(Clone)]
+    enum TestN {
+        SinOsc(gantz_plyphon::SinOsc),
+        Out(gantz_plyphon::Out),
+        Pack(gantz_plyphon::Pack),
+        Unpack(gantz_plyphon::Unpack),
+        Inlet,
+        Outlet,
+    }
+
+    impl gantz_ca::CaHash for TestN {
+        fn hash(&self, hasher: &mut gantz_ca::Hasher) {
+            match self {
+                TestN::SinOsc(s) => gantz_ca::CaHash::hash(s, hasher),
+                TestN::Out(o) => gantz_ca::CaHash::hash(o, hasher),
+                TestN::Pack(p) => gantz_ca::CaHash::hash(p, hasher),
+                TestN::Unpack(u) => gantz_ca::CaHash::hash(u, hasher),
+                TestN::Inlet => {
+                    hasher.update(b"inlet");
+                }
+                TestN::Outlet => {
+                    hasher.update(b"outlet");
+                }
+            }
+        }
+    }
+
+    impl gantz_plyphon::ToNodeDsp for TestN {
+        fn to_node_dsp(&self) -> Option<&dyn gantz_plyphon::NodeDsp> {
+            match self {
+                TestN::SinOsc(s) => Some(s),
+                TestN::Out(o) => Some(o),
+                TestN::Pack(p) => Some(p),
+                TestN::Unpack(u) => Some(u),
+                TestN::Inlet | TestN::Outlet => None,
+            }
+        }
+    }
+
+    impl gantz_core::Node for TestN {
+        fn expr(&self, _ctx: gantz_core::node::ExprCtx<'_, '_>) -> gantz_core::node::ExprResult {
+            gantz_core::node::parse_expr("'()")
+        }
+        fn inlet(&self, _ctx: gantz_core::node::MetaCtx) -> bool {
+            matches!(self, TestN::Inlet)
+        }
+        fn outlet(&self, _ctx: gantz_core::node::MetaCtx) -> bool {
+            matches!(self, TestN::Outlet)
+        }
     }
 }

--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -32,7 +32,7 @@ use gantz_plyphon::{
     AddAction, AsRefNode, Backend, Embedded, GainRef, ROOT_GROUP_ID, RegionDerived, ToNodeDsp,
     derive_synthdefs, flatten_from_registry, structural_sig,
 };
-use plyphon::{Controller, InputRef, Nrt, Options, StreamConsumer, World, engine};
+use plyphon::{Controller, Nrt, Options, StreamConsumer, World, engine};
 // `std::time::Instant` panics ("time not implemented") on `wasm32-unknown-unknown`;
 // `web_time::Instant` shims it to `performance.now()` there and is plain `std::Instant`
 // on native. This clock drives the crossfade fade-out deadlines and the bus-run graveyard.
@@ -734,9 +734,10 @@ fn expire_fades(fading: &mut Vec<FadingSynth>, now: Instant) -> Vec<FadingSynth>
 /// synths: a region whose key + structural signature both match keeps its synth
 /// untouched (its unit state - oscillator phase, delay lines - survives exactly).
 /// A changed region is crossfade-replaced. A disappeared region fades out. Every
-/// signature is computed on the *unpatched* def - `ScopeOut` bufnums, bus
-/// channels and fade defaults are all placeholders at that point - so a
-/// re-derive of the same graph never spuriously respawns.
+/// signature is computed on the final def - bus indices, `ScopeOut` bufnums
+/// and fade defaults are all no-lag control params / baked defaults excluded
+/// from [`structural_sig`] - so a re-derive of the same graph never spuriously
+/// respawns (and the driver never mutates a def copy).
 ///
 /// Park `entity` at `graph_ca` without touching its running synths, so an
 /// unactionable commit (a flatten or derive error) is not retried (and its
@@ -925,12 +926,14 @@ fn structural_sync<N>(
     );
 }
 
-/// Cue scope streams and patch every placeholder (`ScopeOut` bufnums, bus
-/// channels from [`BusAlloc`], fade-gain defaults to `0.0` so the synth spawns
-/// silent), then install and spawn one region's def - `Before` the given anchor
-/// when present, else at the root group's tail. Unbound fade gains are ramped
-/// straight to unity (bound params re-send from node state via the same-frame
-/// param sync). Returns `None` on failure, having cleaned up after itself.
+/// Cue scope streams and allocate buses (so their indices are known), then
+/// install and spawn one region's def - `Before` the given anchor when present,
+/// else at the root group's tail. The synth spawns silent behind its fade
+/// gains' baked `0.0` defaults; bus indices, scope bufnums and unbound
+/// fade-to-unity are then set via `set_control` in one command-ring drain
+/// (landing before the first audible block). Bound params re-send from node
+/// state via the same-frame param sync. Returns `None` on failure, having
+/// cleaned up after itself.
 fn spawn_region(
     controller: &mut Controller,
     state: &mut HeadSynths,
@@ -948,45 +951,45 @@ fn spawn_region(
         bus_reads,
     } = region;
     let gantz_plyphon::Derived {
-        mut def,
+        def,
         params,
         monitors,
         gains,
     } = derived;
 
-    // Patch the bus placeholders from the per-bus-node allocations.
+    // Allocate buses and cue scope streams up front so their indices are known
+    // for the post-spawn `set_control` drain below (no def mutation: the bus
+    // indices and bufnums are no-lag control params, set live per block).
+    let mut set_after_spawn: Vec<(usize, f32)> = Vec::new();
     for binding in bus_writes.iter().chain(&bus_reads) {
         let bus_key = (entity, binding.node_path.clone());
         let Some(run) = state.bus_alloc.get_or_alloc(bus_key, binding.channels, now) else {
             log::error!("bevy_gantz_plyphon: private audio buses exhausted; region not spawned");
             return None;
         };
-        def.units[binding.unit].inputs[0] = InputRef::Constant(run.start as f32);
+        set_after_spawn.push((binding.param, run.start as f32));
     }
 
-    // Cue a scope stream per `~scopeout`, patching its `ScopeOut` bufnum.
     let mut scopes = Vec::new();
     for m in &monitors {
         let index = state.scope_alloc.alloc();
-        def.units[m.scope_unit].inputs[0] = InputRef::Constant(index as f32);
         let channels = m.channels.max(1);
         match controller.cue_scope(index, channels, sample_rate, CHUNK_FRAMES, NUM_CHUNKS) {
-            Ok(consumer) => scopes.push(ScopeSlot {
-                node_path: m.node_path.clone(),
-                size: m.size,
-                channels,
-                index,
-                consumer,
-            }),
+            Ok(consumer) => {
+                set_after_spawn.push((m.bufnum_param, index as f32));
+                scopes.push(ScopeSlot {
+                    node_path: m.node_path.clone(),
+                    size: m.size,
+                    channels,
+                    index,
+                    consumer,
+                })
+            }
             Err(e) => {
                 log::error!("bevy_gantz_plyphon: cue_scope failed: {e:?}");
                 state.scope_alloc.free(index);
             }
         }
-    }
-    // Spawn silent; the fades ramp in below / via the same-frame param sync.
-    for g in &gains {
-        def.params[g.index].default = 0.0;
     }
 
     let def_name = def.name.clone();
@@ -1003,9 +1006,15 @@ fn spawn_region(
     };
     match backend.spawn(&def_name, target, action) {
         Ok(node_id) => {
-            // A gain with no param slot (no node state feeds it - every fade
-            // gain) would stay stuck at the patched 0.0 default. Ramp it
-            // straight to unity instead.
+            // Wire the synth in one command-ring drain: bus indices, scope
+            // bufnums, then the unbound fade gains ramped to unity. All land
+            // before the synth's first audible block (it spawns silent behind
+            // the fade's baked `0.0` default).
+            for (param, value) in &set_after_spawn {
+                if let Err(e) = backend.set_control(node_id, *param, *value) {
+                    log::error!("bevy_gantz_plyphon: post-spawn set_control failed: {e:?}");
+                }
+            }
             for g in &gains {
                 if !params.iter().any(|b| b.index == g.index) {
                     if let Err(e) = backend.set_control(node_id, g.index, 1.0) {

--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -29,8 +29,8 @@ use cpal::{FromSample, SizedSample};
 use gantz_ca as ca;
 use gantz_core::node::graph::Graph;
 use gantz_plyphon::{
-    AddAction, AsRefNode, Backend, Embedded, GainRef, ROOT_GROUP_ID, RegionDerived, ToNodeDsp,
-    derive_synthdefs, flatten_from_registry, structural_sig,
+    AddAction, AsRefNode, Backend, BusKey, Embedded, GainRef, ROOT_GROUP_ID, RegionDerived,
+    ToNodeDsp, derive_synthdefs, flatten_from_registry, structural_sig,
 };
 use plyphon::{Controller, Nrt, Options, StreamConsumer, World, engine};
 // `std::time::Instant` panics ("time not implemented") on `wasm32-unknown-unknown`;
@@ -257,7 +257,7 @@ struct DspEngine {
 /// `~scopeout`'s scope `StreamConsumer` is `Send` but not `Sync`.
 #[derive(Default)]
 struct HeadSynths {
-    heads: HashMap<Entity, HeadRegions>,
+    heads: HashMap<Entity, HeadParts>,
     scope_alloc: ScopeAlloc,
     bus_alloc: BusAlloc,
     /// Installed synthdef names -> `(refcount, structural_sig)`. A def is
@@ -278,9 +278,9 @@ struct HeadSynths {
 /// One open head's running synths: one per boundary-cut region, in region-DAG
 /// topological order (bus writers before their readers - also their node-tree
 /// order). Empty when the head's graph has no dsp sink.
-struct HeadRegions {
+struct HeadParts {
     graph: ca::GraphAddr,
-    regions: Vec<RegionSynth>,
+    parts: Vec<PartSynth>,
 }
 
 /// A run of consecutive private audio-bus channels.
@@ -301,7 +301,7 @@ struct BusAlloc {
     /// Free runs, sorted by start and coalesced.
     free: Vec<Run>,
     /// Live allocations.
-    allocated: HashMap<(Entity, Vec<usize>), Run>,
+    allocated: HashMap<(Entity, BusKey), Run>,
     /// Quarantined runs, returned to `free` once their deadline passes.
     graveyard: Vec<(Run, Instant)>,
 }
@@ -322,7 +322,7 @@ impl BusAlloc {
     /// width change (the old run is quarantined). `None` = range exhausted.
     fn get_or_alloc(
         &mut self,
-        key: (Entity, Vec<usize>),
+        key: (Entity, BusKey),
         channels: usize,
         now: Instant,
     ) -> Option<Run> {
@@ -348,7 +348,7 @@ impl BusAlloc {
     }
 
     /// Quarantine `key`'s run (if any).
-    fn release(&mut self, key: &(Entity, Vec<usize>), now: Instant) {
+    fn release(&mut self, key: &(Entity, BusKey), now: Instant) {
         if let Some(run) = self.allocated.remove(key) {
             self.graveyard.push((run, now + FADE_GRACE * 2));
         }
@@ -437,7 +437,7 @@ impl ScopeAlloc {
 }
 
 /// The installed synthdef + running synth for one region of a head.
-struct RegionSynth {
+struct PartSynth {
     /// The region's identity across re-derives (`RegionDerived::key`), the
     /// driver's match for the keep/replace decision.
     key: u64,
@@ -632,7 +632,7 @@ fn drive_synths<N>(
         let (Some(head), Some(vm)) = (state.heads.get_mut(&entity), vms.get_mut(&entity)) else {
             continue;
         };
-        for synth in &mut head.regions {
+        for synth in &mut head.parts {
             let node_id = synth.node_id;
             let mut backend = Embedded::new(&mut dsp.controller);
             for slot in &mut synth.params {
@@ -699,7 +699,7 @@ fn drive_synths<N>(
         .collect();
     for e in stale {
         if let Some(head) = state.heads.remove(&e) {
-            for synth in head.regions {
+            for synth in head.parts {
                 let def_name = synth.def_name.clone();
                 fade_out(&mut dsp.controller, state, e, synth);
                 release_def(&mut dsp.controller, &mut state.shared_defs, &def_name);
@@ -758,9 +758,9 @@ fn park_head(state: &mut HeadSynths, entity: Entity, graph_ca: ca::GraphAddr) {
         None => {
             state.heads.insert(
                 entity,
-                HeadRegions {
+                HeadParts {
                     graph: graph_ca,
-                    regions: Vec::new(),
+                    parts: Vec::new(),
                 },
             );
         }
@@ -797,7 +797,7 @@ fn structural_sync<N>(
         // the defs now is safe - a fading synth holds its own compiled copy.
         Err(gantz_plyphon::DeriveError::NoSink) => {
             if let Some(head) = state.heads.remove(&entity) {
-                for synth in head.regions {
+                for synth in head.parts {
                     let def_name = synth.def_name.clone();
                     fade_out(controller, state, entity, synth);
                     release_def(controller, &mut state.shared_defs, &def_name);
@@ -808,9 +808,9 @@ fn structural_sync<N>(
             // graphs don't re-derive every frame.
             state.heads.insert(
                 entity,
-                HeadRegions {
+                HeadParts {
                     graph: graph_ca,
-                    regions: Vec::new(),
+                    parts: Vec::new(),
                 },
             );
             return;
@@ -836,16 +836,16 @@ fn structural_sync<N>(
     };
 
     // Release bus runs whose boundary nodes are gone from the derivation.
-    let live_buses: HashSet<Vec<usize>> = derived
+    let live_buses: HashSet<BusKey> = derived
         .iter()
         .flat_map(|r| r.bus_writes.iter().chain(&r.bus_reads))
-        .map(|b| b.node_path.clone())
+        .map(|b| BusKey::Bus(b.node_path.clone()))
         .collect();
     let dead_buses: Vec<_> = state
         .bus_alloc
         .allocated
         .keys()
-        .filter(|(e, path)| *e == entity && !live_buses.contains(path))
+        .filter(|(e, key)| *e == entity && !live_buses.contains(key))
         .cloned()
         .collect();
     for key in dead_buses {
@@ -855,13 +855,13 @@ fn structural_sync<N>(
     // Plan each region: keep the running synth when key + sig match, else spawn
     // a replacement (fading any predecessor once the replacement is up).
     enum Plan {
-        Keep(RegionSynth),
-        Spawn(RegionDerived, u64, Option<RegionSynth>),
+        Keep(PartSynth),
+        Spawn(RegionDerived, u64, Option<PartSynth>),
     }
     let mut prev = state
         .heads
         .remove(&entity)
-        .map(|h| h.regions)
+        .map(|h| h.parts)
         .unwrap_or_default();
     let mut plans: Vec<Plan> = Vec::with_capacity(derived.len());
     for r in derived {
@@ -913,10 +913,10 @@ fn structural_sync<N>(
         })
         .collect();
 
-    let mut regions: Vec<RegionSynth> = Vec::with_capacity(plans.len());
+    let mut parts: Vec<PartSynth> = Vec::with_capacity(plans.len());
     for (plan, anchor) in plans.into_iter().zip(anchors) {
         match plan {
-            Plan::Keep(k) => regions.push(k),
+            Plan::Keep(k) => parts.push(k),
             Plan::Spawn(r, sig, old) => {
                 match spawn_region(controller, state, entity, r, sig, sample_rate, anchor) {
                     Some(synth) => {
@@ -933,20 +933,20 @@ fn structural_sync<N>(
                             fade_out(controller, state, entity, old);
                             release_def(controller, &mut state.shared_defs, &old_def_name);
                         }
-                        regions.push(synth);
+                        parts.push(synth);
                     }
                     // Keep the old synth playing untouched on failure -
                     // strictly better than the silence a teardown would leave.
-                    None => regions.extend(old),
+                    None => parts.extend(old),
                 }
             }
         }
     }
     state.heads.insert(
         entity,
-        HeadRegions {
+        HeadParts {
             graph: graph_ca,
-            regions,
+            parts,
         },
     );
 }
@@ -967,7 +967,7 @@ fn spawn_region(
     sig: u64,
     sample_rate: f64,
     anchor: Option<i32>,
-) -> Option<RegionSynth> {
+) -> Option<PartSynth> {
     let now = Instant::now();
     let RegionDerived {
         key,
@@ -987,7 +987,7 @@ fn spawn_region(
     // indices and bufnums are no-lag control params, set live per block).
     let mut set_after_spawn: Vec<(usize, f32)> = Vec::new();
     for binding in bus_writes.iter().chain(&bus_reads) {
-        let bus_key = (entity, binding.node_path.clone());
+        let bus_key = (entity, BusKey::Bus(binding.node_path.clone()));
         let Some(run) = state.bus_alloc.get_or_alloc(bus_key, binding.channels, now) else {
             log::error!("bevy_gantz_plyphon: private audio buses exhausted; region not spawned");
             return None;
@@ -1073,7 +1073,7 @@ fn spawn_region(
                     last: None,
                 })
                 .collect();
-            Some(RegionSynth {
+            Some(PartSynth {
                 key,
                 def_name,
                 node_id,
@@ -1097,12 +1097,7 @@ fn spawn_region(
 /// and queue the synth - with its cued scope streams - for a deferred free once
 /// the slowest ramp has died away. A synth with no gains (e.g. monitor-only) has
 /// no audible output to de-click and is freed immediately.
-fn fade_out(
-    controller: &mut Controller,
-    state: &mut HeadSynths,
-    entity: Entity,
-    synth: RegionSynth,
-) {
+fn fade_out(controller: &mut Controller, state: &mut HeadSynths, entity: Entity, synth: PartSynth) {
     if synth.gains.is_empty() {
         let _ = Embedded::new(controller).free_node(synth.node_id);
         free_scopes(controller, &mut state.scope_alloc, synth.scopes);
@@ -1379,19 +1374,22 @@ mod tests {
         let base = Instant::now();
         let mut alloc = BusAlloc::new(4, 12);
         let a = alloc
-            .get_or_alloc((e[0], vec![1]), 2, base)
+            .get_or_alloc((e[0], BusKey::Bus(vec![1])), 2, base)
             .expect("2 channels");
         assert_eq!(a, Run { start: 4, len: 2 });
         let b = alloc
-            .get_or_alloc((e[0], vec![2]), 3, base)
+            .get_or_alloc((e[0], BusKey::Bus(vec![2])), 3, base)
             .expect("3 channels");
         assert_eq!(b, Run { start: 6, len: 3 });
         // Same key + width: the same run (an unchanged region's baked channel
         // stays valid).
-        assert_eq!(alloc.get_or_alloc((e[0], vec![1]), 2, base), Some(a));
+        assert_eq!(
+            alloc.get_or_alloc((e[0], BusKey::Bus(vec![1])), 2, base),
+            Some(a)
+        );
         // A width change re-allocates; the old run is quarantined, not reused.
         let a2 = alloc
-            .get_or_alloc((e[0], vec![1]), 4, base)
+            .get_or_alloc((e[0], BusKey::Bus(vec![1])), 4, base)
             .expect("4 channels");
         assert_eq!(a2, Run { start: 9, len: 4 });
         assert!(alloc.graveyard.iter().any(|(run, _)| *run == a));
@@ -1404,19 +1402,29 @@ mod tests {
         let e = entities(1);
         let base = Instant::now();
         let mut alloc = BusAlloc::new(0, 4);
-        let a = alloc.get_or_alloc((e[0], vec![1]), 2, base).expect("a");
-        let b = alloc.get_or_alloc((e[0], vec![2]), 2, base).expect("b");
+        let a = alloc
+            .get_or_alloc((e[0], BusKey::Bus(vec![1])), 2, base)
+            .expect("a");
+        let b = alloc
+            .get_or_alloc((e[0], BusKey::Bus(vec![2])), 2, base)
+            .expect("b");
         assert_eq!((a.start, b.start), (0, 2));
         // Exhausted while both are live.
-        assert_eq!(alloc.get_or_alloc((e[0], vec![3]), 1, base), None);
+        assert_eq!(
+            alloc.get_or_alloc((e[0], BusKey::Bus(vec![3])), 1, base),
+            None
+        );
         // Released runs stay quarantined until the deadline passes...
         alloc.release_head(e[0], base);
         alloc.sweep(base);
-        assert_eq!(alloc.get_or_alloc((e[0], vec![3]), 1, base), None);
+        assert_eq!(
+            alloc.get_or_alloc((e[0], BusKey::Bus(vec![3])), 1, base),
+            None
+        );
         // ...then coalesce back into one allocatable 4-wide run.
         alloc.sweep(base + FADE_GRACE * 2);
         assert_eq!(
-            alloc.get_or_alloc((e[0], vec![3]), 4, base),
+            alloc.get_or_alloc((e[0], BusKey::Bus(vec![3])), 4, base),
             Some(Run { start: 0, len: 4 }),
         );
     }

--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -825,6 +825,14 @@ fn structural_sync<N>(
             park_head(state, entity, graph_ca);
             return;
         }
+        // Instanced-reference failures: keep the previous synths, parking the
+        // head so the error logs once per commit rather than every frame.
+        Err(e @ gantz_plyphon::DeriveError::Unresolved(_))
+        | Err(e @ gantz_plyphon::DeriveError::RefCycle(_)) => {
+            log::error!("bevy_gantz_plyphon: {e:?}, keeping the previous synths");
+            park_head(state, entity, graph_ca);
+            return;
+        }
     };
 
     // Release bus runs whose boundary nodes are gone from the derivation.

--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -4,11 +4,14 @@
 //! stream (its own audio thread, running [`plyphon::World::fill_at`] so the engine
 //! clock is anchored to the host) and keeps the [`plyphon::Controller`] +
 //! [`plyphon::Nrt`] handles. Each update, after [`bevy_gantz::VmSet`], it derives
-//! one synthdef per `~bus`-cut *region* of each open head's DSP subgraph (rooted
-//! at its `~out` outputs and `~scopeout` monitors) and reconciles them with the
-//! running synths via the [`gantz_plyphon::Backend`] seam whenever the head's
-//! committed graph changes: unchanged regions keep their synths (and their unit
-//! state - oscillator phase, delay lines), changed ones are crossfade-replaced.
+//! one synthdef per *part* of each open head's DSP subgraph (rooted at its
+//! `~out` outputs and `~scopeout` monitors): the `~bus`-and-stage-cut regions,
+//! plus one spawn per *instanced* nested-graph ref of its child's shared,
+//! content-named defs (installed once, spawned per instance - see
+//! [`gantz_plyphon::instance`]). Parts reconcile with the running synths via
+//! the [`gantz_plyphon::Backend`] seam whenever the head's committed graph
+//! changes: unchanged parts keep their synths (and their unit state -
+//! oscillator phase, delay lines), changed ones are crossfade-replaced.
 //!
 //! The bridge runs both ways: control values drive dsp params via `set_control`,
 //! and each `~scopeout` monitor's scope stream is drained here into the node's

--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -1682,7 +1682,8 @@ mod tests {
     }
 
     /// A minimal node enum for driver tests: DSP sinks/sources plus the nesting
-    /// markers (`Inlet`/`Outlet`).
+    /// markers (`Inlet`/`Outlet`) and a graph ref carrying its child's content
+    /// address, arity and `inline` flag.
     #[derive(Clone)]
     enum TestN {
         SinOsc(gantz_plyphon::SinOsc),
@@ -1691,6 +1692,7 @@ mod tests {
         Unpack(gantz_plyphon::Unpack),
         Inlet,
         Outlet,
+        Ref(gantz_ca::ContentAddr, usize, usize, bool),
     }
 
     impl gantz_ca::CaHash for TestN {
@@ -1706,6 +1708,13 @@ mod tests {
                 TestN::Outlet => {
                     hasher.update(b"outlet");
                 }
+                TestN::Ref(ca, n_in, n_out, inline) => {
+                    hasher.update(b"ref");
+                    hasher.update(&ca.0);
+                    hasher.update(&n_in.to_le_bytes());
+                    hasher.update(&n_out.to_le_bytes());
+                    hasher.update(&[u8::from(*inline)]);
+                }
             }
         }
     }
@@ -1717,7 +1726,7 @@ mod tests {
                 TestN::Out(o) => Some(o),
                 TestN::Pack(p) => Some(p),
                 TestN::Unpack(u) => Some(u),
-                TestN::Inlet | TestN::Outlet => None,
+                TestN::Inlet | TestN::Outlet | TestN::Ref(..) => None,
             }
         }
     }
@@ -1732,5 +1741,364 @@ mod tests {
         fn outlet(&self, _ctx: gantz_core::node::MetaCtx) -> bool {
             matches!(self, TestN::Outlet)
         }
+        fn n_inputs(&self, _ctx: gantz_core::node::MetaCtx) -> usize {
+            match self {
+                TestN::Ref(_, n_in, _, _) => *n_in,
+                _ => 0,
+            }
+        }
+        fn n_outputs(&self, _ctx: gantz_core::node::MetaCtx) -> usize {
+            match self {
+                TestN::Ref(_, _, n_out, _) => *n_out,
+                _ => 0,
+            }
+        }
+    }
+
+    /// Flatten a head graph over `map`'s children (refs lower per their
+    /// `inline` flag) and pre-flatten every child for the derivation resolver.
+    #[allow(clippy::type_complexity)]
+    fn flatten_head(
+        g: &gantz_core::node::graph::Graph<TestN>,
+        map: &HashMap<gantz_ca::ContentAddr, gantz_core::node::graph::Graph<TestN>>,
+    ) -> (
+        gantz_core::node::graph::Graph<gantz_plyphon::Flat<TestN>>,
+        HashMap<gantz_ca::ContentAddr, gantz_core::node::graph::Graph<gantz_plyphon::Flat<TestN>>>,
+    ) {
+        use gantz_core::node::graph::Graph;
+        use gantz_plyphon::flatten::{RefKind, flatten};
+        fn resolver<'g>(
+            map: &'g HashMap<gantz_ca::ContentAddr, Graph<TestN>>,
+        ) -> impl Fn(&TestN) -> Option<(gantz_ca::ContentAddr, RefKind, Option<&'g Graph<TestN>>)> + 'g
+        {
+            move |n| match n {
+                TestN::Ref(ca, _, _, inline) => {
+                    let kind = if *inline {
+                        RefKind::Inline
+                    } else {
+                        RefKind::Instance
+                    };
+                    Some((*ca, kind, map.get(ca)))
+                }
+                _ => None,
+            }
+        }
+        let resolve = resolver(map);
+        let flat = flatten(&|_| None, g, &resolve).expect("flatten head");
+        let children = map
+            .iter()
+            .map(|(ca, child)| {
+                let resolve = resolver(map);
+                (
+                    *ca,
+                    flatten(&|_| None, child, &resolve).expect("flatten child"),
+                )
+            })
+            .collect();
+        (flat, children)
+    }
+
+    /// Render `frames` mono frames and return their RMS.
+    fn render_rms(world: &mut plyphon::World, frames: usize) -> f32 {
+        let mut out = vec![0.0f32; frames];
+        for block in out.chunks_mut(64) {
+            world.fill(block, 1);
+        }
+        (out.iter().map(|v| v * v).sum::<f32>() / out.len() as f32).sqrt()
+    }
+
+    /// A self-contained child: `~sinosc -> ~out`.
+    fn sine_out_child() -> gantz_core::node::graph::Graph<TestN> {
+        use gantz_core::edge::Edge;
+        let mut g = gantz_core::node::graph::Graph::<TestN>::default();
+        let s = g.add_node(TestN::SinOsc(gantz_plyphon::SinOsc::default()));
+        let o = g.add_node(TestN::Out(gantz_plyphon::Out::default()));
+        g.add_edge(s, o, Edge::new(0.into(), 0.into()));
+        g
+    }
+
+    fn test_engine() -> (Controller, Nrt, plyphon::World) {
+        plyphon::engine(plyphon::Options {
+            sample_rate: 48_000.0,
+            output_channels: 1,
+            ..plyphon::Options::default()
+        })
+    }
+
+    /// Two instances of one self-contained child both sound (louder than one),
+    /// sharing ONE installed def with refcount 2.
+    #[test]
+    fn two_instances_of_one_child_both_sound() {
+        use gantz_core::node::graph::Graph;
+
+        let ca = gantz_ca::ContentAddr([7u8; 32]);
+        let map = HashMap::from([(ca, sine_out_child())]);
+
+        // One instance, for the loudness baseline.
+        let mut g1 = Graph::<TestN>::default();
+        g1.add_node(TestN::Ref(ca, 0, 0, false));
+        let (flat1, children) = flatten_head(&g1, &map);
+        let (mut controller, _nrt, mut world) = test_engine();
+        let mut state = HeadSynths::default();
+        let entity = entities(1)[0];
+        structural_sync(
+            &mut controller,
+            &mut state,
+            entity,
+            gantz_ca::graph_addr(&g1),
+            &flat1,
+            &children,
+            1,
+            48_000.0,
+        );
+        let rms_one = render_rms(&mut world, 48_000 / 2);
+        assert!(rms_one > 0.05, "one instance must sound: rms={rms_one}");
+
+        // Two instances in a fresh engine.
+        let mut g2 = Graph::<TestN>::default();
+        g2.add_node(TestN::Ref(ca, 0, 0, false));
+        g2.add_node(TestN::Ref(ca, 0, 0, false));
+        let (flat2, children) = flatten_head(&g2, &map);
+        let (mut controller, _nrt, mut world) = test_engine();
+        let mut state = HeadSynths::default();
+        structural_sync(
+            &mut controller,
+            &mut state,
+            entity,
+            gantz_ca::graph_addr(&g2),
+            &flat2,
+            &children,
+            1,
+            48_000.0,
+        );
+        assert_eq!(state.heads[&entity].parts.len(), 2, "two instance spawns");
+        assert_eq!(
+            state.shared_defs.len(),
+            1,
+            "one shared def: {:?}",
+            state.shared_defs.keys().collect::<Vec<_>>(),
+        );
+        let (rc, _) = state.shared_defs.values().next().unwrap();
+        assert_eq!(*rc, 2, "both instances hold the def");
+        let rms_two = render_rms(&mut world, 48_000 / 2);
+        assert!(
+            rms_two > rms_one * 1.5,
+            "two in-phase instances sum louder: one={rms_one} two={rms_two}",
+        );
+    }
+
+    /// Editing the child respawns exactly its instances: the head's own region
+    /// keeps its synth (node id unchanged) while both instance spawns are
+    /// replaced and the old pair fade out.
+    #[test]
+    fn child_edit_respawns_only_its_instances() {
+        use gantz_core::edge::Edge;
+        use gantz_core::node::graph::Graph;
+
+        let ca1 = gantz_ca::ContentAddr([1u8; 32]);
+        // The edited child: structurally different (an extra `~pack` stage).
+        let ca2 = gantz_ca::ContentAddr([2u8; 32]);
+        let mut child2 = Graph::<TestN>::default();
+        let s = child2.add_node(TestN::SinOsc(gantz_plyphon::SinOsc::default()));
+        let pk = child2.add_node(TestN::Pack(gantz_plyphon::Pack::default()));
+        let o = child2.add_node(TestN::Out(gantz_plyphon::Out::default()));
+        child2.add_edge(s, pk, Edge::new(0.into(), 0.into()));
+        child2.add_edge(pk, o, Edge::new(0.into(), 0.into()));
+        let map = HashMap::from([(ca1, sine_out_child()), (ca2, child2)]);
+
+        // Head: its own region (sin -> out) + two instances of the child.
+        let head = |ca: gantz_ca::ContentAddr| {
+            let mut g = Graph::<TestN>::default();
+            let s = g.add_node(TestN::SinOsc(gantz_plyphon::SinOsc::default()));
+            let o = g.add_node(TestN::Out(gantz_plyphon::Out::default()));
+            g.add_edge(s, o, Edge::new(0.into(), 0.into()));
+            g.add_node(TestN::Ref(ca, 0, 0, false));
+            g.add_node(TestN::Ref(ca, 0, 0, false));
+            g
+        };
+
+        let (mut controller, _nrt, _world) = test_engine();
+        let mut state = HeadSynths::default();
+        let entity = entities(1)[0];
+        let g1 = head(ca1);
+        let (flat1, children) = flatten_head(&g1, &map);
+        structural_sync(
+            &mut controller,
+            &mut state,
+            entity,
+            gantz_ca::graph_addr(&g1),
+            &flat1,
+            &children,
+            1,
+            48_000.0,
+        );
+        let before: HashMap<u64, i32> = state.heads[&entity]
+            .parts
+            .iter()
+            .map(|p| (p.key, p.node_id))
+            .collect();
+        assert_eq!(before.len(), 3, "own region + two instances");
+
+        let g2 = head(ca2);
+        let (flat2, children) = flatten_head(&g2, &map);
+        structural_sync(
+            &mut controller,
+            &mut state,
+            entity,
+            gantz_ca::graph_addr(&g2),
+            &flat2,
+            &children,
+            1,
+            48_000.0,
+        );
+        let after: HashMap<u64, i32> = state.heads[&entity]
+            .parts
+            .iter()
+            .map(|p| (p.key, p.node_id))
+            .collect();
+        assert_eq!(after.len(), 3);
+
+        // Exactly one part survives by key - the head's own region - with its
+        // synth untouched. The instance parts (child CA in their key) are new,
+        // and the two retired spawns are fading.
+        let kept: Vec<_> = after
+            .iter()
+            .filter(|(k, _)| before.contains_key(k))
+            .collect();
+        assert_eq!(kept.len(), 1, "only the head's own region matches by key");
+        let (kept_key, kept_id) = kept[0];
+        assert_eq!(
+            before[kept_key], *kept_id,
+            "the kept region never respawned"
+        );
+        assert_eq!(state.fading.len(), 2, "both old instance spawns fade out");
+    }
+
+    /// Toggling `inline` on the ref switches the lowering live: the instanced
+    /// spawn crossfades to the spliced one, audibly on both sides.
+    #[test]
+    fn inline_toggle_switches_lowering_live() {
+        use gantz_core::node::graph::Graph;
+
+        let ca = gantz_ca::ContentAddr([3u8; 32]);
+        let map = HashMap::from([(ca, sine_out_child())]);
+        let head = |inline: bool| {
+            let mut g = Graph::<TestN>::default();
+            g.add_node(TestN::Ref(ca, 0, 0, inline));
+            g
+        };
+
+        let (mut controller, _nrt, mut world) = test_engine();
+        let mut state = HeadSynths::default();
+        let entity = entities(1)[0];
+
+        let g1 = head(false);
+        let (flat1, children) = flatten_head(&g1, &map);
+        assert!(
+            flat1
+                .node_indices()
+                .any(|n| matches!(flat1[n], gantz_plyphon::Flat::Instance { .. })),
+            "instanced by default",
+        );
+        structural_sync(
+            &mut controller,
+            &mut state,
+            entity,
+            gantz_ca::graph_addr(&g1),
+            &flat1,
+            &children,
+            1,
+            48_000.0,
+        );
+        let rms1 = render_rms(&mut world, 48_000 / 4);
+        assert!(rms1 > 0.05, "instanced lowering sounds: rms={rms1}");
+
+        let g2 = head(true);
+        let (flat2, children) = flatten_head(&g2, &map);
+        assert!(
+            flat2
+                .node_indices()
+                .all(|n| !matches!(flat2[n], gantz_plyphon::Flat::Instance { .. })),
+            "inline splices",
+        );
+        structural_sync(
+            &mut controller,
+            &mut state,
+            entity,
+            gantz_ca::graph_addr(&g2),
+            &flat2,
+            &children,
+            1,
+            48_000.0,
+        );
+        // Render across the crossfade: the tone stays audible throughout.
+        let rms2 = render_rms(&mut world, 48_000 / 2);
+        assert!(
+            rms2 > 0.05,
+            "inline lowering sounds after the switch: rms={rms2}"
+        );
+        assert_eq!(state.heads[&entity].parts.len(), 1);
+    }
+
+    /// A param edit lands on ONE instance's synth: setting one spawn's freq to
+    /// zero leaves its sibling sounding (the shared def's param index is per
+    /// synth), and the sibling's slot state is untouched.
+    #[test]
+    fn param_edit_on_one_instance_leaves_sibling() {
+        use gantz_core::node::graph::Graph;
+
+        let ca = gantz_ca::ContentAddr([5u8; 32]);
+        let map = HashMap::from([(ca, sine_out_child())]);
+        let mut g = Graph::<TestN>::default();
+        g.add_node(TestN::Ref(ca, 0, 0, false));
+        g.add_node(TestN::Ref(ca, 0, 0, false));
+        let (flat, children) = flatten_head(&g, &map);
+
+        let (mut controller, _nrt, mut world) = test_engine();
+        let mut state = HeadSynths::default();
+        let entity = entities(1)[0];
+        structural_sync(
+            &mut controller,
+            &mut state,
+            entity,
+            gantz_ca::graph_addr(&g),
+            &flat,
+            &children,
+            1,
+            48_000.0,
+        );
+        let rms_both = render_rms(&mut world, 48_000 / 2);
+
+        // Silence the FIRST instance's sine via its own synth's freq param
+        // (the same set_control the driver's param sync issues). The slots
+        // pair absolute node paths with def-local indices: both instances
+        // share the index, but each has its own node id.
+        let parts = &state.heads[&entity].parts;
+        assert_eq!(parts.len(), 2);
+        let (a, b) = (&parts[0], &parts[1]);
+        assert_ne!(a.node_id, b.node_id);
+        assert_ne!(a.params[0].node_path, b.params[0].node_path);
+        assert_eq!(a.params[0].index, b.params[0].index, "shared def index");
+        let freq = a
+            .params
+            .iter()
+            .find(|s| s.node_path.len() == 2)
+            .expect("the nested sine's param slot");
+        Embedded::new(&mut controller)
+            .set_control(a.node_id, freq.index, 0.0)
+            .expect("set_control");
+        let rms_one = render_rms(&mut world, 48_000 / 2);
+        assert!(
+            rms_one > 0.05,
+            "the sibling instance still sounds: rms={rms_one}",
+        );
+        assert!(
+            rms_one < rms_both * 0.75,
+            "one silenced instance is quieter: both={rms_both} one={rms_one}",
+        );
+        assert!(
+            b.params[0].last.is_none(),
+            "the sibling's slot is untouched"
+        );
     }
 }

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -501,6 +501,51 @@ mod tests {
         );
     }
 
+    /// A head graph with `~sinosc -> ~out` plus unconnected `inlet`/`outlet`
+    /// nodes flattens correctly (the inlets/outlets dissolve) and derives a
+    /// sounding synthdef. Regression guard for the GUI's `flatten_from_registry`
+    /// path with `Box<dyn Node>`.
+    #[test]
+    fn head_graph_with_unconnected_inlets_derives_sound() {
+        use gantz_plyphon::ToNodeDsp;
+        use std::time::Duration;
+        type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
+
+        let text = "\
+(graph head
+  (s ~sinosc) (out ~out) (i inlet) (o outlet)
+  (-> s (out 0)))";
+        let export: gantz_egui::export::Export<G> =
+            gantz_egui::format::from_str(text, Duration::from_secs(0)).expect("from_str");
+        let head = gantz_ca::Head::Branch("head".into());
+        let graph = export.registry.head_graph(&head).expect("head graph");
+
+        let flat = gantz_plyphon::flatten_from_registry(graph, &export.registry).expect("flatten");
+        // The inlet/outlet dissolve: only sin + out survive.
+        assert_eq!(
+            flat.node_count(),
+            2,
+            "inlet/outlet dissolve in the head graph"
+        );
+        assert_eq!(flat.edge_count(), 1, "the sin -> out edge survives");
+
+        let regions = gantz_plyphon::derive_synthdefs(&flat, 1, "head").expect("derive");
+        assert_eq!(regions.len(), 1, "one region");
+        let names: Vec<&str> = regions[0]
+            .derived
+            .def
+            .units
+            .iter()
+            .map(|u| u.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["SinOsc", "BinaryOpUGen", "BinaryOpUGen", "Out"]);
+        assert_eq!(
+            regions[0].derived.gains.len(),
+            1,
+            "the out carries a fade gain"
+        );
+    }
+
     /// A nested graph of DSP nodes sounds through the flattening pass: the
     /// child's `~lag` splices into the parent's synthdef carrying its nested
     /// path, and that path reaches the node's live param state in the VM -

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -502,9 +502,9 @@ mod tests {
     }
 
     /// A head graph with `~sinosc -> ~out` plus unconnected `inlet`/`outlet`
-    /// nodes flattens correctly (the inlets/outlets dissolve) and derives a
-    /// sounding synthdef. Regression guard for the GUI's `flatten_from_registry`
-    /// path with `Box<dyn Node>`.
+    /// nodes flattens correctly (root-level boundaries stay as inert non-DSP
+    /// markers) and derives a sounding synthdef. Regression guard for the
+    /// GUI's `flatten_from_registry` path with `Box<dyn Node>`.
     #[test]
     fn head_graph_with_unconnected_inlets_derives_sound() {
         use gantz_plyphon::ToNodeDsp;
@@ -521,13 +521,24 @@ mod tests {
         let graph = export.registry.head_graph(&head).expect("head graph");
 
         let flat = gantz_plyphon::flatten_from_registry(graph, &export.registry).expect("flatten");
-        // The inlet/outlet dissolve: only sin + out survive.
+        // Root inlet/outlet survive as markers (the head graph's interface);
+        // they are non-DSP, so derivation ignores them.
         assert_eq!(
             flat.node_count(),
-            2,
-            "inlet/outlet dissolve in the head graph"
+            4,
+            "sin + out + the two root boundary markers"
         );
         assert_eq!(flat.edge_count(), 1, "the sin -> out edge survives");
+        let markers = flat
+            .node_indices()
+            .filter(|&n| {
+                matches!(
+                    flat[n],
+                    gantz_plyphon::Flat::Inlet { .. } | gantz_plyphon::Flat::Outlet { .. }
+                )
+            })
+            .count();
+        assert_eq!(markers, 2, "the boundaries are kept as markers");
 
         let regions = gantz_plyphon::derive_synthdefs(&flat, 1, "head").expect("derive");
         assert_eq!(regions.len(), 1, "one region");

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -557,12 +557,14 @@ mod tests {
         );
     }
 
-    /// A nested graph of DSP nodes sounds through the flattening pass: the
-    /// child's `~lag` splices into the parent's synthdef carrying its nested
-    /// path, and that path reaches the node's live param state in the VM -
-    /// exactly the contract the audio driver's param sync relies on. Guards
-    /// the whole nested-DSP pipeline (registry ref resolution, flattening,
-    /// derivation, VM state bridge) end to end with the app's real node type.
+    /// A nested graph of DSP nodes lowers through the instancing pass: the
+    /// ref stays an instance marker, the child's `~lag` derives into the
+    /// shared child def, and the resolved part's binding carries the lag's
+    /// ABSOLUTE nested path - which reaches the node's live param state in
+    /// the VM, exactly the contract the audio driver's param sync relies on.
+    /// Guards the whole nested-DSP pipeline (registry ref resolution,
+    /// flattening, template derivation, VM state bridge) end to end with the
+    /// app's real node type.
     #[test]
     fn nested_dsp_graph_flattens_derives_and_bridges_state() {
         use gantz_egui::sync::AsNamedRef;
@@ -604,10 +606,22 @@ mod tests {
             .index();
 
         let flat = gantz_plyphon::flatten_from_registry(parent, &export.registry).expect("flatten");
-        let derived = gantz_plyphon::derive_synthdef(&flat, 1, "test").expect("derive");
-        let binding = derived
-            .params
+        // The DSP-bearing child lowers as an instance marker by default.
+        let markers = flat
+            .node_indices()
+            .filter(|&n| matches!(flat[n], gantz_plyphon::Flat::Instance { .. }))
+            .count();
+        assert_eq!(markers, 1, "the ref stays an instance marker");
+        let children =
+            gantz_plyphon::flatten_instance_children(&flat, &export.registry).expect("children");
+        let resolve = |ca: &gantz_ca::ContentAddr| children.get(ca);
+        let mut cache = gantz_plyphon::DefCache::new();
+        let template =
+            gantz_plyphon::derive_template(&flat, 1, &resolve, &mut cache).expect("derive");
+        let parts = gantz_plyphon::instantiate(&template, &cache);
+        let binding = parts
             .iter()
+            .flat_map(|p| p.params.iter())
             .find(|b| b.node_path == [ref_ix, lag_ix])
             .expect("a param binding keyed by the lag's nested path");
 

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -507,7 +507,6 @@ mod tests {
     /// GUI's `flatten_from_registry` path with `Box<dyn Node>`.
     #[test]
     fn head_graph_with_unconnected_inlets_derives_sound() {
-        use gantz_plyphon::ToNodeDsp;
         use std::time::Duration;
         type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
 

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -639,6 +639,45 @@ mod tests {
         assert!(pending.is_empty());
     }
 
+    /// Two references to one DSP child share a single derived variant: one
+    /// `DefCache` entry, both resolved parts naming the same content-hashed
+    /// def, with per-instance absolute binding paths. Guards the install-once
+    /// spawn-many contract end to end with the app's real node type.
+    #[test]
+    fn instanced_refs_share_one_variant() {
+        use std::time::Duration;
+        type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
+
+        let text = "\
+(graph voice
+  (s ~sinosc) (out ~out)
+  (-> s (out 0)))
+
+(graph env
+  (a (ref voice)) (b (ref voice)))";
+        let export: gantz_egui::export::Export<G> =
+            gantz_egui::format::from_str(text, Duration::from_secs(0)).expect("from_str");
+        let head = gantz_ca::Head::Branch("env".into());
+        let parent = export.registry.head_graph(&head).expect("env graph");
+
+        let flat = gantz_plyphon::flatten_from_registry(parent, &export.registry).expect("flatten");
+        let children =
+            gantz_plyphon::flatten_instance_children(&flat, &export.registry).expect("children");
+        let resolve = |ca: &gantz_ca::ContentAddr| children.get(ca);
+        let mut cache = gantz_plyphon::DefCache::new();
+        let template =
+            gantz_plyphon::derive_template(&flat, 1, &resolve, &mut cache).expect("derive");
+        assert_eq!(cache.len(), 1, "both refs share one variant");
+        let parts = gantz_plyphon::instantiate(&template, &cache);
+        assert_eq!(parts.len(), 2, "one spawn per instance");
+        assert_eq!(parts[0].def.name, parts[1].def.name, "one shared def");
+        assert_ne!(parts[0].key, parts[1].key, "distinct identities");
+        let mut prefixes: Vec<usize> = parts.iter().map(|p| p.params[0].node_path[0]).collect();
+        prefixes.sort_unstable();
+        prefixes.dedup();
+        assert_eq!(prefixes.len(), 2, "bindings carry per-instance prefixes");
+    }
+
     /// `~unpack`'s placeholder expr honours the multi-output contract for any
     /// `count`: a single value for one output, a list of values otherwise. A
     /// wrong shape (e.g. `(list 0)` for count 1) fails `vm::init`'s compile.

--- a/crates/gantz_plyphon/src/backend.rs
+++ b/crates/gantz_plyphon/src/backend.rs
@@ -94,7 +94,12 @@ impl Backend for Embedded<'_> {
     ) -> Result<i32, BackendError> {
         self.controller
             .synth_new(def_name, target, action)
-            .map_err(|e| BackendError::Spawn(format!("{e:?}")))
+            .map_err(|e| match e {
+                // Transient: the ring drains within a block, so the caller can
+                // retry next frame rather than treating the spawn as broken.
+                plyphon::SynthNewError::QueueFull => BackendError::QueueFull,
+                e => BackendError::Spawn(format!("{e:?}")),
+            })
     }
 
     fn free_node(&mut self, node: i32) -> Result<(), BackendError> {

--- a/crates/gantz_plyphon/src/compile.rs
+++ b/crates/gantz_plyphon/src/compile.rs
@@ -28,9 +28,9 @@ pub enum DeriveError {
 }
 
 /// One side of a `~bus` boundary within a region's def: the bus unit whose
-/// input 0 (the bus channel index) is a `0.0` placeholder the driver patches to
-/// a driver-allocated private bus before installing (the `ScopeOut`-bufnum
-/// idiom, so [`structural_sig`] stays stable across allocations).
+/// input 0 (the bus channel index) is a no-lag control param the driver sets to
+/// a driver-allocated private bus via `set_control` after spawning (no def
+/// mutation, so [`structural_sig`] stays stable across allocations).
 #[derive(Clone, Debug)]
 pub struct BusBinding {
     /// The `~bus` node's path - the driver's bus-allocation key. Consecutive
@@ -40,8 +40,11 @@ pub struct BusBinding {
     /// The bus's channel count - the boundary signal's width.
     pub channels: usize,
     /// The index within the def's `units` of the bus `Out` (write side) or `In`
-    /// (read side) whose input 0 is the patchable placeholder.
+    /// (read side) whose input 0 is the bus-index param.
     pub unit: usize,
+    /// The no-lag control param the driver sets to the allocated bus channel
+    /// via `set_control` after spawning.
+    pub param: usize,
 }
 
 /// One region of a boundary-cut graph: its derived synthdef + bindings, plus
@@ -264,8 +267,9 @@ fn merged_pull_order<N: ToNodeDsp>(
 /// `~bus` ([`is_boundary`](crate::NodeDsp::is_boundary)): regions are the
 /// connected components of the dsp-reachable subgraph over non-boundary edges,
 /// and a boundary between two regions lowers to an `Out` to a private bus in
-/// the writer's def and an `In` in each reader's - both with placeholder bus
-/// inputs the driver patches post-sig (see [`BusBinding`]). The point: each
+/// the writer's def and an `In` in each reader's - both with a no-lag
+/// bus-index control param the driver sets via `set_control` after spawning
+/// (see [`BusBinding`]). The point: each
 /// region carries its own [`structural_sig`], so an edit respawns only its own
 /// region's synth and every other region's unit state survives untouched.
 ///
@@ -475,16 +479,21 @@ where
                                 .entry(bus)
                                 .or_insert_with(|| {
                                     let channels = bus_width.get(&bus).copied().unwrap_or(1);
+                                    let bus_param = builder.push_control_param(
+                                        &graph[bus].node_path(bus.index()),
+                                        "bus",
+                                    );
                                     let unit = builder.push_unit(UnitSpec::new(
                                         "In",
                                         Rate::Audio,
-                                        vec![InputRef::Constant(0.0)],
+                                        vec![InputRef::Param(bus_param)],
                                         channels,
                                     ));
                                     bus_reads.push(BusBinding {
                                         node_path: graph[bus].node_path(bus.index()),
                                         channels,
                                         unit: unit as usize,
+                                        param: bus_param as usize,
                                     });
                                     (0..channels as u32)
                                         .map(|output| InputRef::Unit { unit, output })
@@ -512,7 +521,7 @@ where
         }
 
         // Emit the region's bus writes: lift each channel to audio, apply the
-        // driver's fade gain, and write to a placeholder bus.
+        // driver's fade gain, and write to a bus-index param.
         let mut bus_writes = Vec::with_capacity(writes.len());
         for b in writes {
             let (src, port) = bus_source(b).expect("writes are sourced");
@@ -522,7 +531,8 @@ where
                 .cloned()
                 .unwrap_or_else(|| Signal::silent(1));
             let fade = builder.push_fade_gain(&graph[b].node_path(b.index()));
-            let mut out_inputs = vec![InputRef::Constant(0.0)];
+            let bus_param = builder.push_control_param(&graph[b].node_path(b.index()), "bus");
+            let mut out_inputs = vec![InputRef::Param(bus_param)];
             for ch in sig.channels() {
                 let ch = builder.ensure_audio(ch);
                 let mul = builder.push_unit(UnitSpec {
@@ -542,6 +552,7 @@ where
                 node_path: graph[b].node_path(b.index()),
                 channels: sig.width(),
                 unit: unit as usize,
+                param: bus_param as usize,
             });
             bus_width.insert(b, sig.width());
         }

--- a/crates/gantz_plyphon/src/compile.rs
+++ b/crates/gantz_plyphon/src/compile.rs
@@ -25,6 +25,11 @@ pub enum DeriveError {
     /// writer-before-reader order to derive (or run) them in. Deliberate
     /// cross-region feedback (an `InFeedback`-based bus) is a planned follow-up.
     BusCycle,
+    /// An instanced reference's target graph could not be resolved.
+    Unresolved(gantz_ca::ContentAddr),
+    /// Instanced references form a cycle (a graph transitively instancing
+    /// itself), so there is no finite template to derive.
+    RefCycle(gantz_ca::ContentAddr),
 }
 
 /// One side of a `~bus` boundary within a region's def: the bus unit whose
@@ -173,7 +178,7 @@ where
 }
 
 /// Every dsp sink of `graph`: an audio output (`~out`) or a monitor (`~scopeout`).
-fn dsp_sinks<N: ToNodeDsp>(graph: &Graph<N>) -> Vec<NodeIx> {
+pub(crate) fn dsp_sinks<N: ToNodeDsp>(graph: &Graph<N>) -> Vec<NodeIx> {
     graph
         .node_indices()
         .filter(|&n| {
@@ -240,7 +245,7 @@ fn resolved_sources<N: ToNodeDsp>(
 /// Merge each sink's dsp-only pull-eval order into one topological order over
 /// the nodes selected by `keep`, first occurrence wins (a filtered subsequence
 /// of a topological order remains topological for the kept subgraph).
-fn merged_pull_order<N: ToNodeDsp>(
+pub(crate) fn merged_pull_order<N: ToNodeDsp>(
     graph: &Graph<N>,
     seeds: &[NodeIx],
     keep: impl Fn(NodeIx) -> bool,
@@ -585,6 +590,17 @@ where
         });
     }
     Ok(regions)
+}
+
+/// The content-addressed name for a def with the given [`structural_sig`].
+///
+/// Purely a function of the def's structure - no head or region prefix - so
+/// structurally identical defs derived from different heads (or from many
+/// instances of one referenced child graph) collide by design, and the audio
+/// driver's per-name install refcounting shares one installed def between
+/// them. Names change exactly when the structure does.
+pub fn content_def_name(sig: u64) -> String {
+    format!("gantz-def-{sig:016x}")
 }
 
 /// A hash of a synthdef's *structure* - everything except parameter values.

--- a/crates/gantz_plyphon/src/dsp.rs
+++ b/crates/gantz_plyphon/src/dsp.rs
@@ -216,12 +216,13 @@ pub const FADE_LAG: f32 = 0.05;
 
 /// Records a synthdef *fade gain* - a driver-owned param scaling a sink's whole
 /// output - so the audio driver can fade the synth in and out across a
-/// crossfaded replacement (the respawn de-click). The driver patches the
-/// param's `default` from `1.0` to `0.0` before install (the synth spawns
-/// silent. [`structural_sig`](crate::structural_sig) excludes defaults) and
+/// crossfaded replacement (the respawn de-click). The default is baked at
+/// `0.0` so the synth spawns silent without any def mutation, and the driver
 /// ramps it via the param's own `LagControl` - to `1.0` once the synth is up,
-/// to `0.0` ahead of a deferred free. Fade gains have NO [`ParamBinding`]: no
-/// node state feeds them, the driver alone drives them.
+/// to `0.0` ahead of a deferred free. [`structural_sig`](crate::structural_sig)
+/// excludes defaults, so the baked `0.0` does not churn the sig. Fade gains
+/// have NO [`ParamBinding`]: no node state feeds them, the driver alone drives
+/// them.
 #[derive(Clone, Copy, Debug)]
 pub struct GainRef {
     /// The param's index within the synthdef's `params`.
@@ -232,9 +233,9 @@ pub struct GainRef {
 
 /// Records a monitor (`~scopeout`) node's `ScopeOut`, so the audio driver can cue a live
 /// scope stream and route its samples into the right node's ring-buffer state,
-/// capped at `size`. The `ScopeOut`'s `bufnum` input is a placeholder in the derived
-/// def. The driver allocates a globally-unique cued index and patches the unit at
-/// `scope_unit` before installing the def.
+/// capped at `size`. The `ScopeOut`'s `bufnum` is a no-lag control param in the
+/// derived def; the driver allocates a globally-unique cued index and sets it
+/// via `set_control` after spawning (no def mutation).
 #[derive(Clone, Debug)]
 pub struct ScopeOutBinding {
     /// The monitor node's path within the graph (where its ring state lives).
@@ -244,9 +245,11 @@ pub struct ScopeOutBinding {
     /// The number of channels the `ScopeOut` streams (`cue_scope`'s width) -
     /// the width of the monitored input [`Signal`], inferred at derive time.
     pub channels: usize,
-    /// The index within the def's `units` of this monitor's `ScopeOut`, so the driver
-    /// can patch its `bufnum` (input 0) to the cued scope-stream index.
+    /// The index within the def's `units` of this monitor's `ScopeOut`.
     pub scope_unit: usize,
+    /// The no-lag control param the driver sets to the cued scope-stream index
+    /// via `set_control` after spawning.
+    pub bufnum_param: usize,
 }
 
 /// Accumulates the [`UnitSpec`]s and [`Param`]s of a synthdef as nodes emit them.
@@ -295,16 +298,30 @@ impl DspBuilder {
         index as u32
     }
 
+    /// Declare a driver-owned, no-lag control param (no [`ParamBinding`]),
+    /// returning its index for [`InputRef::Param`]. Used for per-instance
+    /// wiring - bus indices, scope bufnums - that the driver sets via
+    /// `set_control` after spawning. No lag, since a lagged bus index would
+    /// glide through wrong buses; the default is `0.0`.
+    pub fn push_control_param(&mut self, path: &[usize], label: &str) -> u32 {
+        let index = self.params.len();
+        self.params
+            .push(Param::control(crate::param::param_name(path, label), 0.0));
+        index as u32
+    }
+
     /// Declare a driver-controlled *fade gain* for the sink at `path`: a lagged
-    /// param (default `1.0`, [`FADE_LAG`] ramp) that must scale the sink's whole
+    /// param (default `0.0`, [`FADE_LAG`] ramp) that must scale the sink's whole
     /// output, recorded as a [`GainRef`] but with NO [`ParamBinding`] - node
-    /// state never feeds it. the driver alone drives it across a crossfaded
-    /// replacement. Returns the param's index for [`InputRef::Param`].
+    /// state never feeds it. The default is baked at `0.0` so the synth spawns
+    /// silent; the driver ramps it to `1.0` via `set_control` once the synth is
+    /// up (and to `0.0` ahead of a deferred free). Returns the param's index
+    /// for [`InputRef::Param`].
     pub fn push_fade_gain(&mut self, path: &[usize]) -> u32 {
         let index = self.params.len();
         self.params.push(Param::lag(
             crate::param::param_name(path, "fade"),
-            1.0,
+            0.0,
             FADE_LAG,
         ));
         self.gains.push(GainRef {
@@ -317,20 +334,23 @@ impl DspBuilder {
     /// Declare a monitor for the dsp node at `path`, recording its [`ScopeOutBinding`]
     /// so the driver can cue a `channels`-wide scope stream and route its samples into
     /// the node's ring state (capped at `size` frames). `scope_unit` is the index of the
-    /// node's `ScopeOut` unit (from [`push_unit`](Self::push_unit)), so the driver can
-    /// patch its `bufnum`.
+    /// node's `ScopeOut` unit (from [`push_unit`](Self::push_unit)); `bufnum_param` is
+    /// the no-lag control param the driver sets to the cued scope-stream index via
+    /// `set_control` after spawning.
     pub fn push_monitor(
         &mut self,
         path: &[usize],
         size: usize,
         channels: usize,
         scope_unit: usize,
+        bufnum_param: usize,
     ) {
         self.monitors.push(ScopeOutBinding {
             node_path: path.to_vec(),
             size,
             channels,
             scope_unit,
+            bufnum_param,
         });
     }
 

--- a/crates/gantz_plyphon/src/egui/ref_ext.rs
+++ b/crates/gantz_plyphon/src/egui/ref_ext.rs
@@ -42,9 +42,10 @@ impl RefExtUi for DspRefExtUi {
                 if ui
                     .checkbox(&mut inline, "")
                     .on_hover_text(
-                        "Inline this reference's DSP nodes into the parent synthdef. \
-                         Currently always the behaviour - the flag records intent \
-                         until shared-synthdef instancing lands.",
+                        "Inline this reference's DSP nodes into the parent synthdef \
+                         instead of spawning them from the shared per-variant \
+                         definition (the default). Inlined copies compile their own \
+                         units; instanced copies share one definition.",
                     )
                     .changed()
                 {

--- a/crates/gantz_plyphon/src/flatten.rs
+++ b/crates/gantz_plyphon/src/flatten.rs
@@ -17,6 +17,16 @@
 //! hash paths. Keeping original paths means a node's identity survives
 //! re-derivation regardless of where it lands in the flat graph.
 //!
+//! Not every ref splices. A ref resolved as [`RefKind::Instance`] stays an
+//! opaque [`Flat::Instance`] marker for
+//! `derive_template` (crate::instance) to lower into a
+//! shared synthdef spawned per instance. Root-level `Inlet`/`Outlet` nodes are
+//! likewise kept as markers ([`Flat::Inlet`]/[`Flat::Outlet`]): they are the
+//! flattened graph's own interface, which template derivation lowers to the
+//! shared def's bus reads and writes. All markers are non-DSP
+//! (`to_node_dsp()` is `None`), so [`derive_synthdef`](crate::derive_synthdef)
+//! and [`derive_synthdefs`](crate::derive_synthdefs) ignore them.
+//!
 //! # Edge bridging
 //!
 //! An edge into a ref's input `i` belongs to every consumer of the referenced
@@ -45,15 +55,62 @@ use crate::dsp::{NodeDsp, ToNodeDsp};
 
 pub use gantz_core::node::AsRefNode;
 
-/// A node spliced out of a nested structure into a flat graph, carrying its
-/// original path (e.g. `[3, 2]` for the node at index 2 within the graph
-/// referenced by the root node at index 3).
+/// A vertex of the flattened graph: a node spliced out of the nested
+/// structure, an opaque instanced-reference marker, or a root-level boundary
+/// marker. Every variant carries its original path (e.g. `[3, 2]` for the
+/// node at index 2 within the graph referenced by the root node at index 3).
 #[derive(Clone, Debug)]
-pub struct Flat<N> {
-    /// The node's original path within the nested structure.
-    pub path: Vec<usize>,
-    /// The node itself.
-    pub node: N,
+pub enum Flat<N> {
+    /// A concrete node spliced into the flat graph.
+    Node {
+        /// The node's original path within the nested structure.
+        path: Vec<usize>,
+        /// The node itself.
+        node: N,
+    },
+    /// An instanced nested-graph ref: opaque to derivation, resolved by
+    /// `derive_template` (crate::instance) into a shared
+    /// synthdef variant wired per instance.
+    Instance {
+        /// The ref node's original path within the nested structure.
+        path: Vec<usize>,
+        /// The referenced child graph's content address.
+        child_ca: ContentAddr,
+        /// The ref's inlet count (the child graph's `Inlet` count), for
+        /// instance-aware reachability and edge bridging.
+        n_inlets: usize,
+        /// The ref's outlet count (the child graph's `Outlet` count).
+        n_outlets: usize,
+    },
+    /// A root-level `Inlet`, kept as a marker: it is the flattened graph's own
+    /// interface, which template derivation lowers to a shared-def bus read.
+    /// (Nested inlets dissolve into the surrounding edges as before.)
+    Inlet {
+        /// The inlet node's path (`[ix]` - root markers are never nested).
+        path: Vec<usize>,
+        /// The inlet's position among the root's inlets in ascending node
+        /// index order (the "input i to inlet i" contract).
+        index: usize,
+    },
+    /// A root-level `Outlet` marker (see [`Flat::Inlet`]).
+    Outlet {
+        /// The outlet node's path.
+        path: Vec<usize>,
+        /// The outlet's position among the root's outlets.
+        index: usize,
+    },
+}
+
+impl<N> Flat<N> {
+    /// The vertex's original path within the nested structure.
+    pub fn path(&self) -> &[usize] {
+        match self {
+            Flat::Node { path, .. }
+            | Flat::Instance { path, .. }
+            | Flat::Inlet { path, .. }
+            | Flat::Outlet { path, .. } => path,
+        }
+    }
 }
 
 /// An error flattening a nested graph.
@@ -69,14 +126,34 @@ pub enum FlattenError {
     Unresolved(ContentAddr),
 }
 
-/// Resolves a node to the committed graph it references, if any.
+/// How a nested-graph ref lowers during flattening.
+///
+/// `Inline` splices the referenced graph's nodes into the flat graph (the
+/// classic behaviour). `Instance` leaves an opaque [`Flat::Instance`] marker,
+/// deferring the child's DSP to a shared synthdef derived once and wired per
+/// instance (see `derive_template` (crate::instance)).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RefKind {
+    /// Splice the referenced graph's nodes into the flat graph.
+    Inline,
+    /// Leave an opaque instance marker; the child's DSP is derived once into a
+    /// shared synthdef and wired per instance.
+    Instance,
+}
+
+/// Resolves a node to the committed graph it references, if any, and how it
+/// lowers.
 ///
 /// - `None`: not a graph ref. The node is copied into the flat graph as-is.
-/// - `Some((ca, Some(graph)))`: a graph ref. The referenced graph is spliced
-///   in place of the node, with `ca` keying the ref-cycle guard.
-/// - `Some((ca, None))`: a graph ref whose target is missing, an
-///   [`FlattenError::Unresolved`] error.
-pub type Resolve<'g, N> = dyn Fn(&N) -> Option<(ContentAddr, Option<&'g Graph<N>>)> + 'g;
+/// - `Some((ca, RefKind::Inline, Some(graph)))`: an inlined graph ref. The
+///   referenced graph is spliced in place of the node, with `ca` keying the
+///   ref-cycle guard.
+/// - `Some((ca, RefKind::Instance, _))`: an instanced graph ref. An opaque
+///   [`Flat::Instance`] marker carrying `ca` is emitted in place of the node;
+///   the child graph is not resolved at flatten time (it may be `None`).
+/// - `Some((_, RefKind::Inline, None))`: a graph ref whose target is missing,
+///   an [`FlattenError::Unresolved`] error.
+pub type Resolve<'g, N> = dyn Fn(&N) -> Option<(ContentAddr, RefKind, Option<&'g Graph<N>>)> + 'g;
 
 /// One level of the nested structure: a graph, where it hangs off its parent,
 /// and where each of its nodes went during splicing. Bridging resolves edge
@@ -101,11 +178,14 @@ type SrcKey = (usize, NodeIx, usize);
 
 impl<N: ToNodeDsp> ToNodeDsp for Flat<N> {
     fn to_node_dsp(&self) -> Option<&dyn NodeDsp> {
-        self.node.to_node_dsp()
+        match self {
+            Flat::Node { node, .. } => node.to_node_dsp(),
+            Flat::Instance { .. } | Flat::Inlet { .. } | Flat::Outlet { .. } => None,
+        }
     }
 
     fn node_path(&self, _ix: usize) -> Vec<usize> {
-        self.path.clone()
+        self.path().to_vec()
     }
 }
 
@@ -157,7 +237,7 @@ where
     let resolve = |n: &N| {
         n.as_ref_node().map(|r| {
             let ca = r.content_addr();
-            (ca, registry.commit_graph_ref(&ca.into()))
+            (ca, RefKind::Inline, registry.commit_graph_ref(&ca.into()))
         })
     };
     let get_node = |ca: &ContentAddr| {
@@ -202,30 +282,67 @@ where
             p.push(ix.index());
             p
         };
-        if let Some((ca, child_graph)) = resolve(node) {
-            if ca_stack.contains(&ca) {
-                return Err(FlattenError::RefCycle(ca));
+        if let Some((ca, kind, child_graph)) = resolve(node) {
+            match kind {
+                // An instanced ref: emit an opaque marker carrying the child
+                // CA and do NOT splice (no recursion, no cycle check - an
+                // instance never resolves its child at flatten time). The
+                // marker behaves as a kept node with the ref's inputs/outputs.
+                RefKind::Instance => {
+                    let n_inlets = node.n_inputs(ctx);
+                    let n_outlets = node.n_outputs(ctx);
+                    let flat = out.add_node(Flat::Instance {
+                        path: path(),
+                        child_ca: ca,
+                        n_inlets,
+                        n_outlets,
+                    });
+                    levels[id].kept.insert(ix, flat);
+                }
+                RefKind::Inline => {
+                    if ca_stack.contains(&ca) {
+                        return Err(FlattenError::RefCycle(ca));
+                    }
+                    let child_graph = child_graph.ok_or(FlattenError::Unresolved(ca))?;
+                    ca_stack.push(ca);
+                    let child = splice(
+                        ctx,
+                        resolve,
+                        child_graph,
+                        Some((id, ix)),
+                        path(),
+                        levels,
+                        out,
+                        ca_stack,
+                    )?;
+                    ca_stack.pop();
+                    levels[id].child.insert(ix, child);
+                }
             }
-            let child_graph = child_graph.ok_or(FlattenError::Unresolved(ca))?;
-            ca_stack.push(ca);
-            let child = splice(
-                ctx,
-                resolve,
-                child_graph,
-                Some((id, ix)),
-                path(),
-                levels,
-                out,
-                ca_stack,
-            )?;
-            ca_stack.pop();
-            levels[id].child.insert(ix, child);
         } else if node.inlet(ctx) {
             levels[id].inlets.push(ix);
+            // A root-level inlet is the flat graph's own interface: keep it
+            // as a marker for template derivation. Nested inlets dissolve.
+            if parent.is_none() {
+                let index = levels[id].inlets.len() - 1;
+                let flat = out.add_node(Flat::Inlet {
+                    path: path(),
+                    index,
+                });
+                levels[id].kept.insert(ix, flat);
+            }
         } else if node.outlet(ctx) {
             levels[id].outlets.push(ix);
+            if parent.is_none() {
+                let index = levels[id].outlets.len() - 1;
+                let flat = out.add_node(Flat::Outlet {
+                    path: path(),
+                    index,
+                });
+                levels[id].kept.insert(ix, flat);
+            }
         } else {
-            let flat = out.add_node(Flat {
+            let flat = out.add_node(Flat::Node {
                 path: path(),
                 node: node.clone(),
             });

--- a/crates/gantz_plyphon/src/flatten.rs
+++ b/crates/gantz_plyphon/src/flatten.rs
@@ -4,10 +4,13 @@
 //! it as a single ref node) is gantz's primary abstraction. The control (Steel)
 //! compiler supports it call-based: each nested level becomes a function the
 //! parent calls. A synthdef is a flat unit list with no notion of calling a
-//! sub-synthdef, so the DSP compiler instead *inlines*: [`flatten`] resolves
-//! each graph ref, splices the referenced graph's nodes into one flat graph and
-//! dissolves the `Inlet`/`Outlet` boundary nodes into the surrounding edges.
-//! The result derives via [`derive_synthdef`](crate::derive_synthdef) or
+//! sub-synthdef, so the DSP compiler lowers a ref one of two ways: *instance*
+//! it (the default for DSP-bearing children) - keep an opaque marker that
+//! `derive_template` (crate::instance) turns into a shared synthdef spawned
+//! per instance - or *inline* it: splice the referenced graph's nodes into
+//! one flat graph, dissolving the `Inlet`/`Outlet` boundary nodes into the
+//! surrounding edges. The spliced result derives via
+//! [`derive_synthdef`](crate::derive_synthdef) or
 //! [`derive_synthdefs`](crate::derive_synthdefs) unchanged.
 //!
 //! Every spliced node carries its original path within the nested structure
@@ -227,17 +230,37 @@ where
 /// [`flatten`] resolving [`AsRefNode`] nodes through the content-addressed
 /// registry (a reference's content address is the referenced graph's commit
 /// address).
+///
+/// How each ref lowers is decided here: a ref whose child (transitively)
+/// contains DSP nodes lowers as [`RefKind::Instance`] by default - its child
+/// derives once into shared synthdefs spawned per instance - unless its
+/// [`DspRefExt`](crate::ref_ext::DspRefExt) ext datum sets `inline`, which
+/// opts back into splicing. Refs to non-DSP children (including pure
+/// `inlet -> outlet` wires) always splice: they carry structure, not sound,
+/// and must dissolve.
 pub fn flatten_from_registry<'g, N>(
     graph: &'g Graph<N>,
     registry: &'g gantz_ca::Registry<Graph<N>>,
 ) -> Result<Graph<Flat<N>>, FlattenError>
 where
-    N: gantz_core::Node + AsRefNode + Clone,
+    N: gantz_core::Node + AsRefNode + ToNodeDsp + Clone,
 {
+    let dsp_memo = std::cell::RefCell::new(HashMap::new());
     let resolve = |n: &N| {
         n.as_ref_node().map(|r| {
             let ca = r.content_addr();
-            (ca, RefKind::Inline, registry.commit_graph_ref(&ca.into()))
+            let inline = r
+                .ext_as::<crate::ref_ext::DspRefExt>(crate::ref_ext::DSP_REF_EXT_KEY)
+                .unwrap_or_default()
+                .inline;
+            let kind = if !inline
+                && crate::ref_ext::is_dsp_commit(registry, ca.into(), &mut dsp_memo.borrow_mut())
+            {
+                RefKind::Instance
+            } else {
+                RefKind::Inline
+            };
+            (ca, kind, registry.commit_graph_ref(&ca.into()))
         })
     };
     let get_node = |ca: &ContentAddr| {
@@ -257,7 +280,7 @@ pub fn flatten_instance_children<N>(
     registry: &gantz_ca::Registry<Graph<N>>,
 ) -> Result<HashMap<ContentAddr, Graph<Flat<N>>>, FlattenError>
 where
-    N: gantz_core::Node + AsRefNode + Clone,
+    N: gantz_core::Node + AsRefNode + ToNodeDsp + Clone,
 {
     fn marker_cas<N>(g: &Graph<Flat<N>>) -> Vec<ContentAddr> {
         g.node_indices()

--- a/crates/gantz_plyphon/src/flatten.rs
+++ b/crates/gantz_plyphon/src/flatten.rs
@@ -248,6 +248,41 @@ where
     flatten(&get_node, graph, &resolve)
 }
 
+/// Flatten every child graph `flat` (transitively) instances, so template
+/// derivation's resolver can hand out `&Graph<Flat<N>>` per child content
+/// address. Walks [`Flat::Instance`] markers to a fixpoint: only children an
+/// instanced ref actually reaches are flattened.
+pub fn flatten_instance_children<N>(
+    flat: &Graph<Flat<N>>,
+    registry: &gantz_ca::Registry<Graph<N>>,
+) -> Result<HashMap<ContentAddr, Graph<Flat<N>>>, FlattenError>
+where
+    N: gantz_core::Node + AsRefNode + Clone,
+{
+    fn marker_cas<N>(g: &Graph<Flat<N>>) -> Vec<ContentAddr> {
+        g.node_indices()
+            .filter_map(|n| match &g[n] {
+                Flat::Instance { child_ca, .. } => Some(*child_ca),
+                _ => None,
+            })
+            .collect()
+    }
+    let mut out: HashMap<ContentAddr, Graph<Flat<N>>> = HashMap::new();
+    let mut queue = marker_cas(flat);
+    while let Some(ca) = queue.pop() {
+        if out.contains_key(&ca) {
+            continue;
+        }
+        let graph = registry
+            .commit_graph_ref(&ca.into())
+            .ok_or(FlattenError::Unresolved(ca))?;
+        let child = flatten_from_registry(graph, registry)?;
+        queue.extend(marker_cas(&child));
+        out.insert(ca, child);
+    }
+    Ok(out)
+}
+
 /// Phase 1: recursively copy `graph`'s concrete nodes into `out` (paths
 /// prefixed by `prefix`), recording each level's boundary nodes and resolved
 /// refs in `levels` for [`bridge`] to resolve edges through. Returns the

--- a/crates/gantz_plyphon/src/instance.rs
+++ b/crates/gantz_plyphon/src/instance.rs
@@ -1,0 +1,1367 @@
+//! Recursive synthdef template derivation for nested-graph instance
+//! composition (#295).
+//!
+//! A flat graph (the output of [`flatten`](crate::flatten::flatten)) may
+//! contain [`Flat::Instance`] markers - opaque references to child graphs
+//! whose DSP is derived once into shared synthdefs and wired per instance via
+//! buses - plus root [`Flat::Inlet`]/[`Flat::Outlet`] markers describing the
+//! graph's own interface. This module's [`derive_template`] produces a
+//! [`GraphTemplate`]: a topologically ordered list of [`Part`]s (regions and
+//! instances) plus the bus wiring connecting them. [`instantiate`] splices a
+//! template (and, recursively, its instances' child templates) into a flat
+//! [`ResolvedPart`] list with absolute paths - the input the audio driver
+//! consumes.
+//!
+//! # Def reuse
+//!
+//! One template is derived per [`VariantKey`] - a content-addressed shape
+//! combining the child's content address, its connected-inlet widths
+//! (unconnected inlets bake mono silence), its consumed-outlet mask and the
+//! engine's output channel count. Every instance of the same child at the
+//! same shape, in any head, shares one [`GraphTemplate`] (memoised in a
+//! [`DefCache`]). Defs are named by structural content
+//! ([`content_def_name`]), so the driver's
+//! per-name install refcounting installs each shared def once and spawns it
+//! per instance, with per-synth wiring set live via `set_control`.
+//!
+//! # Composition
+//!
+//! Defs never reference defs. Composition lives entirely in the template's
+//! wiring metadata - [`BusKey`]s on region reads/writes and instance inlets -
+//! which the driver realises as buses. The child's body derives from the
+//! committed child graph with child-local param names, so
+//! [`structural_sig`] (and hence the def name) is
+//! stable across instances, while [`instantiate`] prefixes every binding path
+//! with the instance's absolute path for the driver's param/scope sync.
+//!
+//! # Staging
+//!
+//! An instance's def runs as its own synth, so a node feeding an instance
+//! must run *before* it and a node reading it *after*. A diamond such as
+//! `src -> instance -> mix` plus `src -> mix` therefore cannot fuse `src` and
+//! `mix` into one def. Each node is assigned a *stage* - the maximum over its
+//! winning sources, bumped when crossing an instance - and regions are the
+//! connected components *within a stage*. A winning edge crossing stages (or
+//! otherwise crossing regions) lowers to an implicit bus
+//! ([`BusKey::Src`]), costing one bus and no latency (writers run before
+//! readers within a block). Cycles *through an instance* have no such order
+//! and are rejected as [`DeriveError::BusCycle`] (deliberate feedback is
+//! planned to land with `InFeedback` lowering, #293).
+
+use std::collections::{HashMap, HashSet};
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::sync::Arc;
+
+use petgraph::Direction;
+use petgraph::visit::EdgeRef;
+use plyphon::Rate;
+use plyphon::synthdef::{InputRef, SynthDef, UnitSpec};
+
+use gantz_ca::ContentAddr;
+use gantz_core::node::graph::{Graph, NodeIx};
+
+use crate::compile::{
+    DeriveError, content_def_name, derive_synthdefs, dsp_sinks, merged_pull_order, structural_sig,
+};
+use crate::dsp::{DspBuilder, GainRef, ParamBinding, ScopeOutBinding, Signal, ToNodeDsp};
+use crate::flatten::Flat;
+
+/// A content-addressed shape identifying one template variant of a child
+/// graph.
+///
+/// Every instance of the same child at the same inlet-width signature, outlet
+/// consumption mask and engine width shares one [`GraphTemplate`]. Unconnected
+/// inlets bake mono silence (part of the key, preserving derivation's constant
+/// folding); the outlet mask records which outlets are consumed downstream.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct VariantKey {
+    /// The referenced child graph's commit content address.
+    pub child: ContentAddr,
+    /// One entry per inlet: `None` for unconnected (baked silence), `Some(w)`
+    /// for connected at width `w`.
+    pub inlets: Vec<Option<usize>>,
+    /// One entry per outlet: `true` if some downstream node consumes it.
+    pub outlets: Vec<bool>,
+    /// The engine's output channel count (baked into sinks).
+    pub out_channels: usize,
+}
+
+/// The identity of one bus within a template, on both its write and read
+/// sides. The driver allocates exactly one bus per distinct *absolute* key
+/// (see [`instantiate`]), so two sides naming the same key share a bus.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum BusKey {
+    /// An explicit `~bus` boundary, keyed by the *effective* bus node's path
+    /// (consecutive `~bus` nodes alias, exactly as in
+    /// [`derive_synthdefs`]).
+    Bus(Vec<usize>),
+    /// An implicit endpoint bus: the output `output` of the node at `path`,
+    /// written where a winning edge crosses a region boundary (a stage cut or
+    /// an instance-inlet feed).
+    Src {
+        /// The source node's path.
+        path: Vec<usize>,
+        /// The source node's output port.
+        output: usize,
+    },
+    /// An instance's consumed outlet. Never allocated directly:
+    /// [`instantiate`] resolves it through the child template's
+    /// [`outlets`](GraphTemplate::outlets) table to the bus actually carrying
+    /// the outlet's signal (falling back to an unwritten - silent - bus for a
+    /// sourceless outlet).
+    InstOut {
+        /// The instance marker's path.
+        path: Vec<usize>,
+        /// The consumed outlet's index.
+        outlet: usize,
+    },
+    /// The template's own `i`-th inlet. Resolved by [`instantiate`] to the
+    /// enclosing graph's feeding bus.
+    IfaceIn(usize),
+}
+
+/// One side of a bus within a region's def: the `In`/`Out` unit and the no-lag
+/// bus-index control param the driver sets via `set_control` after spawning.
+#[derive(Clone, Debug)]
+pub struct TemplateBus {
+    /// The bus's identity (template-relative paths).
+    pub key: BusKey,
+    /// The bus's channel count (the boundary signal's width).
+    pub channels: usize,
+    /// The index within the def's `units` of the bus `Out` (write side) or
+    /// `In` (read side) whose input 0 is the bus-index param.
+    pub unit: usize,
+    /// The no-lag control param the driver sets to the allocated bus channel.
+    pub param: usize,
+}
+
+/// One region of a template: a connected component of DSP nodes within a
+/// stage, derived as its own synthdef, plus the buses its def writes and
+/// reads. Binding paths are template-relative; [`instantiate`] absolutizes
+/// them.
+pub struct TemplateRegion {
+    /// A stable template-relative identity across re-derives: a hash of the
+    /// region's sink paths and bus keys. Combined with the instance path
+    /// prefix by [`instantiate`] for the driver's keep/replace decision.
+    pub key: u64,
+    /// The def's [`structural_sig`] (its name is [`content_def_name`] of
+    /// this).
+    pub sig: u64,
+    /// The region's synthdef, shared by every instance of the template.
+    pub def: Arc<SynthDef>,
+    /// Param bindings (template-relative node paths, def-local indices).
+    pub params: Vec<ParamBinding>,
+    /// Monitor bindings (template-relative node paths).
+    pub monitors: Vec<ScopeOutBinding>,
+    /// The def's driver-ramped fade gains.
+    pub gains: Vec<GainRef>,
+    /// The buses this region's def writes.
+    pub bus_writes: Vec<TemplateBus>,
+    /// The buses this region's def reads.
+    pub bus_reads: Vec<TemplateBus>,
+}
+
+/// One part of a [`GraphTemplate`].
+pub enum Part {
+    /// A derived region synthdef.
+    Region(TemplateRegion),
+    /// An instanced nested-graph ref, wiring a shared child variant via buses.
+    Instance(InstancePart),
+}
+
+/// An instance's identity and wiring within its template. The child's own
+/// `In`/`Out` units live in the child template's regions; this records which
+/// enclosing bus feeds each connected inlet.
+pub struct InstancePart {
+    /// The instance marker's template-relative path (its identity for
+    /// keep/replace and bus resolution).
+    pub path: Vec<usize>,
+    /// The variant this instance instantiates (keys the shared template).
+    pub variant: VariantKey,
+    /// Per inlet: the template-relative key of the bus feeding it (`None` =
+    /// unconnected, baked silence in the variant).
+    pub inlet_keys: Vec<Option<BusKey>>,
+}
+
+/// A derived template: its parts in topological order (bus writers before
+/// readers) and its own outlet table (for nesting into a parent).
+pub struct GraphTemplate {
+    /// The parts, in bus-writer-before-reader topological order.
+    pub parts: Vec<Part>,
+    /// One entry per outlet: the template-relative key of the bus carrying
+    /// the outlet's signal and its width, or `None` for an unconsumed or
+    /// sourceless outlet. A parent's read of the instance's outlet resolves
+    /// through this table at [`instantiate`] time, so an outlet fed by a
+    /// nested instance or passed through from an inlet aliases the underlying
+    /// bus with no relay def.
+    pub outlets: Vec<Option<(BusKey, usize)>>,
+}
+
+/// A memoised cache of derived child templates, keyed by [`VariantKey`].
+#[derive(Default)]
+pub struct DefCache(HashMap<VariantKey, Arc<GraphTemplate>>);
+
+impl DefCache {
+    /// An empty cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Look up a cached template by variant key.
+    pub fn get(&self, key: &VariantKey) -> Option<Arc<GraphTemplate>> {
+        self.0.get(key).cloned()
+    }
+
+    /// Insert a derived template (the caller derives it, then caches).
+    pub fn insert(&mut self, key: VariantKey, t: Arc<GraphTemplate>) {
+        self.0.insert(key, t);
+    }
+
+    /// The number of cached variants.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether the cache holds no variants.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// Resolves a child content address to its committed graph (flattened), for
+/// recursive [`derive_template`]. `None` surfaces as
+/// [`DeriveError::Unresolved`].
+pub type InstanceResolve<'g, N> = dyn Fn(&ContentAddr) -> Option<&'g Graph<Flat<N>>> + 'g;
+
+/// A part with its absolute path resolved - the driver's input.
+///
+/// Produced by [`instantiate`]: instances dissolve into their child
+/// template's regions (spawned per instance from the shared def), so only
+/// region-flavoured parts remain, in global bus-writer-before-reader order.
+pub struct ResolvedPart {
+    /// The part's keep/replace identity: the template region key combined
+    /// with the instance path prefix. Stable across re-derives while the
+    /// part's sinks and wiring shape stay put.
+    pub key: u64,
+    /// The def's [`structural_sig`].
+    pub sig: u64,
+    /// The shared, content-named synthdef.
+    pub def: Arc<SynthDef>,
+    /// Param bindings with ABSOLUTE node paths (def-local indices).
+    pub params: Vec<ParamBinding>,
+    /// Monitor bindings with absolute node paths.
+    pub monitors: Vec<ScopeOutBinding>,
+    /// The def's driver-ramped fade gains.
+    pub gains: Vec<GainRef>,
+    /// The buses this part's synth writes (absolute keys).
+    pub bus_writes: Vec<ResolvedBus>,
+    /// The buses this part's synth reads (absolute keys).
+    pub bus_reads: Vec<ResolvedBus>,
+}
+
+/// A [`TemplateBus`] with its key made absolute.
+#[derive(Clone, Debug)]
+pub struct ResolvedBus {
+    /// The bus's absolute identity - the driver's allocation key.
+    pub key: BusKey,
+    /// The bus's channel count.
+    pub channels: usize,
+    /// The def-local index of the bus `In`/`Out` unit.
+    pub unit: usize,
+    /// The def-local no-lag control param carrying the bus index.
+    pub param: usize,
+}
+
+/// How a flat vertex participates in derivation.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    /// A DSP node that joins a region.
+    Plain,
+    /// A `~bus` boundary.
+    Boundary,
+    /// An instance marker (`n_inlets`, `n_outlets`).
+    Instance(usize, usize),
+    /// A root inlet marker (its interface index).
+    Inlet(usize),
+    /// A root outlet marker (its interface index).
+    Outlet(usize),
+}
+
+/// Where a consumed input's signal comes from.
+enum Feed {
+    /// A same-region source: wire it directly.
+    Wire(NodeIx, usize),
+    /// An external bus: an `In` keyed by `key`, whose write (if any) is owned
+    /// by `writer`.
+    Read {
+        key: BusKey,
+        writer: Option<PartId>,
+        /// For `Src`/`Bus` keys: the plain node + port whose output the
+        /// writer region must emit to the bus.
+        demand: Option<(NodeIx, usize)>,
+        /// The param path + label of the read-side bus-index param.
+        param_at: (Vec<usize>, String),
+    },
+    /// No source: mono silence.
+    Silence,
+}
+
+/// A part of the template DAG.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+enum PartId {
+    Region(usize),
+    Instance(usize),
+}
+
+/// Derive a [`GraphTemplate`] for `graph`, recursing into instance children
+/// per `resolve` (memoised in `cache`).
+///
+/// The head graph is the degenerate case: its interface (any root
+/// inlet/outlet markers) is all-unconnected, so stray boundaries lower to
+/// silence exactly as they always have. When the graph contains no markers at
+/// all, this delegates to [`derive_synthdefs`] (handling `~bus` boundaries
+/// exactly as today) and re-shapes its regions, renamed to content def names.
+pub fn derive_template<N>(
+    graph: &Graph<Flat<N>>,
+    out_channels: usize,
+    resolve: &InstanceResolve<'_, N>,
+    cache: &mut DefCache,
+) -> Result<GraphTemplate, DeriveError>
+where
+    N: ToNodeDsp,
+{
+    let (n_inlets, n_outlets) = iface_arity(graph);
+    let inlets = vec![None; n_inlets];
+    let outlets = vec![false; n_outlets];
+    let mut deriving = Vec::new();
+    derive_parts(
+        graph,
+        out_channels,
+        &inlets,
+        &outlets,
+        resolve,
+        cache,
+        &mut deriving,
+    )
+}
+
+/// The number of root inlet/outlet markers in a flat graph.
+fn iface_arity<N>(graph: &Graph<Flat<N>>) -> (usize, usize) {
+    let mut n_in = 0;
+    let mut n_out = 0;
+    for n in graph.node_indices() {
+        match &graph[n] {
+            Flat::Inlet { .. } => n_in += 1,
+            Flat::Outlet { .. } => n_out += 1,
+            _ => {}
+        }
+    }
+    (n_in, n_out)
+}
+
+/// Whether the child committed at `ca` (transitively) contains a DSP sink -
+/// an instance of it is then itself a sink (it produces audio through the
+/// child's own `~out`/`~scopeout`, no parent wiring needed).
+fn child_has_sink<N>(
+    ca: &ContentAddr,
+    resolve: &InstanceResolve<'_, N>,
+    memo: &mut HashMap<ContentAddr, bool>,
+    stack: &mut Vec<ContentAddr>,
+) -> Result<bool, DeriveError>
+where
+    N: ToNodeDsp,
+{
+    if let Some(&known) = memo.get(ca) {
+        return Ok(known);
+    }
+    if stack.contains(ca) {
+        // A ref cycle cannot introduce a sink its members do not already
+        // contain; the cycle itself errors if such an instance ever derives.
+        return Ok(false);
+    }
+    let graph = resolve(ca).ok_or(DeriveError::Unresolved(*ca))?;
+    stack.push(*ca);
+    let mut has = !dsp_sinks(graph).is_empty();
+    if !has {
+        for n in graph.node_indices() {
+            if let Flat::Instance { child_ca, .. } = &graph[n] {
+                if child_has_sink(child_ca, resolve, memo, stack)? {
+                    has = true;
+                    break;
+                }
+            }
+        }
+    }
+    stack.pop();
+    memo.insert(*ca, has);
+    Ok(has)
+}
+
+/// The unified template derivation: classify, reach, stage, cut into
+/// per-stage regions, order the part DAG and derive each part with its bus
+/// wiring. `inlets`/`outlets_consumed` describe the interface shape the
+/// enclosing graph observes (all-unconnected/unconsumed for the head).
+#[allow(clippy::too_many_lines)]
+fn derive_parts<N>(
+    graph: &Graph<Flat<N>>,
+    out_channels: usize,
+    inlets: &[Option<usize>],
+    outlets_consumed: &[bool],
+    resolve: &InstanceResolve<'_, N>,
+    cache: &mut DefCache,
+    deriving: &mut Vec<ContentAddr>,
+) -> Result<GraphTemplate, DeriveError>
+where
+    N: ToNodeDsp,
+{
+    // Fast path: no markers at all is exactly `derive_synthdefs` (the
+    // pre-instancing pipeline), re-shaped with content def names.
+    let any_marker = graph
+        .node_indices()
+        .any(|n| !matches!(&graph[n], Flat::Node { .. }));
+    if !any_marker {
+        let regions = derive_synthdefs(graph, out_channels, "gantz")?;
+        let parts = regions
+            .into_iter()
+            .map(|r| {
+                let mut def = r.derived.def;
+                let sig = structural_sig(&def);
+                def.name = content_def_name(sig);
+                let to_template = |b: crate::compile::BusBinding| TemplateBus {
+                    key: BusKey::Bus(b.node_path),
+                    channels: b.channels,
+                    unit: b.unit,
+                    param: b.param,
+                };
+                Part::Region(TemplateRegion {
+                    key: r.key,
+                    sig,
+                    def: Arc::new(def),
+                    params: r.derived.params,
+                    monitors: r.derived.monitors,
+                    gains: r.derived.gains,
+                    bus_writes: r.bus_writes.into_iter().map(to_template).collect(),
+                    bus_reads: r.bus_reads.into_iter().map(to_template).collect(),
+                })
+            })
+            .collect();
+        return Ok(GraphTemplate {
+            parts,
+            outlets: Vec::new(),
+        });
+    }
+
+    // Classify every derivation-relevant vertex.
+    let mut kind: HashMap<NodeIx, Kind> = HashMap::new();
+    let mut instance_ixs: Vec<NodeIx> = Vec::new();
+    let mut inlet_paths: HashMap<usize, Vec<usize>> = HashMap::new();
+    let mut outlet_ixs: HashMap<usize, NodeIx> = HashMap::new();
+    for n in graph.node_indices() {
+        match &graph[n] {
+            Flat::Node { node, .. } => {
+                if let Some(dsp) = node.to_node_dsp() {
+                    let k = if dsp.is_boundary() {
+                        Kind::Boundary
+                    } else {
+                        Kind::Plain
+                    };
+                    kind.insert(n, k);
+                }
+            }
+            Flat::Instance {
+                n_inlets,
+                n_outlets,
+                ..
+            } => {
+                kind.insert(n, Kind::Instance(*n_inlets, *n_outlets));
+                instance_ixs.push(n);
+            }
+            Flat::Inlet { index, path } => {
+                kind.insert(n, Kind::Inlet(*index));
+                inlet_paths.insert(*index, path.clone());
+            }
+            Flat::Outlet { index, .. } => {
+                kind.insert(n, Kind::Outlet(*index));
+                outlet_ixs.insert(*index, n);
+            }
+        }
+    }
+    let n_dsp_in = |n: NodeIx| -> usize {
+        match kind.get(&n) {
+            Some(Kind::Plain) | Some(Kind::Boundary) => match &graph[n] {
+                Flat::Node { node, .. } => node.to_node_dsp().map_or(0, |d| d.n_dsp_inputs()),
+                _ => 0,
+            },
+            Some(Kind::Instance(n_in, _)) => *n_in,
+            Some(Kind::Outlet(_)) => 1,
+            Some(Kind::Inlet(_)) | None => 0,
+        }
+    };
+    // Whether a vertex can source a signal (outlets never do).
+    let is_source_kind = |n: NodeIx| -> bool {
+        matches!(
+            kind.get(&n),
+            Some(Kind::Plain)
+                | Some(Kind::Boundary)
+                | Some(Kind::Instance(..))
+                | Some(Kind::Inlet(_))
+        )
+    };
+
+    // Seeds: plain sinks, instances whose child transitively holds a sink,
+    // and consumed root outlets.
+    let mut seeds: Vec<NodeIx> = dsp_sinks(graph);
+    {
+        let mut memo = HashMap::new();
+        let mut stack = Vec::new();
+        for &inst in &instance_ixs {
+            if let Flat::Instance { child_ca, .. } = &graph[inst] {
+                if child_has_sink(child_ca, resolve, &mut memo, &mut stack)? {
+                    seeds.push(inst);
+                }
+            }
+        }
+    }
+    for (j, &consumed) in outlets_consumed.iter().enumerate() {
+        if consumed {
+            if let Some(&o) = outlet_ixs.get(&j) {
+                seeds.push(o);
+            }
+        }
+    }
+    if seeds.is_empty() {
+        return Err(DeriveError::NoSink);
+    }
+
+    // Reach: backward from the seeds through dsp inputs.
+    let mut reach: HashSet<NodeIx> = seeds.iter().copied().collect();
+    let mut stack: Vec<NodeIx> = seeds.clone();
+    while let Some(n) = stack.pop() {
+        let n_in = n_dsp_in(n);
+        for e in graph.edges_directed(n, Direction::Incoming) {
+            if (e.weight().input.0 as usize) < n_in
+                && is_source_kind(e.source())
+                && reach.insert(e.source())
+            {
+                stack.push(e.source());
+            }
+        }
+    }
+
+    // Winning sources per dsp input (oldest edge wins), reach-filtered.
+    let srcs: HashMap<NodeIx, Vec<Option<(NodeIx, usize)>>> = reach
+        .iter()
+        .map(|&n| {
+            let n_in = n_dsp_in(n);
+            let mut inputs: Vec<Option<(NodeIx, usize)>> = vec![None; n_in];
+            let edges: Vec<_> = graph.edges_directed(n, Direction::Incoming).collect();
+            for e in edges.into_iter().rev() {
+                let input_ix = e.weight().input.0 as usize;
+                let s = e.source();
+                if input_ix < n_in
+                    && inputs[input_ix].is_none()
+                    && reach.contains(&s)
+                    && is_source_kind(s)
+                {
+                    inputs[input_ix] = Some((s, e.weight().output.0 as usize));
+                }
+            }
+            (n, inputs)
+        })
+        .collect();
+
+    // Stages, via the SCC condensation of the winning-edge graph so cycles
+    // that were previously legal (pure `~bus` cycles, in-region node cycles)
+    // stay legal: an SCC's members share a stage, and only an SCC containing
+    // an instance - a cycle through an instance - is an error.
+    let stage = {
+        let mut temp = petgraph::graph::DiGraph::<NodeIx, (), usize>::default();
+        let mut to_temp: HashMap<NodeIx, petgraph::graph::NodeIndex<usize>> = HashMap::new();
+        let mut ordered: Vec<NodeIx> = reach.iter().copied().collect();
+        ordered.sort();
+        for &n in &ordered {
+            to_temp.insert(n, temp.add_node(n));
+        }
+        for &n in &ordered {
+            for &(s, _) in srcs[&n].iter().flatten() {
+                temp.add_edge(to_temp[&s], to_temp[&n], ());
+            }
+        }
+        let sccs = petgraph::algo::tarjan_scc(&temp);
+        let mut scc_of: HashMap<NodeIx, usize> = HashMap::new();
+        for (i, scc) in sccs.iter().enumerate() {
+            for &t in scc {
+                scc_of.insert(temp[t], i);
+            }
+        }
+        let mut stage: HashMap<NodeIx, usize> = HashMap::new();
+        let mut scc_stage: HashMap<usize, usize> = HashMap::new();
+        // `tarjan_scc` returns SCCs in reverse topological order.
+        for (i, scc) in sccs.iter().enumerate().rev() {
+            let cyclic = scc.len() > 1
+                || scc
+                    .iter()
+                    .any(|&t| srcs[&temp[t]].iter().flatten().any(|&(s, _)| s == temp[t]));
+            if cyclic
+                && scc
+                    .iter()
+                    .any(|&t| matches!(kind.get(&temp[t]), Some(Kind::Instance(..))))
+            {
+                return Err(DeriveError::BusCycle);
+            }
+            let mut s = 0;
+            for &t in scc {
+                let n = temp[t];
+                for &(src, _) in srcs[&n].iter().flatten() {
+                    let src_scc = scc_of[&src];
+                    if src_scc != i {
+                        let bump = usize::from(matches!(kind.get(&src), Some(Kind::Instance(..))));
+                        s = s.max(scc_stage[&src_scc] + bump);
+                    }
+                }
+            }
+            scc_stage.insert(i, s);
+            for &t in scc {
+                stage.insert(temp[t], s);
+            }
+        }
+        stage
+    };
+
+    // Regions: connected components of reachable Plain vertices over their
+    // winning dsp edges, within a stage (a cross-stage edge never joins).
+    let mut comp: HashMap<NodeIx, usize> = HashMap::new();
+    let mut n_comps = 0;
+    let plain = |n: NodeIx| kind.get(&n) == Some(&Kind::Plain);
+    for start in graph.node_indices() {
+        if !reach.contains(&start) || !plain(start) || comp.contains_key(&start) {
+            continue;
+        }
+        let id = n_comps;
+        n_comps += 1;
+        comp.insert(start, id);
+        let mut stack = vec![start];
+        while let Some(n) = stack.pop() {
+            for &(s, _) in srcs[&n].iter().flatten() {
+                if plain(s) && stage[&s] == stage[&n] && comp.insert(s, id).is_none() {
+                    stack.push(s);
+                }
+            }
+            for e in graph.edges_directed(n, Direction::Outgoing) {
+                let t = e.target();
+                if !reach.contains(&t)
+                    || !plain(t)
+                    || comp.contains_key(&t)
+                    || stage[&t] != stage[&n]
+                {
+                    continue;
+                }
+                let input_ix = e.weight().input.0 as usize;
+                if srcs[&t].get(input_ix).copied().flatten().map(|(s, _)| s) == Some(n) {
+                    comp.insert(t, id);
+                    stack.push(t);
+                }
+            }
+        }
+    }
+    let inst_part: HashMap<NodeIx, usize> = instance_ixs
+        .iter()
+        .filter(|n| reach.contains(n))
+        .enumerate()
+        .map(|(i, &n)| (n, i))
+        .collect();
+    let reachable_instances: Vec<NodeIx> = {
+        let mut v: Vec<NodeIx> = inst_part.keys().copied().collect();
+        v.sort_by_key(|n| inst_part[n]);
+        v
+    };
+
+    // `~bus` aliasing + sourcing, exactly as `derive_synthdefs`.
+    let boundary = |n: NodeIx| kind.get(&n) == Some(&Kind::Boundary);
+    let effective = |b: NodeIx| -> NodeIx {
+        let mut cur = b;
+        let mut visited = HashSet::new();
+        while let Some(&(s, _)) = srcs[&cur].first().and_then(|o| o.as_ref()) {
+            if !boundary(s) || !visited.insert(cur) {
+                break;
+            }
+            cur = s;
+        }
+        cur
+    };
+    // The effective bus's winning source, unless it is itself a boundary (a
+    // pure bus cycle - an unsourced, silent bus).
+    let bus_source = |b: NodeIx| -> Option<(NodeIx, usize)> {
+        srcs[&effective(b)]
+            .first()
+            .copied()
+            .flatten()
+            .filter(|&(s, _)| !boundary(s))
+    };
+
+    // Classify the winning source feeding a consumer. `at` is the consuming
+    // part (None for a root outlet, which belongs to no part).
+    let feed = |src: Option<(NodeIx, usize)>, at: Option<PartId>| -> Feed {
+        let Some((s, port)) = src else {
+            return Feed::Silence;
+        };
+        match kind.get(&s) {
+            Some(Kind::Plain) => {
+                let writer = PartId::Region(comp[&s]);
+                if at == Some(writer) {
+                    Feed::Wire(s, port)
+                } else {
+                    Feed::Read {
+                        key: BusKey::Src {
+                            path: graph[s].path().to_vec(),
+                            output: port,
+                        },
+                        writer: Some(writer),
+                        demand: Some((s, port)),
+                        param_at: (graph[s].path().to_vec(), format!("bus{port}")),
+                    }
+                }
+            }
+            Some(Kind::Boundary) => {
+                let eff = effective(s);
+                match bus_source(eff) {
+                    Some((src, sport)) => match kind.get(&src) {
+                        // A bus is transparent: it carries its source's
+                        // signal, so classify as though reading the source
+                        // directly - except a cross-region plain source keys
+                        // the *bus* (its path is the user-facing identity).
+                        Some(Kind::Plain) => {
+                            let writer = PartId::Region(comp[&src]);
+                            if at == Some(writer) {
+                                Feed::Wire(src, sport)
+                            } else {
+                                Feed::Read {
+                                    key: BusKey::Bus(graph[eff].path().to_vec()),
+                                    writer: Some(writer),
+                                    demand: Some((src, sport)),
+                                    param_at: (graph[eff].path().to_vec(), "bus".to_string()),
+                                }
+                            }
+                        }
+                        Some(Kind::Instance(..)) => Feed::Read {
+                            key: BusKey::InstOut {
+                                path: graph[src].path().to_vec(),
+                                outlet: sport,
+                            },
+                            writer: inst_part.get(&src).map(|&i| PartId::Instance(i)),
+                            demand: None,
+                            param_at: (graph[src].path().to_vec(), format!("out{sport}-bus")),
+                        },
+                        Some(Kind::Inlet(i)) => match inlets.get(*i) {
+                            Some(Some(_)) => Feed::Read {
+                                key: BusKey::IfaceIn(*i),
+                                writer: None,
+                                demand: None,
+                                param_at: (
+                                    inlet_paths.get(i).cloned().unwrap_or_default(),
+                                    "bus".to_string(),
+                                ),
+                            },
+                            _ => Feed::Silence,
+                        },
+                        _ => Feed::Silence,
+                    },
+                    None => Feed::Silence,
+                }
+            }
+            Some(Kind::Instance(..)) => Feed::Read {
+                key: BusKey::InstOut {
+                    path: graph[s].path().to_vec(),
+                    outlet: port,
+                },
+                writer: inst_part.get(&s).map(|&i| PartId::Instance(i)),
+                demand: None,
+                param_at: (graph[s].path().to_vec(), format!("out{port}-bus")),
+            },
+            Some(Kind::Inlet(i)) => match inlets.get(*i) {
+                Some(Some(_)) => Feed::Read {
+                    key: BusKey::IfaceIn(*i),
+                    writer: None,
+                    demand: None,
+                    param_at: (
+                        inlet_paths.get(i).cloned().unwrap_or_default(),
+                        "bus".to_string(),
+                    ),
+                },
+                _ => Feed::Silence,
+            },
+            _ => Feed::Silence,
+        }
+    };
+
+    // Relations: per-part external reads (for the DAG + needed set) and
+    // per-region write demands. Reads are gathered from every reachable
+    // consumer: region nodes, instance inlets and consumed outlets.
+    let mut reads: Vec<(Option<PartId>, BusKey, Option<PartId>)> = Vec::new();
+    let mut demands: HashMap<usize, Vec<(BusKey, (NodeIx, usize))>> = HashMap::new();
+    let mut demand = |writer: Option<PartId>, key: &BusKey, d: Option<(NodeIx, usize)>| {
+        if let (Some(PartId::Region(c)), Some(d)) = (writer, d) {
+            let list = demands.entry(c).or_default();
+            if !list.iter().any(|(k, _)| k == key) {
+                list.push((key.clone(), d));
+            }
+        }
+    };
+    for (&n, inputs) in &srcs {
+        let at = match kind.get(&n) {
+            Some(Kind::Plain) => Some(PartId::Region(comp[&n])),
+            Some(Kind::Instance(..)) => inst_part.get(&n).map(|&i| PartId::Instance(i)),
+            Some(Kind::Outlet(j)) => {
+                if !outlets_consumed.get(*j).copied().unwrap_or(false) {
+                    continue;
+                }
+                None
+            }
+            // Boundaries are transparent (resolved through `bus_source` by
+            // their consumers); inlets consume nothing.
+            _ => continue,
+        };
+        for src in inputs.iter() {
+            if let Feed::Read {
+                key,
+                writer,
+                demand: d,
+                ..
+            } = feed(*src, at)
+            {
+                demand(writer, &key, d);
+                reads.push((at, key, writer));
+            }
+        }
+    }
+
+    // Needed parts: those holding seeds, grown through reads (a needed
+    // reader's writer is needed). A root outlet's reader is the enclosing
+    // graph (always needed, represented as `None`).
+    let mut needed: HashSet<PartId> = HashSet::new();
+    for &s in &seeds {
+        match kind.get(&s) {
+            Some(Kind::Plain) => {
+                needed.insert(PartId::Region(comp[&s]));
+            }
+            Some(Kind::Instance(..)) => {
+                if let Some(&i) = inst_part.get(&s) {
+                    needed.insert(PartId::Instance(i));
+                }
+            }
+            _ => {}
+        }
+    }
+    loop {
+        let mut grew = false;
+        for (at, _, writer) in &reads {
+            let reader_needed = match at {
+                None => true,
+                Some(p) => needed.contains(p),
+            };
+            if reader_needed {
+                if let Some(w) = writer {
+                    grew |= needed.insert(*w);
+                }
+            }
+        }
+        if !grew {
+            break;
+        }
+    }
+
+    // The part DAG (reader -> writers) over needed parts; Kahn's algorithm
+    // yields the derivation (and spawn) order, or reports a cycle through an
+    // instance boundary.
+    let mut deps: HashMap<PartId, HashSet<PartId>> = HashMap::new();
+    for (at, _, writer) in &reads {
+        if let (Some(r), Some(w)) = (at, writer) {
+            if r != w && needed.contains(r) && needed.contains(w) {
+                deps.entry(*r).or_default().insert(*w);
+            }
+        }
+    }
+    let all_parts: Vec<PartId> = (0..n_comps)
+        .map(PartId::Region)
+        .chain((0..reachable_instances.len()).map(PartId::Instance))
+        .filter(|p| needed.contains(p))
+        .collect();
+    let mut topo: Vec<PartId> = Vec::with_capacity(all_parts.len());
+    let mut placed: HashSet<PartId> = HashSet::new();
+    while topo.len() < all_parts.len() {
+        let next = all_parts.iter().find(|p| {
+            !placed.contains(p)
+                && deps
+                    .get(p)
+                    .is_none_or(|ws| ws.iter().all(|w| placed.contains(w)))
+        });
+        match next {
+            Some(&p) => {
+                placed.insert(p);
+                topo.push(p);
+            }
+            None => return Err(DeriveError::BusCycle),
+        }
+    }
+
+    // Derive each part in topo order, flowing bus widths forward.
+    let mut port_width: HashMap<BusKey, usize> = HashMap::new();
+    for (i, w) in inlets.iter().enumerate() {
+        if let Some(w) = *w {
+            port_width.insert(BusKey::IfaceIn(i), w);
+        }
+    }
+    let mut parts: Vec<Part> = Vec::with_capacity(topo.len());
+    for &p in &topo {
+        match p {
+            PartId::Region(c) => {
+                let region = derive_region(
+                    graph,
+                    out_channels,
+                    c,
+                    &comp,
+                    &srcs,
+                    &feed,
+                    demands.get(&c).map(Vec::as_slice).unwrap_or(&[]),
+                    &mut port_width,
+                )?;
+                parts.push(Part::Region(region));
+            }
+            PartId::Instance(i) => {
+                let inst = reachable_instances[i];
+                let part = derive_instance(
+                    graph,
+                    inst,
+                    out_channels,
+                    &srcs,
+                    &feed,
+                    resolve,
+                    cache,
+                    deriving,
+                    &mut port_width,
+                )?;
+                parts.push(Part::Instance(part));
+            }
+        }
+    }
+
+    // The template's own outlet table: the key + width of the bus carrying
+    // each consumed outlet's signal.
+    let outlets = (0..outlets_consumed.len())
+        .map(|j| {
+            if !outlets_consumed.get(j).copied().unwrap_or(false) {
+                return None;
+            }
+            let o = outlet_ixs.get(&j)?;
+            let src = srcs.get(o).and_then(|inputs| inputs.first().copied())?;
+            match feed(src, None) {
+                Feed::Read { key, .. } => {
+                    let w = port_width.get(&key).copied().unwrap_or(1);
+                    Some((key, w))
+                }
+                // An outlet has no part of its own, so a `Wire` feed is
+                // unreachable (its source is always external to `None`).
+                Feed::Wire(..) | Feed::Silence => None,
+            }
+        })
+        .collect();
+
+    Ok(GraphTemplate { parts, outlets })
+}
+
+/// Derive one region's synthdef: its nodes in dsp pull order, `In` units for
+/// its external reads and fade-gained `Out` units for its demanded writes.
+#[allow(clippy::too_many_arguments)]
+fn derive_region<N>(
+    graph: &Graph<Flat<N>>,
+    out_channels: usize,
+    c: usize,
+    comp: &HashMap<NodeIx, usize>,
+    srcs: &HashMap<NodeIx, Vec<Option<(NodeIx, usize)>>>,
+    feed: &impl Fn(Option<(NodeIx, usize)>, Option<PartId>) -> Feed,
+    writes: &[(BusKey, (NodeIx, usize))],
+    port_width: &mut HashMap<BusKey, usize>,
+) -> Result<TemplateRegion, DeriveError>
+where
+    N: ToNodeDsp,
+{
+    let at = Some(PartId::Region(c));
+    let region_sinks: Vec<NodeIx> = graph
+        .node_indices()
+        .filter(|n| comp.get(n) == Some(&c))
+        .filter(|&n| match &graph[n] {
+            Flat::Node { node, .. } => node
+                .to_node_dsp()
+                .is_some_and(|d| d.is_output() || d.is_monitor()),
+            _ => false,
+        })
+        .collect();
+    let seeds: Vec<NodeIx> = region_sinks
+        .iter()
+        .copied()
+        .chain(writes.iter().map(|&(_, (s, _))| s))
+        .collect();
+    let order = merged_pull_order(graph, &seeds, |n| comp.get(&n) == Some(&c));
+
+    let mut builder = DspBuilder::new(out_channels);
+    let mut outputs: HashMap<NodeIx, Vec<Signal>> = HashMap::new();
+    let mut bus_reads: Vec<TemplateBus> = Vec::new();
+    // One `In` per read key, shared by every consumer in the region.
+    let mut in_signals: HashMap<BusKey, Signal> = HashMap::new();
+
+    for n in order {
+        let node = match &graph[n] {
+            Flat::Node { node, .. } => node,
+            _ => continue,
+        };
+        let Some(dsp) = node.to_node_dsp() else {
+            continue;
+        };
+        let path = graph[n].path();
+        let inputs: Vec<Signal> = srcs[&n]
+            .iter()
+            .map(|src| match feed(*src, at) {
+                Feed::Wire(s, port) => outputs
+                    .get(&s)
+                    .and_then(|o| o.get(port))
+                    .cloned()
+                    .unwrap_or_else(|| Signal::silent(1)),
+                Feed::Read { key, param_at, .. } => in_signals
+                    .entry(key.clone())
+                    .or_insert_with(|| {
+                        let channels = port_width.get(&key).copied().unwrap_or(1);
+                        let (p_path, p_label) = &param_at;
+                        let bus_param = builder.push_control_param(p_path, p_label);
+                        let unit = builder.push_unit(UnitSpec::new(
+                            "In",
+                            Rate::Audio,
+                            vec![InputRef::Param(bus_param)],
+                            channels,
+                        ));
+                        bus_reads.push(TemplateBus {
+                            key: key.clone(),
+                            channels,
+                            unit: unit as usize,
+                            param: bus_param as usize,
+                        });
+                        (0..channels as u32)
+                            .map(|output| InputRef::Unit { unit, output })
+                            .collect()
+                    })
+                    .clone(),
+                Feed::Silence => Signal::silent(1),
+            })
+            .collect();
+        let outs = dsp.ugens(path, &inputs, &mut builder);
+        debug_assert_eq!(
+            outs.len(),
+            dsp.n_dsp_outputs(),
+            "a node must return one Signal per dsp output port",
+        );
+        outputs.insert(n, outs);
+    }
+
+    // Emit the demanded bus writes: lift each channel to audio, apply a fade
+    // gain (one per source path) and write to a bus-index param.
+    let mut fades: HashMap<Vec<usize>, u32> = HashMap::new();
+    let mut bus_writes = Vec::with_capacity(writes.len());
+    for (key, (src, port)) in writes {
+        let sig = outputs
+            .get(src)
+            .and_then(|o| o.get(*port))
+            .cloned()
+            .unwrap_or_else(|| Signal::silent(1));
+        let (fade_path, param_at) = match key {
+            BusKey::Bus(bus_path) => (bus_path.clone(), (bus_path.clone(), "bus".to_string())),
+            BusKey::Src { path, output } => (path.clone(), (path.clone(), format!("bus{output}"))),
+            // Only `Bus`/`Src` writes are ever demanded of a region.
+            BusKey::InstOut { .. } | BusKey::IfaceIn(_) => continue,
+        };
+        let fade = *fades
+            .entry(fade_path.clone())
+            .or_insert_with(|| builder.push_fade_gain(&fade_path));
+        let (p_path, p_label) = &param_at;
+        let bus_param = builder.push_control_param(p_path, p_label);
+        let mut out_inputs = vec![InputRef::Param(bus_param)];
+        for ch in sig.channels() {
+            let ch = builder.ensure_audio(ch);
+            let mul = builder.push_unit(UnitSpec {
+                name: "BinaryOpUGen".to_string(),
+                rate: Rate::Audio,
+                inputs: vec![ch, InputRef::Param(fade)],
+                num_outputs: 1,
+                special_index: 2,
+            });
+            out_inputs.push(InputRef::Unit {
+                unit: mul,
+                output: 0,
+            });
+        }
+        let unit = builder.push_unit(UnitSpec::new("Out", Rate::Audio, out_inputs, 0));
+        bus_writes.push(TemplateBus {
+            key: key.clone(),
+            channels: sig.width(),
+            unit: unit as usize,
+            param: bus_param as usize,
+        });
+        port_width.insert(key.clone(), sig.width());
+    }
+
+    // A stable region identity: its sink paths and bus keys.
+    let mut h = DefaultHasher::new();
+    for s in &region_sinks {
+        (0u8, graph[*s].path()).hash(&mut h);
+    }
+    for w in &bus_writes {
+        (1u8, &w.key).hash(&mut h);
+    }
+    for r in &bus_reads {
+        (2u8, &r.key).hash(&mut h);
+    }
+    let key = h.finish();
+
+    let (mut def, params, monitors, gains) = builder.finish(String::new());
+    let sig = structural_sig(&def);
+    def.name = content_def_name(sig);
+    Ok(TemplateRegion {
+        key,
+        sig,
+        def: Arc::new(def),
+        params,
+        monitors,
+        gains,
+        bus_writes,
+        bus_reads,
+    })
+}
+
+/// Derive one instance's part: build its [`VariantKey`] from the widths its
+/// inlet feeds carry and the outlets its consumers demand, recursively derive
+/// the child template (cached by variant) and record the inlet wiring.
+#[allow(clippy::too_many_arguments)]
+fn derive_instance<N>(
+    graph: &Graph<Flat<N>>,
+    inst: NodeIx,
+    out_channels: usize,
+    srcs: &HashMap<NodeIx, Vec<Option<(NodeIx, usize)>>>,
+    feed: &impl Fn(Option<(NodeIx, usize)>, Option<PartId>) -> Feed,
+    resolve: &InstanceResolve<'_, N>,
+    cache: &mut DefCache,
+    deriving: &mut Vec<ContentAddr>,
+    port_width: &mut HashMap<BusKey, usize>,
+) -> Result<InstancePart, DeriveError>
+where
+    N: ToNodeDsp,
+{
+    let Flat::Instance {
+        path,
+        child_ca,
+        n_inlets,
+        n_outlets,
+    } = &graph[inst]
+    else {
+        unreachable!("derive_instance called on a non-instance");
+    };
+    let path = path.clone();
+    let child_ca = *child_ca;
+
+    // Inlet feeds: the key of the bus feeding each connected inlet, and the
+    // width that bus carries (its writer derived earlier in topo order).
+    let mut inlet_keys: Vec<Option<BusKey>> = vec![None; *n_inlets];
+    let mut inlet_widths: Vec<Option<usize>> = vec![None; *n_inlets];
+    for (i, src) in srcs[&inst].iter().enumerate() {
+        // A marker's arity is its `n_inlets`, so `i` is always in range.
+        match feed(*src, None) {
+            Feed::Read { key, .. } => {
+                inlet_widths[i] = Some(port_width.get(&key).copied().unwrap_or(1));
+                inlet_keys[i] = Some(key);
+            }
+            Feed::Wire(..) | Feed::Silence => {}
+        }
+    }
+
+    // Consumed outlets: any reachable consumer whose winning source is this
+    // instance's outlet.
+    let mut outlets = vec![false; *n_outlets];
+    for inputs in srcs.values() {
+        for &(s, port) in inputs.iter().flatten() {
+            if s == inst {
+                if let Some(o) = outlets.get_mut(port) {
+                    *o = true;
+                }
+            }
+        }
+    }
+
+    let variant = VariantKey {
+        child: child_ca,
+        inlets: inlet_widths,
+        outlets,
+        out_channels,
+    };
+
+    // Recursively derive the child template (cached by variant), guarding
+    // against a graph transitively instancing itself.
+    let child = if let Some(t) = cache.get(&variant) {
+        t
+    } else {
+        if deriving.contains(&child_ca) {
+            return Err(DeriveError::RefCycle(child_ca));
+        }
+        let child_graph = resolve(&child_ca).ok_or(DeriveError::Unresolved(child_ca))?;
+        deriving.push(child_ca);
+        let result = derive_parts(
+            child_graph,
+            out_channels,
+            &variant.inlets,
+            &variant.outlets,
+            resolve,
+            cache,
+            deriving,
+        );
+        deriving.pop();
+        let t = Arc::new(result?);
+        cache.insert(variant.clone(), Arc::clone(&t));
+        t
+    };
+
+    // Continue the width flow: each consumed outlet's width, from the child's
+    // outlet table.
+    for (j, out) in child.outlets.iter().enumerate() {
+        if let Some((_, w)) = out {
+            port_width.insert(
+                BusKey::InstOut {
+                    path: path.clone(),
+                    outlet: j,
+                },
+                *w,
+            );
+        }
+    }
+
+    Ok(InstancePart {
+        path,
+        variant,
+        inlet_keys,
+    })
+}
+
+/// Splice `template` (and, recursively, its instances' cached child
+/// templates) into a flat [`ResolvedPart`] list in global topological order,
+/// with absolute binding paths and bus keys.
+///
+/// Instances dissolve: each contributes its child template's regions at the
+/// instance's path prefix, so N instances of one child yield N spawns of the
+/// same shared defs with per-instance wiring. `cache` must be the cache the
+/// template derived against.
+pub fn instantiate(template: &GraphTemplate, cache: &DefCache) -> Vec<ResolvedPart> {
+    let mut out = Vec::new();
+    instantiate_into(template, cache, &[], &[], &mut out);
+    out
+}
+
+/// The recursive splice: returns this template's outlet table with keys made
+/// absolute (for the parent's `InstOut` resolution).
+fn instantiate_into(
+    template: &GraphTemplate,
+    cache: &DefCache,
+    prefix: &[usize],
+    inlet_keys: &[Option<BusKey>],
+    out: &mut Vec<ResolvedPart>,
+) -> Vec<Option<(BusKey, usize)>> {
+    // Per template-local instance path: its child's absolutized outlet table.
+    let mut inst_outlets: HashMap<Vec<usize>, Vec<Option<(BusKey, usize)>>> = HashMap::new();
+
+    let prefixed = |p: &[usize]| -> Vec<usize> {
+        let mut abs = prefix.to_vec();
+        abs.extend_from_slice(p);
+        abs
+    };
+    // Absolutize a template-local key. `InstOut` resolves through the named
+    // instance's child outlet table (writers precede readers in part order,
+    // so the entry exists by the time a reader needs it); a sourceless outlet
+    // falls back to a dedicated unwritten - silent - bus key.
+    let abs_key = |key: &BusKey,
+                   inst_outlets: &HashMap<Vec<usize>, Vec<Option<(BusKey, usize)>>>|
+     -> BusKey {
+        match key {
+            BusKey::Bus(p) => BusKey::Bus(prefixed(p)),
+            BusKey::Src { path, output } => BusKey::Src {
+                path: prefixed(path),
+                output: *output,
+            },
+            BusKey::InstOut { path, outlet } => inst_outlets
+                .get(path)
+                .and_then(|outs| outs.get(*outlet).cloned().flatten())
+                .map(|(k, _)| k)
+                .unwrap_or_else(|| BusKey::InstOut {
+                    path: prefixed(path),
+                    outlet: *outlet,
+                }),
+            BusKey::IfaceIn(i) => inlet_keys
+                .get(*i)
+                .cloned()
+                .flatten()
+                .expect("an IfaceIn read implies a connected inlet in the variant"),
+        }
+    };
+
+    for part in &template.parts {
+        match part {
+            Part::Region(r) => {
+                let mut h = DefaultHasher::new();
+                (prefix, r.key).hash(&mut h);
+                let key = h.finish();
+                let abs_bus = |b: &TemplateBus| ResolvedBus {
+                    key: abs_key(&b.key, &inst_outlets),
+                    channels: b.channels,
+                    unit: b.unit,
+                    param: b.param,
+                };
+                out.push(ResolvedPart {
+                    key,
+                    sig: r.sig,
+                    def: Arc::clone(&r.def),
+                    params: r
+                        .params
+                        .iter()
+                        .map(|b| ParamBinding {
+                            node_path: prefixed(&b.node_path),
+                            index: b.index,
+                        })
+                        .collect(),
+                    monitors: r
+                        .monitors
+                        .iter()
+                        .map(|m| ScopeOutBinding {
+                            node_path: prefixed(&m.node_path),
+                            ..m.clone()
+                        })
+                        .collect(),
+                    gains: r.gains.clone(),
+                    bus_writes: r.bus_writes.iter().map(abs_bus).collect(),
+                    bus_reads: r.bus_reads.iter().map(abs_bus).collect(),
+                });
+            }
+            Part::Instance(ip) => {
+                let child = cache
+                    .get(&ip.variant)
+                    .expect("derive_template populates the cache for every instance part");
+                let child_prefix = prefixed(&ip.path);
+                let child_inlets: Vec<Option<BusKey>> = ip
+                    .inlet_keys
+                    .iter()
+                    .map(|k| k.as_ref().map(|k| abs_key(k, &inst_outlets)))
+                    .collect();
+                let outs = instantiate_into(&child, cache, &child_prefix, &child_inlets, out);
+                inst_outlets.insert(ip.path.clone(), outs);
+            }
+        }
+    }
+
+    template
+        .outlets
+        .iter()
+        .map(|o| o.as_ref().map(|(k, w)| (abs_key(k, &inst_outlets), *w)))
+        .collect()
+}

--- a/crates/gantz_plyphon/src/lib.rs
+++ b/crates/gantz_plyphon/src/lib.rs
@@ -19,8 +19,8 @@
 pub use backend::{AddAction, Backend, BackendError, Embedded, ROOT_GROUP_ID};
 pub use builtin::builtins;
 pub use compile::{
-    BusBinding, DeriveError, Derived, RegionDerived, derive_synthdef, derive_synthdefs,
-    structural_sig,
+    BusBinding, DeriveError, Derived, RegionDerived, content_def_name, derive_synthdef,
+    derive_synthdefs, structural_sig,
 };
 pub use config::{Config, Status};
 pub use dsp::{
@@ -28,6 +28,10 @@ pub use dsp::{
     ToNodeDsp, node_dsp_of,
 };
 pub use flatten::{AsRefNode, Flat, FlattenError, RefKind, flatten, flatten_from_registry};
+pub use instance::{
+    BusKey, DefCache, GraphTemplate, InstancePart, Part, ResolvedBus, ResolvedPart, TemplateBus,
+    TemplateRegion, VariantKey, derive_template, instantiate,
+};
 pub use node::{Bus, Lag, Out, Pack, ScopeOut, SinOsc, Unpack};
 pub use ref_ext::{DSP_REF_EXT_KEY, DspRefExt, dsp_commits};
 pub use sugar::PlyphonSugar;
@@ -43,6 +47,7 @@ pub mod dsp;
 #[cfg(feature = "egui")]
 pub mod egui;
 pub mod flatten;
+pub mod instance;
 pub mod monitor;
 pub mod node;
 pub mod param;

--- a/crates/gantz_plyphon/src/lib.rs
+++ b/crates/gantz_plyphon/src/lib.rs
@@ -27,7 +27,10 @@ pub use dsp::{
     DspBuilder, FADE_LAG, GainRef, NodeDsp, NodeRate, ParamBinding, ScopeOutBinding, Signal,
     ToNodeDsp, node_dsp_of,
 };
-pub use flatten::{AsRefNode, Flat, FlattenError, RefKind, flatten, flatten_from_registry};
+pub use flatten::{
+    AsRefNode, Flat, FlattenError, RefKind, flatten, flatten_from_registry,
+    flatten_instance_children,
+};
 pub use instance::{
     BusKey, DefCache, GraphTemplate, InstancePart, Part, ResolvedBus, ResolvedPart, TemplateBus,
     TemplateRegion, VariantKey, derive_template, instantiate,

--- a/crates/gantz_plyphon/src/lib.rs
+++ b/crates/gantz_plyphon/src/lib.rs
@@ -27,7 +27,7 @@ pub use dsp::{
     DspBuilder, FADE_LAG, GainRef, NodeDsp, NodeRate, ParamBinding, ScopeOutBinding, Signal,
     ToNodeDsp, node_dsp_of,
 };
-pub use flatten::{AsRefNode, Flat, FlattenError, flatten, flatten_from_registry};
+pub use flatten::{AsRefNode, Flat, FlattenError, RefKind, flatten, flatten_from_registry};
 pub use node::{Bus, Lag, Out, Pack, ScopeOut, SinOsc, Unpack};
 pub use ref_ext::{DSP_REF_EXT_KEY, DspRefExt, dsp_commits};
 pub use sugar::PlyphonSugar;

--- a/crates/gantz_plyphon/src/node/scope_out.rs
+++ b/crates/gantz_plyphon/src/node/scope_out.rs
@@ -131,15 +131,22 @@ impl NodeDsp for ScopeOut {
         // `ScopeOut.ar(bufnum, ch0, ch1, …)`: stream *every* sample of each of the
         // input signal's channels (interleaved) off the audio thread into a cued
         // scope stream the driver drains into this node's per-channel rings - the
-        // channel count is the input's width. `bufnum` is a placeholder; the
-        // driver allocates a globally-unique cued index and patches it before
-        // installing.
+        // channel count is the input's width. `bufnum` is a no-lag control param;
+        // the driver allocates a globally-unique cued index and sets it via
+        // `set_control` after spawning (no def mutation).
         let signal = inputs.first().cloned().unwrap_or_else(|| Signal::silent(1));
+        let bufnum = b.push_control_param(path, "bufnum");
         let mut scope_inputs = Vec::with_capacity(signal.width() + 1);
-        scope_inputs.push(InputRef::Constant(0.0));
+        scope_inputs.push(InputRef::Param(bufnum));
         scope_inputs.extend(signal.channels());
         let scope_unit = b.push_unit(UnitSpec::new("ScopeOut", Rate::Audio, scope_inputs, 0));
-        b.push_monitor(path, self.size, signal.width(), scope_unit as usize);
+        b.push_monitor(
+            path,
+            self.size,
+            signal.width(),
+            scope_unit as usize,
+            bufnum as usize,
+        );
         vec![]
     }
 }

--- a/crates/gantz_plyphon/src/ref_ext.rs
+++ b/crates/gantz_plyphon/src/ref_ext.rs
@@ -42,16 +42,30 @@ where
     N: ToNodeDsp + AsRefNode,
 {
     let mut memo: HashMap<CommitAddr, bool> = HashMap::new();
-    let mut stack: Vec<CommitAddr> = Vec::new();
     registry
         .commits()
         .keys()
         .copied()
         .collect::<Vec<_>>()
         .into_iter()
-        .filter(|&ca| is_dsp(registry, ca, &mut memo, &mut stack))
+        .filter(|&ca| is_dsp_commit(registry, ca, &mut memo))
         .map(ContentAddr::from)
         .collect()
+}
+
+/// Whether the graph committed at `ca` contains a DSP node, directly or
+/// transitively through references. Memoized in `memo` so repeated probes over
+/// one registry (e.g. per ref during a flatten) stay linear overall.
+pub(crate) fn is_dsp_commit<N>(
+    registry: &gantz_ca::Registry<Graph<N>>,
+    ca: CommitAddr,
+    memo: &mut HashMap<CommitAddr, bool>,
+) -> bool
+where
+    N: ToNodeDsp + AsRefNode,
+{
+    let mut stack: Vec<CommitAddr> = Vec::new();
+    is_dsp(registry, ca, memo, &mut stack)
 }
 
 /// Whether the graph at `ca` contains a DSP node, directly or transitively

--- a/crates/gantz_plyphon/src/ref_ext.rs
+++ b/crates/gantz_plyphon/src/ref_ext.rs
@@ -23,8 +23,11 @@ pub struct DspRefExt {
     /// Inline the referenced graph's DSP nodes into the parent synthdef,
     /// rather than instancing a shared definition.
     ///
-    /// Inlining is currently the only lowering, so the flag records intent
-    /// until shared-synthdef instancing lands.
+    /// Instancing is the default lowering: the child derives once into shared
+    /// content-named synthdefs, installed once and spawned per instance with
+    /// bus wiring set per synth. Inlining splices the child's units into the
+    /// parent's def instead - each copy compiles its own units, buying full
+    /// cross-boundary fusion at N-times the unit count.
     pub inline: bool,
 }
 

--- a/crates/gantz_plyphon/tests/derive_regions.rs
+++ b/crates/gantz_plyphon/tests/derive_regions.rs
@@ -5,7 +5,7 @@ use gantz_core::edge::Edge;
 use gantz_core::node::graph::Graph;
 use gantz_plyphon::{
     Bus, DeriveError, Lag, NodeDsp, Out, Pack, ScopeOut, SinOsc, ToNodeDsp, derive_synthdef,
-    derive_synthdefs,
+    derive_synthdefs, structural_sig,
 };
 use plyphon::synthdef::InputRef;
 use plyphon::{AddAction, Options, ROOT_GROUP_ID, Rate, World, engine};
@@ -66,7 +66,7 @@ fn sine_bus_out_splits_two_regions() {
     assert_eq!(w.node_path, vec![b.index()]);
     assert_eq!(w.channels, 1);
     assert_eq!(wdef.units[w.unit].name, "Out");
-    assert!(matches!(wdef.units[w.unit].inputs[0], InputRef::Constant(c) if c == 0.0));
+    assert!(matches!(wdef.units[w.unit].inputs[0], InputRef::Param(p) if p == w.param as u32));
     assert_eq!(
         writer.derived.gains.len(),
         1,
@@ -91,7 +91,7 @@ fn sine_bus_out_splits_two_regions() {
     assert_eq!(r.channels, 1);
     assert_eq!(rdef.units[r.unit].name, "In");
     assert_eq!(rdef.units[r.unit].num_outputs, 1);
-    assert!(matches!(rdef.units[r.unit].inputs[0], InputRef::Constant(c) if c == 0.0));
+    assert!(matches!(rdef.units[r.unit].inputs[0], InputRef::Param(p) if p == r.param as u32));
 }
 
 #[test]
@@ -303,11 +303,44 @@ fn no_boundary_graph_matches_single_def() {
 }
 
 #[test]
+fn bus_index_param_is_unlagged_and_sig_stable() {
+    // The bus channel index is a no-lag control param (a lagged bus index would
+    // glide through wrong buses), baked at `0.0` and set per spawn via
+    // `set_control`. The driver never mutates the def, so `structural_sig` is
+    // computed on the final def and is stable across re-derives.
+    let mut g = Graph::<N>::default();
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let b = g.add_node(N::Bus(Bus::default()));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s, b, Edge::new(0.into(), 0.into()));
+    g.add_edge(b, o, Edge::new(0.into(), 0.into()));
+
+    let regions = derive_synthdefs(&g, 1, "head").expect("derive");
+    let writer = &regions[0];
+    let w = &writer.bus_writes[0];
+    let param = &writer.derived.def.params[w.param];
+    assert_eq!(param.default, 0.0, "bus-index defaults to 0.0");
+    assert_eq!(param.lag, None, "bus-index must be unlagged");
+    assert!(
+        !writer.derived.params.iter().any(|b| b.index == w.param),
+        "the bus-index param has no node binding (the driver alone sets it)",
+    );
+
+    let sig = structural_sig(&writer.derived.def);
+    let regions2 = derive_synthdefs(&g, 1, "head").expect("re-derive");
+    assert_eq!(
+        sig,
+        structural_sig(&regions2[0].derived.def),
+        "re-deriving the same graph yields the same sig (no per-spawn patching)",
+    );
+}
+
+#[test]
 fn split_regions_play_through_the_engine() {
-    // `~sinosc -> ~bus -> ~out` end to end offline: patch both bus placeholders
-    // to a real private channel, spawn writer-then-reader, and the tone crosses
-    // the boundary. Reversed spawn order renders silence - `In` reads only
-    // channels written EARLIER in the node tree this block (the ordering
+    // `~sinosc -> ~bus -> ~out` end to end offline: set each region's bus-index
+    // param to a real private channel via `set_control`, spawn writer-then-reader,
+    // and the tone crosses the boundary. Reversed spawn order renders silence -
+    // `In` reads only channels written EARLIER in the node tree this block (the ordering
     // requirement the driver's topo placement exists for).
     let mut g = Graph::<N>::default();
     let s = g.add_node(N::SinOsc(SinOsc::default()));
@@ -324,15 +357,7 @@ fn split_regions_play_through_the_engine() {
     // The first private channel sits after the hardware output + input banks.
     let bus = (opts().output_channels + opts().input_channels) as f32;
 
-    let mut regions = derive_synthdefs(&g, 1, "head").expect("derive");
-    for region in &mut regions {
-        for w in &region.bus_writes {
-            region.derived.def.units[w.unit].inputs[0] = InputRef::Constant(bus);
-        }
-        for r in &region.bus_reads {
-            region.derived.def.units[r.unit].inputs[0] = InputRef::Constant(bus);
-        }
-    }
+    let regions = derive_synthdefs(&g, 1, "head").expect("derive");
     let (writer, reader) = (&regions[0], &regions[1]);
 
     let rms = |s: &[f32]| (s.iter().map(|v| v * v).sum::<f32>() / s.len() as f32).sqrt();
@@ -343,17 +368,45 @@ fn split_regions_play_through_the_engine() {
         }
         out
     };
+    // Wire a region's bus-index param and ramp its fade gains to unity after
+    // spawning (the synth spawns silent behind its baked fade 0.0 default).
+    let wire = |controller: &mut plyphon::Controller,
+                node: i32,
+                bus: &gantz_plyphon::BusBinding,
+                gains: &[gantz_plyphon::GainRef],
+                channel: f32| {
+        controller
+            .set_control(node, bus.param, channel)
+            .expect("set bus");
+        for g in gains {
+            controller.set_control(node, g.index, 1.0).expect("fade in");
+        }
+    };
 
     // Writer before reader: the tone crosses the bus.
     let (mut controller, _nrt, mut world) = engine(opts());
     controller.add_synthdef(writer.derived.def.clone());
     controller.add_synthdef(reader.derived.def.clone());
-    controller
+    let w = controller
         .synth_new(&writer.derived.def.name, ROOT_GROUP_ID, AddAction::Tail)
         .expect("writer");
-    controller
+    let r = controller
         .synth_new(&reader.derived.def.name, ROOT_GROUP_ID, AddAction::Tail)
         .expect("reader");
+    wire(
+        &mut controller,
+        w,
+        &writer.bus_writes[0],
+        &writer.derived.gains,
+        bus,
+    );
+    wire(
+        &mut controller,
+        r,
+        &reader.bus_reads[0],
+        &reader.derived.gains,
+        bus,
+    );
     let out = render(&mut world, SR as usize / 4);
     assert!(
         rms(&out) > 0.05,
@@ -367,12 +420,26 @@ fn split_regions_play_through_the_engine() {
     let (mut controller, _nrt, mut world) = engine(opts());
     controller.add_synthdef(writer.derived.def.clone());
     controller.add_synthdef(reader.derived.def.clone());
-    controller
+    let r = controller
         .synth_new(&reader.derived.def.name, ROOT_GROUP_ID, AddAction::Tail)
         .expect("reader");
-    controller
+    let w = controller
         .synth_new(&writer.derived.def.name, ROOT_GROUP_ID, AddAction::Tail)
         .expect("writer");
+    wire(
+        &mut controller,
+        w,
+        &writer.bus_writes[0],
+        &writer.derived.gains,
+        bus,
+    );
+    wire(
+        &mut controller,
+        r,
+        &reader.bus_reads[0],
+        &reader.derived.gains,
+        bus,
+    );
     let out = render(&mut world, SR as usize / 4);
     assert!(
         rms(&out) < 1e-4,

--- a/crates/gantz_plyphon/tests/derive_synthdef.rs
+++ b/crates/gantz_plyphon/tests/derive_synthdef.rs
@@ -71,7 +71,10 @@ fn derives_expected_units() {
         "gain has a default de-click lag"
     );
     assert!(def.params[2].name.ends_with("/fade"));
-    assert_eq!(def.params[2].default, 1.0, "fade defaults to unity");
+    assert_eq!(
+        def.params[2].default, 0.0,
+        "fade defaults to silence (driver ramps in)"
+    );
 
     // Bindings map each param back to its dsp node (sine at [0], out at [1]);
     // the fade has NO binding - the driver alone drives it.
@@ -298,12 +301,13 @@ fn scopeout_joins_output_in_one_def() {
     assert_eq!(mon.size, ScopeOut::DEFAULT_SIZE);
 
     // The binding's `scope_unit` names the ScopeOut; its bufnum (input 0) is the
-    // placeholder the driver patches, and its value input (1) is the tapped sine.
+    // no-lag control param the driver sets via `set_control`, and its value
+    // input (1) is the tapped sine.
     let scope = &derived.def.units[mon.scope_unit];
     assert_eq!(scope.name, "ScopeOut", "scope_unit must name the ScopeOut");
     assert!(
-        matches!(scope.inputs[0], InputRef::Constant(_)),
-        "bufnum is a patchable constant placeholder",
+        matches!(scope.inputs[0], InputRef::Param(_)),
+        "bufnum is a no-lag control param the driver sets post-spawn",
     );
     assert!(
         matches!(scope.inputs[1], InputRef::Unit { .. }),
@@ -645,12 +649,12 @@ fn scopeout_streams_every_sample() {
     let t = g.add_node(N::ScopeOut(ScopeOut::default()));
     g.add_edge(s, t, Edge::new(0.into(), 0.into()));
 
-    let mut derived = derive_synthdef(&g, 1, "t").expect("derive");
-    // The driver patches the ScopeOut's bufnum (at the monitor's `scope_unit`) to the
-    // cued scope index; here that index is 0.
+    let derived = derive_synthdef(&g, 1, "t").expect("derive");
+    // The driver sets the ScopeOut's bufnum param to the cued scope index via
+    // `set_control` after spawning; here that index is 0 (the param default).
+    let bufnum_param = derived.monitors[0].bufnum_param;
     let scope_unit = derived.monitors[0].scope_unit;
     assert_eq!(derived.def.units[scope_unit].name, "ScopeOut");
-    derived.def.units[scope_unit].inputs[0] = InputRef::Constant(0.0);
 
     // A pool generous enough to hold the whole run, so nothing overruns before the
     // single drain at the end (one chunk per block).
@@ -665,9 +669,12 @@ fn scopeout_streams_every_sample() {
         .cue_scope(0, 1, SR as f64, BLOCK, blocks + 2)
         .expect("cue_scope");
     controller.add_synthdef(derived.def);
-    controller
+    let node = controller
         .synth_new("t", ROOT_GROUP_ID, AddAction::Tail)
         .expect("synth_new");
+    controller
+        .set_control(node, bufnum_param, 0.0)
+        .expect("set bufnum");
 
     // Render a stretch of audio, then drain every streamed sample.
     let mut buf = vec![0.0f32; BLOCK];
@@ -738,17 +745,23 @@ fn render(world: &mut World, frames: usize) -> Vec<f32> {
 #[test]
 fn derived_synth_plays_expected_tone() {
     let g = sine_to_out();
-    let def = derive_synthdef(&g, 1, "test").expect("derive").def;
+    let derived = derive_synthdef(&g, 1, "test").expect("derive");
 
     let (mut controller, _nrt, mut world) = engine(Options {
         sample_rate: SR as f64,
         output_channels: 1,
         ..Options::default()
     });
-    controller.add_synthdef(def);
-    controller
+    controller.add_synthdef(derived.def);
+    let node = controller
         .synth_new("test", ROOT_GROUP_ID, AddAction::Tail)
         .expect("synth_new");
+    {
+        let mut backend = Embedded::new(&mut controller);
+        for gain in &derived.gains {
+            backend.set_control(node, gain.index, 1.0).expect("fade in");
+        }
+    }
 
     // The freq/gain params default to the nodes' nominal defaults (220 Hz, 0.2), so
     // the synth plays a 220 Hz tone with no set_control.
@@ -803,6 +816,12 @@ fn stereo_pack_plays_per_channel_tones() {
     let node = controller
         .synth_new("t", ROOT_GROUP_ID, AddAction::Tail)
         .expect("synth_new");
+    {
+        let mut backend = Embedded::new(&mut controller);
+        for gain in &derived.gains {
+            backend.set_control(node, gain.index, 1.0).expect("fade in");
+        }
+    }
     Embedded::new(&mut controller)
         .set_control(node, s1_freq, 330.0)
         .expect("re-tune sine1");
@@ -856,6 +875,12 @@ fn scheduled_control_change_takes_effect_at_its_time() {
     let node = controller
         .synth_new("test", ROOT_GROUP_ID, AddAction::Tail)
         .expect("synth_new");
+    {
+        let mut backend = Embedded::new(&mut controller);
+        for gain in &derived.gains {
+            backend.set_control(node, gain.index, 1.0).expect("fade in");
+        }
+    }
 
     // Schedule freq -> 440 Hz at 0.25 s on the engine's OSC clock.
     let osc = |secs: f64| (secs * OSC_UNITS_PER_SEC) as u64;
@@ -920,28 +945,30 @@ fn out_registers_a_fade_gain() {
 
 #[test]
 fn zeroed_gain_default_keeps_sig() {
-    // The driver patches gain defaults to 0.0 AFTER computing the sig (the
-    // spawn-silent half of the crossfade); the sig must not see the patch, or
-    // every re-derive would spuriously respawn.
+    // The fade default is baked at 0.0 (the spawn-silent half of the crossfade);
+    // the sig must exclude defaults, or every re-derive would spuriously
+    // respawn. Changing the default to any value must leave the sig untouched.
     let g = sine_to_out();
     let mut derived = derive_synthdef(&g, 1, "t").expect("derive");
+    for g in &derived.gains {
+        assert_eq!(derived.def.params[g.index].default, 0.0, "fade bakes 0.0");
+    }
     let sig = structural_sig(&derived.def);
     for g in &derived.gains {
-        derived.def.params[g.index].default = 0.0;
+        derived.def.params[g.index].default = 1.0;
     }
     assert_eq!(sig, structural_sig(&derived.def));
 }
 
 #[test]
 fn patched_fade_default_fades_in() {
-    // The crossfade's fade-in half: with the fade default patched to 0.0 the
+    // The crossfade's fade-in half: the fade default is baked at 0.0 so the
     // synth spawns SILENT (defaults seed the lag state too - no ramp-from-zero
     // surprise in reverse), and restoring the fade to unity ramps the output in
     // over `FADE_LAG` rather than stepping.
     let g = sine_to_out();
-    let mut derived = derive_synthdef(&g, 1, "t").expect("derive");
+    let derived = derive_synthdef(&g, 1, "t").expect("derive");
     let fade = derived.gains[0].index;
-    derived.def.params[fade].default = 0.0;
 
     let (mut controller, _nrt, mut world) = engine(Options {
         sample_rate: SR as f64,
@@ -993,13 +1020,15 @@ fn redefining_a_def_name_keeps_old_synth_playing() {
     let old = controller
         .synth_new("t", ROOT_GROUP_ID, AddAction::Tail)
         .expect("old synth");
+    Embedded::new(&mut controller)
+        .set_control(old, fade, 1.0)
+        .expect("fade old in");
     let before = render(&mut world, SR as usize / 10);
     assert!(rms(&before) > 0.05, "old synth must sound");
 
-    // Re-add the SAME name (a fresh derive, fade default patched to 0.0 as the
-    // driver would): the old synth keeps playing, unaffected.
-    let mut derived_new = derive_synthdef(&g, 1, "t").expect("derive");
-    derived_new.def.params[fade].default = 0.0;
+    // Re-add the SAME name (a fresh derive, fade default baked at 0.0): the old
+    // synth keeps playing, unaffected.
+    let derived_new = derive_synthdef(&g, 1, "t").expect("derive");
     controller.add_synthdef(derived_new.def);
     let after_redef = render(&mut world, SR as usize / 10);
     assert!(
@@ -1123,17 +1152,23 @@ fn kr_source_reaches_output() {
     let s = g.add_node(N::SinOsc(sine));
     let o = g.add_node(N::Out(Out::default()));
     g.add_edge(s, o, Edge::new(0.into(), 0.into()));
-    let def = derive_synthdef(&g, 1, "t").expect("derive").def;
+    let derived = derive_synthdef(&g, 1, "t").expect("derive");
 
     let (mut controller, _nrt, mut world) = engine(Options {
         sample_rate: SR as f64,
         output_channels: 1,
         ..Options::default()
     });
-    controller.add_synthdef(def);
-    controller
+    controller.add_synthdef(derived.def);
+    let node = controller
         .synth_new("t", ROOT_GROUP_ID, AddAction::Tail)
         .expect("synth_new");
+    {
+        let mut backend = Embedded::new(&mut controller);
+        for gain in &derived.gains {
+            backend.set_control(node, gain.index, 1.0).expect("fade in");
+        }
+    }
 
     let out = render(&mut world, SR as usize / 2);
     assert!(rms(&out) > 0.02, "kr source must be audible");

--- a/crates/gantz_plyphon/tests/flatten.rs
+++ b/crates/gantz_plyphon/tests/flatten.rs
@@ -441,17 +441,22 @@ fn nested_synth_plays_expected_tone() {
     g.add_edge(r, o, Edge::new(0.into(), 0.into()));
 
     let flat = flatten_with(&g, &map);
-    let def = derive_synthdef(&flat, 1, "test").expect("derive").def;
+    let derived = derive_synthdef(&flat, 1, "test").expect("derive");
 
     let (mut controller, _nrt, mut world) = engine(Options {
         sample_rate: SR as f64,
         output_channels: 1,
         ..Options::default()
     });
-    controller.add_synthdef(def);
-    controller
+    controller.add_synthdef(derived.def);
+    let node = controller
         .synth_new("test", ROOT_GROUP_ID, AddAction::Tail)
         .expect("synth_new");
+    for gain in &derived.gains {
+        controller
+            .set_control(node, gain.index, 1.0)
+            .expect("fade in");
+    }
 
     let a = render(&mut world, SR as usize / 2);
     assert!(a.iter().any(|s| s.abs() > 0.1), "nested synth was silent");

--- a/crates/gantz_plyphon/tests/flatten.rs
+++ b/crates/gantz_plyphon/tests/flatten.rs
@@ -8,7 +8,7 @@ use gantz_ca::ContentAddr;
 use gantz_core::edge::Edge;
 use gantz_core::node::graph::{Graph, NodeIx};
 use gantz_core::node::{ExprCtx, ExprResult, MetaCtx, parse_expr};
-use gantz_plyphon::flatten::{Flat, FlattenError, flatten};
+use gantz_plyphon::flatten::{Flat, FlattenError, RefKind, flatten};
 use gantz_plyphon::{
     AddAction, Bus, Lag, NodeDsp, Out, ROOT_GROUP_ID, ScopeOut, SinOsc, ToNodeDsp, derive_synthdef,
     derive_synthdefs, structural_sig,
@@ -32,6 +32,8 @@ enum N {
     Inlet,
     Outlet,
     Ref(ContentAddr),
+    /// A DSP-aware ref: the child CA + the `inline` flag.
+    DspRef(ContentAddr, bool),
     Other,
 }
 
@@ -43,7 +45,7 @@ impl ToNodeDsp for N {
             N::Out(o) => Some(o),
             N::ScopeOut(t) => Some(t),
             N::Bus(b) => Some(b),
-            N::Inlet | N::Outlet | N::Ref(_) | N::Other => None,
+            N::Inlet | N::Outlet | N::Ref(_) | N::DspRef(_, _) | N::Other => None,
         }
     }
 }
@@ -70,9 +72,17 @@ fn ca(byte: u8) -> ContentAddr {
 /// (missing entries surface as `Unresolved`), everything else is concrete.
 fn resolver<'g>(
     map: &'g HashMap<ContentAddr, Graph<N>>,
-) -> impl Fn(&N) -> Option<(ContentAddr, Option<&'g Graph<N>>)> + 'g {
+) -> impl Fn(&N) -> Option<(ContentAddr, RefKind, Option<&'g Graph<N>>)> + 'g {
     move |n| match n {
-        N::Ref(ca) => Some((*ca, map.get(ca))),
+        N::Ref(ca) => Some((*ca, RefKind::Inline, map.get(ca))),
+        N::DspRef(ca, inline) => {
+            let kind = if *inline {
+                RefKind::Inline
+            } else {
+                RefKind::Instance
+            };
+            Some((*ca, kind, map.get(ca)))
+        }
         _ => None,
     }
 }
@@ -92,7 +102,7 @@ fn try_flatten<'g>(
 /// The flat node with the given original path.
 fn at<'a>(flat: &'a Graph<Flat<N>>, path: &[usize]) -> NodeIx {
     flat.node_indices()
-        .find(|&n| flat[n].path == path)
+        .find(|&n| flat[n].path() == path)
         .unwrap_or_else(|| panic!("no flat node at path {path:?}"))
 }
 
@@ -103,7 +113,7 @@ fn edges_into(flat: &Graph<Flat<N>>, path: &[usize]) -> Vec<(Vec<usize>, u16, u1
         .edges_directed(n, Direction::Incoming)
         .map(|e| {
             let w = e.weight();
-            (flat[e.source()].path.clone(), w.output.0, w.input.0)
+            (flat[e.source()].path().to_vec(), w.output.0, w.input.0)
         })
         .collect();
     edges.reverse();
@@ -145,7 +155,7 @@ fn flat_graph_flattens_to_identity() {
     assert_eq!(flat.node_count(), 3);
     assert_eq!(flat.edge_count(), 2);
     for n in flat.node_indices() {
-        assert_eq!(flat[n].path, vec![n.index()], "flat paths are [ix]");
+        assert_eq!(flat[n].path(), vec![n.index()], "flat paths are [ix]");
     }
 
     let raw = derive_synthdef(&g, 1, "t").expect("derive raw");
@@ -493,4 +503,128 @@ fn render(world: &mut World, frames: usize) -> Vec<f32> {
     }
     out.truncate(frames);
     out
+}
+
+/// The flat vertex at `path`.
+fn flat_kind<'a>(flat: &'a Graph<Flat<N>>, path: &[usize]) -> &'a Flat<N> {
+    &flat[at(flat, path)]
+}
+
+#[test]
+fn instanced_ref_stays_an_opaque_marker() {
+    // parent: sin -> dsp-ref(child, inline=false) -> out. The ref is NOT
+    // spliced: it survives as a single `Flat::Instance` marker carrying the
+    // child's CA, with parent edges into/out of it preserved (the child's
+    // nodes do not appear in the flat graph).
+    let map = HashMap::from([(ca(1), lag_child())]);
+    let mut g = Graph::<N>::default();
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::DspRef(ca(1), false));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(r, o, Edge::new(0.into(), 0.into()));
+
+    let flat = flatten_with(&g, &map);
+    // sin + the instance marker + out. The child's lag is NOT spliced.
+    assert_eq!(flat.node_count(), 3, "the instanced ref is not spliced");
+    assert_eq!(edges_into(&flat, &[2]), vec![(vec![1], 0, 0)]);
+    assert!(
+        matches!(flat_kind(&flat, &[1]), Flat::Instance { child_ca, .. } if *child_ca == ca(1)),
+        "the ref lowers as an Instance marker carrying the child CA",
+    );
+}
+
+#[test]
+fn inlined_dsp_ref_splices_as_a_plain_ref() {
+    // The same topology with `inline: true` splices the child's lag, matching
+    // the plain `Ref` behaviour: the marker is gone and the lag carries its
+    // nested path.
+    let map = HashMap::from([(ca(1), lag_child())]);
+    let mut g = Graph::<N>::default();
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::DspRef(ca(1), true));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(r, o, Edge::new(0.into(), 0.into()));
+
+    let flat = flatten_with(&g, &map);
+    assert_eq!(flat.node_count(), 3, "sin + spliced lag + out");
+    assert!(
+        matches!(flat_kind(&flat, &[1, 1]), Flat::Node { .. }),
+        "the inlined ref splices the child's nodes",
+    );
+    assert_eq!(edges_into(&flat, &[2]), vec![(vec![1, 1], 0, 0)]);
+}
+
+#[test]
+fn instance_marker_preserves_multiport_edges() {
+    // An instanced ref with two inlets and two outlets: parent edges into each
+    // input and out of each output are kept on the marker (input i / output j
+    // positional), so `derive_template` sees a node with the ref's arity.
+    let mut child = Graph::<N>::default();
+    let i0 = child.add_node(N::Inlet);
+    let i1 = child.add_node(N::Inlet);
+    let o0 = child.add_node(N::Outlet);
+    let o1 = child.add_node(N::Outlet);
+    child.add_edge(i0, o0, Edge::new(0.into(), 0.into()));
+    child.add_edge(i1, o1, Edge::new(0.into(), 0.into()));
+    let map = HashMap::from([(ca(2), child)]);
+
+    let mut g = Graph::<N>::default();
+    let s0 = g.add_node(N::SinOsc(SinOsc::default()));
+    let s1 = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::DspRef(ca(2), false));
+    let pk = g.add_node(N::Out(Out::default()));
+    // Two inputs into the ref (input 0 and 1), two outputs out (0 and 1 - the
+    // second into the out's gain input to keep it distinct).
+    g.add_edge(s0, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(s1, r, Edge::new(0.into(), 1.into()));
+    g.add_edge(r, pk, Edge::new(0.into(), 0.into()));
+    g.add_edge(r, pk, Edge::new(1.into(), 1.into()));
+
+    let flat = flatten_with(&g, &map);
+    // The marker is at path [2]; both input edges and both output edges survive.
+    let mut ins = edges_into(&flat, &[2]);
+    ins.sort();
+    assert_eq!(ins, vec![(vec![0], 0, 0), (vec![1], 0, 1)]);
+    // Output 0 -> out input 0; output 1 -> out input 1.
+    let mut outs: Vec<_> = flat
+        .edges_directed(at(&flat, &[2]), Direction::Outgoing)
+        .map(|e| (e.weight().output.0, e.weight().input.0))
+        .collect();
+    outs.sort();
+    assert_eq!(outs, vec![(0, 0), (1, 1)]);
+}
+
+#[test]
+fn root_boundaries_kept_as_markers() {
+    // Root-level inlets/outlets are the flat graph's own interface: they stay
+    // as `Flat::Inlet`/`Flat::Outlet` markers with positional indices, and
+    // their edges survive (inlet feeding a consumer, source feeding an
+    // outlet). Nested boundaries keep dissolving (covered elsewhere).
+    let mut g = Graph::<N>::default();
+    let i0 = g.add_node(N::Inlet);
+    let l = g.add_node(N::Lag(Lag::default()));
+    let i1 = g.add_node(N::Inlet);
+    let o0 = g.add_node(N::Outlet);
+    g.add_edge(i0, l, Edge::new(0.into(), 0.into()));
+    g.add_edge(l, o0, Edge::new(0.into(), 0.into()));
+    let _ = i1;
+
+    let flat = flatten_with(&g, &HashMap::new());
+    assert_eq!(flat.node_count(), 4, "lag + three root boundary markers");
+    assert!(
+        matches!(flat_kind(&flat, &[0]), Flat::Inlet { index: 0, .. }),
+        "first inlet is marker 0",
+    );
+    assert!(
+        matches!(flat_kind(&flat, &[2]), Flat::Inlet { index: 1, .. }),
+        "second inlet is marker 1 (ascending node index order)",
+    );
+    assert!(
+        matches!(flat_kind(&flat, &[3]), Flat::Outlet { index: 0, .. }),
+        "outlet is marker 0",
+    );
+    assert_eq!(edges_into(&flat, &[1]), vec![(vec![0], 0, 0)]);
+    assert_eq!(edges_into(&flat, &[3]), vec![(vec![1], 0, 0)]);
 }

--- a/crates/gantz_plyphon/tests/instance.rs
+++ b/crates/gantz_plyphon/tests/instance.rs
@@ -1,0 +1,558 @@
+//! Offline tests for `derive_template`/`instantiate`: instance composition
+//! (shared synthdefs for nested-graph refs, #295).
+
+use std::collections::HashMap;
+
+use gantz_core::edge::Edge;
+use gantz_core::node::graph::Graph;
+use gantz_plyphon::flatten::{Flat, RefKind, flatten};
+use gantz_plyphon::instance::{
+    BusKey, DefCache, GraphTemplate, Part, ResolvedPart, derive_template, instantiate,
+};
+use gantz_plyphon::{DeriveError, Lag, NodeDsp, Out, Pack, SinOsc, ToNodeDsp};
+
+/// A minimal erased node enum, standing in for the app's `Box<dyn Node>`.
+#[derive(Clone)]
+enum N {
+    SinOsc(SinOsc),
+    Lag(Lag),
+    Out(Out),
+    Pack(Pack),
+    Inlet,
+    Outlet,
+    /// A ref standing in for an instanced graph: child CA + its arity
+    /// (the reference reports the child's inlet/outlet counts).
+    Ref(gantz_ca::ContentAddr, usize, usize),
+    Other,
+}
+
+impl ToNodeDsp for N {
+    fn to_node_dsp(&self) -> Option<&dyn NodeDsp> {
+        match self {
+            N::SinOsc(s) => Some(s),
+            N::Lag(l) => Some(l),
+            N::Out(o) => Some(o),
+            N::Pack(p) => Some(p),
+            N::Inlet | N::Outlet | N::Ref(..) | N::Other => None,
+        }
+    }
+}
+
+impl gantz_core::Node for N {
+    fn expr(&self, _ctx: gantz_core::node::ExprCtx<'_, '_>) -> gantz_core::node::ExprResult {
+        gantz_core::node::parse_expr("'()")
+    }
+
+    fn inlet(&self, _ctx: gantz_core::node::MetaCtx) -> bool {
+        matches!(self, N::Inlet)
+    }
+
+    fn outlet(&self, _ctx: gantz_core::node::MetaCtx) -> bool {
+        matches!(self, N::Outlet)
+    }
+
+    fn n_inputs(&self, _ctx: gantz_core::node::MetaCtx) -> usize {
+        match self {
+            N::Ref(_, n_in, _) => *n_in,
+            _ => 0,
+        }
+    }
+
+    fn n_outputs(&self, _ctx: gantz_core::node::MetaCtx) -> usize {
+        match self {
+            N::Ref(_, _, n_out) => *n_out,
+            _ => 0,
+        }
+    }
+}
+
+fn ca(byte: u8) -> gantz_ca::ContentAddr {
+    gantz_ca::ContentAddr([byte; 32])
+}
+
+/// A child graph that produces a 220 Hz sine through its own `~out` (no
+/// inlets/outlets): a complete, self-contained subgraph.
+fn sine_out_child() -> Graph<N> {
+    let mut g = Graph::<N>::default();
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s, o, Edge::new(0.into(), 0.into()));
+    g
+}
+
+/// A child graph `inlet -> ~lag -> outlet`.
+fn lag_child() -> Graph<N> {
+    let mut g = Graph::<N>::default();
+    let i = g.add_node(N::Inlet);
+    let l = g.add_node(N::Lag(Lag::default()));
+    let o = g.add_node(N::Outlet);
+    g.add_edge(i, l, Edge::new(0.into(), 0.into()));
+    g.add_edge(l, o, Edge::new(0.into(), 0.into()));
+    g
+}
+
+/// Flatten with every ref lowering as an instance marker.
+fn flatten_with(
+    graph: &Graph<N>,
+    map: &HashMap<gantz_ca::ContentAddr, Graph<N>>,
+) -> Graph<Flat<N>> {
+    let resolve = |n: &N| match n {
+        N::Ref(c, _, _) => Some((*c, RefKind::Instance, map.get(c))),
+        _ => None,
+    };
+    flatten(&|_| None, graph, &resolve).expect("flatten")
+}
+
+/// Pre-flatten every child in `map` so `derive_template`'s `resolve` can
+/// return `&Graph<Flat<N>>`.
+fn flat_children(
+    map: &HashMap<gantz_ca::ContentAddr, Graph<N>>,
+) -> HashMap<gantz_ca::ContentAddr, Graph<Flat<N>>> {
+    map.iter()
+        .map(|(c, child)| (*c, flatten_with(child, map)))
+        .collect()
+}
+
+/// Derive a head graph's template + cache against `map`'s children.
+fn derive(
+    g: &Graph<N>,
+    map: &HashMap<gantz_ca::ContentAddr, Graph<N>>,
+) -> Result<(GraphTemplate, DefCache), DeriveError> {
+    let flat = flatten_with(g, map);
+    let children = flat_children(map);
+    let resolve = |c: &gantz_ca::ContentAddr| children.get(c);
+    let mut cache = DefCache::new();
+    let template = derive_template(&flat, 1, &resolve, &mut cache)?;
+    Ok((template, cache))
+}
+
+fn regions(t: &GraphTemplate) -> Vec<&gantz_plyphon::TemplateRegion> {
+    t.parts
+        .iter()
+        .filter_map(|p| match p {
+            Part::Region(r) => Some(r),
+            Part::Instance(_) => None,
+        })
+        .collect()
+}
+
+fn instances(t: &GraphTemplate) -> Vec<&gantz_plyphon::InstancePart> {
+    t.parts
+        .iter()
+        .filter_map(|p| match p {
+            Part::Instance(i) => Some(i),
+            Part::Region(_) => None,
+        })
+        .collect()
+}
+
+#[test]
+fn no_instances_delegates_to_derive_synthdefs() {
+    // A plain graph (no markers) derives via the region path: one region per
+    // `~out` sink, no cached variants, content-hashed def name.
+    let mut g = Graph::<N>::default();
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s, o, Edge::new(0.into(), 0.into()));
+
+    let (template, cache) = derive(&g, &HashMap::new()).expect("derive");
+    assert!(cache.is_empty(), "no instances -> no cached variants");
+    assert_eq!(template.parts.len(), 1, "one region");
+    let r = &regions(&template)[0];
+    assert_eq!(
+        r.def.name,
+        gantz_plyphon::compile::content_def_name(r.sig),
+        "defs are content-named",
+    );
+}
+
+#[test]
+fn two_instances_share_one_variant() {
+    // parent: two instances of the same sine-producing child (each child has
+    // its own `~out`, so each instance is a sink). Both share one VariantKey
+    // (same child, no inlets/outlets), so the DefCache holds one entry and
+    // both resolved parts name the same def.
+    let map = HashMap::from([(ca(1), sine_out_child())]);
+    let mut g = Graph::<N>::default();
+    let _r0 = g.add_node(N::Ref(ca(1), 0, 0));
+    let _r1 = g.add_node(N::Ref(ca(1), 0, 0));
+
+    let (template, cache) = derive(&g, &map).expect("derive");
+    assert_eq!(cache.len(), 1, "two instances share one variant");
+    assert_eq!(instances(&template).len(), 2, "two instance parts");
+
+    let resolved = instantiate(&template, &cache);
+    assert_eq!(resolved.len(), 2, "each instance spawns the child's region");
+    assert_eq!(
+        resolved[0].def.name, resolved[1].def.name,
+        "both instances share one installed def",
+    );
+    assert_ne!(resolved[0].key, resolved[1].key, "distinct identities");
+    let paths: Vec<_> = resolved
+        .iter()
+        .map(|p| p.params[0].node_path.clone())
+        .collect();
+    assert!(
+        paths.contains(&vec![0, 0]) && paths.contains(&vec![1, 0]),
+        "bindings carry absolute instance-prefixed paths: {paths:?}",
+    );
+}
+
+#[test]
+fn distinct_children_produce_distinct_variants() {
+    // Two instances of DIFFERENT children (different content addresses)
+    // produce two distinct variants.
+    let map = HashMap::from([(ca(1), sine_out_child()), (ca(2), sine_out_child())]);
+    let mut g = Graph::<N>::default();
+    let _r0 = g.add_node(N::Ref(ca(1), 0, 0));
+    let _r1 = g.add_node(N::Ref(ca(2), 0, 0));
+
+    let (_template, cache) = derive(&g, &map).expect("derive");
+    assert_eq!(cache.len(), 2, "distinct children -> distinct variants");
+}
+
+#[test]
+fn staging_diamond_derives_two_stages() {
+    // src -> instance -> mix plus src -> mix directly: `src` must run before
+    // the instance and `mix` after it, so they cannot share a def. The
+    // staging pass splits them into two regions and the direct edge lowers to
+    // an implicit `Src` bus - no `BusCycle`.
+    let map = HashMap::from([(ca(1), lag_child())]);
+    let mut g = Graph::<N>::default();
+    let src = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::Ref(ca(1), 1, 1));
+    let mix = g.add_node(N::Pack(Pack::default()));
+    let out = g.add_node(N::Out(Out::default()));
+    g.add_edge(src, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(r, mix, Edge::new(0.into(), 0.into()));
+    g.add_edge(src, mix, Edge::new(0.into(), 1.into()));
+    g.add_edge(mix, out, Edge::new(0.into(), 0.into()));
+
+    let (template, _cache) = derive(&g, &map).expect("the diamond derives");
+    let rs = regions(&template);
+    assert_eq!(rs.len(), 2, "src and mix land in separate stage regions");
+    assert_eq!(instances(&template).len(), 1);
+
+    let src_key = BusKey::Src {
+        path: vec![src.index()],
+        output: 0,
+    };
+    let writer = rs
+        .iter()
+        .find(|r| r.bus_writes.iter().any(|w| w.key == src_key))
+        .expect("the stage-0 region writes src's endpoint bus");
+    assert_eq!(
+        writer.bus_writes.len(),
+        1,
+        "one write serves both the instance inlet and the cross-stage read",
+    );
+    let reader = rs
+        .iter()
+        .find(|r| r.bus_reads.iter().any(|b| b.key == src_key))
+        .expect("the mix region reads src's endpoint bus");
+    let inst_key = BusKey::InstOut {
+        path: vec![r.index()],
+        outlet: 0,
+    };
+    assert!(
+        reader.bus_reads.iter().any(|b| b.key == inst_key),
+        "the mix region also reads the instance's outlet bus",
+    );
+    let inst = &instances(&template)[0];
+    assert_eq!(inst.inlet_keys, vec![Some(src_key)]);
+}
+
+#[test]
+fn width_flows_through_an_instance() {
+    // A stereo (2ch pack) signal into the instance's inlet: the variant keys
+    // the width, the child's `In` is 2 wide, the child's outlet carries width
+    // 2 and the downstream reader's `In` sees width 2.
+    let map = HashMap::from([(ca(1), lag_child())]);
+    let mut g = Graph::<N>::default();
+    let s0 = g.add_node(N::SinOsc(SinOsc::default()));
+    let s1 = g.add_node(N::SinOsc(SinOsc::default()));
+    let pack = g.add_node(N::Pack(Pack::default()));
+    let r = g.add_node(N::Ref(ca(1), 1, 1));
+    let out = g.add_node(N::Out(Out::default()));
+    g.add_edge(s0, pack, Edge::new(0.into(), 0.into()));
+    g.add_edge(s1, pack, Edge::new(0.into(), 1.into()));
+    g.add_edge(pack, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(r, out, Edge::new(0.into(), 0.into()));
+
+    let (template, cache) = derive(&g, &map).expect("derive");
+    let inst = &instances(&template)[0];
+    assert_eq!(inst.variant.inlets, vec![Some(2)], "inlet width keyed at 2");
+
+    let child = cache.get(&inst.variant).expect("cached child template");
+    let child_region = &regions(&child)[0];
+    let in_read = child_region
+        .bus_reads
+        .iter()
+        .find(|b| matches!(b.key, BusKey::IfaceIn(0)))
+        .expect("the child's In reads its interface inlet");
+    assert_eq!(in_read.channels, 2, "the child's In is 2 wide");
+    assert_eq!(
+        child.outlets[0].as_ref().map(|(_, w)| *w),
+        Some(2),
+        "the child's outlet carries width 2",
+    );
+
+    let reader = regions(&template)
+        .into_iter()
+        .find(|r| !r.bus_reads.is_empty() && r.bus_writes.is_empty())
+        .expect("the out region reads the instance's outlet");
+    assert_eq!(reader.bus_reads[0].channels, 2, "the reader sees width 2");
+}
+
+#[test]
+fn unconnected_inlet_bakes_silence() {
+    // A child with two inlets, only the first fed: the variant records
+    // `[Some(1), None]` and the child def holds exactly one interface `In`.
+    let mut child = Graph::<N>::default();
+    let i0 = child.add_node(N::Inlet);
+    let i1 = child.add_node(N::Inlet);
+    let pack = child.add_node(N::Pack(Pack::default()));
+    let o = child.add_node(N::Outlet);
+    child.add_edge(i0, pack, Edge::new(0.into(), 0.into()));
+    child.add_edge(i1, pack, Edge::new(0.into(), 1.into()));
+    child.add_edge(pack, o, Edge::new(0.into(), 0.into()));
+    let map = HashMap::from([(ca(1), child)]);
+
+    let mut g = Graph::<N>::default();
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::Ref(ca(1), 2, 1));
+    let out = g.add_node(N::Out(Out::default()));
+    g.add_edge(s, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(r, out, Edge::new(0.into(), 0.into()));
+
+    let (template, cache) = derive(&g, &map).expect("derive");
+    let inst = &instances(&template)[0];
+    assert_eq!(inst.variant.inlets, vec![Some(1), None]);
+    assert_eq!(inst.inlet_keys.len(), 2);
+    assert!(inst.inlet_keys[1].is_none(), "unconnected inlet has no bus");
+
+    let child = cache.get(&inst.variant).expect("cached child");
+    let child_region = &regions(&child)[0];
+    let iface_reads = child_region
+        .bus_reads
+        .iter()
+        .filter(|b| matches!(b.key, BusKey::IfaceIn(_)))
+        .count();
+    assert_eq!(iface_reads, 1, "one In; the silent inlet bakes silence");
+}
+
+#[test]
+fn consumed_outlet_mask_keys_the_variant() {
+    // A child with two outlets, only the second consumed: the variant records
+    // `[false, true]` and the child def writes exactly one outlet bus.
+    let mut child = Graph::<N>::default();
+    let s0 = child.add_node(N::SinOsc(SinOsc::default()));
+    let s1 = child.add_node(N::Lag(Lag::default()));
+    let o0 = child.add_node(N::Outlet);
+    let o1 = child.add_node(N::Outlet);
+    child.add_edge(s0, o0, Edge::new(0.into(), 0.into()));
+    child.add_edge(s1, o1, Edge::new(0.into(), 0.into()));
+    let map = HashMap::from([(ca(1), child)]);
+
+    let mut g = Graph::<N>::default();
+    let r = g.add_node(N::Ref(ca(1), 0, 2));
+    let out = g.add_node(N::Out(Out::default()));
+    g.add_edge(r, out, Edge::new(1.into(), 0.into()));
+
+    let (template, cache) = derive(&g, &map).expect("derive");
+    let inst = &instances(&template)[0];
+    assert_eq!(inst.variant.outlets, vec![false, true]);
+
+    let child = cache.get(&inst.variant).expect("cached child");
+    assert!(child.outlets[0].is_none(), "unconsumed outlet has no bus");
+    assert!(child.outlets[1].is_some(), "consumed outlet carries a bus");
+    let writes: usize = regions(&child).iter().map(|r| r.bus_writes.len()).sum();
+    assert_eq!(writes, 1, "one outlet write");
+}
+
+#[test]
+fn def_names_are_stable_across_heads() {
+    // The same child variant derived under two different heads (fresh caches)
+    // yields identical content-hashed def names - the cross-head sharing the
+    // driver's install refcounting relies on.
+    let map = HashMap::from([(ca(1), sine_out_child())]);
+
+    let mut g1 = Graph::<N>::default();
+    let _r = g1.add_node(N::Ref(ca(1), 0, 0));
+
+    let mut g2 = Graph::<N>::default();
+    // A different head: its own sine plus the same child instance.
+    let s = g2.add_node(N::SinOsc(SinOsc::default()));
+    let o = g2.add_node(N::Out(Out::default()));
+    g2.add_edge(s, o, Edge::new(0.into(), 0.into()));
+    let _r = g2.add_node(N::Ref(ca(1), 0, 0));
+
+    let (t1, c1) = derive(&g1, &map).expect("derive head 1");
+    let (t2, c2) = derive(&g2, &map).expect("derive head 2");
+    let name = |t: &GraphTemplate, c: &DefCache| {
+        let inst = instances(t)[0];
+        let child = c.get(&inst.variant).expect("cached");
+        regions(&child)[0].def.name.clone()
+    };
+    assert_eq!(
+        name(&t1, &c1),
+        name(&t2, &c2),
+        "same variant, same content name, regardless of head",
+    );
+}
+
+#[test]
+fn bus_params_are_unlagged_and_named_by_key() {
+    // Every read/write bus param indexes a no-lag control in its own def,
+    // named by the key's path + label - the contract the driver's post-spawn
+    // `set_control` wiring relies on.
+    let map = HashMap::from([(ca(1), lag_child())]);
+    let mut g = Graph::<N>::default();
+    let src = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::Ref(ca(1), 1, 1));
+    let mix = g.add_node(N::Pack(Pack::default()));
+    let out = g.add_node(N::Out(Out::default()));
+    g.add_edge(src, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(r, mix, Edge::new(0.into(), 0.into()));
+    g.add_edge(src, mix, Edge::new(0.into(), 1.into()));
+    g.add_edge(mix, out, Edge::new(0.into(), 0.into()));
+
+    let (template, cache) = derive(&g, &map).expect("derive");
+    let resolved = instantiate(&template, &cache);
+    for part in &resolved {
+        for bus in part.bus_reads.iter().chain(&part.bus_writes) {
+            let param = &part.def.params[bus.param];
+            assert_eq!(param.lag, None, "bus-index params must be unlagged");
+            assert!(
+                param.name.ends_with("bus") || param.name.contains("/bus"),
+                "bus param named by its key: {}",
+                param.name,
+            );
+        }
+    }
+    // Two readers share src's endpoint bus: the child's interface In (its
+    // param named by the child-local inlet marker path) and the mix region
+    // (its param named by the source path + port). One bus, two synths, each
+    // with its own def-local param.
+    let src_key = BusKey::Src {
+        path: vec![src.index()],
+        output: 0,
+    };
+    let readers: Vec<&ResolvedPart> = resolved
+        .iter()
+        .filter(|p| p.bus_reads.iter().any(|b| b.key == src_key))
+        .collect();
+    assert_eq!(readers.len(), 2, "the child In and the mix region");
+    let names: Vec<&str> = readers
+        .iter()
+        .map(|p| {
+            let read = p.bus_reads.iter().find(|b| b.key == src_key).unwrap();
+            p.def.params[read.param].name.as_str()
+        })
+        .collect();
+    assert!(
+        names.contains(&"0/bus"),
+        "child-local inlet param: {names:?}"
+    );
+    assert!(
+        names.contains(&"0/bus0"),
+        "mix-side source param: {names:?}"
+    );
+}
+
+#[test]
+fn instance_ref_cycle_errors() {
+    // A instances B instances A: no finite template exists.
+    let mut a = Graph::<N>::default();
+    let s = a.add_node(N::SinOsc(SinOsc::default()));
+    let o = a.add_node(N::Out(Out::default()));
+    a.add_edge(s, o, Edge::new(0.into(), 0.into()));
+    a.add_node(N::Ref(ca(2), 0, 0));
+    let mut b = Graph::<N>::default();
+    b.add_node(N::Ref(ca(1), 0, 0));
+    let map = HashMap::from([(ca(1), a), (ca(2), b)]);
+
+    let mut g = Graph::<N>::default();
+    g.add_node(N::Ref(ca(1), 0, 0));
+
+    match derive(&g, &map) {
+        Err(DeriveError::RefCycle(_)) => {}
+        Err(e) => panic!("expected RefCycle, got {e:?}"),
+        Ok(_) => panic!("expected RefCycle, derived fine"),
+    }
+}
+
+#[test]
+fn recursive_instantiate_prefixes_paths() {
+    // head -> I1(child A), where A contains I2(child B, self-contained sine).
+    // The resolved list carries B's region at the absolute prefix [I1, I2],
+    // in global topo order, with absolute binding paths.
+    let mut b = Graph::<N>::default();
+    let s = b.add_node(N::SinOsc(SinOsc::default()));
+    let o = b.add_node(N::Out(Out::default()));
+    b.add_edge(s, o, Edge::new(0.into(), 0.into()));
+
+    let mut a = Graph::<N>::default();
+    let _i2 = a.add_node(N::Ref(ca(2), 0, 0));
+    let map = HashMap::from([(ca(1), a), (ca(2), b)]);
+
+    let mut g = Graph::<N>::default();
+    let i1 = g.add_node(N::Ref(ca(1), 0, 0));
+
+    let (template, cache) = derive(&g, &map).expect("derive");
+    let resolved = instantiate(&template, &cache);
+    assert_eq!(resolved.len(), 1, "one resolved part: B's region via A");
+    let part = &resolved[0];
+    assert_eq!(
+        part.params[0].node_path,
+        vec![i1.index(), 0, 0],
+        "the sine's binding path is instance-prefixed through both levels",
+    );
+}
+
+#[test]
+fn instance_to_instance_shares_one_bus() {
+    // I1's consumed outlet feeds I2's inlet: both sides resolve to ONE
+    // absolute bus (the bus carrying I1's child outlet signal) - no relay.
+    let mut producer = Graph::<N>::default();
+    let s = producer.add_node(N::SinOsc(SinOsc::default()));
+    let o = producer.add_node(N::Outlet);
+    producer.add_edge(s, o, Edge::new(0.into(), 0.into()));
+
+    let mut consumer = Graph::<N>::default();
+    let i = consumer.add_node(N::Inlet);
+    let out = consumer.add_node(N::Out(Out::default()));
+    consumer.add_edge(i, out, Edge::new(0.into(), 0.into()));
+
+    let map = HashMap::from([(ca(1), producer), (ca(2), consumer)]);
+    let mut g = Graph::<N>::default();
+    let i1 = g.add_node(N::Ref(ca(1), 0, 1));
+    let i2 = g.add_node(N::Ref(ca(2), 1, 0));
+    g.add_edge(i1, i2, Edge::new(0.into(), 0.into()));
+
+    let (template, cache) = derive(&g, &map).expect("derive");
+    let resolved = instantiate(&template, &cache);
+    assert_eq!(resolved.len(), 2, "producer region + consumer region");
+    let writes: Vec<&ResolvedPart> = resolved
+        .iter()
+        .filter(|p| !p.bus_writes.is_empty())
+        .collect();
+    let reads: Vec<&ResolvedPart> = resolved
+        .iter()
+        .filter(|p| !p.bus_reads.is_empty())
+        .collect();
+    assert_eq!(writes.len(), 1, "one writer (inside I1)");
+    assert_eq!(reads.len(), 1, "one reader (inside I2)");
+    assert_eq!(
+        writes[0].bus_writes[0].key, reads[0].bus_reads[0].key,
+        "both sides name one absolute bus - no relay",
+    );
+    assert_eq!(
+        writes[0].bus_writes[0].key,
+        BusKey::Src {
+            path: vec![i1.index(), s.index()],
+            output: 0,
+        },
+        "the bus is the producer's absolutized source endpoint",
+    );
+}

--- a/crates/gantz_plyphon/tests/instance.rs
+++ b/crates/gantz_plyphon/tests/instance.rs
@@ -23,7 +23,6 @@ enum N {
     /// A ref standing in for an instanced graph: child CA + its arity
     /// (the reference reports the child's inlet/outlet counts).
     Ref(gantz_ca::ContentAddr, usize, usize),
-    Other,
 }
 
 impl ToNodeDsp for N {
@@ -33,7 +32,7 @@ impl ToNodeDsp for N {
             N::Lag(l) => Some(l),
             N::Out(o) => Some(o),
             N::Pack(p) => Some(p),
-            N::Inlet | N::Outlet | N::Ref(..) | N::Other => None,
+            N::Inlet | N::Outlet | N::Ref(..) => None,
         }
     }
 }

--- a/crates/gantz_plyphon/tests/ref_ext.rs
+++ b/crates/gantz_plyphon/tests/ref_ext.rs
@@ -1,5 +1,6 @@
-//! Tests for `dsp_commits`: the DSP-graph discovery backing the `inline`
-//! ref-extension UI.
+//! Tests for `dsp_commits` - the DSP-graph discovery backing the `inline`
+//! ref-extension UI - and for the `DspRefExt`-driven lowering decision in
+//! `flatten_from_registry`.
 
 use gantz_ca::{CaHash, ContentAddr};
 use gantz_core::node::graph::Graph;
@@ -7,11 +8,13 @@ use gantz_core::node::{AsRefNode, ExprCtx, ExprResult, MetaCtx, Ref, parse_expr}
 use gantz_plyphon::{NodeDsp, SinOsc, ToNodeDsp, dsp_commits};
 
 /// A minimal node standing in for the app's node set: one DSP node, the
-/// reference node, and a non-DSP stand-in.
+/// reference node, boundary nodes and a non-DSP stand-in.
 #[derive(Clone)]
 enum N {
     SinOsc(SinOsc),
     Ref(Ref),
+    Inlet,
+    Outlet,
     Other,
 }
 
@@ -19,7 +22,7 @@ impl ToNodeDsp for N {
     fn to_node_dsp(&self) -> Option<&dyn NodeDsp> {
         match self {
             N::SinOsc(s) => Some(s),
-            N::Ref(_) | N::Other => None,
+            N::Ref(_) | N::Inlet | N::Outlet | N::Other => None,
         }
     }
 }
@@ -41,6 +44,14 @@ impl gantz_core::Node for N {
     fn n_outputs(&self, _ctx: MetaCtx) -> usize {
         1
     }
+
+    fn inlet(&self, _ctx: MetaCtx) -> bool {
+        matches!(self, N::Inlet)
+    }
+
+    fn outlet(&self, _ctx: MetaCtx) -> bool {
+        matches!(self, N::Outlet)
+    }
 }
 
 impl CaHash for N {
@@ -48,6 +59,12 @@ impl CaHash for N {
         match self {
             N::SinOsc(s) => CaHash::hash(s, hasher),
             N::Ref(r) => CaHash::hash(r, hasher),
+            N::Inlet => {
+                hasher.update(b"test.inlet");
+            }
+            N::Outlet => {
+                hasher.update(b"test.outlet");
+            }
             N::Other => {
                 hasher.update(b"test.other");
             }
@@ -107,4 +124,62 @@ fn dsp_commits_discovers_direct_and_transitive() {
     assert!(set.contains(&wrapper2_ca), "two hops through refs");
     assert!(!set.contains(&plain_ca));
     assert!(!set.contains(&dangling_ca));
+}
+
+/// The lowering decision in `flatten_from_registry`: a DSP-bearing child
+/// instances by default, its `DspRefExt { inline: true }` ext opts back into
+/// splicing, and non-DSP children (including pure wire children) always
+/// splice.
+#[test]
+fn default_lowering_instances_dsp_refs_and_splices_the_rest() {
+    use gantz_plyphon::{DSP_REF_EXT_KEY, DspRefExt, Flat};
+
+    let mut registry = gantz_ca::Registry::<Graph<N>>::default();
+
+    // A DSP-bearing child.
+    let mut dsp: Graph<N> = Graph::default();
+    dsp.add_node(N::SinOsc(SinOsc::default()));
+    let dsp_ca = commit(&mut registry, "dsp", dsp);
+
+    // A pure wire child: bridges signals but contains no DSP.
+    let mut wire: Graph<N> = Graph::default();
+    let i = wire.add_node(N::Inlet);
+    let o = wire.add_node(N::Outlet);
+    wire.add_edge(i, o, gantz_core::Edge::new(0.into(), 0.into()));
+    let wire_ca = commit(&mut registry, "wire", wire);
+
+    // The head: a default DSP ref, an inline-flagged DSP ref, a wire ref.
+    let mut inline_ref = Ref::new(dsp_ca);
+    inline_ref
+        .set_ext(DSP_REF_EXT_KEY, &DspRefExt { inline: true })
+        .expect("datum-representable");
+    let mut head: Graph<N> = Graph::default();
+    head.add_node(ref_node(dsp_ca));
+    head.add_node(N::Ref(inline_ref));
+    head.add_node(ref_node(wire_ca));
+
+    let flat = gantz_plyphon::flatten_from_registry(&head, &registry).expect("flatten");
+    let markers: Vec<_> = flat
+        .node_indices()
+        .filter(|&n| matches!(flat[n], Flat::Instance { .. }))
+        .collect();
+    assert_eq!(markers.len(), 1, "only the default DSP ref instances");
+    assert!(
+        matches!(flat[markers[0]], Flat::Instance { child_ca, .. } if child_ca == dsp_ca),
+        "the marker carries the DSP child's address",
+    );
+    // The inline-flagged ref spliced its sine; the wire child dissolved.
+    let sines = flat
+        .node_indices()
+        .filter(|&n| {
+            matches!(
+                &flat[n],
+                Flat::Node {
+                    node: N::SinOsc(_),
+                    ..
+                }
+            )
+        })
+        .count();
+    assert_eq!(sines, 1, "the inline ref splices the child's sine");
 }


### PR DESCRIPTION
Closes #295

DSP child refs now derive **once** into shared synthdefs and spawn **per instance** instead of always inlining.

A child with DSP nodes shares one installed def across all instances and heads (content-named by structural sig), while pure inlet->outlet wires still splice as before.

## Core: staged template derivation (plyphon)

- `derive_template` lowers a flat graph (DSP nodes, `~bus` boundaries, instance markers, root interface markers) into a `GraphTemplate`: regions and instances ordered bus-writer-before-reader, connected by `BusKey` wiring metadata the driver realises as actual buses.
- One template derives per `VariantKey` (child content address + inlet widths + outlet mask + engine width), memoised in a `DefCache`.
- Defs are content-named (`structural_sig`), so identical structure shares one installed def across instances and heads.
- `instantiate` splices templates recursively with instance path prefixes into a flat `ResolvedPart` list carrying absolute binding paths and bus keys - instances dissolve into per-instance spawns of shared defs.
- A staging pass makes dry/wet diamonds work: stage is the max over winning sources, bumped across instances, computed over SCC condensation. Cycles through an instance error as `BusCycle`.
- Marker-free graphs delegate to the pre-instancing `derive_synthdefs`, re-shaped with content def names.

## Driver: refcounted shared defs

- `HeadSynths` tracks `(refcount, structural_sig)` per installed def name. Installs only when absent or sig changed.
- Respawns and fade-outs release refcounts; defs free when last synth retires. Retired defs are reaped each frame.

## Driver: param-based bus/scope/fade wiring

- Bus-index, scope-bufnum, and fade-gain move from baked `Constant(0.0)` to no-lag `Param`s the driver sets via `set_control` post-spawn. A single shared def now serves many instances with different wiring.
- `spawn_region` allocates buses, cues scopes, then drains a single command-ring of `set_control`s. All land before the synth's first audible block.

## Driver: structural_sync overhaul

- Derives through `derive_template` (child templates memoised in a `DefCache` shared across heads), consumes `instantiate`'s flat `ResolvedPart` list.
- `spawn_region` becomes `spawn_part`: one bus per absolute `BusKey` (first side allocates, counterpart looks up), cue scopes, install-or-reuse via name+sig gate, spawn, post-spawn `set_control` drain.
- Keep/replace matches part key + def structural sig + wiring hash - re-routes keep the def still (crossfade-respawn instead of clicking through a bus-index switch).

## Lowering: instancing is the default

- `flatten_from_registry` decides each ref's lowering: a ref whose child (transitively) contains DSP nodes stays an **instance marker** by default - the child derives once, installed once, spawned per instance. `DspRefExt { inline: true }` opts back into splicing.
- Non-DSP children (including pure inlet->outlet wires) always splice.

## Flatten: marker-only mode

- `Flat` becomes an enum: spliced `Node` weights plus three non-DSP marker variants. `RefKind::Instance` stays an opaque marker carrying the child's content address and arity (no recursion at flatten time).
- Root-level `Inlet`/`Outlet` nodes kept as positional markers for template derivation. Nested boundaries dissolve as before.

## Resilience: retry transient spawn failures

- `QueueFull` surfaced as `BackendError::QueueFull`. On transient failure the driver keeps old synths playing and marks the head to re-run structural sync next frame - already-spawned parts match by key + sig + wiring, so the re-run converges. Permanent failures still park the head.

## Data model: `BusKey`-keyed bus allocation

- `HeadRegions/RegionSynth` renamed to `HeadParts/PartSynth`.
- `BusAlloc` keyed by `(Entity, BusKey)` instead of bare bus path - a path can't key instance ports (in0 vs in1 collide) or source endpoint outputs.