### PR TITLE
fix(web): let browser paste events through to the app

### DIFF
--- a/crates/gantz/src/window.rs
+++ b/crates/gantz/src/window.rs
@@ -36,6 +36,16 @@ pub fn plugin() -> WindowPlugin {
             // notice tearing or simialr issues, open an issue so we can try and
             // select the right `PresentMode` for each system!
             present_mode: bevy::window::PresentMode::AutoNoVsync,
+            // On web, let the browser's default keydown handling proceed:
+            // winit otherwise calls `preventDefault()` on *every* keydown,
+            // which cancels the browser's paste event - the only source of
+            // paste input on wasm (bevy_egui's Ctrl+V clipboard fallback is
+            // compiled out there). eframe ships the same policy. The
+            // side-effects we care about (the native context menu, file
+            // shortcuts) are guarded by small JS listeners in
+            // `web/index.html`.
+            #[cfg(target_arch = "wasm32")]
+            prevent_default_event_handling: false,
             ..default()
         }),
         ..default()

--- a/crates/gantz/web/index.html
+++ b/crates/gantz/web/index.html
@@ -119,6 +119,18 @@ worker: only one service worker can own the scope, and the cross-origin-isolatio
                 document.addEventListener(eventName, resumeAllContexts);
             });
         })();
+
+        // With winit's blanket keydown `preventDefault` disabled (so browser
+        // paste events reach the app - see `crates/gantz/src/window.rs`),
+        // guard the browser file shortcuts that would fight it (the native
+        // context menu is already suppressed above). Clipboard combos
+        // (Ctrl/Cmd+C/V/X) are deliberately left alone.
+        document.addEventListener('keydown', (e) => {
+            const mod = e.ctrlKey || e.metaKey;
+            if (mod && ['s', 'o', 'p'].includes(e.key.toLowerCase())) {
+                e.preventDefault();
+            }
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
Pasting into the web build (e.g. a session invite ticket) did nothing: winit's wasm backend calls `preventDefault()` on every keydown when bevy's default `prevent_default_event_handling: true` is set, which cancels the browser's default paste action - and the resulting `paste` ClipboardEvent is the ONLY source of paste input on wasm (bevy_egui's Ctrl+V clipboard fallback is compiled out there; writes go through the separate async clipboard API, which is why copy already worked). eframe deliberately ships without preventing clipboard-combo defaults for exactly this reason.

Flip the flag off for the wasm build only, and guard the two defaults that would now fight the app with small JS listeners in index.html: the native context menu (gantz has its own right-click menus) and Ctrl/Cmd+S/O/P.