### PR TITLE
fix: Editor Robustness

### DIFF
--- a/crates/bevy_gantz/src/head.rs
+++ b/crates/bevy_gantz/src/head.rs
@@ -144,6 +144,10 @@ pub struct ChangedEvent {
     pub entity: Entity,
     pub old_head: ca::Head,
     pub new_head: ca::Head,
+    /// The commit the head pointed at before the change, if it resolved.
+    pub old_commit: Option<ca::CommitAddr>,
+    /// The commit the head points at after the change, if it resolves.
+    pub new_commit: Option<ca::CommitAddr>,
     /// Whether the new commit shares the previous commit's graph content
     /// address, i.e. only layout/metadata changed (e.g. a layout undo/redo).
     /// The VM and its node state are preserved across such a change.
@@ -380,13 +384,13 @@ pub fn on_replace<N>(
     let old_graph = old_head
         .as_ref()
         .and_then(|h| registry.head_commit(h).map(|c| c.graph));
+    let new_ca = registry.head_commit_ca(new_head).copied();
     let new_graph = registry.head_commit(new_head).map(|c| c.graph);
     let same_graph = matches!((old_graph, new_graph), (Some(a), Some(b)) if a == b);
     if same_graph {
         cmds.entity(focused_entity)
             .insert((HeadRef(new_head.clone()), WorkingGraph(graph)));
     } else {
-        let new_ca = registry.head_commit_ca(new_head).copied();
         crate::vm::migrate_vm_state(&registry, &mut vms, focused_entity, old_ca, new_ca);
         cmds.entity(focused_entity).insert((
             HeadRef(new_head.clone()),
@@ -401,6 +405,8 @@ pub fn on_replace<N>(
             entity: focused_entity,
             old_head: old,
             new_head: new_head.clone(),
+            old_commit: old_ca,
+            new_commit: new_ca,
             same_graph,
         });
     }
@@ -550,6 +556,8 @@ pub fn on_move_branch<N>(
         entity: event.entity,
         old_head: head.clone(),
         new_head: head,
+        old_commit: old_ca,
+        new_commit: Some(event.target),
         same_graph,
     });
 }

--- a/crates/bevy_gantz/src/head.rs
+++ b/crates/bevy_gantz/src/head.rs
@@ -178,10 +178,12 @@ pub struct CommittedEvent {
 /// VMs are keyed by Entity ID since `Engine` is not `Send`.
 ///
 /// A head's VM owns its graph's runtime node state. Paths that point a head
-/// at a *different* graph (replace, branch move) remove the VM (and reset
-/// [`vm::CompiledInputs`][crate::vm::CompiledInputs]) so that `vm::sync`
-/// performs a fresh init, discarding the old graph's state; in-place edits
-/// leave the VM so recompiles preserve it.
+/// at a *different* graph (replace, branch move - undo/redo and history
+/// navigation) keep the VM and migrate its node state through the commits'
+/// node-identity mapping (see [`vm::migrate_vm_state`][crate::vm::migrate_vm_state]),
+/// resetting [`vm::CompiledInputs`][crate::vm::CompiledInputs] so `vm::sync`
+/// recompiles; in-place edits leave both untouched-but-memoised. The VM is
+/// dropped (fresh init, default state) only when no mapping can be derived.
 #[derive(Default)]
 pub struct HeadVms(pub HashMap<Entity, Engine>);
 
@@ -343,7 +345,7 @@ pub fn on_replace<N>(
     mut vms: NonSendMut<HeadVms>,
     heads: Query<(Entity, &HeadRef), With<OpenHead>>,
 ) where
-    N: 'static + Clone + Send + Sync,
+    N: 'static + Clone + ca::CaHash + Send + Sync,
 {
     let ReplaceEvent(new_head) = trigger.event();
 
@@ -367,9 +369,14 @@ pub fn on_replace<N>(
     // When the new commit shares the old commit's graph content (a layout-only
     // change, e.g. a layout undo/redo), the graph is byte-identical, so keep the
     // VM and its node state and leave the compile memo intact (`vm::sync` then
-    // skips recompilation). Only when the graph actually differs do we drop the
-    // VM and reset the memo so `vm::sync` performs a fresh init.
+    // skips recompilation). When the graph differs, migrate the node state
+    // through the commits' node-identity mapping (state survives navigation
+    // for every node present on both sides) and reset the memo so `vm::sync`
+    // recompiles.
     // Note: HeadGuiState and GraphViews are updated by GantzEguiPlugin observer.
+    let old_ca = old_head
+        .as_ref()
+        .and_then(|h| registry.head_commit_ca(h).copied());
     let old_graph = old_head
         .as_ref()
         .and_then(|h| registry.head_commit(h).map(|c| c.graph));
@@ -379,7 +386,8 @@ pub fn on_replace<N>(
         cmds.entity(focused_entity)
             .insert((HeadRef(new_head.clone()), WorkingGraph(graph)));
     } else {
-        vms.remove(&focused_entity);
+        let new_ca = registry.head_commit_ca(new_head).copied();
+        crate::vm::migrate_vm_state(&registry, &mut vms, focused_entity, old_ca, new_ca);
         cmds.entity(focused_entity).insert((
             HeadRef(new_head.clone()),
             WorkingGraph(graph),
@@ -503,12 +511,14 @@ pub fn on_move_branch<N>(
     mut registry: ResMut<Registry<N>>,
     mut vms: NonSendMut<HeadVms>,
 ) where
-    N: 'static + Clone + Send + Sync,
+    N: 'static + Clone + ca::CaHash + Send + Sync,
 {
     let event = trigger.event();
     let head = ca::Head::Branch(event.name.clone());
-    // Capture the current graph before moving the branch pointer so we can
-    // detect a same-graph move (a layout-only undo/redo) below.
+    // Capture the current commit before moving the branch pointer so we can
+    // detect a same-graph move (a layout-only undo/redo) and migrate node
+    // state below.
+    let old_ca = registry.head_commit_ca(&head).copied();
     let old_graph = registry.head_commit(&head).map(|c| c.graph);
     registry.insert_name(event.name.clone(), event.target);
     let Some(graph) = registry.head_graph(&head).cloned() else {
@@ -517,14 +527,22 @@ pub fn on_move_branch<N>(
     };
     // When the target shares the old commit's graph content (a layout-only
     // change), keep the VM, its node state and the compile memo intact so
-    // `vm::sync` skips recompilation. Otherwise drop the VM and reset the memo
-    // so `vm::sync` performs a fresh init.
+    // `vm::sync` skips recompilation. Otherwise migrate the node state
+    // through the commits' node-identity mapping - undo/redo and history
+    // navigation keep the state of every node present on both sides - and
+    // reset the memo so `vm::sync` recompiles.
     let new_graph = registry.head_commit(&head).map(|c| c.graph);
     let same_graph = matches!((old_graph, new_graph), (Some(a), Some(b)) if a == b);
     if same_graph {
         cmds.entity(event.entity).insert(WorkingGraph(graph));
     } else {
-        vms.remove(&event.entity);
+        crate::vm::migrate_vm_state(
+            &registry,
+            &mut vms,
+            event.entity,
+            old_ca,
+            Some(event.target),
+        );
         cmds.entity(event.entity)
             .insert((WorkingGraph(graph), crate::vm::CompiledInputs::default()));
     }

--- a/crates/bevy_gantz/src/vm.rs
+++ b/crates/bevy_gantz/src/vm.rs
@@ -175,6 +175,74 @@ where
     gantz_core::vm::compile(get_node, graph, vm, entrypoints, config)
 }
 
+/// The node-identity mapping for navigating a head from the `from` commit to
+/// the `to` commit: old node index -> new node index.
+///
+/// Prefers chain-tracked identity (see [`gantz_ca::diff::matching`]) in
+/// whichever direction has a first-parent chain - `to` descending from
+/// `from` (redo) or `from` descending from `to` (undo, inverted) - falling
+/// back to direct content matching for divergent navigation (e.g. across
+/// history-pane jumps). `None` only when an endpoint commit or graph is
+/// missing from the registry.
+pub fn navigation_matching<N>(
+    registry: &ca::Registry<Graph<N>>,
+    from: ca::CommitAddr,
+    to: ca::CommitAddr,
+) -> Option<ca::Matching>
+where
+    N: ca::CaHash,
+{
+    let commits = registry.commits();
+    if ca::history::first_parent_chain_to(commits, to, from).is_some() {
+        ca::diff::matching(registry, from, to)
+    } else if ca::history::first_parent_chain_to(commits, from, to).is_some() {
+        // The chain runs the other way: track identity along it and invert
+        // (matchings are injective).
+        let matching = ca::diff::matching(registry, to, from)?;
+        Some(matching.into_iter().map(|(t, f)| (f, t)).collect())
+    } else {
+        let from_g = registry.commit_graph_ref(&from)?;
+        let to_g = registry.commit_graph_ref(&to)?;
+        Some(ca::diff::match_nodes(from_g, to_g))
+    }
+}
+
+/// Migrate a navigating head's VM node state from the `from` commit's graph
+/// to the `to` commit's, keeping the VM so that every node present on both
+/// sides retains its state (`vm::sync` re-registers the new graph over the
+/// kept VM, initialising only the nodes without state).
+///
+/// The VM is dropped - falling back to a fresh init - only when no mapping
+/// can be derived or the state fails to remap.
+pub fn migrate_vm_state<N>(
+    registry: &ca::Registry<Graph<N>>,
+    vms: &mut head::HeadVms,
+    entity: Entity,
+    from: Option<ca::CommitAddr>,
+    to: Option<ca::CommitAddr>,
+) where
+    N: ca::CaHash,
+{
+    let (Some(from), Some(to)) = (from, to) else {
+        vms.remove(&entity);
+        return;
+    };
+    let Some(vm) = vms.get_mut(&entity) else {
+        return;
+    };
+    match navigation_matching(registry, from, to) {
+        Some(mapping) => {
+            if let Err(e) = gantz_core::node::state::remap_root(vm, &mapping) {
+                log::error!("navigation: failed to remap node state: {e}; reinitialising");
+                vms.remove(&entity);
+            }
+        }
+        None => {
+            vms.remove(&entity);
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Observers
 // ---------------------------------------------------------------------------
@@ -361,5 +429,64 @@ pub fn validate_committed<N>(
                 committed.map(|c| c.display_short().to_string()),
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// A minimal registry: base `[10, 20, 30]`, then a child commit deleting
+    /// index 1 (swap-removal: `[10, 30]`).
+    fn base_and_child() -> (ca::Registry<Graph<u32>>, ca::CommitAddr, ca::CommitAddr) {
+        let mut reg = ca::Registry::default();
+        let mut g = Graph::<u32>::default();
+        for w in [10u32, 20, 30] {
+            g.add_node(w);
+        }
+        let base_ca = ca::graph_addr(&g);
+        let base = reg.commit_graph(Duration::from_secs(1), None, base_ca, || g);
+        let mut g = Graph::<u32>::default();
+        for w in [10u32, 30] {
+            g.add_node(w);
+        }
+        let child_ca = ca::graph_addr(&g);
+        let child = reg.commit_graph(Duration::from_secs(2), Some(base), child_ca, || g);
+        (reg, base, child)
+    }
+
+    #[test]
+    fn navigation_matching_tracks_redo_along_the_chain() {
+        let (reg, base, child) = base_and_child();
+        // Redo direction: base -> child. Index 2 swap-moved to 1; 1 deleted.
+        let m = navigation_matching(&reg, base, child).unwrap();
+        assert_eq!(m, ca::Matching::from([(0, 0), (2, 1)]));
+    }
+
+    #[test]
+    fn navigation_matching_inverts_for_undo() {
+        let (reg, base, child) = base_and_child();
+        // Undo direction: child -> base. The chain runs the other way, so
+        // the tracked matching is inverted: child index 1 returns to 2.
+        let m = navigation_matching(&reg, child, base).unwrap();
+        assert_eq!(m, ca::Matching::from([(0, 0), (1, 2)]));
+    }
+
+    #[test]
+    fn navigation_matching_falls_back_to_content_for_divergent_commits() {
+        let mut reg = ca::Registry::<Graph<u32>>::default();
+        let mut g = Graph::<u32>::default();
+        g.add_node(7);
+        let a_ca = ca::graph_addr(&g);
+        let a = reg.commit_graph(Duration::from_secs(1), None, a_ca, || g);
+        let mut g = Graph::<u32>::default();
+        g.add_node(9);
+        g.add_node(7);
+        let b_ca = ca::graph_addr(&g);
+        let b = reg.commit_graph(Duration::from_secs(2), None, b_ca, || g);
+        // Unrelated commits: direct content matching pairs the equal node.
+        let m = navigation_matching(&reg, a, b).unwrap();
+        assert_eq!(m, ca::Matching::from([(0, 1)]));
     }
 }

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -633,10 +633,10 @@ pub fn on_head_opened<N: 'static + Send + Sync>(
 /// Migrate GUI state for changed head and reset components.
 ///
 /// Loads views for the new head and updates `GraphView` + `HeadGuiState` components.
-pub fn on_head_changed<N: 'static + Send + Sync>(
+pub fn on_head_changed<N: 'static + ca::CaHash + Send + Sync>(
     trigger: On<head::ChangedEvent>,
     registry: Res<Registry<N>>,
-    views: Res<Views>,
+    mut views: ResMut<Views>,
     mut gui_state: ResMut<GuiState>,
     mut ctxs: EguiContexts,
     graph_views: Query<&GraphView>,
@@ -648,11 +648,39 @@ pub fn on_head_changed<N: 'static + Send + Sync>(
         gantz_egui::widget::update_graph_pane_head(ctx, &event.old_head, &event.new_head);
     }
 
-    // Load the view for the new head's commit.
-    let mut head_view = registry
-        .head_commit_ca(&event.new_head)
-        .and_then(|ca| views.get(ca).cloned())
-        .unwrap_or_default();
+    // Load the view for the new head's commit. When the target commit has no
+    // stored view (e.g. a wire-fetched merge tip whose view blob went
+    // missing, or a commit minted by a headless peer), carry the live layout
+    // forward through the navigation node-identity matching rather than
+    // falling back to an empty layout - which the scene would destructively
+    // auto-layout - and seed the store so the commit has a view before any
+    // same-frame session announce.
+    let stored = event.new_commit.and_then(|ca| views.get(&ca).cloned());
+    let mut head_view = match stored {
+        Some(view) => view,
+        None => {
+            let live = graph_views.get(event.entity).ok();
+            let carried = match (live, event.old_commit, event.new_commit) {
+                (Some(live), _, _) if event.same_graph => live.0.clone(),
+                (Some(live), Some(old), Some(new)) => {
+                    let node_count = registry
+                        .commit_graph_ref(&new)
+                        .map(|g| g.node_count())
+                        .unwrap_or(0);
+                    bevy_gantz::vm::navigation_matching(&registry, old, new)
+                        .map(|m| gantz_egui::ops::carry_layout(&live.0, &m, node_count))
+                        .unwrap_or_default()
+                }
+                _ => Default::default(),
+            };
+            if let Some(new) = event.new_commit {
+                if !carried.layout.is_empty() {
+                    views.insert(new, carried.clone());
+                }
+            }
+            carried
+        }
+    };
 
     // Camera is excluded from undo: on a same-graph navigation (a layout
     // undo/redo) keep the live camera rather than restoring the target commit's

--- a/crates/gantz_egui/src/node.rs
+++ b/crates/gantz_egui/src/node.rs
@@ -19,6 +19,7 @@ pub mod inspect;
 pub mod named_ref;
 pub mod plot;
 pub mod ref_ext;
+mod size_sync;
 
 /// Builtin specs for the egui node set.
 pub fn builtins<N>() -> Vec<gantz_core::Builtin<N>>

--- a/crates/gantz_egui/src/node/comment.rs
+++ b/crates/gantz_egui/src/node/comment.rs
@@ -1,5 +1,6 @@
 //! A Comment node for documenting patches.
 
+use super::size_sync::{SizeSync, fitted_size, size_sync_frame};
 use crate::widget::node_inspector;
 use crate::{InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse};
 use gantz_ca::CaHash;
@@ -24,45 +25,6 @@ fn text_hash(text: &str) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::default();
     Hash::hash(&text, &mut hasher);
     hasher.finish()
-}
-
-/// Per-frame size bookkeeping stored in egui temp memory, keyed by the node's
-/// egui id `.with("size_sync")`.
-///
-/// `last_seen` is the node's committed size at the end of the last UI pass: a
-/// mismatch at frame start means the value was replaced *externally* (undo,
-/// collab sync, merge), which must update the display rather than be
-/// clobbered by it. Keyed by node index, so index reuse after a deletion can
-/// leave a stale entry - the mismatch then reads as an external change, which
-/// self-heals (push, no commit).
-#[derive(Clone, Copy)]
-struct SizeSync {
-    last_seen: [u16; 2],
-    was_resizing: bool,
-}
-
-/// The size-sync decisions for one frame: `(push_external, drag_released)`.
-///
-/// - `push_external`: the committed size must be pushed into the displayed
-///   resize state (first frame under this id, or the node value changed
-///   externally). An external change also wins over an in-flight drag.
-/// - `drag_released`: the resize corner was released since the last frame -
-///   the one local interaction (besides a text edit) allowed to write the
-///   committed size.
-fn size_sync_frame(prev: Option<SizeSync>, size: [u16; 2], resizing: bool) -> (bool, bool) {
-    match prev {
-        None => (true, false),
-        Some(prev) => {
-            let push = prev.last_seen != size;
-            let released = !push && prev.was_resizing && !resizing;
-            (push, released)
-        }
-    }
-}
-
-/// The committed form of a rendered size.
-fn fitted_size(width: f32, height: f32) -> [u16; 2] {
-    [width.round() as u16, height.round() as u16]
 }
 
 /// A transparent comment node for documenting graphs.
@@ -370,55 +332,5 @@ mod tests {
             size: [100, 40],
         };
         assert_ne!(content_addr(&a), content_addr(&b));
-    }
-
-    /// The size-sync state machine: external changes always push into the
-    /// display (never commit); a commit-worthy release fires only on a
-    /// clean corner-drag `true -> false` transition.
-    #[test]
-    fn size_sync_frame_decisions() {
-        let sync = |last_seen, was_resizing| {
-            Some(super::SizeSync {
-                last_seen,
-                was_resizing,
-            })
-        };
-        // First frame under this id: push, never commit.
-        assert_eq!(
-            super::size_sync_frame(None, [100, 40], false),
-            (true, false)
-        );
-        // Steady state: nothing to do.
-        assert_eq!(
-            super::size_sync_frame(sync([100, 40], false), [100, 40], false),
-            (false, false)
-        );
-        // External change: push - even mid-drag (external wins, no release).
-        assert_eq!(
-            super::size_sync_frame(sync([100, 40], true), [120, 40], true),
-            (true, false)
-        );
-        // Drag in progress (starting or continuing): no push, no release.
-        assert_eq!(
-            super::size_sync_frame(sync([100, 40], false), [100, 40], true),
-            (false, false)
-        );
-        assert_eq!(
-            super::size_sync_frame(sync([100, 40], true), [100, 40], true),
-            (false, false)
-        );
-        // Release transition: commit-worthy.
-        assert_eq!(
-            super::size_sync_frame(sync([100, 40], true), [100, 40], false),
-            (false, true)
-        );
-    }
-
-    /// Committed sizes round rather than truncate, so two machines whose
-    /// rendered heights straddle an integer don't disagree by a whole unit.
-    #[test]
-    fn fitted_size_rounds() {
-        assert_eq!(super::fitted_size(100.6, 40.4), [101, 40]);
-        assert_eq!(super::fitted_size(100.4, 40.5), [100, 41]);
     }
 }

--- a/crates/gantz_egui/src/node/comment.rs
+++ b/crates/gantz_egui/src/node/comment.rs
@@ -26,6 +26,45 @@ fn text_hash(text: &str) -> u64 {
     hasher.finish()
 }
 
+/// Per-frame size bookkeeping stored in egui temp memory, keyed by the node's
+/// egui id `.with("size_sync")`.
+///
+/// `last_seen` is the node's committed size at the end of the last UI pass: a
+/// mismatch at frame start means the value was replaced *externally* (undo,
+/// collab sync, merge), which must update the display rather than be
+/// clobbered by it. Keyed by node index, so index reuse after a deletion can
+/// leave a stale entry - the mismatch then reads as an external change, which
+/// self-heals (push, no commit).
+#[derive(Clone, Copy)]
+struct SizeSync {
+    last_seen: [u16; 2],
+    was_resizing: bool,
+}
+
+/// The size-sync decisions for one frame: `(push_external, drag_released)`.
+///
+/// - `push_external`: the committed size must be pushed into the displayed
+///   resize state (first frame under this id, or the node value changed
+///   externally). An external change also wins over an in-flight drag.
+/// - `drag_released`: the resize corner was released since the last frame -
+///   the one local interaction (besides a text edit) allowed to write the
+///   committed size.
+fn size_sync_frame(prev: Option<SizeSync>, size: [u16; 2], resizing: bool) -> (bool, bool) {
+    match prev {
+        None => (true, false),
+        Some(prev) => {
+            let push = prev.last_seen != size;
+            let released = !push && prev.was_resizing && !resizing;
+            (push, released)
+        }
+    }
+}
+
+/// The committed form of a rendered size.
+fn fitted_size(width: f32, height: f32) -> [u16; 2] {
+    [width.round() as u16, height.round() as u16]
+}
+
 /// A transparent comment node for documenting graphs.
 ///
 /// Both `text` and `size` are part of the content address: editing the note or
@@ -113,6 +152,7 @@ impl NodeUi for Comment {
         // Use a transparent frame with resizable content
         let node_egui_id = uictx.egui_id();
         let resize_id = node_egui_id.with("resize");
+        let size_sync_id = node_egui_id.with("size_sync");
         let min_resize = egui::Vec2::splat(style.interaction.interact_radius);
         let default_size = egui::vec2(self.size[0] as f32, self.size[1] as f32);
         let framed = uictx.framed_with(frame, |ui, _sockets| {
@@ -131,105 +171,142 @@ impl NodeUi for Comment {
                 ui.ctx().request_repaint();
             }
 
-            egui::containers::Resize::default()
+            let sync: Option<SizeSync> = ui.memory_mut(|m| m.data.get_temp(size_sync_id));
+            let (push_external, drag_released) = size_sync_frame(sync, self.size, resizing);
+
+            let resize = egui::containers::Resize::default()
                 .id(resize_id)
+                .with_stroke(false);
+            let resize = if push_external {
+                // One-frame push of the committed size into the displayed
+                // resize state: `fixed_size` sets min == max == the size, and
+                // egui clamps the *stored* state through min/max on `begin`
+                // and stores it back on `end`, so this overrides persisted
+                // state. It also leaves the corner unregistered this frame,
+                // cancelling any in-flight drag (external changes win).
+                ui.ctx().request_repaint();
+                let w = (self.size[0] as f32).max(min_resize.x);
+                let h = (self.size[1] as f32).max(min_resize.y);
+                resize.fixed_size(egui::vec2(w, h))
+            } else {
                 // Width is user-resizable (and persists). Height auto-fits the
                 // text - except while the corner is actively dragged, when it
                 // follows the cursor and snaps back to fit on release.
-                .resizable(egui::Vec2b::new(
-                    interaction.selected,
-                    interaction.selected && resizing,
-                ))
-                .default_size(default_size)
-                .min_size(min_resize)
-                .with_stroke(false)
-                .show(ui, |ui| {
-                    // The width the user has dragged to; the height auto-fits the
-                    // text below (so we don't read it from `available_size`).
-                    let width = ui.available_width();
+                resize
+                    .resizable(egui::Vec2b::new(
+                        interaction.selected,
+                        interaction.selected && resizing,
+                    ))
+                    .default_size(default_size)
+                    .min_size(min_resize)
+            };
+            let inner = resize.show(ui, |ui| {
+                // The width the user has dragged to; the height auto-fits the
+                // text below (so we don't read it from `available_size`).
+                let width = ui.available_width();
 
-                    let text_id = node_egui_id.with("comment_text");
+                let text_id = node_egui_id.with("comment_text");
 
-                    // Load or initialize the editing state.
-                    let mut state: CommentEditState = ui
-                        .memory_mut(|m| m.data.remove_temp(text_id))
-                        .unwrap_or_default();
+                // Load or initialize the editing state.
+                let mut state: CommentEditState = ui
+                    .memory_mut(|m| m.data.remove_temp(text_id))
+                    .unwrap_or_default();
 
-                    // Sync from node if the node's text changed externally (undo, etc.).
-                    let current_hash = text_hash(&self.text);
-                    if current_hash != state.text_hash {
-                        state.text_hash = current_hash;
-                        state.text = self.text.clone();
+                // Sync from node if the node's text changed externally (undo, etc.).
+                let current_hash = text_hash(&self.text);
+                if current_hash != state.text_hash {
+                    state.text_hash = current_hash;
+                    state.text = self.text.clone();
+                }
+
+                // Render the TextEdit against the buffered string. With
+                // auto-height the box always fits its text, so no scroll
+                // area is needed - the TextEdit reports its wrapped height.
+                let response = ui.add(
+                    egui::TextEdit::multiline(&mut state.text)
+                        .desired_rows(1)
+                        .hint_text("Add comment...")
+                        .frame(egui::Frame::NONE)
+                        .desired_width(f32::INFINITY),
+                );
+
+                // Track when the buffer was last edited.
+                let time = ui.input(|i| i.time);
+                if response.changed() {
+                    state.last_edit_time = time;
+                }
+
+                // Determine whether the buffer has uncommitted changes.
+                let buffer_dirty = text_hash(&state.text) != state.text_hash;
+
+                // Flush conditions:
+                // 1. Focus lost (existing)
+                // 2. 5+ seconds since last edit with dirty buffer
+                // 3. Any mouse activity with dirty buffer
+                let timed_out = buffer_dirty && (time - state.last_edit_time >= 5.0);
+                let mouse_active = buffer_dirty
+                    && ui.input(|i| {
+                        i.pointer.is_moving() || i.pointer.any_pressed() || i.pointer.any_released()
+                    });
+                let should_flush = response.lost_focus() || timed_out || mouse_active;
+
+                let mut text_flushed = false;
+                if should_flush {
+                    // A flush that alters the stored text is a CA edit.
+                    text_flushed = self.text != state.text;
+                    changed |= text_flushed;
+                    self.text = state.text.clone();
+                    state.text_hash = text_hash(&self.text);
+                }
+
+                // Schedule a repaint at the timeout for reactive mode.
+                if buffer_dirty && !should_flush {
+                    let remaining = 10.0 - (time - state.last_edit_time);
+                    if remaining > 0.0 {
+                        ui.ctx()
+                            .request_repaint_after(std::time::Duration::from_secs_f64(remaining));
                     }
+                }
 
-                    // Render the TextEdit against the buffered string. With
-                    // auto-height the box always fits its text, so no scroll
-                    // area is needed - the TextEdit reports its wrapped height.
-                    let response = ui.add(
-                        egui::TextEdit::multiline(&mut state.text)
-                            .desired_rows(1)
-                            .hint_text("Add comment...")
-                            .frame(egui::Frame::NONE)
-                            .desired_width(f32::INFINITY),
-                    );
+                // Persist the editing state.
+                ui.memory_mut(|m| m.data.insert_temp(text_id, state));
 
-                    // Track when the buffer was last edited.
-                    let time = ui.input(|i| i.time);
-                    if response.changed() {
-                        state.last_edit_time = time;
-                    }
+                // The fitted size: the dragged width and the content height
+                // the box auto-fits to. `size` is part of the content
+                // address, so it is written ONLY by genuine local
+                // interaction: (a) a flushed text change (the auto-fit
+                // height rides along), or (b) a settled corner-drag
+                // release. External changes (undo, collab sync) instead
+                // pushed into the resize state above, and a locally
+                // drifting auto-fit height (fonts, DPI, rounding) must
+                // never "correct" the committed value - that would mint
+                // spurious commits and loop between collaborating peers.
+                // The displayed height still auto-fits every frame; the
+                // committed height merely goes advisory-stale until the
+                // next genuine edit.
+                let fitted = fitted_size(width, ui.min_rect().height());
+                let text_committed = text_flushed && !resizing && !push_external;
+                if (text_committed || drag_released) && self.size != fitted {
+                    self.size = fitted;
+                    changed = true;
+                }
 
-                    // Determine whether the buffer has uncommitted changes.
-                    let buffer_dirty = text_hash(&state.text) != state.text_hash;
+                response
+            });
 
-                    // Flush conditions:
-                    // 1. Focus lost (existing)
-                    // 2. 5+ seconds since last edit with dirty buffer
-                    // 3. Any mouse activity with dirty buffer
-                    let timed_out = buffer_dirty && (time - state.last_edit_time >= 5.0);
-                    let mouse_active = buffer_dirty
-                        && ui.input(|i| {
-                            i.pointer.is_moving()
-                                || i.pointer.any_pressed()
-                                || i.pointer.any_released()
-                        });
-                    let should_flush = response.lost_focus() || timed_out || mouse_active;
+            // Persist the sync state *after* any local write, so a local
+            // commit never masquerades as an external change next frame.
+            ui.memory_mut(|m| {
+                m.data.insert_temp(
+                    size_sync_id,
+                    SizeSync {
+                        last_seen: self.size,
+                        was_resizing: if push_external { false } else { resizing },
+                    },
+                )
+            });
 
-                    if should_flush {
-                        // A flush that alters the stored text is a CA edit.
-                        changed |= self.text != state.text;
-                        self.text = state.text.clone();
-                        state.text_hash = text_hash(&self.text);
-                    }
-
-                    // Schedule a repaint at the timeout for reactive mode.
-                    if buffer_dirty && !should_flush {
-                        let remaining = 10.0 - (time - state.last_edit_time);
-                        if remaining > 0.0 {
-                            ui.ctx()
-                                .request_repaint_after(std::time::Duration::from_secs_f64(
-                                    remaining,
-                                ));
-                        }
-                    }
-
-                    // Persist the editing state.
-                    ui.memory_mut(|m| m.data.insert_temp(text_id, state));
-
-                    // The fitted size: the dragged width and the content height
-                    // the box auto-fits to. `size` is part of the content
-                    // address, so only commit it once *settled* - never while
-                    // the corner is actively dragged (which would churn a new
-                    // commit every frame of the drag). On release the height
-                    // snaps back to fit, giving a single settled value.
-                    let new_size = [width as u16, ui.min_rect().height() as u16];
-                    if !resizing && self.size != new_size {
-                        self.size = new_size;
-                        changed = true;
-                    }
-
-                    response
-                })
+            inner
         });
 
         let mut resp = NodeUiResponse::new(framed);
@@ -293,5 +370,55 @@ mod tests {
             size: [100, 40],
         };
         assert_ne!(content_addr(&a), content_addr(&b));
+    }
+
+    /// The size-sync state machine: external changes always push into the
+    /// display (never commit); a commit-worthy release fires only on a
+    /// clean corner-drag `true -> false` transition.
+    #[test]
+    fn size_sync_frame_decisions() {
+        let sync = |last_seen, was_resizing| {
+            Some(super::SizeSync {
+                last_seen,
+                was_resizing,
+            })
+        };
+        // First frame under this id: push, never commit.
+        assert_eq!(
+            super::size_sync_frame(None, [100, 40], false),
+            (true, false)
+        );
+        // Steady state: nothing to do.
+        assert_eq!(
+            super::size_sync_frame(sync([100, 40], false), [100, 40], false),
+            (false, false)
+        );
+        // External change: push - even mid-drag (external wins, no release).
+        assert_eq!(
+            super::size_sync_frame(sync([100, 40], true), [120, 40], true),
+            (true, false)
+        );
+        // Drag in progress (starting or continuing): no push, no release.
+        assert_eq!(
+            super::size_sync_frame(sync([100, 40], false), [100, 40], true),
+            (false, false)
+        );
+        assert_eq!(
+            super::size_sync_frame(sync([100, 40], true), [100, 40], true),
+            (false, false)
+        );
+        // Release transition: commit-worthy.
+        assert_eq!(
+            super::size_sync_frame(sync([100, 40], true), [100, 40], false),
+            (false, true)
+        );
+    }
+
+    /// Committed sizes round rather than truncate, so two machines whose
+    /// rendered heights straddle an integer don't disagree by a whole unit.
+    #[test]
+    fn fitted_size_rounds() {
+        assert_eq!(super::fitted_size(100.6, 40.4), [101, 40]);
+        assert_eq!(super::fitted_size(100.4, 40.5), [100, 41]);
     }
 }

--- a/crates/gantz_egui/src/node/comment.rs
+++ b/crates/gantz_egui/src/node/comment.rs
@@ -1,6 +1,6 @@
 //! A Comment node for documenting patches.
 
-use super::size_sync::{SizeSync, fitted_size, size_sync_frame};
+use super::size_sync::{self, fitted_size};
 use crate::widget::node_inspector;
 use crate::{InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse};
 use gantz_ca::CaHash;
@@ -118,23 +118,11 @@ impl NodeUi for Comment {
         let min_resize = egui::Vec2::splat(style.interaction.interact_radius);
         let default_size = egui::vec2(self.size[0] as f32, self.size[1] as f32);
         let framed = uictx.framed_with(frame, |ui, _sockets| {
-            // `Resize` registers its corner interaction under this salt (egui
-            // 0.34.x internal, see `containers/resize.rs`). Reading the previous
-            // frame's response tells us whether the corner is being dragged.
-            let corner_id = resize_id.with("__resize_corner");
-            let resizing = ui
-                .ctx()
-                .read_response(corner_id)
-                .is_some_and(|r| r.dragged());
-
-            // While dragging, keep requesting repaints so the frame *after*
-            // release - when the height snaps back to fit the text - is drawn.
-            if resizing {
-                ui.ctx().request_repaint();
-            }
-
-            let sync: Option<SizeSync> = ui.memory_mut(|m| m.data.get_temp(size_sync_id));
-            let (push_external, drag_released) = size_sync_frame(sync, self.size, resizing);
+            let size_sync::Decisions {
+                resizing,
+                push_external,
+                drag_released,
+            } = size_sync::begin(ui, size_sync_id, resize_id, self.size);
 
             let resize = egui::containers::Resize::default()
                 .id(resize_id)
@@ -256,17 +244,7 @@ impl NodeUi for Comment {
                 response
             });
 
-            // Persist the sync state *after* any local write, so a local
-            // commit never masquerades as an external change next frame.
-            ui.memory_mut(|m| {
-                m.data.insert_temp(
-                    size_sync_id,
-                    SizeSync {
-                        last_seen: self.size,
-                        was_resizing: if push_external { false } else { resizing },
-                    },
-                )
-            });
+            size_sync::store(ui, size_sync_id, self.size, push_external, resizing);
 
             inner
         });

--- a/crates/gantz_egui/src/node/plot.rs
+++ b/crates/gantz_egui/src/node/plot.rs
@@ -21,7 +21,7 @@
 //! value unchanged (like [`super::Inspect`]), so a value can be observed without
 //! breaking the chain it flows through.
 
-use super::size_sync::{SizeSync, fitted_size, size_sync_frame};
+use super::size_sync::{self, fitted_size};
 use crate::widget::node_inspector;
 use crate::widget::node_inspector::radio_option;
 use crate::{
@@ -507,20 +507,11 @@ impl NodeUi for Plot {
 
         let size_sync_id = node_egui_id.with("size_sync");
         let framed = uictx.framed_with(frame, |ui, _sockets| {
-            // `Resize` registers its corner under this salt; reading last frame's
-            // response tells us whether it is being actively dragged.
-            let corner_id = resize_id.with("__resize_corner");
-            let resizing = ui
-                .ctx()
-                .read_response(corner_id)
-                .is_some_and(|r| r.dragged());
-            if resizing {
-                ui.ctx().request_repaint();
-            }
-
-            let sync: Option<SizeSync> = ui.memory_mut(|m| m.data.get_temp(size_sync_id));
-            let (push_external, drag_released) =
-                size_sync_frame(sync, [self.width, self.height], resizing);
+            let size_sync::Decisions {
+                resizing,
+                push_external,
+                drag_released,
+            } = size_sync::begin(ui, size_sync_id, resize_id, [self.width, self.height]);
 
             let resize = egui::containers::Resize::default()
                 .id(resize_id)
@@ -558,17 +549,13 @@ impl NodeUi for Plot {
                 self.plot_body(&ys, plot_id, avail, ui)
             });
 
-            // Persist the sync state *after* any local write, so a local
-            // commit never masquerades as an external change next frame.
-            ui.memory_mut(|m| {
-                m.data.insert_temp(
-                    size_sync_id,
-                    SizeSync {
-                        last_seen: [self.width, self.height],
-                        was_resizing: if push_external { false } else { resizing },
-                    },
-                )
-            });
+            size_sync::store(
+                ui,
+                size_sync_id,
+                [self.width, self.height],
+                push_external,
+                resizing,
+            );
 
             inner
         });

--- a/crates/gantz_egui/src/node/plot.rs
+++ b/crates/gantz_egui/src/node/plot.rs
@@ -21,6 +21,7 @@
 //! value unchanged (like [`super::Inspect`]), so a value can be observed without
 //! breaking the chain it flows through.
 
+use super::size_sync::{SizeSync, fitted_size, size_sync_frame};
 use crate::widget::node_inspector;
 use crate::widget::node_inspector::radio_option;
 use crate::{
@@ -504,6 +505,7 @@ impl NodeUi for Plot {
         // Read the series once, up-front (only borrows `ctx`).
         let ys = series(&ctx);
 
+        let size_sync_id = node_egui_id.with("size_sync");
         let framed = uictx.framed_with(frame, |ui, _sockets| {
             // `Resize` registers its corner under this salt; reading last frame's
             // response tells us whether it is being actively dragged.
@@ -516,30 +518,59 @@ impl NodeUi for Plot {
                 ui.ctx().request_repaint();
             }
 
-            // Both axes are user-resizable while the node is selected.
-            let resizable = egui::Vec2b::new(interaction.selected, interaction.selected);
-            egui::containers::Resize::default()
+            let sync: Option<SizeSync> = ui.memory_mut(|m| m.data.get_temp(size_sync_id));
+            let (push_external, drag_released) =
+                size_sync_frame(sync, [self.width, self.height], resizing);
+
+            let resize = egui::containers::Resize::default()
                 .id(resize_id)
-                .resizable(resizable)
-                .default_size(default_size)
-                .min_size(min_size)
-                .with_stroke(false)
-                .show(ui, |ui| {
-                    let avail = ui.available_size();
+                .with_stroke(false);
+            let resize = if push_external {
+                // One-frame push of the committed size into the displayed
+                // resize state (see `node::size_sync`): overrides persisted
+                // state and cancels any in-flight drag - external wins.
+                ui.ctx().request_repaint();
+                let w = (self.width as f32).max(min_size.x);
+                let h = (self.height as f32).max(min_size.y);
+                resize.fixed_size(egui::vec2(w, h))
+            } else {
+                // Both axes are user-resizable while the node is selected.
+                let resizable = egui::Vec2b::new(interaction.selected, interaction.selected);
+                resize
+                    .resizable(resizable)
+                    .default_size(default_size)
+                    .min_size(min_size)
+            };
+            let inner = resize.show(ui, |ui| {
+                let avail = ui.available_size();
 
-                    // `size` is part of the content address, so only commit it
-                    // once *settled* - never mid-drag, which would churn a commit
-                    // every frame.
-                    let new_w = avail.x.max(min_size.x).round() as u16;
-                    let new_h = avail.y.max(min_size.y).round() as u16;
-                    if !resizing && (self.width != new_w || self.height != new_h) {
-                        self.width = new_w;
-                        self.height = new_h;
-                        changed = true;
-                    }
+                // `size` is part of the content address, so it is written
+                // only on a settled corner-drag release - never mid-drag
+                // (a commit per drag frame), and never merely because the
+                // rendered size differs (which would clobber external
+                // changes from undo/collab sync and mint spurious commits).
+                let fitted = fitted_size(avail.x.max(min_size.x), avail.y.max(min_size.y));
+                if drag_released && [self.width, self.height] != fitted {
+                    [self.width, self.height] = fitted;
+                    changed = true;
+                }
 
-                    self.plot_body(&ys, plot_id, avail, ui)
-                })
+                self.plot_body(&ys, plot_id, avail, ui)
+            });
+
+            // Persist the sync state *after* any local write, so a local
+            // commit never masquerades as an external change next frame.
+            ui.memory_mut(|m| {
+                m.data.insert_temp(
+                    size_sync_id,
+                    SizeSync {
+                        last_seen: [self.width, self.height],
+                        was_resizing: if push_external { false } else { resizing },
+                    },
+                )
+            });
+
+            inner
         });
 
         let mut resp = NodeUiResponse::new(framed);

--- a/crates/gantz_egui/src/node/size_sync.rs
+++ b/crates/gantz_egui/src/node/size_sync.rs
@@ -26,23 +26,80 @@
 /// leave a stale entry - the mismatch then reads as an external change,
 /// which self-heals (push, no commit).
 #[derive(Clone, Copy)]
-pub(crate) struct SizeSync {
-    pub last_seen: [u16; 2],
-    pub was_resizing: bool,
+struct SizeSync {
+    last_seen: [u16; 2],
+    was_resizing: bool,
 }
 
-/// The size-sync decisions for one frame: `(push_external, drag_released)`.
+/// The per-frame size-sync decisions (see [`begin`]).
 ///
+/// - `resizing`: the resize corner is actively dragged this frame.
 /// - `push_external`: the committed size must be pushed into the displayed
 ///   resize state (first frame under this id, or the node value changed
 ///   externally). An external change also wins over an in-flight drag.
 /// - `drag_released`: the resize corner was released since the last frame -
 ///   the interaction allowed to write the committed size.
-pub(crate) fn size_sync_frame(
-    prev: Option<SizeSync>,
+#[derive(Clone, Copy)]
+pub(crate) struct Decisions {
+    pub resizing: bool,
+    pub push_external: bool,
+    pub drag_released: bool,
+}
+
+/// Begin a frame: read whether the resize corner is dragged (requesting
+/// repaints while it is, so the post-release snap frame draws), load the
+/// stored sync state and derive this frame's [`Decisions`] against the
+/// committed `size`.
+///
+/// `resize_id` is the id of the node's `egui::containers::Resize`; the
+/// corner interaction registers under its `"__resize_corner"` salt (egui
+/// 0.34.x internal, see `containers/resize.rs`).
+pub(crate) fn begin(
+    ui: &egui::Ui,
+    sync_id: egui::Id,
+    resize_id: egui::Id,
     size: [u16; 2],
+) -> Decisions {
+    let corner_id = resize_id.with("__resize_corner");
+    let resizing = ui
+        .ctx()
+        .read_response(corner_id)
+        .is_some_and(|r| r.dragged());
+    if resizing {
+        ui.ctx().request_repaint();
+    }
+    let prev: Option<SizeSync> = ui.memory_mut(|m| m.data.get_temp(sync_id));
+    let (push_external, drag_released) = size_sync_frame(prev, size, resizing);
+    Decisions {
+        resizing,
+        push_external,
+        drag_released,
+    }
+}
+
+/// Persist the sync state at the end of the frame, *after* any local write,
+/// so a local commit never masquerades as an external change next frame.
+pub(crate) fn store(
+    ui: &egui::Ui,
+    sync_id: egui::Id,
+    size: [u16; 2],
+    push_external: bool,
     resizing: bool,
-) -> (bool, bool) {
+) {
+    ui.memory_mut(|m| {
+        m.data.insert_temp(
+            sync_id,
+            SizeSync {
+                last_seen: size,
+                was_resizing: if push_external { false } else { resizing },
+            },
+        )
+    });
+}
+
+/// The pure size-sync decisions for one frame: `(push_external,
+/// drag_released)` (see [`Decisions`]).
+fn size_sync_frame(prev: Option<SizeSync>, size: [u16; 2], resizing: bool) -> (bool, bool) {
     match prev {
         None => (true, false),
         Some(prev) => {

--- a/crates/gantz_egui/src/node/size_sync.rs
+++ b/crates/gantz_egui/src/node/size_sync.rs
@@ -1,0 +1,111 @@
+//! Committed-size synchronisation for resizable node bodies (comment, plot).
+//!
+//! A node's committed size is part of its content address, while the
+//! *displayed* size lives in egui's persisted `Resize` state. Left
+//! unreconciled, the two feed back: external changes (undo, collab sync,
+//! merge) neither display nor survive - the next frame overwrites them from
+//! the local layout and mints a spurious commit - and collaborating peers
+//! whose rendered sizes round differently "correct" each other in an endless
+//! commit ping-pong.
+//!
+//! [`size_sync_frame`] is the per-frame state machine both nodes share:
+//! external changes *push* into the display (a one-frame
+//! `Resize::fixed_size` container - egui clamps persisted state through
+//! min/max and stores it back, overriding stale state) and never commit; the
+//! committed size is written only by genuine local interaction (a settled
+//! resize-corner release, or a node-specific edit such as a comment text
+//! flush).
+
+/// Per-frame size bookkeeping stored in egui temp memory, keyed by the
+/// node's egui id `.with("size_sync")`.
+///
+/// `last_seen` is the node's committed size at the end of the last UI pass:
+/// a mismatch at frame start means the value was replaced *externally*
+/// (undo, collab sync, merge), which must update the display rather than be
+/// clobbered by it. Keyed by node index, so index reuse after a deletion can
+/// leave a stale entry - the mismatch then reads as an external change,
+/// which self-heals (push, no commit).
+#[derive(Clone, Copy)]
+pub(crate) struct SizeSync {
+    pub last_seen: [u16; 2],
+    pub was_resizing: bool,
+}
+
+/// The size-sync decisions for one frame: `(push_external, drag_released)`.
+///
+/// - `push_external`: the committed size must be pushed into the displayed
+///   resize state (first frame under this id, or the node value changed
+///   externally). An external change also wins over an in-flight drag.
+/// - `drag_released`: the resize corner was released since the last frame -
+///   the interaction allowed to write the committed size.
+pub(crate) fn size_sync_frame(
+    prev: Option<SizeSync>,
+    size: [u16; 2],
+    resizing: bool,
+) -> (bool, bool) {
+    match prev {
+        None => (true, false),
+        Some(prev) => {
+            let push = prev.last_seen != size;
+            let released = !push && prev.was_resizing && !resizing;
+            (push, released)
+        }
+    }
+}
+
+/// The committed form of a rendered size: rounded rather than truncated, so
+/// two machines whose rendered sizes straddle an integer don't disagree by a
+/// whole unit.
+pub(crate) fn fitted_size(width: f32, height: f32) -> [u16; 2] {
+    [width.round() as u16, height.round() as u16]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The size-sync state machine: external changes always push into the
+    /// display (never commit); a commit-worthy release fires only on a
+    /// clean corner-drag `true -> false` transition.
+    #[test]
+    fn size_sync_frame_decisions() {
+        let sync = |last_seen, was_resizing| {
+            Some(SizeSync {
+                last_seen,
+                was_resizing,
+            })
+        };
+        // First frame under this id: push, never commit.
+        assert_eq!(size_sync_frame(None, [100, 40], false), (true, false));
+        // Steady state: nothing to do.
+        assert_eq!(
+            size_sync_frame(sync([100, 40], false), [100, 40], false),
+            (false, false)
+        );
+        // External change: push - even mid-drag (external wins, no release).
+        assert_eq!(
+            size_sync_frame(sync([100, 40], true), [120, 40], true),
+            (true, false)
+        );
+        // Drag in progress (starting or continuing): no push, no release.
+        assert_eq!(
+            size_sync_frame(sync([100, 40], false), [100, 40], true),
+            (false, false)
+        );
+        assert_eq!(
+            size_sync_frame(sync([100, 40], true), [100, 40], true),
+            (false, false)
+        );
+        // Release transition: commit-worthy.
+        assert_eq!(
+            size_sync_frame(sync([100, 40], true), [100, 40], false),
+            (false, true)
+        );
+    }
+
+    #[test]
+    fn fitted_size_rounds() {
+        assert_eq!(fitted_size(100.6, 40.4), [101, 40]);
+        assert_eq!(fitted_size(100.4, 40.5), [100, 41]);
+    }
+}

--- a/crates/gantz_egui/src/ops.rs
+++ b/crates/gantz_egui/src/ops.rs
@@ -532,6 +532,44 @@ pub fn redo(
     redo_stacks.get_mut(head)?.pop()
 }
 
+/// Build a view for a navigation target commit that has no stored view by
+/// carrying the live view's node positions forward through the navigation
+/// node-identity `matching` (old index -> new index), keeping the live
+/// camera.
+///
+/// Nodes of the new graph absent from the matching (e.g. merged-in from a
+/// peer) are placed in a cascade from the camera centre. An empty live
+/// layout, or a matching that
+/// carries no positions at all, yields an empty result: the scene's one-shot
+/// auto-layout is the right treatment for a genuinely layoutless graph (e.g.
+/// a join placeholder), not a cascade of every node.
+pub fn carry_layout(
+    live: &crate::SceneView,
+    matching: &gantz_ca::Matching,
+    new_node_count: usize,
+) -> crate::SceneView {
+    let node_id = |ix: usize| egui_graph::NodeId::from_u64(ix as u64);
+    let mut view = crate::SceneView {
+        camera: live.camera,
+        layout: Default::default(),
+    };
+    for (&old_ix, &new_ix) in matching {
+        if let Some(pos) = live.layout.get(&node_id(old_ix)) {
+            view.layout.insert(node_id(new_ix), *pos);
+        }
+    }
+    if view.layout.is_empty() {
+        return view;
+    }
+    let unmapped: Vec<usize> = (0..new_node_count)
+        .filter(|&ix| !view.layout.contains_key(&node_id(ix)))
+        .collect();
+    for (i, ix) in unmapped.into_iter().enumerate() {
+        let pos = view.camera.center + egui::vec2(20.0, 20.0) * i as f32;
+        view.layout.insert(node_id(ix), pos);
+    }
+    view
+}
 /// The result of a [`merge_head`] call.
 #[derive(Debug)]
 pub enum MergeHeadOutcome {
@@ -771,6 +809,59 @@ mod tests {
             selection.nodes.iter().copied().collect::<Vec<_>>(),
             vec![NodeIx::new(1)],
         );
+    }
+
+    // carry_layout maps live positions through the navigation matching, keeps
+    // the camera, and cascades unmapped new nodes from the camera centre.
+    #[test]
+    fn carry_layout_remaps_and_places_new_nodes() {
+        let mut live = crate::SceneView::default();
+        live.camera.center = egui::pos2(100.0, 50.0);
+        live.layout.insert(node_id(0), egui::pos2(1.0, 1.0));
+        live.layout.insert(node_id(1), egui::pos2(2.0, 2.0));
+        live.layout.insert(node_id(2), egui::pos2(3.0, 3.0));
+
+        // 0 -> 1, 2 -> 0 (a swap-style remap); live node 1 was removed; the
+        // new graph has an extra node at index 2 with no provenance.
+        let matching: gantz_ca::Matching = [(0, 1), (2, 0)].into_iter().collect();
+        let view = carry_layout(&live, &matching, 3);
+
+        assert_eq!(view.camera, live.camera);
+        assert_eq!(view.layout.len(), 3);
+        assert_eq!(
+            view.layout.get(&node_id(1)).copied(),
+            Some(egui::pos2(1.0, 1.0))
+        );
+        assert_eq!(
+            view.layout.get(&node_id(0)).copied(),
+            Some(egui::pos2(3.0, 3.0))
+        );
+        // The unmapped new node cascades from the camera centre.
+        assert_eq!(
+            view.layout.get(&node_id(2)).copied(),
+            Some(egui::pos2(100.0, 50.0))
+        );
+    }
+
+    // An empty live layout carries nothing: the scene's one-shot auto-layout
+    // is the right treatment for a genuinely layoutless graph.
+    #[test]
+    fn carry_layout_empty_live_yields_empty() {
+        let live = crate::SceneView::default();
+        let matching: gantz_ca::Matching = [(0, 0)].into_iter().collect();
+        let view = carry_layout(&live, &matching, 4);
+        assert!(view.layout.is_empty());
+    }
+
+    // When the matching carries no positions at all, the result stays empty
+    // rather than cascading every node from the camera centre.
+    #[test]
+    fn carry_layout_no_carried_positions_yields_empty() {
+        let mut live = crate::SceneView::default();
+        live.layout.insert(node_id(5), egui::pos2(1.0, 1.0));
+        let matching = gantz_ca::Matching::new();
+        let view = carry_layout(&live, &matching, 3);
+        assert!(view.layout.is_empty());
     }
 
     /// A minimal node type satisfying [`merge_head`]'s bounds.


### PR DESCRIPTION
A collection of fixes improving editor resilience across navigation, undo/redo, and size synchronisation.

## Changes

### Preserve VM node state across undo/redo and navigation
Navigating to a different-graph commit (undo, redo, history pane) previously dropped the VM and reinitialised every node's state to defaults. Now the VM is kept and node state is migrated through a new `vm::navigation_matching` function that prefers chain-tracked identity (for undo/redo) with a content-matching fallback for divergent jumps.

### Carry live layout forward on viewless navigation
When a head changes to a commit with no stored view (e.g. a wire-fetched merge tip or a headless peer's commit), the live scene layout is now carried forward via node-identity matching rather than falling back to an empty layout that triggers destructive auto-layout. A new `ops::carry_layout` function maps positions through the matching and cascades unmapped new nodes from the camera centre.

### Fix plot size writes to interaction-only discipline
The plot body no longer writes committed size on every frame - it only commits when a resize corner is genuinely released (same discipline as comments).

### Fix comment size writes to interaction-only discipline
Similarly, the comment body no longer overwrites the committed size every frame. Size changes are now deferred until a text flush interaction.

### Refactor `size_sync` begin/store
The shared-frame size sync plumbing in `begin()` and `store()` is absorbed into a single `size_sync_frame` call, simplifying the per-frame state machine used by both comment and plot nodes.

### `ChangedEvent` carries old/new commit addresses
`head::ChangedEvent` now exposes `old_commit` and `new_commit` fields, which the layout-carry logic above relies on.

## Related

Addresses layout loss and node state resets that occur when navigating between commits or undoing/deleting. Also prevents the endless commit ping-pong between collaborating peers with differing rendered sizes on resizable nodes.