### PR TITLE
feat: Support for DSP input implicit summing, introduce `~sum` as an explicit option

### DIFF
--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -51,6 +51,7 @@ gantz_format::impl_node_set_serde! {
         gantz_plyphon::Lag,
         gantz_plyphon::ScopeOut,
         gantz_plyphon::Pack,
+        gantz_plyphon::Sum,
         gantz_plyphon::Unpack,
         gantz_plyphon::Bus,
     }
@@ -193,6 +194,7 @@ mod tests {
             "~pack",
             "~scopeout",
             "~sinosc",
+            "~sum",
             "~unpack",
         ];
         let builtins = super::builtins();
@@ -320,6 +322,8 @@ mod tests {
             ),
             node_datum("Pack", vec![]),
             node_datum("Pack", vec![("count", Datum::U64(4))]),
+            node_datum("Sum", vec![]),
+            node_datum("Sum", vec![("count", Datum::U64(4))]),
             node_datum("Unpack", vec![]),
             node_datum("Unpack", vec![("count", Datum::U64(4))]),
             node_datum("Bus", vec![]),
@@ -424,7 +428,7 @@ mod tests {
         use gantz_format::{NodeSugar, Sugar, to_datum};
 
         let sugar = <Box<dyn Node> as NodeSugar>::sugar();
-        let cases: [(Box<dyn Node>, &str, &str); 7] = [
+        let cases: [(Box<dyn Node>, &str, &str); 8] = [
             (
                 Box::new(gantz_plyphon::SinOsc::default()),
                 "SinOsc",
@@ -438,6 +442,7 @@ mod tests {
                 "~scopeout",
             ),
             (Box::new(gantz_plyphon::Pack::default()), "Pack", "~pack"),
+            (Box::new(gantz_plyphon::Sum::default()), "Sum", "~sum"),
             (
                 Box::new(gantz_plyphon::Unpack::default()),
                 "Unpack",

--- a/crates/gantz_plyphon/src/builtin.rs
+++ b/crates/gantz_plyphon/src/builtin.rs
@@ -1,6 +1,6 @@
 //! Builtin specs for the DSP node set.
 
-use crate::node::{Bus, Lag, Out, Pack, ScopeOut, SinOsc, Unpack};
+use crate::node::{Bus, Lag, Out, Pack, ScopeOut, SinOsc, Sum, Unpack};
 use gantz_core::{Builtin, FromNode};
 
 /// Builtin specs for the DSP node set.
@@ -12,6 +12,7 @@ where
         + FromNode<Pack>
         + FromNode<ScopeOut>
         + FromNode<SinOsc>
+        + FromNode<Sum>
         + FromNode<Unpack>,
 {
     vec![
@@ -21,6 +22,7 @@ where
         Builtin::new("~pack", || N::from_node(Pack::default())),
         Builtin::new("~scopeout", || N::from_node(ScopeOut::default())),
         Builtin::new("~sinosc", || N::from_node(SinOsc::default())),
+        Builtin::new("~sum", || N::from_node(Sum::default())),
         Builtin::new("~unpack", || N::from_node(Unpack::default())),
     ]
 }

--- a/crates/gantz_plyphon/src/compile.rs
+++ b/crates/gantz_plyphon/src/compile.rs
@@ -13,7 +13,9 @@ use gantz_core::compile::pull_eval_order;
 use gantz_core::node::Conns;
 use gantz_core::node::graph::{Graph, NodeIx};
 
-use crate::dsp::{DspBuilder, GainRef, ParamBinding, ScopeOutBinding, Signal, ToNodeDsp};
+use crate::dsp::{
+    DspBuilder, GainRef, ParamBinding, ScopeOutBinding, Signal, ToNodeDsp, sum_signals,
+};
 
 /// An error deriving a synthdef from a graph.
 #[derive(Debug)]
@@ -41,6 +43,9 @@ pub struct BusBinding {
     /// The `~bus` node's path - the driver's bus-allocation key. Consecutive
     /// buses alias (a `~bus` fed directly by another `~bus` shares the upstream
     /// bus), so reads name the *effective* upstream node's path.
+    ///
+    /// For an implicit endpoint bus (see [`output`](Self::output)) this is the
+    /// endpoint *source* node's path instead.
     pub node_path: Vec<usize>,
     /// The bus's channel count - the boundary signal's width.
     pub channels: usize,
@@ -50,6 +55,23 @@ pub struct BusBinding {
     /// The no-lag control param the driver sets to the allocated bus channel
     /// via `set_control` after spawning.
     pub param: usize,
+    /// `None` for a classic single-writer `~bus` (keyed by the effective bus
+    /// node). `Some(port)` for an *implicit endpoint bus*: when a boundary's
+    /// source chain fans out (several summands feed it), the `~bus` keeps only
+    /// its cut role and each transitive endpoint gets its own single-writer
+    /// bus, keyed by the endpoint source's path + output port. Readers emit
+    /// one `In` per endpoint and sum them.
+    pub output: Option<usize>,
+}
+
+/// A cross-region bus identity within [`derive_synthdefs`]: a classic
+/// single-writer `~bus` chain (keyed by the effective bus node), or an
+/// implicit per-endpoint bus where the chain fans out (keyed by the endpoint
+/// source node + output port). See [`BusBinding::output`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum RegionBus {
+    Bus(NodeIx),
+    Src(NodeIx, usize),
 }
 
 /// One region of a boundary-cut graph: its derived synthdef + bindings, plus
@@ -120,8 +142,15 @@ pub struct Derived {
 /// carrying its original nested path via [`ToNodeDsp::node_path`]) before
 /// derivation runs.
 ///
-/// Phase-1 limitations: a single edge per DSP input (no summing) and acyclic
-/// graphs only (no feedback).
+/// Multiple edges into one dsp input *sum*: the input's value is the
+/// unity-gain mix of every incoming edge ([`sum_signals`]) - the result is as
+/// wide as the widest summand, a mono summand broadcasts across every channel
+/// and a narrower one contributes silence past its own width. Summands take a
+/// canonical order (sorted by source node path + output port), so the derived
+/// def is independent of edge insertion order. A single edge passes through
+/// unit-free.
+///
+/// Phase-1 limitation: acyclic graphs only (no feedback).
 pub fn derive_synthdef<N>(
     graph: &Graph<N>,
     out_channels: usize,
@@ -153,10 +182,13 @@ where
         };
         let inputs: Vec<Signal> = sources[&n]
             .iter()
-            .map(|src| {
-                src.and_then(|(s, port)| outputs.get(&s).and_then(|o| o.get(port)).cloned())
-                    // Unconnected inputs default to mono silence.
-                    .unwrap_or_else(|| Signal::silent(1))
+            .map(|summands| {
+                let sigs: Vec<Signal> = summands
+                    .iter()
+                    .filter_map(|&(s, port)| outputs.get(&s).and_then(|o| o.get(port)).cloned())
+                    .collect();
+                // An unconnected input sums to mono silence.
+                sum_signals(&mut builder, &sigs)
             })
             .collect();
         let outs = dsp.ugens(&graph[n].node_path(n.index()), &inputs, &mut builder);
@@ -210,32 +242,31 @@ fn dsp_reachable<N: ToNodeDsp>(graph: &Graph<N>, sinks: &[NodeIx]) -> HashSet<No
     reachable
 }
 
-/// The winning `(source node, output port)` per dsp input of every reachable
-/// node: only reachable dsp sources contribute, and the *first-added* edge to
-/// an input wins (no summing of multiple sources yet) - `edges_directed`
-/// iterates newest-edge-first, so the reversed pass makes the oldest edge
-/// authoritative.
+/// The summand `(source node, output port)`s per dsp input of every reachable
+/// node: only reachable dsp sources contribute, every edge into an input is a
+/// summand (an empty list = unconnected), and summands take a canonical order
+/// (sorted by source node path + output port, duplicates kept) so the derived
+/// def is independent of edge insertion order.
 #[allow(clippy::type_complexity)]
 fn resolved_sources<N: ToNodeDsp>(
     graph: &Graph<N>,
     reachable: &HashSet<NodeIx>,
-) -> HashMap<NodeIx, Vec<Option<(NodeIx, usize)>>> {
+) -> HashMap<NodeIx, Vec<Vec<(NodeIx, usize)>>> {
     reachable
         .iter()
         .map(|&n| {
             let n_dsp_in = graph[n].to_node_dsp().map_or(0, |d| d.n_dsp_inputs());
-            let mut inputs: Vec<Option<(NodeIx, usize)>> = vec![None; n_dsp_in];
-            let edges: Vec<_> = graph.edges_directed(n, Direction::Incoming).collect();
-            for e in edges.into_iter().rev() {
+            let mut inputs: Vec<Vec<(NodeIx, usize)>> = vec![Vec::new(); n_dsp_in];
+            for e in graph.edges_directed(n, Direction::Incoming) {
                 let input_ix = e.weight().input.0 as usize;
                 let s = e.source();
-                if input_ix < n_dsp_in
-                    && inputs[input_ix].is_none()
-                    && reachable.contains(&s)
-                    && graph[s].to_node_dsp().is_some()
+                if input_ix < n_dsp_in && reachable.contains(&s) && graph[s].to_node_dsp().is_some()
                 {
-                    inputs[input_ix] = Some((s, e.weight().output.0 as usize));
+                    inputs[input_ix].push((s, e.weight().output.0 as usize));
                 }
+            }
+            for summands in &mut inputs {
+                summands.sort_by_cached_key(|&(s, port)| (graph[s].node_path(s.index()), port));
             }
             (n, inputs)
         })
@@ -280,11 +311,15 @@ pub(crate) fn merged_pull_order<N: ToNodeDsp>(
 ///
 /// A boundary whose two sides share a region lowers to a plain wire. A
 /// boundary fed directly by another boundary *aliases* it (no relay def, no
-/// extra latency). An unconnected boundary reads as mono silence. A region is
-/// derived only if it feeds a sink transitively. Bus writes are lifted to audio
-/// rate ([`DspBuilder::ensure_audio`]) and fade-gained (the crossfade lever,
-/// [`DspBuilder::push_fade_gain`]). Widths flow forward across boundaries -
-/// hence the topological derivation order. Defs are named
+/// extra latency). An unconnected boundary reads as mono silence. A boundary
+/// fed by *several* summands keeps only its cut role: each transitive endpoint
+/// writes its own implicit single-writer bus ([`BusBinding::output`]) and
+/// every reader emits one `In` per endpoint, summing after the reads
+/// ([`sum_signals`] - so mono-broadcast reconciles on materialized signals). A
+/// region is derived only if it feeds a sink transitively. Bus writes are
+/// lifted to audio rate ([`DspBuilder::ensure_audio`]) and fade-gained (the
+/// crossfade lever, [`DspBuilder::push_fade_gain`]). Widths flow forward
+/// across boundaries - hence the topological derivation order. Defs are named
 /// `<name_prefix>-<region key>`.
 pub fn derive_synthdefs<N>(
     graph: &Graph<N>,
@@ -304,7 +339,7 @@ where
         |n: NodeIx| -> bool { graph[n].to_node_dsp().is_some_and(|d| d.is_boundary()) };
 
     // Regions: connected components of the reachable NON-boundary nodes over
-    // their winning dsp edges (edges into or out of a boundary never join).
+    // their dsp edges (edges into or out of a boundary never join).
     let mut comp: HashMap<NodeIx, usize> = HashMap::new();
     let mut n_comps = 0;
     for start in graph.node_indices() {
@@ -316,21 +351,24 @@ where
         comp.insert(start, id);
         let mut stack = vec![start];
         while let Some(n) = stack.pop() {
-            // Upstream: this node's winning sources.
+            // Upstream: this node's summand sources.
             for &(s, _) in sources[&n].iter().flatten() {
                 if !is_boundary(s) && comp.insert(s, id).is_none() {
                     stack.push(s);
                 }
             }
-            // Downstream: reachable non-boundary consumers whose winning source
-            // for that input is this node.
+            // Downstream: reachable non-boundary consumers with this node
+            // among that input's summands.
             for e in graph.edges_directed(n, Direction::Outgoing) {
                 let t = e.target();
                 if !reachable.contains(&t) || is_boundary(t) || comp.contains_key(&t) {
                     continue;
                 }
                 let input_ix = e.weight().input.0 as usize;
-                if sources[&t].get(input_ix).copied().flatten().map(|(s, _)| s) == Some(n) {
+                let among = sources[&t]
+                    .get(input_ix)
+                    .is_some_and(|ss| ss.iter().any(|&(s, _)| s == n));
+                if among {
                     comp.insert(t, id);
                     stack.push(t);
                 }
@@ -338,8 +376,14 @@ where
         }
     }
 
-    // Each boundary's *effective* bus (consecutive boundaries alias) and that
-    // bus's winning source. A pure boundary cycle degrades to an unsourced bus.
+    // Boundary lowering. A *pure* single-summand chain of boundaries keeps the
+    // classic single-writer bus identity: consecutive buses alias, keyed by the
+    // *effective* (top-most) bus node. A boundary whose chain fans out keeps
+    // only its cut role: each transitive non-boundary endpoint gets its own
+    // implicit single-writer bus and readers sum after their `In`s (width
+    // reconciliation needs locally materialized signals - a writer cannot know
+    // the sum's final width at its own derive time). A pure boundary cycle
+    // degrades to an unsourced (silent) bus.
     let boundaries: Vec<NodeIx> = graph
         .node_indices()
         .filter(|&n| reachable.contains(&n) && is_boundary(n))
@@ -347,7 +391,7 @@ where
     let effective = |b: NodeIx| -> NodeIx {
         let mut cur = b;
         let mut visited = HashSet::new();
-        while let Some(&(s, _)) = sources[&cur].first().and_then(|o| o.as_ref()) {
+        while let Some(&[(s, _)]) = sources[&cur].first().map(|v| v.as_slice()) {
             if !is_boundary(s) || !visited.insert(cur) {
                 break;
             }
@@ -355,18 +399,51 @@ where
         }
         cur
     };
-    // The effective bus's source, unless it is itself a boundary (a cycle).
-    let bus_source = |b: NodeIx| -> Option<(NodeIx, usize)> {
-        sources[&effective(b)]
-            .first()
-            .copied()
-            .flatten()
-            .filter(|&(s, _)| !is_boundary(s))
+    // The classic case: the effective bus's lone summand is a non-boundary
+    // source (every hop of the chain had exactly one). `None` = the chain fans
+    // out somewhere, is unsourced, or is a pure bus cycle.
+    let classic_source = |b: NodeIx| -> Option<(NodeIx, usize)> {
+        match sources[&effective(b)].first().map(|v| v.as_slice()) {
+            Some(&[(s, port)]) if !is_boundary(s) => Some((s, port)),
+            _ => None,
+        }
+    };
+    // Every transitive non-boundary endpoint feeding `b`, canonical order,
+    // duplicates kept (each is a summand). Empty = unsourced (silence).
+    let bus_endpoints = |b: NodeIx| -> Vec<(NodeIx, usize)> {
+        let mut endpoints = Vec::new();
+        let mut visited = HashSet::new();
+        let mut stack = vec![b];
+        while let Some(cur) = stack.pop() {
+            if !visited.insert(cur) {
+                continue;
+            }
+            for &(s, port) in sources[&cur].iter().flatten() {
+                match is_boundary(s) {
+                    true => stack.push(s),
+                    false => endpoints.push((s, port)),
+                }
+            }
+        }
+        endpoints.sort_by_cached_key(|&(s, port)| (graph[s].node_path(s.index()), port));
+        endpoints
+    };
+    // The buses a boundary lowers to, each with its writing source.
+    let region_buses = |b: NodeIx| -> Vec<(RegionBus, (NodeIx, usize))> {
+        match classic_source(b) {
+            Some(src) => vec![(RegionBus::Bus(effective(b)), src)],
+            None => bus_endpoints(b)
+                .into_iter()
+                .map(|(s, port)| (RegionBus::Src(s, port), (s, port)))
+                .collect(),
+        }
     };
 
-    // Cross-region reads: (reader component, effective bus), from every winning
-    // boundary-sourced input whose bus originates in another component.
-    let mut cross_reads: HashSet<(usize, NodeIx)> = HashSet::new();
+    // Cross-region reads - (reader component, bus), from every boundary
+    // summand whose bus originates in another component - and each bus's
+    // writing source.
+    let mut cross_reads: HashSet<(usize, RegionBus)> = HashSet::new();
+    let mut bus_writer: HashMap<RegionBus, (NodeIx, usize)> = HashMap::new();
     for (&n, srcs) in &sources {
         if is_boundary(n) {
             continue;
@@ -375,9 +452,10 @@ where
             if !is_boundary(s) {
                 continue;
             }
-            if let Some((src, _)) = bus_source(s) {
+            for (bus, (src, port)) in region_buses(s) {
+                bus_writer.insert(bus, (src, port));
                 if comp[&src] != comp[&n] {
-                    cross_reads.insert((comp[&n], effective(s)));
+                    cross_reads.insert((comp[&n], bus));
                 }
             }
         }
@@ -390,9 +468,8 @@ where
         let mut grew = false;
         for &(reader, bus) in &cross_reads {
             if needed.contains(&reader) {
-                if let Some((src, _)) = bus_source(bus) {
-                    grew |= needed.insert(comp[&src]);
-                }
+                let (src, _) = bus_writer[&bus];
+                grew |= needed.insert(comp[&src]);
             }
         }
         if !grew {
@@ -407,11 +484,10 @@ where
         if !needed.contains(&reader) {
             continue;
         }
-        if let Some((src, _)) = bus_source(bus) {
-            let writer = comp[&src];
-            if writer != reader {
-                deps.entry(reader).or_default().insert(writer);
-            }
+        let (src, _) = bus_writer[&bus];
+        let writer = comp[&src];
+        if writer != reader {
+            deps.entry(reader).or_default().insert(writer);
         }
     }
     let mut topo: Vec<usize> = Vec::with_capacity(needed.len());
@@ -437,85 +513,98 @@ where
 
     // Derive each region in topo order; widths flow forward via `bus_width`.
     let mut regions = Vec::with_capacity(topo.len());
-    let mut bus_width: HashMap<NodeIx, usize> = HashMap::new();
+    let mut bus_width: HashMap<RegionBus, usize> = HashMap::new();
     for c in topo {
-        // The region's roots: its sinks, plus the buses it writes (an effective
-        // bus sourced here and read from another needed component).
+        // The region's roots: its sinks, plus the sources of the buses it
+        // writes (a bus sourced here and read from another needed component).
+        // Boundary node-index order keeps the write order deterministic.
+        let mut writes: Vec<(RegionBus, (NodeIx, usize))> = Vec::new();
+        for &b in &boundaries {
+            for (bus, src) in region_buses(b) {
+                if comp[&src.0] == c
+                    && cross_reads
+                        .iter()
+                        .any(|&(r, rb)| rb == bus && needed.contains(&r))
+                    && !writes.iter().any(|&(wb, _)| wb == bus)
+                {
+                    writes.push((bus, src));
+                }
+            }
+        }
         let region_sinks: Vec<NodeIx> = sinks.iter().copied().filter(|s| comp[s] == c).collect();
-        let writes: Vec<NodeIx> = boundaries
+
+        let seeds: Vec<NodeIx> = region_sinks
             .iter()
             .copied()
-            .filter(|&b| effective(b) == b)
-            .filter(|&b| bus_source(b).is_some_and(|(s, _)| comp[&s] == c))
-            .filter(|&b| {
-                cross_reads
-                    .iter()
-                    .any(|&(r, bus)| bus == b && needed.contains(&r))
-            })
+            .chain(writes.iter().map(|&(_, (s, _))| s))
             .collect();
-
-        let seeds: Vec<NodeIx> = region_sinks.iter().chain(writes.iter()).copied().collect();
         let order = merged_pull_order(graph, &seeds, |n| comp.get(&n) == Some(&c));
 
         let mut builder = DspBuilder::new(out_channels);
         let mut outputs: HashMap<NodeIx, Vec<Signal>> = HashMap::new();
         let mut bus_reads: Vec<BusBinding> = Vec::new();
         // One `In` per bus read, shared by every consumer in the region.
-        let mut in_signals: HashMap<NodeIx, Signal> = HashMap::new();
+        let mut in_signals: HashMap<RegionBus, Signal> = HashMap::new();
 
         for n in order {
             let Some(dsp) = graph[n].to_node_dsp() else {
                 continue;
             };
-            let inputs: Vec<Signal> = sources[&n]
-                .iter()
-                .map(|src| match src {
-                    // A boundary source: a wire within the region, an `In` from
-                    // another region's bus, or silence when unsourced.
-                    Some((s, _)) if is_boundary(*s) => match bus_source(*s) {
-                        Some((src, port)) if comp[&src] == c => outputs
-                            .get(&src)
-                            .and_then(|o| o.get(port))
-                            .cloned()
-                            .unwrap_or_else(|| Signal::silent(1)),
-                        Some(_) => {
-                            let bus = effective(*s);
-                            in_signals
-                                .entry(bus)
-                                .or_insert_with(|| {
-                                    let channels = bus_width.get(&bus).copied().unwrap_or(1);
-                                    let bus_param = builder.push_control_param(
-                                        &graph[bus].node_path(bus.index()),
-                                        "bus",
-                                    );
-                                    let unit = builder.push_unit(UnitSpec::new(
-                                        "In",
-                                        Rate::Audio,
-                                        vec![InputRef::Param(bus_param)],
-                                        channels,
-                                    ));
-                                    bus_reads.push(BusBinding {
-                                        node_path: graph[bus].node_path(bus.index()),
-                                        channels,
-                                        unit: unit as usize,
-                                        param: bus_param as usize,
-                                    });
-                                    (0..channels as u32)
-                                        .map(|output| InputRef::Unit { unit, output })
-                                        .collect()
-                                })
-                                .clone()
+            // Each input sums its summands: a plain summand wires directly, a
+            // boundary summand lowers to its buses - in-region wires or `In`s.
+            let mut inputs: Vec<Signal> = Vec::with_capacity(sources[&n].len());
+            for summands in &sources[&n] {
+                let mut sigs: Vec<Signal> = Vec::new();
+                for &(s, port) in summands {
+                    let lowered: Vec<(Option<RegionBus>, (NodeIx, usize))> = match is_boundary(s) {
+                        true => region_buses(s)
+                            .into_iter()
+                            .map(|(bus, src)| (Some(bus), src))
+                            .collect(),
+                        false => vec![(None, (s, port))],
+                    };
+                    for (bus, (src, sport)) in lowered {
+                        match bus {
+                            Some(bus) if comp[&src] != c => {
+                                let sig = in_signals
+                                    .entry(bus)
+                                    .or_insert_with(|| {
+                                        let channels = bus_width.get(&bus).copied().unwrap_or(1);
+                                        let (path, label, output) = bus_param_at(graph, bus);
+                                        let bus_param = builder.push_control_param(&path, &label);
+                                        let unit = builder.push_unit(UnitSpec::new(
+                                            "In",
+                                            Rate::Audio,
+                                            vec![InputRef::Param(bus_param)],
+                                            channels,
+                                        ));
+                                        bus_reads.push(BusBinding {
+                                            node_path: path,
+                                            channels,
+                                            unit: unit as usize,
+                                            param: bus_param as usize,
+                                            output,
+                                        });
+                                        (0..channels as u32)
+                                            .map(|output| InputRef::Unit { unit, output })
+                                            .collect()
+                                    })
+                                    .clone();
+                                sigs.push(sig);
+                            }
+                            _ => sigs.push(
+                                outputs
+                                    .get(&src)
+                                    .and_then(|o| o.get(sport))
+                                    .cloned()
+                                    .unwrap_or_else(|| Signal::silent(1)),
+                            ),
                         }
-                        None => Signal::silent(1),
-                    },
-                    Some((s, port)) => outputs
-                        .get(s)
-                        .and_then(|o| o.get(*port))
-                        .cloned()
-                        .unwrap_or_else(|| Signal::silent(1)),
-                    None => Signal::silent(1),
-                })
-                .collect();
+                    }
+                }
+                // An unconnected (or unsourced-boundary) input sums to silence.
+                inputs.push(sum_signals(&mut builder, &sigs));
+            }
             let outs = dsp.ugens(&graph[n].node_path(n.index()), &inputs, &mut builder);
             debug_assert_eq!(
                 outs.len(),
@@ -526,17 +615,21 @@ where
         }
 
         // Emit the region's bus writes: lift each channel to audio, apply the
-        // driver's fade gain, and write to a bus-index param.
+        // driver's fade gain (one per param path), and write to a bus-index
+        // param.
+        let mut fades: HashMap<Vec<usize>, u32> = HashMap::new();
         let mut bus_writes = Vec::with_capacity(writes.len());
-        for b in writes {
-            let (src, port) = bus_source(b).expect("writes are sourced");
+        for (bus, (src, port)) in writes {
             let sig = outputs
                 .get(&src)
                 .and_then(|o| o.get(port))
                 .cloned()
                 .unwrap_or_else(|| Signal::silent(1));
-            let fade = builder.push_fade_gain(&graph[b].node_path(b.index()));
-            let bus_param = builder.push_control_param(&graph[b].node_path(b.index()), "bus");
+            let (path, label, output) = bus_param_at(graph, bus);
+            let fade = *fades
+                .entry(path.clone())
+                .or_insert_with(|| builder.push_fade_gain(&path));
+            let bus_param = builder.push_control_param(&path, &label);
             let mut out_inputs = vec![InputRef::Param(bus_param)];
             for ch in sig.channels() {
                 let ch = builder.ensure_audio(ch);
@@ -554,24 +647,33 @@ where
             }
             let unit = builder.push_unit(UnitSpec::new("Out", Rate::Audio, out_inputs, 0));
             bus_writes.push(BusBinding {
-                node_path: graph[b].node_path(b.index()),
+                node_path: path,
                 channels: sig.width(),
                 unit: unit as usize,
                 param: bus_param as usize,
+                output,
             });
-            bus_width.insert(b, sig.width());
+            bus_width.insert(bus, sig.width());
         }
 
-        // A stable region identity: its sink and boundary roles + node paths.
+        // A stable region identity: its sink and boundary roles + node paths
+        // (an endpoint bus also hashes its output port; a classic bus hashes
+        // nothing extra, so pre-summing region keys survive).
         let mut h = DefaultHasher::new();
         for s in &region_sinks {
             (0u8, graph[*s].node_path(s.index())).hash(&mut h);
         }
         for w in &bus_writes {
             (1u8, &w.node_path).hash(&mut h);
+            if let Some(o) = w.output {
+                o.hash(&mut h);
+            }
         }
         for r in &bus_reads {
             (2u8, &r.node_path).hash(&mut h);
+            if let Some(o) = r.output {
+                o.hash(&mut h);
+            }
         }
         let key = h.finish();
 
@@ -590,6 +692,24 @@ where
         });
     }
     Ok(regions)
+}
+
+/// The param path, label and endpoint port of a region bus: a classic bus is
+/// keyed by the effective `~bus` node with the plain `"bus"` label, an
+/// endpoint bus by its source node with a port-suffixed `"bus{port}"` label
+/// (matching the instancing pipeline's `Src` convention).
+fn bus_param_at<N: ToNodeDsp>(
+    graph: &Graph<N>,
+    bus: RegionBus,
+) -> (Vec<usize>, String, Option<usize>) {
+    match bus {
+        RegionBus::Bus(b) => (graph[b].node_path(b.index()), "bus".to_string(), None),
+        RegionBus::Src(s, port) => (
+            graph[s].node_path(s.index()),
+            format!("bus{port}"),
+            Some(port),
+        ),
+    }
 }
 
 /// The content-addressed name for a def with the given [`structural_sig`].

--- a/crates/gantz_plyphon/src/dsp.rs
+++ b/crates/gantz_plyphon/src/dsp.rs
@@ -426,9 +426,91 @@ pub fn node_dsp_of(any: &dyn std::any::Any) -> Option<&dyn NodeDsp> {
         .or_else(|| probe::<crate::Bus>(any))
 }
 
+/// Sum channel groups into one group: the unity-gain mix of every summand.
+///
+/// The result's width is the widest summand's. A mono summand broadcasts its
+/// single channel into every result channel. A wider-but-narrower summand
+/// contributes silence past its own width. Constant channels fold at derive
+/// time (so silent placeholders vanish). No summands sum to mono silence, and
+/// a lone summand passes through untouched (zero units), keeping a
+/// single-edge input's derive byte-identical to a direct wire.
+pub fn sum_signals(b: &mut DspBuilder, signals: &[Signal]) -> Signal {
+    match signals {
+        [] => Signal::silent(1),
+        [s] => s.clone(),
+        _ => {
+            let width = signals.iter().map(Signal::width).max().unwrap_or(1);
+            (0..width).map(|ch| sum_channel(b, signals, ch)).collect()
+        }
+    }
+}
+
+/// The wire carrying channel `ch` of the sum of `signals`: each summand
+/// contributes its channel `ch`, a mono summand its broadcast channel `0`, a
+/// wider-but-narrower summand nothing. Constant contributions fold into one
+/// trailing term, dropped when zero and other wires remain.
+fn sum_channel(b: &mut DspBuilder, signals: &[Signal], ch: usize) -> InputRef {
+    let mut constant = 0.0;
+    let mut wires = Vec::new();
+    let contributions = signals.iter().filter_map(|s| match s.width() {
+        1 => s.channel(0),
+        _ => s.channel(ch),
+    });
+    for c in contributions {
+        match c {
+            InputRef::Constant(v) => constant += v,
+            wire => wires.push(wire),
+        }
+    }
+    if constant != 0.0 || wires.is_empty() {
+        wires.push(InputRef::Constant(constant));
+    }
+    sum_wires(b, wires)
+}
+
+/// Sum a non-empty list of mono wires, tiling plyphon's summing units: one
+/// wire passes through, two add via a `BinaryOpUGen`, three or four via
+/// `Sum3`/`Sum4` (strict arity - `SumCtor` rejects a padded input list), and
+/// more tile as a `Sum4` over the first four fed back as the leading summand
+/// of the rest.
+fn sum_wires(b: &mut DspBuilder, mut wires: Vec<InputRef>) -> InputRef {
+    while wires.len() > 4 {
+        let head: Vec<InputRef> = wires.drain(..4).collect();
+        let sum = push_sum_unit(b, head);
+        wires.insert(0, sum);
+    }
+    match wires.len() {
+        1 => wires[0],
+        _ => push_sum_unit(b, wires),
+    }
+}
+
+/// Emit one summing unit over `inputs` (2 -> `BinaryOpUGen` add, 3 -> `Sum3`,
+/// 4 -> `Sum4`): audio rate if any input is audio, else control rate. Each
+/// input is still read at its own rate.
+fn push_sum_unit(b: &mut DspBuilder, inputs: Vec<InputRef>) -> InputRef {
+    let audio = inputs
+        .iter()
+        .any(|i| matches!(b.input_rate(i), Rate::Audio));
+    let rate = match audio {
+        true => Rate::Audio,
+        false => Rate::Control,
+    };
+    let name = match inputs.len() {
+        2 => "BinaryOpUGen",
+        3 => "Sum3",
+        _ => "Sum4",
+    };
+    let unit = b.push_unit(UnitSpec::new(name, rate, inputs, 1));
+    InputRef::Unit { unit, output: 0 }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::node_dsp_of;
+    use plyphon::Rate;
+    use plyphon::synthdef::{InputRef, UnitSpec};
+
+    use super::{DspBuilder, Signal, node_dsp_of, sum_signals};
 
     /// Every DSP node type in this crate must be found by [`node_dsp_of`], so
     /// a probe arm forgotten when adding a node fails here rather than in
@@ -446,5 +528,166 @@ mod tests {
         check::<crate::Pack>();
         check::<crate::Unpack>();
         check::<crate::Bus>();
+    }
+
+    /// A unit-backed mono wire at `rate` to feed the summing helpers.
+    fn wire(b: &mut DspBuilder, rate: Rate) -> InputRef {
+        let unit = b.push_unit(UnitSpec::new("SinOsc", rate, vec![], 1));
+        InputRef::Unit { unit, output: 0 }
+    }
+
+    /// The names of the units pushed at or after index `from`.
+    fn unit_names(b: &DspBuilder, from: usize) -> Vec<String> {
+        b.units[from..].iter().map(|u| u.name.clone()).collect()
+    }
+
+    /// `InputRef` derives no `PartialEq`; compare wires via `Debug`.
+    fn wire_eq(a: &InputRef, b: &InputRef) -> bool {
+        format!("{a:?}") == format!("{b:?}")
+    }
+
+    #[test]
+    fn sum_of_none_is_mono_silence() {
+        let mut b = DspBuilder::new(2);
+        let sum = sum_signals(&mut b, &[]);
+        assert_eq!(sum.width(), 1);
+        assert!(wire_eq(&sum.channel(0).unwrap(), &InputRef::Constant(0.0)));
+        assert!(b.units.is_empty());
+    }
+
+    #[test]
+    fn sum_of_one_passes_through_unit_free() {
+        let mut b = DspBuilder::new(2);
+        let w0 = wire(&mut b, Rate::Audio);
+        let w1 = wire(&mut b, Rate::Audio);
+        let stereo: Signal = [w0, w1].into_iter().collect();
+        let before = b.units.len();
+        let sum = sum_signals(&mut b, &[stereo.clone()]);
+        assert_eq!(b.units.len(), before);
+        assert_eq!(sum.width(), 2);
+        assert!(wire_eq(&sum.channel(0).unwrap(), &w0));
+        assert!(wire_eq(&sum.channel(1).unwrap(), &w1));
+    }
+
+    #[test]
+    fn sum_tiles_binary_sum3_sum4_and_chains() {
+        for (n, expected) in [
+            (2, vec!["BinaryOpUGen"]),
+            (3, vec!["Sum3"]),
+            (4, vec!["Sum4"]),
+            (5, vec!["Sum4", "BinaryOpUGen"]),
+            (9, vec!["Sum4", "Sum4", "Sum3"]),
+        ] {
+            let mut b = DspBuilder::new(2);
+            let signals: Vec<Signal> = (0..n)
+                .map(|_| Signal::mono(wire(&mut b, Rate::Audio)))
+                .collect();
+            let before = b.units.len();
+            let sum = sum_signals(&mut b, &signals);
+            assert_eq!(sum.width(), 1);
+            assert_eq!(unit_names(&b, before), expected, "n = {n}");
+            // An add is special_index 0 (a `BinaryOpUGen` selector, unset on
+            // `Sum3`/`Sum4`).
+            assert!(b.units[before..].iter().all(|u| u.special_index == 0));
+        }
+    }
+
+    #[test]
+    fn mono_broadcasts_into_every_channel() {
+        let mut b = DspBuilder::new(2);
+        let m = wire(&mut b, Rate::Audio);
+        let s0 = wire(&mut b, Rate::Audio);
+        let s1 = wire(&mut b, Rate::Audio);
+        let stereo: Signal = [s0, s1].into_iter().collect();
+        let sum = sum_signals(&mut b, &[Signal::mono(m), stereo]);
+        assert_eq!(sum.width(), 2);
+        for (ch, s) in [(0, s0), (1, s1)] {
+            let InputRef::Unit { unit, .. } = sum.channel(ch).unwrap() else {
+                panic!("channel {ch} is not a summing unit");
+            };
+            let inputs = &b.units[unit as usize].inputs;
+            assert!(inputs.iter().any(|i| wire_eq(i, &m)));
+            assert!(inputs.iter().any(|i| wire_eq(i, &s)));
+        }
+    }
+
+    #[test]
+    fn narrower_summand_contributes_silence_past_its_width() {
+        let mut b = DspBuilder::new(2);
+        let s0 = wire(&mut b, Rate::Audio);
+        let s1 = wire(&mut b, Rate::Audio);
+        let w0 = wire(&mut b, Rate::Audio);
+        let w1 = wire(&mut b, Rate::Audio);
+        let w2 = wire(&mut b, Rate::Audio);
+        let stereo: Signal = [s0, s1].into_iter().collect();
+        let wide: Signal = [w0, w1, w2].into_iter().collect();
+        let before = b.units.len();
+        let sum = sum_signals(&mut b, &[stereo, wide]);
+        assert_eq!(sum.width(), 3);
+        // Channels 0 and 1 sum a pair; channel 2 is the wide summand's own
+        // wire passed through (the stereo summand contributes nothing there).
+        assert_eq!(unit_names(&b, before), vec!["BinaryOpUGen", "BinaryOpUGen"]);
+        assert!(wire_eq(&sum.channel(2).unwrap(), &w2));
+    }
+
+    #[test]
+    fn constants_fold_at_derive_time() {
+        // Silence + a wire: the zero constant vanishes, the wire passes
+        // through, no units.
+        let mut b = DspBuilder::new(2);
+        let w = wire(&mut b, Rate::Audio);
+        let before = b.units.len();
+        let sum = sum_signals(&mut b, &[Signal::silent(1), Signal::mono(w)]);
+        assert_eq!(b.units.len(), before);
+        assert!(wire_eq(&sum.channel(0).unwrap(), &w));
+
+        // Pure constants fold to one constant, no units.
+        let mut b = DspBuilder::new(2);
+        let sum = sum_signals(
+            &mut b,
+            &[
+                Signal::mono(InputRef::Constant(1.5)),
+                Signal::mono(InputRef::Constant(2.0)),
+            ],
+        );
+        assert!(b.units.is_empty());
+        assert!(wire_eq(&sum.channel(0).unwrap(), &InputRef::Constant(3.5)));
+
+        // A non-zero folded constant joins the wires as one trailing summand.
+        let mut b = DspBuilder::new(2);
+        let w0 = wire(&mut b, Rate::Audio);
+        let w1 = wire(&mut b, Rate::Audio);
+        let before = b.units.len();
+        let sum = sum_signals(
+            &mut b,
+            &[
+                Signal::mono(w0),
+                Signal::mono(InputRef::Constant(1.5)),
+                Signal::mono(w1),
+            ],
+        );
+        assert_eq!(unit_names(&b, before), vec!["Sum3"]);
+        let InputRef::Unit { unit, .. } = sum.channel(0).unwrap() else {
+            panic!("expected a summing unit");
+        };
+        let inputs = &b.units[unit as usize].inputs;
+        assert!(inputs.iter().any(|i| wire_eq(i, &InputRef::Constant(1.5))));
+    }
+
+    #[test]
+    fn sum_unit_rate_is_audio_iff_any_summand_is() {
+        let mut b = DspBuilder::new(2);
+        let k0 = wire(&mut b, Rate::Control);
+        let k1 = wire(&mut b, Rate::Control);
+        let before = b.units.len();
+        sum_signals(&mut b, &[Signal::mono(k0), Signal::mono(k1)]);
+        assert_eq!(b.units[before].rate, Rate::Control);
+
+        let mut b = DspBuilder::new(2);
+        let k = wire(&mut b, Rate::Control);
+        let a = wire(&mut b, Rate::Audio);
+        let before = b.units.len();
+        sum_signals(&mut b, &[Signal::mono(k), Signal::mono(a)]);
+        assert_eq!(b.units[before].rate, Rate::Audio);
     }
 }

--- a/crates/gantz_plyphon/src/dsp.rs
+++ b/crates/gantz_plyphon/src/dsp.rs
@@ -165,7 +165,9 @@ pub trait NodeDsp {
     /// `path` is the node's path within the graph (e.g. `[2]` for the node at
     /// index 2 of a flat graph). Use it to name any control [`Param`]s
     /// uniquely within the synthdef (see [`param_name`](crate::param::param_name)).
-    /// `inputs` has length [`n_dsp_inputs`](Self::n_dsp_inputs). An unconnected
+    /// `inputs` has length [`n_dsp_inputs`](Self::n_dsp_inputs), each input
+    /// arriving pre-summed (a multi-edge input is the unity-gain mix of its
+    /// summands, [`sum_signals`]). An unconnected
     /// input is [`Signal::silent`]`(1)` (mono silence). Params should broadcast
     /// across an input's channels (e.g. `~lag` emits one `Lag` unit per channel,
     /// all sharing the one `dur` param).
@@ -422,6 +424,7 @@ pub fn node_dsp_of(any: &dyn std::any::Any) -> Option<&dyn NodeDsp> {
         .or_else(|| probe::<crate::Lag>(any))
         .or_else(|| probe::<crate::ScopeOut>(any))
         .or_else(|| probe::<crate::Pack>(any))
+        .or_else(|| probe::<crate::Sum>(any))
         .or_else(|| probe::<crate::Unpack>(any))
         .or_else(|| probe::<crate::Bus>(any))
 }
@@ -526,6 +529,7 @@ mod tests {
         check::<crate::Lag>();
         check::<crate::ScopeOut>();
         check::<crate::Pack>();
+        check::<crate::Sum>();
         check::<crate::Unpack>();
         check::<crate::Bus>();
     }

--- a/crates/gantz_plyphon/src/egui/node/mod.rs
+++ b/crates/gantz_plyphon/src/egui/node/mod.rs
@@ -11,4 +11,5 @@ pub mod out;
 pub mod pack;
 pub mod scope_out;
 pub mod sin_osc;
+pub mod sum;
 pub mod unpack;

--- a/crates/gantz_plyphon/src/egui/node/sum.rs
+++ b/crates/gantz_plyphon/src/egui/node/sum.rs
@@ -1,0 +1,50 @@
+//! `~sum`'s egui implementation.
+
+use crate::egui::param::value_row;
+use crate::node::Sum;
+use gantz_egui::{
+    InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind,
+};
+
+impl NodeUi for Sum {
+    fn name(&self, _: &dyn Registry) -> &str {
+        "~sum"
+    }
+
+    fn description(&self) -> Option<&'static str> {
+        Some("Sum signals into their unity-gain mix (mixed, not packed)")
+    }
+
+    fn ui(&mut self, _ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
+        let framed =
+            uictx.framed(|ui, _sockets| ui.add(egui::Label::new("~sum").selectable(false)));
+        NodeUiResponse::new(framed)
+    }
+
+    fn inspector_rows(
+        &mut self,
+        _ctx: &mut NodeCtx,
+        body: &mut egui_extras::TableBody,
+    ) -> InspectorRowsResponse {
+        let mut resp = InspectorRowsResponse::default();
+        // Input count (structural: it changes the node's sockets -> respawn).
+        let mut count = self.count();
+        let dv = egui::DragValue::new(&mut count).range(1..=64).speed(1.0);
+        if value_row(body, "count", dv) {
+            self.set_count(count);
+            resp.mark_changed();
+        }
+        resp
+    }
+
+    fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, ix: usize) -> Option<SocketDoc> {
+        match kind {
+            SocketKind::Input => Some(SocketDoc::ty("signal").with_description(format!(
+                "signal {ix} to sum (any channel width; silence when unconnected)"
+            ))),
+            SocketKind::Output => Some(SocketDoc::ty("signal").with_description(
+                "the channel-wise sum (width = the widest input; mono inputs broadcast)",
+            )),
+        }
+    }
+}

--- a/crates/gantz_plyphon/src/flatten.rs
+++ b/crates/gantz_plyphon/src/flatten.rs
@@ -34,15 +34,16 @@
 //!
 //! An edge into a ref's input `i` belongs to every consumer of the referenced
 //! graph's `i`-th inlet, and an edge from a ref's output `j` re-sources from
-//! the single edge feeding the referenced graph's `j`-th outlet (inlets and
+//! the edges feeding the referenced graph's `j`-th outlet (inlets and
 //! outlets map positionally by ascending node index, the same "input i to
 //! inlet i" contract the control compiler uses). Bridging resolves through
 //! arbitrarily deep chains of boundaries (a pure `inlet -> outlet` wire
-//! dissolves entirely). At each hop the *oldest* edge whose chain resolves
-//! wins, matching derivation's oldest-edge-wins input resolution, and an
-//! unresolvable chain (an unconnected inlet or outlet along the way) produces
-//! no edge, so the consumer's input falls back to derivation's usual mono
-//! silence.
+//! dissolves entirely). *Every* resolving chain bridges as its own flat edge
+//! - derivation sums a multi-fed input, so a boundary fanned in by several
+//! sources delivers every summand (two distinct chains reaching the same
+//! source deliberately sum it twice). An unresolvable chain (an unconnected
+//! inlet or outlet along the way) produces no edge, so the consumer's input
+//! falls back to derivation's usual mono silence.
 
 use std::collections::HashMap;
 
@@ -413,10 +414,11 @@ where
 /// Phase 2: emit the flat edges. Only edges whose target was kept are
 /// considered (each concrete input's feeds are enumerated exactly once, at
 /// the level where the target lives), with each source resolved through the
-/// boundary chain via [`resolve_src`]. Levels are visited in splice order and
-/// edges in creation (age) order, so a kept input's flat edges keep their
-/// original relative age and derivation's oldest-edge-wins resolution behaves
-/// as on an equivalent hand-flattened graph.
+/// boundary chain via [`resolve_src`] - one flat edge per resolving chain
+/// (derivation sums a multi-fed input). Levels are visited in splice order
+/// and edges in creation (age) order, so a kept input's flat edges keep their
+/// original relative age and the flat graph matches an equivalent
+/// hand-flattened one.
 fn bridge<N>(levels: &[Level<'_, N>], out: &mut Graph<Flat<N>>) {
     for (id, level) in levels.iter().enumerate() {
         for e in level.graph.edge_references() {
@@ -425,7 +427,7 @@ fn bridge<N>(levels: &[Level<'_, N>], out: &mut Graph<Flat<N>>) {
             };
             let mut stack = Vec::new();
             let src = e.weight().output.0 as usize;
-            if let Some((flat_s, port)) = resolve_src(levels, id, e.source(), src, &mut stack) {
+            for (flat_s, port) in resolve_src(levels, id, e.source(), src, &mut stack) {
                 let edge = Edge::new((port as u16).into(), e.weight().input);
                 out.add_edge(flat_s, flat_t, edge);
             }
@@ -433,58 +435,60 @@ fn bridge<N>(levels: &[Level<'_, N>], out: &mut Graph<Flat<N>>) {
     }
 }
 
-/// Resolve the source endpoint `(s, sp)` at level `lvl` to a kept flat node's
-/// output, following ref outputs down into their child's outlet and inlet
-/// outputs up into the parent's edges. `None` when the chain dead-ends
-/// (an unconnected boundary) or revisits an endpoint on `stack` (a pure
-/// boundary wiring cycle).
+/// Resolve the source endpoint `(s, sp)` at level `lvl` to every kept flat
+/// node output its boundary chains reach, following ref outputs down into
+/// their child's outlet and inlet outputs up into the parent's edges. Empty
+/// when every chain dead-ends (an unconnected boundary) or revisits an
+/// endpoint on `stack` (a pure boundary wiring cycle).
 fn resolve_src<N>(
     levels: &[Level<'_, N>],
     lvl: usize,
     s: NodeIx,
     sp: usize,
     stack: &mut Vec<SrcKey>,
-) -> Option<(NodeIx, usize)> {
+) -> Vec<(NodeIx, usize)> {
     let key = (lvl, s, sp);
     if stack.contains(&key) {
-        return None;
+        return Vec::new();
     }
     stack.push(key);
     let level = &levels[lvl];
     let resolved = if let Some(&flat) = level.kept.get(&s) {
-        Some((flat, sp))
+        vec![(flat, sp)]
     } else if let Some(&child) = level.child.get(&s) {
-        // A ref's output `sp` reads the child's `sp`-th outlet's one input.
+        // A ref's output `sp` reads the child's `sp`-th outlet's feeds.
         levels[child]
             .outlets
             .get(sp)
             .copied()
-            .and_then(|outlet| resolve_via_input(levels, child, outlet, 0, stack))
+            .map(|outlet| resolve_via_input(levels, child, outlet, 0, stack))
+            .unwrap_or_default()
     } else if let Some(i) = level.inlets.iter().position(|&n| n == s) {
         // An inlet's output reads the parent ref's input `i`. A root-level
         // inlet has no parent to read, so it dissolves unconnected.
         level
             .parent
-            .and_then(|(p, r)| resolve_via_input(levels, p, r, i, stack))
+            .map(|(p, r)| resolve_via_input(levels, p, r, i, stack))
+            .unwrap_or_default()
     } else {
         // An outlet as a source (outlets have no outputs) or a node dropped
         // by an earlier error path: nothing to wire.
-        None
+        Vec::new()
     };
     stack.pop();
     resolved
 }
 
-/// Resolve the winning source feeding `node`'s `input` at level `lvl`: the
-/// oldest edge whose chain resolves (`edges_directed` iterates newest-first,
-/// hence the reversal), matching derivation's input resolution.
+/// Resolve every source feeding `node`'s `input` at level `lvl`, oldest edge
+/// first (`edges_directed` iterates newest-first, hence the reversal) - each
+/// resolving chain is a summand of the consumer's input.
 fn resolve_via_input<N>(
     levels: &[Level<'_, N>],
     lvl: usize,
     node: NodeIx,
     input: usize,
     stack: &mut Vec<SrcKey>,
-) -> Option<(NodeIx, usize)> {
+) -> Vec<(NodeIx, usize)> {
     let edges: Vec<_> = levels[lvl]
         .graph
         .edges_directed(node, Direction::Incoming)
@@ -494,5 +498,6 @@ fn resolve_via_input<N>(
     edges
         .into_iter()
         .rev()
-        .find_map(|(s, sp)| resolve_src(levels, lvl, s, sp, stack))
+        .flat_map(|(s, sp)| resolve_src(levels, lvl, s, sp, stack))
+        .collect()
 }

--- a/crates/gantz_plyphon/src/instance.rs
+++ b/crates/gantz_plyphon/src/instance.rs
@@ -40,13 +40,26 @@
 //! must run *before* it and a node reading it *after*. A diamond such as
 //! `src -> instance -> mix` plus `src -> mix` therefore cannot fuse `src` and
 //! `mix` into one def. Each node is assigned a *stage* - the maximum over its
-//! winning sources, bumped when crossing an instance - and regions are the
-//! connected components *within a stage*. A winning edge crossing stages (or
+//! summand sources, bumped when crossing an instance - and regions are the
+//! connected components *within a stage*. An edge crossing stages (or
 //! otherwise crossing regions) lowers to an implicit bus
 //! ([`BusKey::Src`]), costing one bus and no latency (writers run before
 //! readers within a block). Cycles *through an instance* have no such order
 //! and are rejected as [`DeriveError::BusCycle`] (deliberate feedback is
 //! planned to land with `InFeedback` lowering, #293).
+//!
+//! # Summing
+//!
+//! Multiple edges into one dsp input sum
+//! ([`sum_signals`](crate::dsp::sum_signals)), exactly as in
+//! [`derive_synthdefs`]. Every summand of a consumed input is classified
+//! ([`Feed`]) and the consumer sums the resolved signals - in-region wires
+//! and bus `In`s alike - after materializing them. A multi-fed instance
+//! *inlet* sums inside the child template (the summand widths are part of the
+//! [`VariantKey`], and each summand gets its own [`BusKey::IfaceIn`] bus). A
+//! multi-fed root *outlet* exports one bus per summand
+//! ([`GraphTemplate::outlets`]) and the enclosing reader sums after its
+//! per-summand `In`s ([`BusKey::InstOut`]).
 
 use std::collections::{HashMap, HashSet};
 use std::hash::{DefaultHasher, Hash, Hasher};
@@ -63,7 +76,9 @@ use gantz_core::node::graph::{Graph, NodeIx};
 use crate::compile::{
     DeriveError, content_def_name, derive_synthdefs, dsp_sinks, merged_pull_order, structural_sig,
 };
-use crate::dsp::{DspBuilder, GainRef, ParamBinding, ScopeOutBinding, Signal, ToNodeDsp};
+use crate::dsp::{
+    DspBuilder, GainRef, ParamBinding, ScopeOutBinding, Signal, ToNodeDsp, sum_signals,
+};
 use crate::flatten::Flat;
 
 /// A content-addressed shape identifying one template variant of a child
@@ -77,9 +92,10 @@ use crate::flatten::Flat;
 pub struct VariantKey {
     /// The referenced child graph's commit content address.
     pub child: ContentAddr,
-    /// One entry per inlet: `None` for unconnected (baked silence), `Some(w)`
-    /// for connected at width `w`.
-    pub inlets: Vec<Option<usize>>,
+    /// One entry per inlet: the width of each summand feeding it, in canonical
+    /// order (empty = unconnected, baked silence). The child sums a multi-fed
+    /// inlet's summands where the inlet is consumed.
+    pub inlets: Vec<Vec<usize>>,
     /// One entry per outlet: `true` if some downstream node consumes it.
     pub outlets: Vec<bool>,
     /// The engine's output channel count (baked into sinks).
@@ -104,20 +120,28 @@ pub enum BusKey {
         /// The source node's output port.
         output: usize,
     },
-    /// An instance's consumed outlet. Never allocated directly:
-    /// [`instantiate`] resolves it through the child template's
+    /// One summand of an instance's consumed outlet. Never allocated
+    /// directly: [`instantiate`] resolves it through the child template's
     /// [`outlets`](GraphTemplate::outlets) table to the bus actually carrying
-    /// the outlet's signal (falling back to an unwritten - silent - bus for a
-    /// sourceless outlet).
+    /// that summand's signal (falling back to an unwritten - silent - bus for
+    /// a sourceless outlet). A reader emits one `In` per summand and sums.
     InstOut {
         /// The instance marker's path.
         path: Vec<usize>,
         /// The consumed outlet's index.
         outlet: usize,
+        /// The summand's index within the outlet's exported buses.
+        summand: usize,
     },
-    /// The template's own `i`-th inlet. Resolved by [`instantiate`] to the
-    /// enclosing graph's feeding bus.
-    IfaceIn(usize),
+    /// One summand of the template's own `inlet`-th inlet. Resolved by
+    /// [`instantiate`] to the enclosing graph's feeding bus for that summand.
+    IfaceIn {
+        /// The inlet's interface index.
+        inlet: usize,
+        /// The summand's index within the inlet's feeds (canonical order,
+        /// matching [`VariantKey::inlets`]).
+        summand: usize,
+    },
 }
 
 /// One side of a bus within a region's def: the `In`/`Out` unit and the no-lag
@@ -178,9 +202,9 @@ pub struct InstancePart {
     pub path: Vec<usize>,
     /// The variant this instance instantiates (keys the shared template).
     pub variant: VariantKey,
-    /// Per inlet: the template-relative key of the bus feeding it (`None` =
-    /// unconnected, baked silence in the variant).
-    pub inlet_keys: Vec<Option<BusKey>>,
+    /// Per inlet: the template-relative key of the bus feeding each summand,
+    /// in canonical order (empty = unconnected, baked silence in the variant).
+    pub inlet_keys: Vec<Vec<BusKey>>,
 }
 
 /// A derived template: its parts in topological order (bus writers before
@@ -188,13 +212,14 @@ pub struct InstancePart {
 pub struct GraphTemplate {
     /// The parts, in bus-writer-before-reader topological order.
     pub parts: Vec<Part>,
-    /// One entry per outlet: the template-relative key of the bus carrying
-    /// the outlet's signal and its width, or `None` for an unconsumed or
-    /// sourceless outlet. A parent's read of the instance's outlet resolves
-    /// through this table at [`instantiate`] time, so an outlet fed by a
-    /// nested instance or passed through from an inlet aliases the underlying
-    /// bus with no relay def.
-    pub outlets: Vec<Option<(BusKey, usize)>>,
+    /// One entry per outlet: the template-relative key + width of the bus
+    /// carrying each of the outlet's summands, in canonical order (empty =
+    /// unconsumed or sourceless). A parent's read of the instance's outlet
+    /// resolves through this table at [`instantiate`] time, so an outlet fed
+    /// by a nested instance or passed through from an inlet aliases the
+    /// underlying buses with no relay def. A multi-fed outlet exports one bus
+    /// per summand and the enclosing reader sums.
+    pub outlets: Vec<Vec<(BusKey, usize)>>,
 }
 
 /// A memoised cache of derived child templates, keyed by [`VariantKey`].
@@ -313,6 +338,12 @@ enum PartId {
     Instance(usize),
 }
 
+/// Per (instance path, outlet): the number of summand buses the derived child
+/// template exports for that outlet ([`GraphTemplate::outlets`]). Populated in
+/// part order (writers precede readers), so a reader's `InstOut` expansion
+/// sees its instance's counts.
+type OutSummands = HashMap<(Vec<usize>, usize), usize>;
+
 /// Derive a [`GraphTemplate`] for `graph`, recursing into instance children
 /// per `resolve` (memoised in `cache`).
 ///
@@ -331,7 +362,7 @@ where
     N: ToNodeDsp,
 {
     let (n_inlets, n_outlets) = iface_arity(graph);
-    let inlets = vec![None; n_inlets];
+    let inlets = vec![Vec::new(); n_inlets];
     let outlets = vec![false; n_outlets];
     let mut deriving = Vec::new();
     derive_parts(
@@ -405,7 +436,7 @@ where
 fn derive_parts<N>(
     graph: &Graph<Flat<N>>,
     out_channels: usize,
-    inlets: &[Option<usize>],
+    inlets: &[Vec<usize>],
     outlets_consumed: &[bool],
     resolve: &InstanceResolve<'_, N>,
     cache: &mut DefCache,
@@ -554,23 +585,24 @@ where
         }
     }
 
-    // Winning sources per dsp input (oldest edge wins), reach-filtered.
-    let srcs: HashMap<NodeIx, Vec<Option<(NodeIx, usize)>>> = reach
+    // Summand sources per dsp input, reach-filtered: every edge into an input
+    // is a summand (empty = unconnected), canonically ordered (sorted by
+    // source path + output port) so derivation is independent of edge
+    // insertion order.
+    let srcs: HashMap<NodeIx, Vec<Vec<(NodeIx, usize)>>> = reach
         .iter()
         .map(|&n| {
             let n_in = n_dsp_in(n);
-            let mut inputs: Vec<Option<(NodeIx, usize)>> = vec![None; n_in];
-            let edges: Vec<_> = graph.edges_directed(n, Direction::Incoming).collect();
-            for e in edges.into_iter().rev() {
+            let mut inputs: Vec<Vec<(NodeIx, usize)>> = vec![Vec::new(); n_in];
+            for e in graph.edges_directed(n, Direction::Incoming) {
                 let input_ix = e.weight().input.0 as usize;
                 let s = e.source();
-                if input_ix < n_in
-                    && inputs[input_ix].is_none()
-                    && reach.contains(&s)
-                    && is_source_kind(s)
-                {
-                    inputs[input_ix] = Some((s, e.weight().output.0 as usize));
+                if input_ix < n_in && reach.contains(&s) && is_source_kind(s) {
+                    inputs[input_ix].push((s, e.weight().output.0 as usize));
                 }
+            }
+            for summands in &mut inputs {
+                summands.sort_by_cached_key(|&(s, port)| (graph[s].path().to_vec(), port));
             }
             (n, inputs)
         })
@@ -663,7 +695,10 @@ where
                     continue;
                 }
                 let input_ix = e.weight().input.0 as usize;
-                if srcs[&t].get(input_ix).copied().flatten().map(|(s, _)| s) == Some(n) {
+                let among = srcs[&t]
+                    .get(input_ix)
+                    .is_some_and(|ss| ss.iter().any(|&(s, _)| s == n));
+                if among {
                     comp.insert(t, id);
                     stack.push(t);
                 }
@@ -682,12 +717,15 @@ where
         v
     };
 
-    // `~bus` aliasing + sourcing, exactly as `derive_synthdefs`.
+    // `~bus` aliasing + sourcing, exactly as `derive_synthdefs`: a *pure*
+    // single-summand chain of boundaries keeps the classic effective-bus
+    // identity, while a fanned-out chain lowers to its transitive endpoints
+    // (each a summand the consumer classifies as though wired directly).
     let boundary = |n: NodeIx| kind.get(&n) == Some(&Kind::Boundary);
     let effective = |b: NodeIx| -> NodeIx {
         let mut cur = b;
         let mut visited = HashSet::new();
-        while let Some(&(s, _)) = srcs[&cur].first().and_then(|o| o.as_ref()) {
+        while let Some(&[(s, _)]) = srcs[&cur].first().map(|v| v.as_slice()) {
             if !boundary(s) || !visited.insert(cur) {
                 break;
             }
@@ -695,29 +733,54 @@ where
         }
         cur
     };
-    // The effective bus's winning source, unless it is itself a boundary (a
-    // pure bus cycle - an unsourced, silent bus).
-    let bus_source = |b: NodeIx| -> Option<(NodeIx, usize)> {
-        srcs[&effective(b)]
-            .first()
-            .copied()
-            .flatten()
-            .filter(|&(s, _)| !boundary(s))
+    // The classic case: the effective bus's lone summand is a non-boundary
+    // source (every hop of the chain had exactly one). `None` = the chain
+    // fans out somewhere, is unsourced, or is a pure bus cycle.
+    let classic_source = |b: NodeIx| -> Option<(NodeIx, usize)> {
+        match srcs[&effective(b)].first().map(|v| v.as_slice()) {
+            Some(&[(s, port)]) if !boundary(s) => Some((s, port)),
+            _ => None,
+        }
+    };
+    // Every transitive non-boundary endpoint feeding `b`, canonical order,
+    // duplicates kept (each is a summand). Empty = unsourced (silence).
+    let bus_endpoints = |b: NodeIx| -> Vec<(NodeIx, usize)> {
+        let mut endpoints = Vec::new();
+        let mut visited = HashSet::new();
+        let mut stack = vec![b];
+        while let Some(cur) = stack.pop() {
+            if !visited.insert(cur) {
+                continue;
+            }
+            for &(s, port) in srcs[&cur].iter().flatten() {
+                match boundary(s) {
+                    true => stack.push(s),
+                    false => endpoints.push((s, port)),
+                }
+            }
+        }
+        endpoints.sort_by_cached_key(|&(s, port)| (graph[s].path().to_vec(), port));
+        endpoints
     };
 
-    // Classify the winning source feeding a consumer. `at` is the consuming
-    // part (None for a root outlet, which belongs to no part).
-    let feed = |src: Option<(NodeIx, usize)>, at: Option<PartId>| -> Feed {
-        let Some((s, port)) = src else {
-            return Feed::Silence;
-        };
+    // Classify one *direct* (non-boundary) source feeding a consumer. `at` is
+    // the consuming part (None for a root outlet or instance inlet, which
+    // belong to no part). An inlet source expands to one read per enclosing
+    // summand; an instance-outlet source to one read per exported summand
+    // (`out_summands` - a lone silent read before the child is derived or for
+    // a sourceless outlet, preserving the In-on-silent-bus shape).
+    let direct_feeds = |s: NodeIx,
+                        port: usize,
+                        at: Option<PartId>,
+                        out_summands: &HashMap<(Vec<usize>, usize), usize>|
+     -> Vec<Feed> {
         match kind.get(&s) {
             Some(Kind::Plain) => {
                 let writer = PartId::Region(comp[&s]);
                 if at == Some(writer) {
-                    Feed::Wire(s, port)
+                    vec![Feed::Wire(s, port)]
                 } else {
-                    Feed::Read {
+                    vec![Feed::Read {
                         key: BusKey::Src {
                             path: graph[s].path().to_vec(),
                             output: port,
@@ -725,78 +788,80 @@ where
                         writer: Some(writer),
                         demand: Some((s, port)),
                         param_at: (graph[s].path().to_vec(), format!("bus{port}")),
-                    }
+                    }]
                 }
             }
-            Some(Kind::Boundary) => {
-                let eff = effective(s);
-                match bus_source(eff) {
-                    Some((src, sport)) => match kind.get(&src) {
-                        // A bus is transparent: it carries its source's
-                        // signal, so classify as though reading the source
-                        // directly - except a cross-region plain source keys
-                        // the *bus* (its path is the user-facing identity).
-                        Some(Kind::Plain) => {
-                            let writer = PartId::Region(comp[&src]);
-                            if at == Some(writer) {
-                                Feed::Wire(src, sport)
-                            } else {
-                                Feed::Read {
-                                    key: BusKey::Bus(graph[eff].path().to_vec()),
-                                    writer: Some(writer),
-                                    demand: Some((src, sport)),
-                                    param_at: (graph[eff].path().to_vec(), "bus".to_string()),
-                                }
-                            }
-                        }
-                        Some(Kind::Instance(..)) => Feed::Read {
-                            key: BusKey::InstOut {
-                                path: graph[src].path().to_vec(),
-                                outlet: sport,
-                            },
-                            writer: inst_part.get(&src).map(|&i| PartId::Instance(i)),
-                            demand: None,
-                            param_at: (graph[src].path().to_vec(), format!("out{sport}-bus")),
+            Some(Kind::Instance(..)) => {
+                let path = graph[s].path().to_vec();
+                let n = out_summands
+                    .get(&(path.clone(), port))
+                    .copied()
+                    .unwrap_or(1)
+                    .max(1);
+                (0..n)
+                    .map(|summand| Feed::Read {
+                        key: BusKey::InstOut {
+                            path: path.clone(),
+                            outlet: port,
+                            summand,
                         },
-                        Some(Kind::Inlet(i)) => match inlets.get(*i) {
-                            Some(Some(_)) => Feed::Read {
-                                key: BusKey::IfaceIn(*i),
-                                writer: None,
-                                demand: None,
-                                param_at: (
-                                    inlet_paths.get(i).cloned().unwrap_or_default(),
-                                    "bus".to_string(),
-                                ),
-                            },
-                            _ => Feed::Silence,
-                        },
-                        _ => Feed::Silence,
-                    },
-                    None => Feed::Silence,
+                        writer: inst_part.get(&s).map(|&i| PartId::Instance(i)),
+                        demand: None,
+                        param_at: (
+                            path.clone(),
+                            summand_label(&format!("out{port}-bus"), summand),
+                        ),
+                    })
+                    .collect()
+            }
+            Some(Kind::Inlet(i)) => {
+                let summands = inlets.get(*i).map(Vec::as_slice).unwrap_or(&[]);
+                (0..summands.len())
+                    .map(|summand| Feed::Read {
+                        key: BusKey::IfaceIn { inlet: *i, summand },
+                        writer: None,
+                        demand: None,
+                        param_at: (
+                            inlet_paths.get(i).cloned().unwrap_or_default(),
+                            summand_label("bus", summand),
+                        ),
+                    })
+                    .collect()
+            }
+            _ => vec![Feed::Silence],
+        }
+    };
+    // Classify every read a summand source lowers to. A boundary is
+    // transparent: a pure single-summand chain to a cross-region plain source
+    // keys the *bus* (its path is the user-facing identity); any other chain
+    // lowers to its endpoints, each classified as though wired directly.
+    let feeds = |src: (NodeIx, usize),
+                 at: Option<PartId>,
+                 out_summands: &HashMap<(Vec<usize>, usize), usize>|
+     -> Vec<Feed> {
+        let (s, port) = src;
+        if !boundary(s) {
+            return direct_feeds(s, port, at, out_summands);
+        }
+        let eff = effective(s);
+        match classic_source(eff) {
+            Some((src, sport)) if kind.get(&src) == Some(&Kind::Plain) => {
+                let writer = PartId::Region(comp[&src]);
+                if at == Some(writer) {
+                    vec![Feed::Wire(src, sport)]
+                } else {
+                    vec![Feed::Read {
+                        key: BusKey::Bus(graph[eff].path().to_vec()),
+                        writer: Some(writer),
+                        demand: Some((src, sport)),
+                        param_at: (graph[eff].path().to_vec(), "bus".to_string()),
+                    }]
                 }
             }
-            Some(Kind::Instance(..)) => Feed::Read {
-                key: BusKey::InstOut {
-                    path: graph[s].path().to_vec(),
-                    outlet: port,
-                },
-                writer: inst_part.get(&s).map(|&i| PartId::Instance(i)),
-                demand: None,
-                param_at: (graph[s].path().to_vec(), format!("out{port}-bus")),
-            },
-            Some(Kind::Inlet(i)) => match inlets.get(*i) {
-                Some(Some(_)) => Feed::Read {
-                    key: BusKey::IfaceIn(*i),
-                    writer: None,
-                    demand: None,
-                    param_at: (
-                        inlet_paths.get(i).cloned().unwrap_or_default(),
-                        "bus".to_string(),
-                    ),
-                },
-                _ => Feed::Silence,
-            },
-            _ => Feed::Silence,
+            _ => bus_endpoints(s)
+                .into_iter()
+                .flat_map(|(e, eport)| direct_feeds(e, eport, at, out_summands))
+                .collect(),
         }
     };
 
@@ -813,6 +878,10 @@ where
             }
         }
     };
+    // Summand counts are unknown before derivation, so the DAG pass expands
+    // `InstOut` reads against an empty map (a single read - enough for the
+    // reader/writer relations, which are summand-agnostic).
+    let no_summands = OutSummands::new();
     for (&n, inputs) in &srcs {
         let at = match kind.get(&n) {
             Some(Kind::Plain) => Some(PartId::Region(comp[&n])),
@@ -823,20 +892,24 @@ where
                 }
                 None
             }
-            // Boundaries are transparent (resolved through `bus_source` by
+            // Boundaries are transparent (resolved through their endpoints by
             // their consumers); inlets consume nothing.
             _ => continue,
         };
-        for src in inputs.iter() {
-            if let Feed::Read {
-                key,
-                writer,
-                demand: d,
-                ..
-            } = feed(*src, at)
-            {
-                demand(writer, &key, d);
-                reads.push((at, key, writer));
+        for summands in inputs.iter() {
+            for &src in summands {
+                for f in feeds(src, at, &no_summands) {
+                    if let Feed::Read {
+                        key,
+                        writer,
+                        demand: d,
+                        ..
+                    } = f
+                    {
+                        demand(writer, &key, d);
+                        reads.push((at, key, writer));
+                    }
+                }
             }
         }
     }
@@ -910,11 +983,13 @@ where
         }
     }
 
-    // Derive each part in topo order, flowing bus widths forward.
+    // Derive each part in topo order, flowing bus widths (and outlet summand
+    // counts) forward.
     let mut port_width: HashMap<BusKey, usize> = HashMap::new();
-    for (i, w) in inlets.iter().enumerate() {
-        if let Some(w) = *w {
-            port_width.insert(BusKey::IfaceIn(i), w);
+    let mut out_summands = OutSummands::new();
+    for (i, ws) in inlets.iter().enumerate() {
+        for (summand, &w) in ws.iter().enumerate() {
+            port_width.insert(BusKey::IfaceIn { inlet: i, summand }, w);
         }
     }
     let mut parts: Vec<Part> = Vec::with_capacity(topo.len());
@@ -927,9 +1002,10 @@ where
                     c,
                     &comp,
                     &srcs,
-                    &feed,
+                    &feeds,
                     demands.get(&c).map(Vec::as_slice).unwrap_or(&[]),
                     &mut port_width,
+                    &out_summands,
                 )?;
                 parts.push(Part::Region(region));
             }
@@ -940,11 +1016,12 @@ where
                     inst,
                     out_channels,
                     &srcs,
-                    &feed,
+                    &feeds,
                     resolve,
                     cache,
                     deriving,
                     &mut port_width,
+                    &mut out_summands,
                 )?;
                 parts.push(Part::Instance(part));
             }
@@ -952,23 +1029,33 @@ where
     }
 
     // The template's own outlet table: the key + width of the bus carrying
-    // each consumed outlet's signal.
+    // each consumed outlet summand's signal.
     let outlets = (0..outlets_consumed.len())
         .map(|j| {
             if !outlets_consumed.get(j).copied().unwrap_or(false) {
-                return None;
+                return Vec::new();
             }
-            let o = outlet_ixs.get(&j)?;
-            let src = srcs.get(o).and_then(|inputs| inputs.first().copied())?;
-            match feed(src, None) {
-                Feed::Read { key, .. } => {
-                    let w = port_width.get(&key).copied().unwrap_or(1);
-                    Some((key, w))
-                }
-                // An outlet has no part of its own, so a `Wire` feed is
-                // unreachable (its source is always external to `None`).
-                Feed::Wire(..) | Feed::Silence => None,
-            }
+            let Some(o) = outlet_ixs.get(&j) else {
+                return Vec::new();
+            };
+            let summands = srcs
+                .get(o)
+                .and_then(|inputs| inputs.first())
+                .cloned()
+                .unwrap_or_default();
+            summands
+                .into_iter()
+                .flat_map(|src| feeds(src, None, &out_summands))
+                .filter_map(|f| match f {
+                    Feed::Read { key, .. } => {
+                        let w = port_width.get(&key).copied().unwrap_or(1);
+                        Some((key, w))
+                    }
+                    // An outlet has no part of its own, so a `Wire` feed is
+                    // unreachable (its source is always external to `None`).
+                    Feed::Wire(..) | Feed::Silence => None,
+                })
+                .collect()
         })
         .collect();
 
@@ -976,17 +1063,19 @@ where
 }
 
 /// Derive one region's synthdef: its nodes in dsp pull order, `In` units for
-/// its external reads and fade-gained `Out` units for its demanded writes.
+/// its external reads (each multi-summand input summed after materializing
+/// its wires and reads) and fade-gained `Out` units for its demanded writes.
 #[allow(clippy::too_many_arguments)]
 fn derive_region<N>(
     graph: &Graph<Flat<N>>,
     out_channels: usize,
     c: usize,
     comp: &HashMap<NodeIx, usize>,
-    srcs: &HashMap<NodeIx, Vec<Option<(NodeIx, usize)>>>,
-    feed: &impl Fn(Option<(NodeIx, usize)>, Option<PartId>) -> Feed,
+    srcs: &HashMap<NodeIx, Vec<Vec<(NodeIx, usize)>>>,
+    feeds: &impl Fn((NodeIx, usize), Option<PartId>, &OutSummands) -> Vec<Feed>,
     writes: &[(BusKey, (NodeIx, usize))],
     port_width: &mut HashMap<BusKey, usize>,
+    out_summands: &OutSummands,
 ) -> Result<TemplateRegion, DeriveError>
 where
     N: ToNodeDsp,
@@ -1024,40 +1113,49 @@ where
             continue;
         };
         let path = graph[n].path();
-        let inputs: Vec<Signal> = srcs[&n]
-            .iter()
-            .map(|src| match feed(*src, at) {
-                Feed::Wire(s, port) => outputs
-                    .get(&s)
-                    .and_then(|o| o.get(port))
-                    .cloned()
-                    .unwrap_or_else(|| Signal::silent(1)),
-                Feed::Read { key, param_at, .. } => in_signals
-                    .entry(key.clone())
-                    .or_insert_with(|| {
-                        let channels = port_width.get(&key).copied().unwrap_or(1);
-                        let (p_path, p_label) = &param_at;
-                        let bus_param = builder.push_control_param(p_path, p_label);
-                        let unit = builder.push_unit(UnitSpec::new(
-                            "In",
-                            Rate::Audio,
-                            vec![InputRef::Param(bus_param)],
-                            channels,
-                        ));
-                        bus_reads.push(TemplateBus {
-                            key: key.clone(),
-                            channels,
-                            unit: unit as usize,
-                            param: bus_param as usize,
-                        });
-                        (0..channels as u32)
-                            .map(|output| InputRef::Unit { unit, output })
-                            .collect()
-                    })
-                    .clone(),
-                Feed::Silence => Signal::silent(1),
-            })
-            .collect();
+        // Each input sums its summands' resolved signals.
+        let mut inputs: Vec<Signal> = Vec::with_capacity(srcs[&n].len());
+        for summands in &srcs[&n] {
+            let mut sigs: Vec<Signal> = Vec::new();
+            for &src in summands {
+                for f in feeds(src, at, out_summands) {
+                    let sig = match f {
+                        Feed::Wire(s, port) => outputs
+                            .get(&s)
+                            .and_then(|o| o.get(port))
+                            .cloned()
+                            .unwrap_or_else(|| Signal::silent(1)),
+                        Feed::Read { key, param_at, .. } => in_signals
+                            .entry(key.clone())
+                            .or_insert_with(|| {
+                                let channels = port_width.get(&key).copied().unwrap_or(1);
+                                let (p_path, p_label) = &param_at;
+                                let bus_param = builder.push_control_param(p_path, p_label);
+                                let unit = builder.push_unit(UnitSpec::new(
+                                    "In",
+                                    Rate::Audio,
+                                    vec![InputRef::Param(bus_param)],
+                                    channels,
+                                ));
+                                bus_reads.push(TemplateBus {
+                                    key: key.clone(),
+                                    channels,
+                                    unit: unit as usize,
+                                    param: bus_param as usize,
+                                });
+                                (0..channels as u32)
+                                    .map(|output| InputRef::Unit { unit, output })
+                                    .collect()
+                            })
+                            .clone(),
+                        Feed::Silence => Signal::silent(1),
+                    };
+                    sigs.push(sig);
+                }
+            }
+            // An unconnected (or unsourced-boundary) input sums to silence.
+            inputs.push(sum_signals(&mut builder, &sigs));
+        }
         let outs = dsp.ugens(path, &inputs, &mut builder);
         debug_assert_eq!(
             outs.len(),
@@ -1081,7 +1179,7 @@ where
             BusKey::Bus(bus_path) => (bus_path.clone(), (bus_path.clone(), "bus".to_string())),
             BusKey::Src { path, output } => (path.clone(), (path.clone(), format!("bus{output}"))),
             // Only `Bus`/`Src` writes are ever demanded of a region.
-            BusKey::InstOut { .. } | BusKey::IfaceIn(_) => continue,
+            BusKey::InstOut { .. } | BusKey::IfaceIn { .. } => continue,
         };
         let fade = *fades
             .entry(fade_path.clone())
@@ -1149,12 +1247,13 @@ fn derive_instance<N>(
     graph: &Graph<Flat<N>>,
     inst: NodeIx,
     out_channels: usize,
-    srcs: &HashMap<NodeIx, Vec<Option<(NodeIx, usize)>>>,
-    feed: &impl Fn(Option<(NodeIx, usize)>, Option<PartId>) -> Feed,
+    srcs: &HashMap<NodeIx, Vec<Vec<(NodeIx, usize)>>>,
+    feeds: &impl Fn((NodeIx, usize), Option<PartId>, &OutSummands) -> Vec<Feed>,
     resolve: &InstanceResolve<'_, N>,
     cache: &mut DefCache,
     deriving: &mut Vec<ContentAddr>,
     port_width: &mut HashMap<BusKey, usize>,
+    out_summands: &mut OutSummands,
 ) -> Result<InstancePart, DeriveError>
 where
     N: ToNodeDsp,
@@ -1171,18 +1270,22 @@ where
     let path = path.clone();
     let child_ca = *child_ca;
 
-    // Inlet feeds: the key of the bus feeding each connected inlet, and the
+    // Inlet feeds: the key of the bus feeding each inlet summand, and the
     // width that bus carries (its writer derived earlier in topo order).
-    let mut inlet_keys: Vec<Option<BusKey>> = vec![None; *n_inlets];
-    let mut inlet_widths: Vec<Option<usize>> = vec![None; *n_inlets];
-    for (i, src) in srcs[&inst].iter().enumerate() {
+    let mut inlet_keys: Vec<Vec<BusKey>> = vec![Vec::new(); *n_inlets];
+    let mut inlet_widths: Vec<Vec<usize>> = vec![Vec::new(); *n_inlets];
+    for (i, summands) in srcs[&inst].iter().enumerate() {
         // A marker's arity is its `n_inlets`, so `i` is always in range.
-        match feed(*src, None) {
-            Feed::Read { key, .. } => {
-                inlet_widths[i] = Some(port_width.get(&key).copied().unwrap_or(1));
-                inlet_keys[i] = Some(key);
+        for &src in summands {
+            for f in feeds(src, None, out_summands) {
+                match f {
+                    Feed::Read { key, .. } => {
+                        inlet_widths[i].push(port_width.get(&key).copied().unwrap_or(1));
+                        inlet_keys[i].push(key);
+                    }
+                    Feed::Wire(..) | Feed::Silence => {}
+                }
             }
-            Feed::Wire(..) | Feed::Silence => {}
         }
     }
 
@@ -1231,16 +1334,18 @@ where
         t
     };
 
-    // Continue the width flow: each consumed outlet's width, from the child's
-    // outlet table.
+    // Continue the width flow: each consumed outlet summand's width and the
+    // outlet's summand count, from the child's outlet table.
     for (j, out) in child.outlets.iter().enumerate() {
-        if let Some((_, w)) = out {
+        out_summands.insert((path.clone(), j), out.len());
+        for (summand, &(_, w)) in out.iter().enumerate() {
             port_width.insert(
                 BusKey::InstOut {
                     path: path.clone(),
                     outlet: j,
+                    summand,
                 },
-                *w,
+                w,
             );
         }
     }
@@ -1272,11 +1377,11 @@ fn instantiate_into(
     template: &GraphTemplate,
     cache: &DefCache,
     prefix: &[usize],
-    inlet_keys: &[Option<BusKey>],
+    inlet_keys: &[Vec<BusKey>],
     out: &mut Vec<ResolvedPart>,
-) -> Vec<Option<(BusKey, usize)>> {
+) -> Vec<Vec<(BusKey, usize)>> {
     // Per template-local instance path: its child's absolutized outlet table.
-    let mut inst_outlets: HashMap<Vec<usize>, Vec<Option<(BusKey, usize)>>> = HashMap::new();
+    let mut inst_outlets: HashMap<Vec<usize>, Vec<Vec<(BusKey, usize)>>> = HashMap::new();
 
     let prefixed = |p: &[usize]| -> Vec<usize> {
         let mut abs = prefix.to_vec();
@@ -1287,30 +1392,35 @@ fn instantiate_into(
     // instance's child outlet table (writers precede readers in part order,
     // so the entry exists by the time a reader needs it); a sourceless outlet
     // falls back to a dedicated unwritten - silent - bus key.
-    let abs_key = |key: &BusKey,
-                   inst_outlets: &HashMap<Vec<usize>, Vec<Option<(BusKey, usize)>>>|
-     -> BusKey {
-        match key {
-            BusKey::Bus(p) => BusKey::Bus(prefixed(p)),
-            BusKey::Src { path, output } => BusKey::Src {
-                path: prefixed(path),
-                output: *output,
-            },
-            BusKey::InstOut { path, outlet } => inst_outlets
-                .get(path)
-                .and_then(|outs| outs.get(*outlet).cloned().flatten())
-                .map(|(k, _)| k)
-                .unwrap_or_else(|| BusKey::InstOut {
+    let abs_key =
+        |key: &BusKey, inst_outlets: &HashMap<Vec<usize>, Vec<Vec<(BusKey, usize)>>>| -> BusKey {
+            match key {
+                BusKey::Bus(p) => BusKey::Bus(prefixed(p)),
+                BusKey::Src { path, output } => BusKey::Src {
                     path: prefixed(path),
-                    outlet: *outlet,
-                }),
-            BusKey::IfaceIn(i) => inlet_keys
-                .get(*i)
-                .cloned()
-                .flatten()
-                .expect("an IfaceIn read implies a connected inlet in the variant"),
-        }
-    };
+                    output: *output,
+                },
+                BusKey::InstOut {
+                    path,
+                    outlet,
+                    summand,
+                } => inst_outlets
+                    .get(path)
+                    .and_then(|outs| outs.get(*outlet))
+                    .and_then(|ss| ss.get(*summand).cloned())
+                    .map(|(k, _)| k)
+                    .unwrap_or_else(|| BusKey::InstOut {
+                        path: prefixed(path),
+                        outlet: *outlet,
+                        summand: *summand,
+                    }),
+                BusKey::IfaceIn { inlet, summand } => inlet_keys
+                    .get(*inlet)
+                    .and_then(|ks| ks.get(*summand))
+                    .cloned()
+                    .expect("an IfaceIn read implies a connected inlet summand in the variant"),
+            }
+        };
 
     for part in &template.parts {
         match part {
@@ -1354,10 +1464,10 @@ fn instantiate_into(
                     .get(&ip.variant)
                     .expect("derive_template populates the cache for every instance part");
                 let child_prefix = prefixed(&ip.path);
-                let child_inlets: Vec<Option<BusKey>> = ip
+                let child_inlets: Vec<Vec<BusKey>> = ip
                     .inlet_keys
                     .iter()
-                    .map(|k| k.as_ref().map(|k| abs_key(k, &inst_outlets)))
+                    .map(|ks| ks.iter().map(|k| abs_key(k, &inst_outlets)).collect())
                     .collect();
                 let outs = instantiate_into(&child, cache, &child_prefix, &child_inlets, out);
                 inst_outlets.insert(ip.path.clone(), outs);
@@ -1368,6 +1478,20 @@ fn instantiate_into(
     template
         .outlets
         .iter()
-        .map(|o| o.as_ref().map(|(k, w)| (abs_key(k, &inst_outlets), *w)))
+        .map(|ss| {
+            ss.iter()
+                .map(|(k, w)| (abs_key(k, &inst_outlets), *w))
+                .collect()
+        })
         .collect()
+}
+
+/// A per-summand bus param label: summand 0 keeps the bare `base` (def-sig
+/// stability for pre-summing single-summand shapes), later summands suffix
+/// their index.
+fn summand_label(base: &str, summand: usize) -> String {
+    match summand {
+        0 => base.to_string(),
+        j => format!("{base}{j}"),
+    }
 }

--- a/crates/gantz_plyphon/src/instance.rs
+++ b/crates/gantz_plyphon/src/instance.rs
@@ -50,10 +50,9 @@
 //!
 //! # Summing
 //!
-//! Multiple edges into one dsp input sum
-//! ([`sum_signals`](crate::dsp::sum_signals)), exactly as in
+//! Multiple edges into one dsp input sum ([`sum_signals`]), exactly as in
 //! [`derive_synthdefs`]. Every summand of a consumed input is classified
-//! ([`Feed`]) and the consumer sums the resolved signals - in-region wires
+//! (a `Feed`) and the consumer sums the resolved signals - in-region wires
 //! and bus `In`s alike - after materializing them. A multi-fed instance
 //! *inlet* sums inside the child template (the summand widths are part of the
 //! [`VariantKey`], and each summand gets its own [`BusKey::IfaceIn`] bus). A

--- a/crates/gantz_plyphon/src/instance.rs
+++ b/crates/gantz_plyphon/src/instance.rs
@@ -428,7 +428,13 @@ where
                 let sig = structural_sig(&def);
                 def.name = content_def_name(sig);
                 let to_template = |b: crate::compile::BusBinding| TemplateBus {
-                    key: BusKey::Bus(b.node_path),
+                    key: match b.output {
+                        None => BusKey::Bus(b.node_path),
+                        Some(output) => BusKey::Src {
+                            path: b.node_path,
+                            output,
+                        },
+                    },
                     channels: b.channels,
                     unit: b.unit,
                     param: b.param,

--- a/crates/gantz_plyphon/src/lib.rs
+++ b/crates/gantz_plyphon/src/lib.rs
@@ -35,7 +35,7 @@ pub use instance::{
     BusKey, DefCache, GraphTemplate, InstancePart, Part, ResolvedBus, ResolvedPart, TemplateBus,
     TemplateRegion, VariantKey, derive_template, instantiate,
 };
-pub use node::{Bus, Lag, Out, Pack, ScopeOut, SinOsc, Unpack};
+pub use node::{Bus, Lag, Out, Pack, ScopeOut, SinOsc, Sum, Unpack};
 pub use ref_ext::{DSP_REF_EXT_KEY, DspRefExt, dsp_commits};
 pub use sugar::PlyphonSugar;
 // `self::` disambiguates from the extern `egui` crate at the crate root.

--- a/crates/gantz_plyphon/src/node/bus.rs
+++ b/crates/gantz_plyphon/src/node/bus.rs
@@ -19,6 +19,10 @@ use crate::dsp::{DspBuilder, NodeDsp, Signal, ToNodeDsp};
 /// Cutting comes at a price on the wire itself: the write is lifted to audio
 /// rate and fade-gained (the crossfade lever), and cross-region feedback is not
 /// yet supported (a bus cycle fails derivation).
+///
+/// A `~bus` fed by several summands keeps only its cut role: each transitive
+/// source writes its own implicit single-writer bus and every reader emits one
+/// `In` per source, summing after the reads.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash, NodeTag)]
 pub struct Bus {}
 

--- a/crates/gantz_plyphon/src/node/mod.rs
+++ b/crates/gantz_plyphon/src/node/mod.rs
@@ -12,6 +12,7 @@ pub use out::Out;
 pub use pack::Pack;
 pub use scope_out::ScopeOut;
 pub use sin_osc::SinOsc;
+pub use sum::Sum;
 pub use unpack::Unpack;
 
 pub mod bus;
@@ -20,4 +21,5 @@ pub mod out;
 pub mod pack;
 pub mod scope_out;
 pub mod sin_osc;
+pub mod sum;
 pub mod unpack;

--- a/crates/gantz_plyphon/src/node/sum.rs
+++ b/crates/gantz_plyphon/src/node/sum.rs
@@ -1,31 +1,29 @@
-//! The `~pack` node: concatenate signals into one channel group.
+//! The `~sum` node: sum signals into their unity-gain mix.
 
 use gantz_ca::CaHash;
 use gantz_core::node::{ExprCtx, ExprResult, MetaCtx};
 use gantz_nodetag::NodeTag;
 use serde::{Deserialize, Serialize};
 
-use crate::dsp::{DspBuilder, NodeDsp, Signal, ToNodeDsp};
+use crate::dsp::{DspBuilder, NodeDsp, Signal, ToNodeDsp, sum_signals};
 
-/// Concatenate `count` input signals into one channel group (like Max's
-/// `mc.pack~` or a VCV merge): the output's width is the sum of the input
-/// widths, an unconnected input contributing one channel of silence. Channels
-/// are *packed*, never summed - summing is `~sum` (and per-input-gain mixing
-/// a future `~mix`).
-///
-/// A routing node: it emits no UGens, it only re-groups wires at
-/// synthdef-derivation time (and is Steel-inert like the other dsp nodes).
+/// Sum `count` input signals into one channel group - the same unity-gain mix
+/// ([`sum_signals`]) as wiring several edges into one input, as an explicit
+/// node: the output is as wide as the widest input, a mono input broadcasts
+/// across every channel and a narrower one contributes silence past its own
+/// width. Per-input gain is a different (future `~mix`) node; channel
+/// concatenation is `~pack`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, NodeTag)]
-pub struct Pack {
+pub struct Sum {
     #[serde(default = "default_count")]
     count: usize,
 }
 
-impl Pack {
-    /// The number of inputs a fresh `~pack` starts with.
+impl Sum {
+    /// The number of inputs a fresh `~sum` starts with.
     pub const DEFAULT_COUNT: usize = 2;
 
-    /// The number of dsp inputs to concatenate.
+    /// The number of dsp inputs to sum.
     pub fn count(&self) -> usize {
         self.count
     }
@@ -37,22 +35,22 @@ impl Pack {
     }
 }
 
-impl Default for Pack {
+impl Default for Sum {
     fn default() -> Self {
-        Pack {
+        Sum {
             count: default_count(),
         }
     }
 }
 
-impl CaHash for Pack {
+impl CaHash for Sum {
     fn hash(&self, hasher: &mut gantz_ca::Hasher) {
-        hasher.update(b"gantz.plyphon.pack");
+        hasher.update(b"gantz.plyphon.sum");
         hasher.update(&self.count.to_le_bytes());
     }
 }
 
-impl gantz_core::Node for Pack {
+impl gantz_core::Node for Sum {
     fn n_inputs(&self, _ctx: MetaCtx) -> usize {
         // Every input is a dsp signal (any channel width each).
         self.count
@@ -63,13 +61,13 @@ impl gantz_core::Node for Pack {
     }
 
     fn expr(&self, _ctx: ExprCtx<'_, '_>) -> ExprResult {
-        // Steel-inert: the packing happens at synthdef derivation. A placeholder
+        // Steel-inert: the summing happens at synthdef derivation. A placeholder
         // output feeds the inert dsp output edge.
         gantz_core::node::parse_expr("0")
     }
 }
 
-impl NodeDsp for Pack {
+impl NodeDsp for Sum {
     fn n_dsp_inputs(&self) -> usize {
         self.count
     }
@@ -78,19 +76,18 @@ impl NodeDsp for Pack {
         1
     }
 
-    fn ugens(&self, _path: &[usize], inputs: &[Signal], _b: &mut DspBuilder) -> Vec<Signal> {
-        // Pure re-grouping: no units, just the concatenation of every input's
-        // channels (unconnected inputs are already mono silence).
-        vec![Signal::concat(inputs.iter().cloned())]
+    fn ugens(&self, _path: &[usize], inputs: &[Signal], b: &mut DspBuilder) -> Vec<Signal> {
+        // Unconnected inputs are already mono silence, which folds away.
+        vec![sum_signals(b, inputs)]
     }
 }
 
-impl ToNodeDsp for Pack {
+impl ToNodeDsp for Sum {
     fn to_node_dsp(&self) -> Option<&dyn NodeDsp> {
         Some(self)
     }
 }
 
 fn default_count() -> usize {
-    Pack::DEFAULT_COUNT
+    Sum::DEFAULT_COUNT
 }

--- a/crates/gantz_plyphon/src/sugar.rs
+++ b/crates/gantz_plyphon/src/sugar.rs
@@ -4,6 +4,7 @@
 //! bare `~sinosc`/`~out`/`~lag`/`~scopeout`/`~pack`/`~unpack`, with optional
 //! `(~sinosc #:freq-lag s [#:rate ar|kr])`, `(~lag #:rate ar|kr)`,
 //! `(~out #:gain-lag s)`, `(~scopeout #:size n)` and `(~pack #:count n)`/
+//! `(~sum #:count n)`/
 //! `(~unpack #:count n)` forms carrying the structural smoothing lag / ugen
 //! rate / ring length / socket count. The `freq`/`gain`/`dur` param *values*
 //! live in VM state (not the node weight), so they are not serialized and never
@@ -14,7 +15,7 @@ use gantz_format::{Datum, FormatError, Sugar, SugarArgs, node_datum};
 
 /// Keyword sugar for the plyphon DSP nodes ([`SinOsc`](crate::SinOsc),
 /// [`Out`](crate::Out), [`Lag`](crate::Lag), [`ScopeOut`](crate::ScopeOut),
-/// [`Pack`](crate::Pack), [`Unpack`](crate::Unpack)).
+/// [`Pack`](crate::Pack), [`Sum`](crate::Sum), [`Unpack`](crate::Unpack)).
 #[derive(Clone, Copy, Debug, Default)]
 pub struct PlyphonSugar;
 
@@ -25,6 +26,7 @@ const KEYWORD_TAG: &[(&str, &str)] = &[
     ("~lag", "Lag"),
     ("~scopeout", "ScopeOut"),
     ("~pack", "Pack"),
+    ("~sum", "Sum"),
     ("~unpack", "Unpack"),
     ("~bus", "Bus"),
 ];
@@ -53,6 +55,7 @@ impl Sugar for PlyphonSugar {
             "~lag" => rate_spec("Lag", args)?,
             "~scopeout" => size_spec(args)?,
             "~pack" => count_spec("Pack", args)?,
+            "~sum" => count_spec("Sum", args)?,
             "~unpack" => count_spec("Unpack", args)?,
             "~bus" => node_datum("Bus", vec![]),
             _ => return Ok(None),
@@ -83,6 +86,7 @@ impl Sugar for PlyphonSugar {
             "Lag" => Some(write_form("~lag", rate_part(node).into_iter().collect())),
             "ScopeOut" => Some(write_size(node)),
             "Pack" => Some(write_count("~pack", crate::Pack::DEFAULT_COUNT, node)),
+            "Sum" => Some(write_count("~sum", crate::Sum::DEFAULT_COUNT, node)),
             "Unpack" => Some(write_count("~unpack", crate::Unpack::DEFAULT_COUNT, node)),
             other => keyword_for_tag(other).map(str::to_string),
         }
@@ -347,10 +351,11 @@ mod tests {
     }
 
     #[test]
-    fn pack_and_unpack_round_trip() {
+    fn count_nodes_round_trip() {
         let s = PlyphonSugar;
         for (kw, tag, default) in [
             ("~pack", "Pack", crate::Pack::DEFAULT_COUNT),
+            ("~sum", "Sum", crate::Sum::DEFAULT_COUNT),
             ("~unpack", "Unpack", crate::Unpack::DEFAULT_COUNT),
         ] {
             // A default count stays bare (read as a bare keyword or an empty spec),

--- a/crates/gantz_plyphon/tests/derive_regions.rs
+++ b/crates/gantz_plyphon/tests/derive_regions.rs
@@ -463,3 +463,90 @@ fn goertzel(samples: &[f32], freq: f32) -> f32 {
     let power = s1 * s1 + s2 * s2 - coeff * s1 * s2;
     power.max(0.0).sqrt() / n as f32
 }
+
+#[test]
+fn multi_fed_bus_sums_at_the_reader() {
+    // Two `~sinosc` (each its own region - they meet only at the boundary)
+    // feeding one `~bus`, read by `~out`: the bus keeps only its cut role.
+    // Each sine writes its own implicit endpoint bus, and the reader emits
+    // one `In` per endpoint and sums them after the reads.
+    let mut g = Graph::<N>::default();
+    let s0 = g.add_node(N::SinOsc(SinOsc::default()));
+    let s1 = g.add_node(N::SinOsc(SinOsc::default()));
+    let b = g.add_node(N::Bus(Bus::default()));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s0, b, Edge::new(0.into(), 0.into()));
+    g.add_edge(s1, b, Edge::new(0.into(), 0.into()));
+    g.add_edge(b, o, Edge::new(0.into(), 0.into()));
+
+    let regions = derive_synthdefs(&g, 1, "head").expect("derive");
+    assert_eq!(regions.len(), 3, "two writers + one reader");
+
+    // Each writer emits one endpoint-keyed bus write (the sine's own path +
+    // output port), not a `~bus`-keyed one.
+    for (region, s) in regions[..2].iter().zip([s0, s1]) {
+        assert_eq!(region.bus_writes.len(), 1);
+        let w = &region.bus_writes[0];
+        assert_eq!(w.node_path, vec![s.index()]);
+        assert_eq!(w.output, Some(0));
+        assert_eq!(w.channels, 1);
+        assert!(region.bus_reads.is_empty());
+    }
+
+    // The reader holds two `In`s (canonical endpoint order) and one add.
+    let reader = &regions[2];
+    assert_eq!(reader.bus_reads.len(), 2);
+    assert_eq!(reader.bus_reads[0].node_path, vec![s0.index()]);
+    assert_eq!(reader.bus_reads[1].node_path, vec![s1.index()]);
+    assert!(reader.bus_reads.iter().all(|r| r.output == Some(0)));
+    let rdef = &reader.derived.def;
+    assert_eq!(rdef.units.iter().filter(|u| u.name == "In").count(), 2);
+    let adds: Vec<_> = rdef
+        .units
+        .iter()
+        .filter(|u| u.name == "BinaryOpUGen" && u.special_index == 0)
+        .collect();
+    assert_eq!(adds.len(), 1, "the two bus reads sum after the `In`s");
+    assert!(matches!(adds[0].rate, Rate::Audio));
+}
+
+#[test]
+fn single_fed_bus_keeps_its_classic_shape_and_key() {
+    // A single-summand `~bus` chain must keep the exact pre-summing lowering:
+    // bus-keyed bindings (no endpoint port) and unchanged region keys, so
+    // existing patches neither respawn nor resound differently.
+    let build = |extra_edge: bool| {
+        let mut g = Graph::<N>::default();
+        let s = g.add_node(N::SinOsc(SinOsc::default()));
+        let b = g.add_node(N::Bus(Bus::default()));
+        let o = g.add_node(N::Out(Out::default()));
+        g.add_edge(s, b, Edge::new(0.into(), 0.into()));
+        g.add_edge(b, o, Edge::new(0.into(), 0.into()));
+        if extra_edge {
+            // A second summand flips the boundary out of the classic case.
+            let s1 = g.add_node(N::SinOsc(SinOsc::default()));
+            g.add_edge(s1, b, Edge::new(0.into(), 0.into()));
+        }
+        (g, b)
+    };
+    let (g, b) = build(false);
+    let regions = derive_synthdefs(&g, 1, "head").expect("derive");
+    assert_eq!(regions.len(), 2);
+    let (writer, reader) = (&regions[0], &regions[1]);
+    assert_eq!(writer.bus_writes[0].node_path, vec![b.index()]);
+    assert_eq!(writer.bus_writes[0].output, None, "classic bus identity");
+    assert_eq!(reader.bus_reads[0].node_path, vec![b.index()]);
+    assert_eq!(reader.bus_reads[0].output, None);
+
+    // Adding a second summand re-keys the boundary's buses (endpoint-keyed),
+    // while removing it again restores the classic keys.
+    let (g2, _) = build(true);
+    let regions2 = derive_synthdefs(&g2, 1, "head").expect("derive");
+    assert_eq!(regions2.len(), 3);
+    let reader2 = &regions2[2];
+    assert!(reader2.bus_reads.iter().all(|r| r.output.is_some()));
+    let (g3, _) = build(false);
+    let regions3 = derive_synthdefs(&g3, 1, "head").expect("derive");
+    assert_eq!(regions3[0].key, regions[0].key, "writer key is stable");
+    assert_eq!(regions3[1].key, regions[1].key, "reader key is stable");
+}

--- a/crates/gantz_plyphon/tests/derive_synthdef.rs
+++ b/crates/gantz_plyphon/tests/derive_synthdef.rs
@@ -6,7 +6,7 @@ use gantz_core::edge::Edge;
 use gantz_core::node::graph::Graph;
 use gantz_plyphon::{
     Backend, DeriveError, DspBuilder, Embedded, Lag, NodeDsp, NodeRate, Out, Pack, ScopeOut,
-    Signal, SinOsc, ToNodeDsp, Unpack, derive_synthdef, structural_sig,
+    Signal, SinOsc, Sum, ToNodeDsp, Unpack, derive_synthdef, structural_sig,
 };
 use plyphon::synthdef::{InputRef, SynthDef, UnitSpec};
 use plyphon::{AddAction, Options, ROOT_GROUP_ID, Rate, World, engine};
@@ -21,6 +21,7 @@ enum N {
     Out(Out),
     ScopeOut(ScopeOut),
     Pack(Pack),
+    Sum(Sum),
     Unpack(Unpack),
     Other,
 }
@@ -33,6 +34,7 @@ impl ToNodeDsp for N {
             N::Out(o) => Some(o),
             N::ScopeOut(t) => Some(t),
             N::Pack(p) => Some(p),
+            N::Sum(s) => Some(s),
             N::Unpack(u) => Some(u),
             N::Other => None,
         }
@@ -1392,5 +1394,58 @@ fn summed_sines_are_both_audible() {
     assert!(
         m220 > 5.0 * m550 && m330 > 5.0 * m550,
         "both summands must be audible: m220={m220}, m330={m330}, m550={m550}",
+    );
+}
+
+#[test]
+fn sum_node_mixes_mono_and_stereo() {
+    // `~sum` of a mono sine and a stereo `~pack`: the node's output is the
+    // stereo unity-gain mix (one add per channel, the mono input broadcast),
+    // exactly the implicit-summing width policy as an explicit node.
+    let mut g = Graph::<N>::default();
+    let m = g.add_node(N::SinOsc(SinOsc::default()));
+    let s0 = g.add_node(N::SinOsc(SinOsc::default()));
+    let s1 = g.add_node(N::SinOsc(SinOsc::default()));
+    let pk = g.add_node(N::Pack(Pack::default()));
+    let sm = g.add_node(N::Sum(Sum::default()));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s0, pk, Edge::new(0.into(), 0.into()));
+    g.add_edge(s1, pk, Edge::new(0.into(), 1.into()));
+    g.add_edge(m, sm, Edge::new(0.into(), 0.into()));
+    g.add_edge(pk, sm, Edge::new(0.into(), 1.into()));
+    g.add_edge(sm, o, Edge::new(0.into(), 0.into()));
+    let def = derive_synthdef(&g, 2, "t").expect("derive").def;
+
+    let adds = sum_units(&def);
+    assert_eq!(adds.len(), 2, "one add per output channel");
+    let (a, b) = (unit_refs(adds[0]), unit_refs(adds[1]));
+    let shared: Vec<_> = a.iter().filter(|r| b.contains(r)).collect();
+    assert_eq!(shared.len(), 1, "the mono input broadcasts into both");
+    let out = def.units.iter().find(|u| u.name == "Out").expect("Out");
+    assert_eq!(out.inputs.len(), 1 + 2, "the stereo mix reaches both buses");
+}
+
+#[test]
+fn sum_node_with_single_input_is_unit_free() {
+    // A count-1 (or singly-fed) `~sum` passes its input through with no
+    // units, so it derives identically to a plain wire.
+    let mut g = Graph::<N>::default();
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let mut sum = Sum::default();
+    sum.set_count(1);
+    let sm = g.add_node(N::Sum(sum));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s, sm, Edge::new(0.into(), 0.into()));
+    g.add_edge(sm, o, Edge::new(0.into(), 0.into()));
+    let def = derive_synthdef(&g, 1, "t").expect("derive").def;
+    assert!(sum_units(&def).is_empty());
+    // The same unit chain as a bare `~sinosc -> ~out` (params differ only by
+    // node path).
+    let bare = derive_synthdef(&sine_to_out(), 1, "t").expect("derive").def;
+    let names = |d: &SynthDef| d.units.iter().map(|u| u.name.clone()).collect::<Vec<_>>();
+    assert_eq!(
+        names(&def),
+        names(&bare),
+        "a pass-through ~sum leaves no trace in the def",
     );
 }

--- a/crates/gantz_plyphon/tests/derive_synthdef.rs
+++ b/crates/gantz_plyphon/tests/derive_synthdef.rs
@@ -8,7 +8,7 @@ use gantz_plyphon::{
     Backend, DeriveError, DspBuilder, Embedded, Lag, NodeDsp, NodeRate, Out, Pack, ScopeOut,
     Signal, SinOsc, ToNodeDsp, Unpack, derive_synthdef, structural_sig,
 };
-use plyphon::synthdef::InputRef;
+use plyphon::synthdef::{InputRef, SynthDef, UnitSpec};
 use plyphon::{AddAction, Options, ROOT_GROUP_ID, Rate, World, engine};
 
 const SR: f32 = 48_000.0;
@@ -1176,5 +1176,221 @@ fn kr_source_reaches_output() {
     assert!(
         m220 > 3.0 * m440,
         "expected 220 Hz dominant: m220={m220}, m440={m440}",
+    );
+}
+
+/// The summing units of a def: `Sum3`/`Sum4` and add-selector `BinaryOpUGen`s
+/// (`special_index` 0 - the gain muls select 2).
+fn sum_units(def: &SynthDef) -> Vec<&UnitSpec> {
+    def.units
+        .iter()
+        .filter(|u| {
+            u.name == "Sum3"
+                || u.name == "Sum4"
+                || (u.name == "BinaryOpUGen" && u.special_index == 0)
+        })
+        .collect()
+}
+
+/// The `(unit, output)` wires among a unit's inputs.
+fn unit_refs(u: &UnitSpec) -> Vec<(u32, u32)> {
+    u.inputs
+        .iter()
+        .filter_map(|i| match i {
+            InputRef::Unit { unit, output } => Some((*unit, *output)),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn single_edge_input_sums_unit_free() {
+    // A lone summand passes through: no summing units, so a single-edge patch
+    // derives exactly as before implicit summing existed.
+    let g = sine_to_out();
+    let def = derive_synthdef(&g, 1, "t").expect("derive").def;
+    assert!(sum_units(&def).is_empty());
+}
+
+#[test]
+fn two_edges_into_one_input_sum() {
+    // Two `~sinosc` into one `~out` input: the input is their unity-gain mix
+    // via a single audio-rate add, and both sines land in the def (neither
+    // edge is dropped).
+    let mut g = Graph::<N>::default();
+    let s0 = g.add_node(N::SinOsc(SinOsc::default()));
+    let s1 = g.add_node(N::SinOsc(SinOsc::default()));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s0, o, Edge::new(0.into(), 0.into()));
+    g.add_edge(s1, o, Edge::new(0.into(), 0.into()));
+    let def = derive_synthdef(&g, 1, "t").expect("derive").def;
+
+    assert_eq!(def.units.iter().filter(|u| u.name == "SinOsc").count(), 2);
+    let adds = sum_units(&def);
+    assert_eq!(adds.len(), 1, "one binary add for two summands");
+    assert_eq!(adds[0].name, "BinaryOpUGen");
+    assert!(matches!(adds[0].rate, Rate::Audio));
+    // The add reads both sines.
+    assert_eq!(unit_refs(adds[0]).len(), 2);
+}
+
+#[test]
+fn summands_tile_sum3_and_sum4() {
+    // Three summands lower to one `Sum3`; five to a `Sum4` fed back into a
+    // binary add.
+    for (n, expected) in [(3, vec!["Sum3"]), (5, vec!["Sum4", "BinaryOpUGen"])] {
+        let mut g = Graph::<N>::default();
+        let o = g.add_node(N::Out(Out::default()));
+        for _ in 0..n {
+            let s = g.add_node(N::SinOsc(SinOsc::default()));
+            g.add_edge(s, o, Edge::new(0.into(), 0.into()));
+        }
+        let def = derive_synthdef(&g, 1, "t").expect("derive").def;
+        let names: Vec<&str> = sum_units(&def).iter().map(|u| u.name.as_str()).collect();
+        assert_eq!(names, expected, "{n} summands");
+    }
+}
+
+#[test]
+fn summand_order_is_canonical() {
+    // The same two-source graph with its edges added in either order derives
+    // the same def: summands sort canonically, so `structural_sig` (and the
+    // content def name) is independent of edge insertion order.
+    let build = |flip: bool| {
+        let mut g = Graph::<N>::default();
+        let s0 = g.add_node(N::SinOsc(SinOsc::default()));
+        let s1 = g.add_node(N::SinOsc(SinOsc::default()));
+        let o = g.add_node(N::Out(Out::default()));
+        let (a, b) = if flip { (s1, s0) } else { (s0, s1) };
+        g.add_edge(a, o, Edge::new(0.into(), 0.into()));
+        g.add_edge(b, o, Edge::new(0.into(), 0.into()));
+        derive_synthdef(&g, 1, "t").expect("derive").def
+    };
+    assert_eq!(structural_sig(&build(false)), structural_sig(&build(true)));
+}
+
+#[test]
+fn mono_broadcasts_across_a_summed_stereo() {
+    // A mono `~sinosc` summed with a stereo `~pack` into `~out` on a 2-channel
+    // device: the sum is stereo (one add per channel) and the mono summand
+    // feeds BOTH adds (broadcast, not left-only).
+    let mut g = Graph::<N>::default();
+    let m = g.add_node(N::SinOsc(SinOsc::default()));
+    let s0 = g.add_node(N::SinOsc(SinOsc::default()));
+    let s1 = g.add_node(N::SinOsc(SinOsc::default()));
+    let pk = g.add_node(N::Pack(Pack::default()));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s0, pk, Edge::new(0.into(), 0.into()));
+    g.add_edge(s1, pk, Edge::new(0.into(), 1.into()));
+    g.add_edge(m, o, Edge::new(0.into(), 0.into()));
+    g.add_edge(pk, o, Edge::new(0.into(), 0.into()));
+    let def = derive_synthdef(&g, 2, "t").expect("derive").def;
+
+    let adds = sum_units(&def);
+    assert_eq!(adds.len(), 2, "one add per summed channel");
+    let (a, b) = (unit_refs(adds[0]), unit_refs(adds[1]));
+    let shared: Vec<_> = a.iter().filter(|r| b.contains(r)).collect();
+    assert_eq!(shared.len(), 1, "the mono summand feeds both channels");
+    // The `~out` writes both summed channels.
+    let out = def.units.iter().find(|u| u.name == "Out").expect("Out");
+    assert_eq!(out.inputs.len(), 1 + 2);
+}
+
+#[test]
+fn narrower_summand_pads_with_silence() {
+    // A stereo `~pack` summed with a 3-wide `~pack`: channels 0 and 1 sum a
+    // pair each, channel 2 passes the wide summand's own channel through
+    // unsummed (the narrower summand contributes silence there, which folds
+    // away).
+    let mut g = Graph::<N>::default();
+    let mut wide = Pack::default();
+    wide.set_count(3);
+    let p2 = g.add_node(N::Pack(Pack::default()));
+    let p3 = g.add_node(N::Pack(wide));
+    let o = g.add_node(N::Out(Out::default()));
+    for i in 0..5 {
+        let s = g.add_node(N::SinOsc(SinOsc::default()));
+        let (pk, input) = if i < 2 { (p2, i) } else { (p3, i - 2) };
+        g.add_edge(s, pk, Edge::new(0.into(), (input as u16).into()));
+    }
+    g.add_edge(p2, o, Edge::new(0.into(), 0.into()));
+    g.add_edge(p3, o, Edge::new(0.into(), 0.into()));
+    let def = derive_synthdef(&g, 3, "t").expect("derive").def;
+
+    assert_eq!(sum_units(&def).len(), 2, "adds on channels 0 and 1 only");
+    let out = def.units.iter().find(|u| u.name == "Out").expect("Out");
+    assert_eq!(out.inputs.len(), 1 + 3, "all three channels written");
+}
+
+#[test]
+fn summed_rate_is_audio_iff_any_summand_is() {
+    let build = |rates: [NodeRate; 2]| {
+        let mut g = Graph::<N>::default();
+        let o = g.add_node(N::Out(Out::default()));
+        for rate in rates {
+            let mut sine = SinOsc::default();
+            sine.set_rate(rate);
+            let s = g.add_node(N::SinOsc(sine));
+            g.add_edge(s, o, Edge::new(0.into(), 0.into()));
+        }
+        derive_synthdef(&g, 1, "t").expect("derive").def
+    };
+    let kk = build([NodeRate::Control, NodeRate::Control]);
+    assert!(matches!(sum_units(&kk)[0].rate, Rate::Control));
+    let ka = build([NodeRate::Control, NodeRate::Audio]);
+    assert!(matches!(sum_units(&ka)[0].rate, Rate::Audio));
+}
+
+#[test]
+fn summed_sines_are_both_audible() {
+    // Two sines summed into one `~out` input, the second re-tuned to 330 Hz:
+    // the rendered audio carries BOTH tones - the end-to-end proof that no
+    // edge is dropped.
+    let mut g = Graph::<N>::default();
+    let s0 = g.add_node(N::SinOsc(SinOsc::default()));
+    let s1 = g.add_node(N::SinOsc(SinOsc::default()));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s0, o, Edge::new(0.into(), 0.into()));
+    g.add_edge(s1, o, Edge::new(0.into(), 0.into()));
+    let derived = derive_synthdef(&g, 1, "t").expect("derive");
+    let s1_freq = derived
+        .params
+        .iter()
+        .find(|b| b.node_path == [s1.index()])
+        .expect("sine1 freq binding")
+        .index;
+
+    let (mut controller, _nrt, mut world) = engine(Options {
+        sample_rate: SR as f64,
+        output_channels: 1,
+        ..Options::default()
+    });
+    controller.add_synthdef(derived.def);
+    let node = controller
+        .synth_new("t", ROOT_GROUP_ID, AddAction::Tail)
+        .expect("synth_new");
+    {
+        let mut backend = Embedded::new(&mut controller);
+        for gain in &derived.gains {
+            backend.set_control(node, gain.index, 1.0).expect("fade in");
+        }
+        backend
+            .set_control(node, s1_freq, 330.0)
+            .expect("re-tune sine1");
+    }
+
+    let out = render(&mut world, SR as usize / 2);
+    assert!(
+        out.iter().all(|s| s.abs() <= 1.001),
+        "output exceeded full scale"
+    );
+    let (m220, m330, m550) = (
+        goertzel(&out, 220.0),
+        goertzel(&out, 330.0),
+        goertzel(&out, 550.0),
+    );
+    assert!(
+        m220 > 5.0 * m550 && m330 > 5.0 * m550,
+        "both summands must be audible: m220={m220}, m330={m330}, m550={m550}",
     );
 }

--- a/crates/gantz_plyphon/tests/flatten.rs
+++ b/crates/gantz_plyphon/tests/flatten.rs
@@ -358,9 +358,9 @@ fn boundary_wiring_cycle_dissolves() {
 }
 
 #[test]
-fn oldest_edge_wins_across_a_bridge() {
-    // Two sources race for the ref's one input: the oldest resolving edge wins
-    // at each hop, matching derivation's input resolution.
+fn every_edge_bridges_across_a_boundary() {
+    // Two sources feed the ref's one input: BOTH chains bridge (oldest first),
+    // so derivation sums them - no edge is dropped at the boundary.
     let map = HashMap::from([(ca(1), wire_child())]);
     let mut g = Graph::<N>::default();
     let s_old = g.add_node(N::SinOsc(SinOsc::default()));
@@ -374,8 +374,46 @@ fn oldest_edge_wins_across_a_bridge() {
     let flat = flatten_with(&g, &map);
     assert_eq!(
         edges_into(&flat, &[3]),
-        vec![(vec![0], 0, 0)],
-        "the older source feeds the consumer",
+        vec![(vec![0], 0, 0), (vec![1], 0, 0)],
+        "both sources feed the consumer",
+    );
+
+    // Derivation sums the bridged summands: one add ties both sines into
+    // the out.
+    let def = derive_synthdef(&flat, 1, "t").expect("derive").def;
+    assert_eq!(def.units.iter().filter(|u| u.name == "SinOsc").count(), 2);
+    let adds = def
+        .units
+        .iter()
+        .filter(|u| u.name == "BinaryOpUGen" && u.special_index == 0)
+        .count();
+    assert_eq!(adds, 1, "the bridged summands sum at the input");
+}
+
+#[test]
+fn duplicate_chains_bridge_as_two_summands() {
+    // A child whose inlet fans to its outlet twice: both chains resolve to
+    // the same source, and both bridge - two distinct wires deliberately sum
+    // the signal twice (doubling), the honest reading of the patch.
+    let mut child = Graph::<N>::default();
+    let i = child.add_node(N::Inlet);
+    let o = child.add_node(N::Outlet);
+    child.add_edge(i, o, Edge::new(0.into(), 0.into()));
+    child.add_edge(i, o, Edge::new(0.into(), 0.into()));
+    let map = HashMap::from([(ca(1), child)]);
+
+    let mut g = Graph::<N>::default();
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::Ref(ca(1)));
+    let out = g.add_node(N::Out(Out::default()));
+    g.add_edge(s, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(r, out, Edge::new(0.into(), 0.into()));
+
+    let flat = flatten_with(&g, &map);
+    assert_eq!(
+        edges_into(&flat, &[2]),
+        vec![(vec![0], 0, 0), (vec![0], 0, 0)],
+        "each chain is a summand, even to the same source",
     );
 }
 

--- a/crates/gantz_plyphon/tests/instance.rs
+++ b/crates/gantz_plyphon/tests/instance.rs
@@ -252,13 +252,14 @@ fn staging_diamond_derives_two_stages() {
     let inst_key = BusKey::InstOut {
         path: vec![r.index()],
         outlet: 0,
+        summand: 0,
     };
     assert!(
         reader.bus_reads.iter().any(|b| b.key == inst_key),
         "the mix region also reads the instance's outlet bus",
     );
     let inst = &instances(&template)[0];
-    assert_eq!(inst.inlet_keys, vec![Some(src_key)]);
+    assert_eq!(inst.inlet_keys, vec![vec![src_key]]);
 }
 
 #[test]
@@ -280,18 +281,18 @@ fn width_flows_through_an_instance() {
 
     let (template, cache) = derive(&g, &map).expect("derive");
     let inst = &instances(&template)[0];
-    assert_eq!(inst.variant.inlets, vec![Some(2)], "inlet width keyed at 2");
+    assert_eq!(inst.variant.inlets, vec![vec![2]], "inlet width keyed at 2");
 
     let child = cache.get(&inst.variant).expect("cached child template");
     let child_region = &regions(&child)[0];
     let in_read = child_region
         .bus_reads
         .iter()
-        .find(|b| matches!(b.key, BusKey::IfaceIn(0)))
+        .find(|b| matches!(b.key, BusKey::IfaceIn { inlet: 0, .. }))
         .expect("the child's In reads its interface inlet");
     assert_eq!(in_read.channels, 2, "the child's In is 2 wide");
     assert_eq!(
-        child.outlets[0].as_ref().map(|(_, w)| *w),
+        child.outlets[0].first().map(|(_, w)| *w),
         Some(2),
         "the child's outlet carries width 2",
     );
@@ -326,16 +327,19 @@ fn unconnected_inlet_bakes_silence() {
 
     let (template, cache) = derive(&g, &map).expect("derive");
     let inst = &instances(&template)[0];
-    assert_eq!(inst.variant.inlets, vec![Some(1), None]);
+    assert_eq!(inst.variant.inlets, vec![vec![1], vec![]]);
     assert_eq!(inst.inlet_keys.len(), 2);
-    assert!(inst.inlet_keys[1].is_none(), "unconnected inlet has no bus");
+    assert!(
+        inst.inlet_keys[1].is_empty(),
+        "unconnected inlet has no bus"
+    );
 
     let child = cache.get(&inst.variant).expect("cached child");
     let child_region = &regions(&child)[0];
     let iface_reads = child_region
         .bus_reads
         .iter()
-        .filter(|b| matches!(b.key, BusKey::IfaceIn(_)))
+        .filter(|b| matches!(b.key, BusKey::IfaceIn { .. }))
         .count();
     assert_eq!(iface_reads, 1, "one In; the silent inlet bakes silence");
 }
@@ -363,8 +367,11 @@ fn consumed_outlet_mask_keys_the_variant() {
     assert_eq!(inst.variant.outlets, vec![false, true]);
 
     let child = cache.get(&inst.variant).expect("cached child");
-    assert!(child.outlets[0].is_none(), "unconsumed outlet has no bus");
-    assert!(child.outlets[1].is_some(), "consumed outlet carries a bus");
+    assert!(child.outlets[0].is_empty(), "unconsumed outlet has no bus");
+    assert!(
+        !child.outlets[1].is_empty(),
+        "consumed outlet carries a bus"
+    );
     let writes: usize = regions(&child).iter().map(|r| r.bus_writes.len()).sum();
     assert_eq!(writes, 1, "one outlet write");
 }
@@ -553,5 +560,200 @@ fn instance_to_instance_shares_one_bus() {
             output: 0,
         },
         "the bus is the producer's absolutized source endpoint",
+    );
+}
+
+/// A child graph of two sines both feeding one `outlet` (a multi-fed root
+/// outlet).
+fn two_sines_outlet_child() -> Graph<N> {
+    let mut g = Graph::<N>::default();
+    let s0 = g.add_node(N::SinOsc(SinOsc::default()));
+    let s1 = g.add_node(N::SinOsc(SinOsc::default()));
+    let o = g.add_node(N::Outlet);
+    g.add_edge(s0, o, Edge::new(0.into(), 0.into()));
+    g.add_edge(s1, o, Edge::new(0.into(), 0.into()));
+    g
+}
+
+/// The add-selector summing units of a def (`special_index` 0; `Sum3`/`Sum4`
+/// would count too, but these tests sum pairs).
+fn n_adds(def: &plyphon::synthdef::SynthDef) -> usize {
+    def.units
+        .iter()
+        .filter(|u| {
+            u.name == "Sum3"
+                || u.name == "Sum4"
+                || (u.name == "BinaryOpUGen" && u.special_index == 0)
+        })
+        .count()
+}
+
+#[test]
+fn multi_fed_inlet_sums_inside_the_child() {
+    // Two `~sinosc` feeding ONE instance inlet: the variant keys both summand
+    // widths, the instance records one bus key per summand, and the child def
+    // reads two interface `In`s summed where the inlet is consumed.
+    let map = HashMap::from([(ca(1), lag_child())]);
+    let mut g = Graph::<N>::default();
+    let s0 = g.add_node(N::SinOsc(SinOsc::default()));
+    let s1 = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::Ref(ca(1), 1, 1));
+    let out = g.add_node(N::Out(Out::default()));
+    g.add_edge(s0, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(s1, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(r, out, Edge::new(0.into(), 0.into()));
+
+    let (template, cache) = derive(&g, &map).expect("derive");
+    let inst = &instances(&template)[0];
+    assert_eq!(inst.variant.inlets, vec![vec![1, 1]]);
+    assert_eq!(
+        inst.inlet_keys,
+        vec![vec![
+            BusKey::Src {
+                path: vec![s0.index()],
+                output: 0,
+            },
+            BusKey::Src {
+                path: vec![s1.index()],
+                output: 0,
+            },
+        ]],
+    );
+
+    let child = cache.get(&inst.variant).expect("cached child");
+    let region = &regions(&child)[0];
+    let iface: Vec<&BusKey> = region
+        .bus_reads
+        .iter()
+        .filter(|b| matches!(b.key, BusKey::IfaceIn { .. }))
+        .map(|b| &b.key)
+        .collect();
+    assert_eq!(
+        iface,
+        vec![
+            &BusKey::IfaceIn {
+                inlet: 0,
+                summand: 0,
+            },
+            &BusKey::IfaceIn {
+                inlet: 0,
+                summand: 1,
+            },
+        ],
+    );
+    assert_eq!(n_adds(&region.def), 1, "the child sums its inlet summands");
+}
+
+#[test]
+fn instance_outlet_and_plain_node_sum_at_a_parent_input() {
+    // A plain `~sinosc` and an instance's outlet both wired into one `~out`
+    // input: the reader region emits an `In` per source (the sine sits a
+    // stage below the instance-fed consumer, so it also crosses regions) and
+    // sums them.
+    let map = HashMap::from([(ca(1), lag_child())]);
+    let mut g = Graph::<N>::default();
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let feed = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::Ref(ca(1), 1, 1));
+    let out = g.add_node(N::Out(Out::default()));
+    g.add_edge(feed, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(s, out, Edge::new(0.into(), 0.into()));
+    g.add_edge(r, out, Edge::new(0.into(), 0.into()));
+
+    let (template, _cache) = derive(&g, &map).expect("derive");
+    let reader = regions(&template)
+        .into_iter()
+        .find(|reg| {
+            reg.bus_reads
+                .iter()
+                .any(|b| matches!(b.key, BusKey::InstOut { .. }))
+        })
+        .expect("a region reads the instance outlet");
+    let keys: Vec<&BusKey> = reader.bus_reads.iter().map(|b| &b.key).collect();
+    assert_eq!(
+        keys,
+        vec![
+            &BusKey::Src {
+                path: vec![s.index()],
+                output: 0,
+            },
+            &BusKey::InstOut {
+                path: vec![r.index()],
+                outlet: 0,
+                summand: 0,
+            },
+        ],
+    );
+    assert_eq!(n_adds(&reader.def), 1, "the two reads sum at the input");
+}
+
+#[test]
+fn multi_fed_outlet_exports_a_bus_per_summand() {
+    // A child whose outlet is fed by two sines: the child exports one bus per
+    // summand (no relay def sums inside the child), the parent reader emits
+    // one `In` per summand and sums, and `instantiate` resolves each summand
+    // read to the child's own endpoint bus.
+    let map = HashMap::from([(ca(1), two_sines_outlet_child())]);
+    let mut g = Graph::<N>::default();
+    let r = g.add_node(N::Ref(ca(1), 0, 1));
+    let out = g.add_node(N::Out(Out::default()));
+    g.add_edge(r, out, Edge::new(0.into(), 0.into()));
+
+    let (template, cache) = derive(&g, &map).expect("derive");
+    let inst = &instances(&template)[0];
+    let child = cache.get(&inst.variant).expect("cached child");
+    assert_eq!(child.outlets.len(), 1);
+    assert_eq!(
+        child.outlets[0]
+            .iter()
+            .map(|(k, w)| (k.clone(), *w))
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                BusKey::Src {
+                    path: vec![0],
+                    output: 0,
+                },
+                1,
+            ),
+            (
+                BusKey::Src {
+                    path: vec![1],
+                    output: 0,
+                },
+                1,
+            ),
+        ],
+        "one exported bus per outlet summand",
+    );
+
+    // The parent reader holds one `In` per summand and sums them.
+    let reader = regions(&template)
+        .into_iter()
+        .find(|reg| !reg.bus_reads.is_empty())
+        .expect("the out region reads the instance outlet");
+    assert_eq!(reader.bus_reads.len(), 2);
+    assert_eq!(n_adds(&reader.def), 1);
+
+    // `instantiate` resolves each summand read to the child's endpoint bus,
+    // absolutized under the instance path.
+    let resolved = instantiate(&template, &cache);
+    let rreader = resolved
+        .iter()
+        .find(|p| p.bus_reads.len() == 2)
+        .expect("resolved reader");
+    let keys: Vec<&BusKey> = rreader.bus_reads.iter().map(|b| &b.key).collect();
+    assert_eq!(
+        keys,
+        vec![
+            &BusKey::Src {
+                path: vec![r.index(), 0],
+                output: 0,
+            },
+            &BusKey::Src {
+                path: vec![r.index(), 1],
+                output: 0,
+            },
+        ],
     );
 }


### PR DESCRIPTION
Adds unity-gain summing for DSP inputs that are fed by multiple edges, and an explicit `~sum` node for manual mixing.

Previously, multiple edges into one input silently let the oldest wire win. Now all sources are summed.

## Changes

### Implicit input summing
Multiple edges into a single DSP input now sum (unity gain) instead of the oldest edge silently winning. `resolved_sources` keeps every reachable summand per input, sorted canonically by source path and port, making derived defs independent of edge insertion order. A single edge passes through unit-free, keeping existing single-edge defs byte-identical.

### Inlet / outlet summing across instance boundaries
Multi-fed instance inlets sum inside the child template, with each summand getting its own bus (summand 0 keeps the bare label, later summands suffix their index to preserve existing def sigs). Root outlets export one bus per summand, and the enclosing reader emits one `In` per summand and sums. Boundary chains keep classic effective-bus identity when every hop has a single summand.

### Flatten boundary bridging
Inline/splice bridging now emits one flat edge per resolving chain (oldest first), so multi-fed inputs sum correctly across flattened boundaries. Two distinct wires resolving to the same source deliberately sum it twice.

### `sum_signals` helper
A free function that sums channel groups with a unity-gain mix. The output width is the widest summand's. Mono broadcasts into every channel, narrower inputs contribute silence past their own width. Constant channels fold at derive time and a lone summand passes through with zero units. Sums lower to plyphon's `BinaryOpUGen` / `Sum3` / `Sum4` / tiled `Sum4` per channel, emitted at audio rate if any input is audio.

### `~sum` node
An explicit unity-gain mixer that sums N input signals into one channel group via `sum_signals`. Same width policy as implicit input summing. Modeled on `~pack` (structural count, Steel-inert, egui count inspector, `(~sum #:count n)` sugar). Per-input gain is left for a future `~mix` node.

