### PR TITLE
feat: Concurrent editing with content-addressed convergence

### DIFF
--- a/crates/gantz_ca/src/history.rs
+++ b/crates/gantz_ca/src/history.rs
@@ -59,14 +59,14 @@ pub fn first_parent_chain(
     })
 }
 
-/// The best common ancestor of `a` and `b`, or `None` when their histories
-/// are unrelated.
+/// All best common ancestors of `a` and `b`, canonically sorted ascending by
+/// `(timestamp, addr)`; empty when their histories are unrelated.
 ///
 /// A common ancestor is "best" when it is not itself an ancestor of another
-/// common ancestor. When several such candidates exist (criss-cross
-/// histories), one is chosen deterministically by max `(timestamp, addr)`;
-/// recursively merging the candidates is out of scope.
-pub fn merge_base(commits: &Commits, a: CommitAddr, b: CommitAddr) -> Option<CommitAddr> {
+/// common ancestor. More than one candidate indicates criss-cross histories
+/// (each side merged the other); see [`crate::merge::merge_commits`] for how
+/// candidates are recursively merged into a virtual base.
+pub fn merge_bases(commits: &Commits, a: CommitAddr, b: CommitAddr) -> Vec<CommitAddr> {
     let a_ancestors: HashSet<CommitAddr> = ancestors(commits, a).collect();
     let mut common: HashSet<CommitAddr> = ancestors(commits, b)
         .filter(|ca| a_ancestors.contains(ca))
@@ -80,9 +80,19 @@ pub fn merge_base(commits: &Commits, a: CommitAddr, b: CommitAddr) -> Option<Com
             common.remove(&ancestor);
         }
     }
-    common
-        .into_iter()
-        .max_by_key(|&ca| (commits.get(&ca).map(|c| c.timestamp), ca))
+    let mut bases: Vec<CommitAddr> = common.into_iter().collect();
+    bases.sort_by_key(|&ca| (commits.get(&ca).map(|c| c.timestamp), ca));
+    bases
+}
+
+/// The best common ancestor of `a` and `b`, or `None` when their histories
+/// are unrelated.
+///
+/// When several best candidates exist (criss-cross histories, see
+/// [`merge_bases`]), one is chosen deterministically by max
+/// `(timestamp, addr)`.
+pub fn merge_base(commits: &Commits, a: CommitAddr, b: CommitAddr) -> Option<CommitAddr> {
+    merge_bases(commits, a, b).last().copied()
 }
 
 /// Analyze the relationship between two tips, from the perspective of merging
@@ -241,7 +251,10 @@ mod tests {
         // Criss-cross: each side merges the other's tip.
         let ma = add_merge(&mut commits, 4, a, b, 4);
         let mb = add_merge(&mut commits, 5, b, a, 5);
-        // Both a and b are best common ancestors; the later timestamp wins.
+        // Both a and b are best common ancestors, canonically ordered; the
+        // later timestamp wins the tie-break.
+        assert_eq!(merge_bases(&commits, ma, mb), vec![a, b]);
+        assert_eq!(merge_bases(&commits, mb, ma), vec![a, b]);
         assert_eq!(merge_base(&commits, ma, mb), Some(b));
     }
 

--- a/crates/gantz_ca/src/history.rs
+++ b/crates/gantz_ca/src/history.rs
@@ -66,7 +66,7 @@ pub fn first_parent_chain(
 /// common ancestor. More than one candidate indicates criss-cross histories
 /// (each side merged the other); see [`crate::merge::merge_commits`] for how
 /// candidates are recursively merged into a virtual base.
-pub fn merge_bases(commits: &Commits, a: CommitAddr, b: CommitAddr) -> Vec<CommitAddr> {
+pub(crate) fn merge_bases(commits: &Commits, a: CommitAddr, b: CommitAddr) -> Vec<CommitAddr> {
     let a_ancestors: HashSet<CommitAddr> = ancestors(commits, a).collect();
     let mut common: HashSet<CommitAddr> = ancestors(commits, b)
         .filter(|ca| a_ancestors.contains(ca))
@@ -89,7 +89,7 @@ pub fn merge_bases(commits: &Commits, a: CommitAddr, b: CommitAddr) -> Vec<Commi
 /// are unrelated.
 ///
 /// When several best candidates exist (criss-cross histories, see
-/// [`merge_bases`]), one is chosen deterministically by max
+/// `merge_bases`), one is chosen deterministically by max
 /// `(timestamp, addr)`.
 pub fn merge_base(commits: &Commits, a: CommitAddr, b: CommitAddr) -> Option<CommitAddr> {
     merge_bases(commits, a, b).last().copied()

--- a/crates/gantz_ca/src/lib.rs
+++ b/crates/gantz_ca/src/lib.rs
@@ -25,7 +25,7 @@ pub use merge::{
 #[doc(inline)]
 pub use registry::Registry;
 #[doc(inline)]
-pub use sync::{SyncStep, canonical_tips, merge_timestamp, monotonic_timestamp, plan_sync_step};
+pub use sync::{SyncStep, monotonic_timestamp, plan_sync_step};
 
 mod ca;
 mod commit;

--- a/crates/gantz_ca/src/lib.rs
+++ b/crates/gantz_ca/src/lib.rs
@@ -24,6 +24,8 @@ pub use merge::{
 };
 #[doc(inline)]
 pub use registry::Registry;
+#[doc(inline)]
+pub use sync::{SyncStep, canonical_tips, merge_timestamp, monotonic_timestamp, plan_sync_step};
 
 mod ca;
 mod commit;
@@ -34,3 +36,4 @@ pub mod history;
 pub mod merge;
 pub mod registry;
 pub mod serde_sorted;
+pub mod sync;

--- a/crates/gantz_ca/src/merge.rs
+++ b/crates/gantz_ca/src/merge.rs
@@ -11,8 +11,7 @@
 //! surface the conflicts, or accept the defaults.
 
 use crate::{
-    CaHash, CommitAddr, Diff, GraphAddr, Matching, MergeAnalysis, Registry, Timestamp,
-    content_addr, diff, history,
+    CaHash, CommitAddr, Diff, GraphAddr, Matching, Registry, Timestamp, content_addr, diff, history,
 };
 use petgraph::{
     Directed,
@@ -176,6 +175,10 @@ pub enum MergeResolution<N, E, Ix: IndexType> {
     /// The tips have diverged and a three-way merge was performed.
     Diverged {
         /// The merge base the diffs are relative to.
+        ///
+        /// For criss-cross histories this is the nominal (tie-break)
+        /// candidate; the diffs and outcome are computed against a *virtual*
+        /// base merged from all candidates (see [`merge_commits`]).
         base: CommitAddr,
         /// Ours' changes relative to the base.
         ours_diff: Diff<E>,
@@ -220,11 +223,22 @@ enum Fate {
     KeepTheirs,
 }
 
+/// Maximum recursion depth when constructing virtual merge bases for
+/// criss-cross histories; beyond it the deterministic tie-break candidate is
+/// used directly as the base.
+const MAX_BASE_RECURSION: usize = 5;
+
 /// Merge two tips of a registry's commit DAG.
 ///
 /// Pure: the registry is not mutated, so this doubles as a dry run for
 /// previews. On [`MergeResolution::Diverged`], committing the result is the
 /// caller's job (see [`Registry::commit_merge_to_head`]).
+///
+/// Criss-cross histories (multiple best common ancestors, e.g. session peers
+/// repeatedly merging one another) are handled git-style: the candidates are
+/// recursively merged into a *virtual* base, so changes both tips already
+/// contain via different merge paths are part of the base rather than
+/// duplicated as parallel additions.
 pub fn merge_commits<N, E, Ix>(
     reg: &Registry<Graph<N, E, Ix>>,
     ours: CommitAddr,
@@ -236,53 +250,199 @@ where
     E: Clone + Ord,
     Ix: IndexType,
 {
+    merge_commits_recursive(reg, ours, theirs, resolutions, 0)
+}
+
+/// The implementation of [`merge_commits`]; `depth` guards the virtual-base
+/// recursion for criss-cross histories.
+fn merge_commits_recursive<N, E, Ix>(
+    reg: &Registry<Graph<N, E, Ix>>,
+    ours: CommitAddr,
+    theirs: CommitAddr,
+    resolutions: Resolutions,
+    depth: usize,
+) -> Result<MergeResolution<N, E, Ix>, MergeError>
+where
+    N: Clone + CaHash,
+    E: Clone + Ord,
+    Ix: IndexType,
+{
     let commits = reg.commits();
-    let base = match history::analyze(commits, ours, theirs) {
-        MergeAnalysis::Unrelated => return Err(MergeError::Unrelated),
-        MergeAnalysis::AlreadyUpToDate => return Ok(MergeResolution::AlreadyUpToDate),
-        MergeAnalysis::FastForward => return Ok(MergeResolution::FastForward),
-        MergeAnalysis::Diverged(base) => base,
-    };
-    let graph_of = |ca: CommitAddr| {
-        let commit = commits.get(&ca).ok_or(MergeError::MissingCommit(ca))?;
-        reg.graphs()
-            .get(&commit.graph)
-            .ok_or(MergeError::MissingGraph(commit.graph))
-    };
-    let base_g = graph_of(base)?;
-    let ours_g = graph_of(ours)?;
-    let theirs_g = graph_of(theirs)?;
-    // Endpoints are verified above, so `matching_with_times` cannot fail;
-    // degrade to direct matching rather than panicking should that ever
-    // change.
-    let (mo, ours_times) = diff::matching_with_times(reg, base, ours)
-        .unwrap_or_else(|| (diff::match_nodes(base_g, ours_g), Default::default()));
-    let (mt, theirs_times) = diff::matching_with_times(reg, base, theirs)
-        .unwrap_or_else(|| (diff::match_nodes(base_g, theirs_g), Default::default()));
-    let ours_diff = diff::diff(base_g, ours_g, &mo);
-    let theirs_diff = diff::diff(base_g, theirs_g, &mt);
+    // A tip that is itself a common ancestor is always the sole candidate,
+    // so the singleton checks cover the analysis (see `history::analyze`).
+    let bases = history::merge_bases(commits, ours, theirs);
+    match bases.as_slice() {
+        [] => return Err(MergeError::Unrelated),
+        [base] if *base == theirs => return Ok(MergeResolution::AlreadyUpToDate),
+        [base] if *base == ours => return Ok(MergeResolution::FastForward),
+        _ => (),
+    }
+    let ours_g = commit_graph_of(reg, ours)?;
+    let theirs_g = commit_graph_of(reg, theirs)?;
     let tip_time = |ca: CommitAddr| commits.get(&ca).map(|c| c.timestamp).unwrap_or_default();
-    let edit_times = EditTimes {
-        ours: ours_times,
-        theirs: theirs_times,
-        ours_tip: tip_time(ours),
-        theirs_tip: tip_time(theirs),
+    // The nominal base reported in the resolution: the tie-break candidate.
+    let base = *bases.last().expect("diverged tips have a merge base");
+    let (ours_diff, theirs_diff, outcome) = if bases.len() > 1 && depth < MAX_BASE_RECURSION {
+        // Criss-cross: merge the candidates into a virtual base. It has no
+        // commit chain, so node identity and edit times degrade to direct
+        // content matching and tip timestamps - deterministic (hence still
+        // convergent), just coarser.
+        let virt = virtual_base(reg, &bases, resolutions, depth + 1)?;
+        let edit_times = EditTimes {
+            ours: BTreeMap::new(),
+            theirs: BTreeMap::new(),
+            ours_tip: tip_time(ours),
+            theirs_tip: tip_time(theirs),
+        };
+        merge_graphs_direct(&virt, ours_g, theirs_g, resolutions, &edit_times)
+    } else {
+        let base_g = commit_graph_of(reg, base)?;
+        // Endpoints are verified above, so `matching_with_times` cannot
+        // fail; degrade to direct matching rather than panicking should that
+        // ever change.
+        let (mo, ours_times) = diff::matching_with_times(reg, base, ours)
+            .unwrap_or_else(|| (diff::match_nodes(base_g, ours_g), Default::default()));
+        let (mt, theirs_times) = diff::matching_with_times(reg, base, theirs)
+            .unwrap_or_else(|| (diff::match_nodes(base_g, theirs_g), Default::default()));
+        let ours_diff = diff::diff(base_g, ours_g, &mo);
+        let theirs_diff = diff::diff(base_g, theirs_g, &mt);
+        let edit_times = EditTimes {
+            ours: ours_times,
+            theirs: theirs_times,
+            ours_tip: tip_time(ours),
+            theirs_tip: tip_time(theirs),
+        };
+        let outcome = merge_graphs(
+            base_g,
+            ours_g,
+            theirs_g,
+            &ours_diff,
+            &theirs_diff,
+            resolutions,
+            &edit_times,
+        );
+        (ours_diff, theirs_diff, outcome)
     };
-    let outcome = merge_graphs(
-        base_g,
-        ours_g,
-        theirs_g,
-        &ours_diff,
-        &theirs_diff,
-        resolutions,
-        &edit_times,
-    );
     Ok(MergeResolution::Diverged {
         base,
         ours_diff,
         theirs_diff,
         outcome,
     })
+}
+
+/// The graph pointed to by `ca`'s commit.
+fn commit_graph_of<N, E, Ix>(
+    reg: &Registry<Graph<N, E, Ix>>,
+    ca: CommitAddr,
+) -> Result<&Graph<N, E, Ix>, MergeError>
+where
+    Ix: IndexType,
+{
+    let commit = reg
+        .commits()
+        .get(&ca)
+        .ok_or(MergeError::MissingCommit(ca))?;
+    reg.graphs()
+        .get(&commit.graph)
+        .ok_or(MergeError::MissingGraph(commit.graph))
+}
+
+/// [`merge_graphs`] under diffs computed by direct content matching against
+/// `base`: the path for virtual bases, which have no commit chain to track
+/// node identity along.
+fn merge_graphs_direct<N, E, Ix>(
+    base: &Graph<N, E, Ix>,
+    ours: &Graph<N, E, Ix>,
+    theirs: &Graph<N, E, Ix>,
+    resolutions: Resolutions,
+    edit_times: &EditTimes,
+) -> (Diff<E>, Diff<E>, MergeOutcome<N, E, Ix>)
+where
+    N: Clone + CaHash,
+    E: Clone + Ord,
+    Ix: IndexType,
+{
+    let mo = diff::match_nodes(base, ours);
+    let mt = diff::match_nodes(base, theirs);
+    let ours_diff = diff::diff(base, ours, &mo);
+    let theirs_diff = diff::diff(base, theirs, &mt);
+    let outcome = merge_graphs(
+        base,
+        ours,
+        theirs,
+        &ours_diff,
+        &theirs_diff,
+        resolutions,
+        edit_times,
+    );
+    (ours_diff, theirs_diff, outcome)
+}
+
+/// The merged graph of two commit tips, minting nothing: the building block
+/// for virtual bases.
+fn merged_tip_graph<N, E, Ix>(
+    reg: &Registry<Graph<N, E, Ix>>,
+    a: CommitAddr,
+    b: CommitAddr,
+    resolutions: Resolutions,
+    depth: usize,
+) -> Result<Graph<N, E, Ix>, MergeError>
+where
+    N: Clone + CaHash,
+    E: Clone + Ord,
+    Ix: IndexType,
+{
+    match merge_commits_recursive(reg, a, b, resolutions, depth) {
+        Ok(MergeResolution::AlreadyUpToDate) => Ok(commit_graph_of(reg, a)?.clone()),
+        Ok(MergeResolution::FastForward) => Ok(commit_graph_of(reg, b)?.clone()),
+        Ok(MergeResolution::Diverged { outcome, .. }) => Ok(outcome.graph),
+        // Unrelated candidates (e.g. merged-in foreign roots): merge against
+        // an empty base - everything unions, deterministically.
+        Err(MergeError::Unrelated) => {
+            let a_g = commit_graph_of(reg, a)?;
+            let b_g = commit_graph_of(reg, b)?;
+            let empty = Graph::default();
+            let (_, _, outcome) =
+                merge_graphs_direct(&empty, a_g, b_g, resolutions, &EditTimes::default());
+            Ok(outcome.graph)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// A virtual base graph for criss-cross merge-base `candidates` (canonically
+/// sorted, at least two): the candidates merged left to right.
+fn virtual_base<N, E, Ix>(
+    reg: &Registry<Graph<N, E, Ix>>,
+    candidates: &[CommitAddr],
+    resolutions: Resolutions,
+    depth: usize,
+) -> Result<Graph<N, E, Ix>, MergeError>
+where
+    N: Clone + CaHash,
+    E: Clone + Ord,
+    Ix: IndexType,
+{
+    let mut virt = merged_tip_graph(reg, candidates[0], candidates[1], resolutions, depth)?;
+    for &c in &candidates[2..] {
+        let c_g = commit_graph_of(reg, c)?;
+        // The fold step's base: the (possibly itself criss-cross) base of
+        // the first candidate and `c`; an empty graph when unrelated.
+        let pair_bases = history::merge_bases(reg.commits(), candidates[0], c);
+        let step_base = match pair_bases.as_slice() {
+            [] => Graph::default(),
+            [only] => commit_graph_of(reg, *only)?.clone(),
+            _ if depth < MAX_BASE_RECURSION => {
+                virtual_base(reg, &pair_bases, resolutions, depth + 1)?
+            }
+            _ => commit_graph_of(reg, *pair_bases.last().expect("non-empty"))?.clone(),
+        };
+        let (_, _, outcome) =
+            merge_graphs_direct(&step_base, &virt, c_g, resolutions, &EditTimes::default());
+        virt = outcome.graph;
+    }
+    Ok(virt)
 }
 
 /// Three-way merge of `ours` and `theirs` against their common `base`, under
@@ -554,7 +714,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Head, graph_addr};
+    use crate::{Commit, Head, graph_addr};
     use std::time::Duration;
 
     type G = petgraph::graph::Graph<String, u32, Directed, usize>;
@@ -629,6 +789,42 @@ mod tests {
             MergeResolution::Diverged { outcome, .. } => outcome,
             other => panic!("expected Diverged, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn criss_cross_merges_via_virtual_base_without_duplication() {
+        // Each side merged the other's tip (with differing merge commits, as
+        // pre-canonical or manual merges produce), so both best common
+        // ancestors {a, b} predate the shared additions x and y. A single
+        // tie-break base would see x (or y) as an addition on *both* sides
+        // and union it twice; the virtual base already contains both.
+        let mut reg = Registry::<G>::default();
+        let root = commit(&mut reg, 1, None, &graph(&["n"], &[]));
+        let ga = graph(&["n", "x"], &[]);
+        let gb = graph(&["n", "y"], &[]);
+        let a = commit(&mut reg, 2, Some(root), &ga);
+        let b = commit(&mut reg, 3, Some(root), &gb);
+        let gab = graph(&["n", "x", "y"], &[]);
+        let gba = graph(&["n", "y", "x"], &[]);
+        reg.add_graph(gab.clone());
+        reg.add_graph(gba.clone());
+        let mab = reg.add_commit(Commit::new_merge(
+            Duration::from_secs(4),
+            a,
+            b,
+            graph_addr(&gab),
+        ));
+        let mba = reg.add_commit(Commit::new_merge(
+            Duration::from_secs(5),
+            b,
+            a,
+            graph_addr(&gba),
+        ));
+        let res = merge_commits(&reg, mab, mba, Resolutions::default()).unwrap();
+        let out = diverged(res);
+        assert!(out.conflicts.is_empty());
+        // Ours' order, exactly one of each: no duplicated x or y.
+        assert_eq!(nodes(&out.graph), vec!["n", "x", "y"]);
     }
 
     #[test]

--- a/crates/gantz_ca/src/merge.rs
+++ b/crates/gantz_ca/src/merge.rs
@@ -287,7 +287,7 @@ where
         // commit chain, so node identity and edit times degrade to direct
         // content matching and tip timestamps - deterministic (hence still
         // convergent), just coarser.
-        let virt = virtual_base(reg, &bases, resolutions, depth + 1)?;
+        let virt = base_graph(reg, &bases, resolutions, depth)?;
         let edit_times = EditTimes {
             ours: BTreeMap::new(),
             theirs: BTreeMap::new(),
@@ -411,9 +411,16 @@ where
     }
 }
 
-/// A virtual base graph for criss-cross merge-base `candidates` (canonically
-/// sorted, at least two): the candidates merged left to right.
-fn virtual_base<N, E, Ix>(
+/// The base graph for canonically-sorted merge-base `candidates` at the
+/// given recursion `depth`:
+///
+/// - none (unrelated tips): an empty graph, so everything unions.
+/// - one: that candidate's graph.
+/// - several within [`MAX_BASE_RECURSION`] (criss-cross): the candidates
+///   merged left to right into a *virtual* base.
+/// - several at the recursion cap: the deterministic tie-break candidate's
+///   graph, directly.
+fn base_graph<N, E, Ix>(
     reg: &Registry<Graph<N, E, Ix>>,
     candidates: &[CommitAddr],
     resolutions: Resolutions,
@@ -424,20 +431,22 @@ where
     E: Clone + Ord,
     Ix: IndexType,
 {
-    let mut virt = merged_tip_graph(reg, candidates[0], candidates[1], resolutions, depth)?;
+    match candidates {
+        [] => return Ok(Graph::default()),
+        [only] => return Ok(commit_graph_of(reg, *only)?.clone()),
+        _ if depth >= MAX_BASE_RECURSION => {
+            let last = *candidates.last().expect("non-empty");
+            return Ok(commit_graph_of(reg, last)?.clone());
+        }
+        _ => (),
+    }
+    let mut virt = merged_tip_graph(reg, candidates[0], candidates[1], resolutions, depth + 1)?;
     for &c in &candidates[2..] {
         let c_g = commit_graph_of(reg, c)?;
         // The fold step's base: the (possibly itself criss-cross) base of
         // the first candidate and `c`; an empty graph when unrelated.
         let pair_bases = history::merge_bases(reg.commits(), candidates[0], c);
-        let step_base = match pair_bases.as_slice() {
-            [] => Graph::default(),
-            [only] => commit_graph_of(reg, *only)?.clone(),
-            _ if depth < MAX_BASE_RECURSION => {
-                virtual_base(reg, &pair_bases, resolutions, depth + 1)?
-            }
-            _ => commit_graph_of(reg, *pair_bases.last().expect("non-empty"))?.clone(),
-        };
+        let step_base = base_graph(reg, &pair_bases, resolutions, depth + 1)?;
         let (_, _, outcome) =
             merge_graphs_direct(&step_base, &virt, c_g, resolutions, &EditTimes::default());
         virt = outcome.graph;

--- a/crates/gantz_ca/src/registry.rs
+++ b/crates/gantz_ca/src/registry.rs
@@ -189,6 +189,38 @@ impl<G> Registry<G> {
         commit_merge_to_head(self, timestamp, graph_ca, graph, theirs, head)
     }
 
+    /// Commit the graph at the given address as a *canonical* merge of the
+    /// diverged tips `a` and `b`, and update `head` to the new merge commit.
+    ///
+    /// Unlike [`commit_merge_to_head`](Self::commit_merge_to_head), which
+    /// keeps the head's tip as the first parent, both the parent order and
+    /// the timestamp here are pure functions of the two tips (see
+    /// [`sync::canonical_tips`](crate::sync::canonical_tips) and
+    /// [`sync::merge_timestamp`](crate::sync::merge_timestamp)): peers that
+    /// merge the same pair independently mint the *identical* merge commit,
+    /// which is what lets their DAGs converge rather than re-diverge.
+    ///
+    /// The caller must have produced the graph by merging in the same
+    /// canonical orientation (see
+    /// [`sync::plan_sync_step`](crate::sync::plan_sync_step)), as the merged
+    /// graph's node order depends on which side plays "ours".
+    ///
+    /// Only calls `graph` if no graph exists within the registry for the given
+    /// address.
+    ///
+    /// NOTE: Assumes `graph_ca` is a correct address for the graph resulting
+    /// from `graph()`.
+    pub fn commit_merge_canonical(
+        &mut self,
+        a: CommitAddr,
+        b: CommitAddr,
+        graph_ca: GraphAddr,
+        graph: impl FnOnce() -> G,
+        head: &mut Head,
+    ) -> CommitAddr {
+        commit_merge_canonical(self, a, b, graph_ca, graph, head)
+    }
+
     /// Insert the given name mapping into the registry.
     ///
     /// Returns the previous mapping if one exists.
@@ -219,6 +251,19 @@ impl<G> Registry<G> {
         let ca = commit_addr(&commit);
         self.commits.insert(ca, commit);
         ca
+    }
+
+    /// Insert a commit under a claimed (already validated or grandfathered)
+    /// address, used only by [`sync::Staged::apply`](crate::sync::Staged),
+    /// which inserts oldest-first with absent parents detached.
+    pub(crate) fn insert_commit_at(&mut self, ca: CommitAddr, commit: Commit) {
+        self.commits.insert(ca, commit);
+    }
+
+    /// Insert a graph under a claimed (already validated) address, used only
+    /// by [`sync::Staged::apply`](crate::sync::Staged).
+    pub(crate) fn insert_graph_at(&mut self, ca: GraphAddr, graph: G) {
+        self.graphs.entry(ca).or_insert(graph);
     }
 
     /// Insert a graph, computing its address from the graph's contents.
@@ -434,6 +479,29 @@ fn commit_merge_to_head<G>(
     let ours = *head_commit_ca(&reg.names, head).unwrap();
     reg.graphs.entry(graph_ca).or_insert_with(graph);
     let commit = Commit::new_merge(timestamp, ours, theirs, graph_ca);
+    let commit_ca = commit_addr(&commit);
+    reg.commits.insert(commit_ca, commit);
+    point_head_at(reg, head, commit_ca);
+    commit_ca
+}
+
+/// Commit the given graph to the given head as a canonical merge of the
+/// diverged tips `a` and `b` (see [`Registry::commit_merge_canonical`]).
+///
+/// If the graph doesn't exist, calls `graph()` to retrieve the graph for the
+/// registry.
+fn commit_merge_canonical<G>(
+    reg: &mut Registry<G>,
+    a: CommitAddr,
+    b: CommitAddr,
+    graph_ca: GraphAddr,
+    graph: impl FnOnce() -> G,
+    head: &mut Head,
+) -> CommitAddr {
+    let (first, second) = crate::sync::canonical_tips(&reg.commits, a, b);
+    let timestamp = crate::sync::merge_timestamp(&reg.commits, first, second);
+    reg.graphs.entry(graph_ca).or_insert_with(graph);
+    let commit = Commit::new_merge(timestamp, first, second, graph_ca);
     let commit_ca = commit_addr(&commit);
     reg.commits.insert(commit_ca, commit);
     point_head_at(reg, head, commit_ca);

--- a/crates/gantz_ca/src/registry.rs
+++ b/crates/gantz_ca/src/registry.rs
@@ -195,8 +195,8 @@ impl<G> Registry<G> {
     /// Unlike [`commit_merge_to_head`](Self::commit_merge_to_head), which
     /// keeps the head's tip as the first parent, both the parent order and
     /// the timestamp here are pure functions of the two tips (see
-    /// [`sync::canonical_tips`](crate::sync::canonical_tips) and
-    /// [`sync::merge_timestamp`](crate::sync::merge_timestamp)): peers that
+    /// `sync::canonical_tips` and
+    /// `sync::merge_timestamp`): peers that
     /// merge the same pair independently mint the *identical* merge commit,
     /// which is what lets their DAGs converge rather than re-diverge.
     ///

--- a/crates/gantz_ca/src/sync.rs
+++ b/crates/gantz_ca/src/sync.rs
@@ -60,7 +60,7 @@ pub enum SyncStep {
     /// do - the remote peer adopts ours.
     Adopt(CommitAddr),
     /// The tips truly diverged: merge `(first, second)` in canonical
-    /// orientation (see [`canonical_tips`]) and commit the outcome via
+    /// orientation (see `canonical_tips`) and commit the outcome via
     /// [`Registry::commit_merge_canonical`].
     Merge {
         first: CommitAddr,
@@ -384,7 +384,11 @@ impl std::error::Error for ApplyError {}
 /// same orientation for the same pair - the prerequisite for identical merge
 /// outcomes, as the merged graph's node order depends on which side plays
 /// "ours" (see [`MergeOutcome::graph`](crate::merge::MergeOutcome::graph)).
-pub fn canonical_tips(commits: &Commits, a: CommitAddr, b: CommitAddr) -> (CommitAddr, CommitAddr) {
+pub(crate) fn canonical_tips(
+    commits: &Commits,
+    a: CommitAddr,
+    b: CommitAddr,
+) -> (CommitAddr, CommitAddr) {
     let key = |ca: CommitAddr| (commits.get(&ca).map(|c| c.timestamp), ca);
     if key(a) <= key(b) { (a, b) } else { (b, a) }
 }
@@ -395,7 +399,11 @@ pub fn canonical_tips(commits: &Commits, a: CommitAddr, b: CommitAddr) -> (Commi
 ///
 /// Being strictly newer also means chain-tracked edit times through the merge
 /// never tie against pre-merge edits.
-pub fn merge_timestamp(commits: &Commits, first: CommitAddr, second: CommitAddr) -> Timestamp {
+pub(crate) fn merge_timestamp(
+    commits: &Commits,
+    first: CommitAddr,
+    second: CommitAddr,
+) -> Timestamp {
     let ts = |ca: CommitAddr| commits.get(&ca).map(|c| c.timestamp).unwrap_or_default();
     ts(first).max(ts(second)).saturating_add(NANO)
 }

--- a/crates/gantz_ca/src/sync.rs
+++ b/crates/gantz_ca/src/sync.rs
@@ -1,0 +1,832 @@
+//! Convergence primitives for synchronising commit DAGs between peers.
+//!
+//! Peers collaborating on a shared graph exchange commits and independently
+//! decide how to bring their local tip up to date with a remote one. For all
+//! peers to *converge* - identical tip [`CommitAddr`]s with no further
+//! exchange - every decision here is a pure, side-independent function of
+//! commit content:
+//!
+//! - [`plan_sync_step`] classifies a `(local, remote)` tip pair. Diverged
+//!   tips whose commits point at the *same* graph are resolved by
+//!   deterministic adoption ([`SyncStep::Adopt`]): no merge commit is minted
+//!   for "twin" commits differing only in timestamp. Truly diverged graphs
+//!   are merged in *canonical orientation* ([`SyncStep::Merge`]): every peer
+//!   merges the same `(first, second)` pair, so the merged graph (whose node
+//!   order depends on orientation, see [`MergeOutcome::graph`]) and the
+//!   resulting merge commit are identical on every peer - see
+//!   [`Registry::commit_merge_canonical`].
+//! - [`Staged`] validates fetched commits and graphs against their claimed
+//!   addresses before they may touch a registry. Graph content is recomputed
+//!   and rejected on mismatch - the security-critical check, as graphs
+//!   compile to executed code. Commit chains apply oldest-first under their
+//!   claimed keys, preserving addresses that [`Registry::add_commit`]'s
+//!   parent-clearing would rewrite.
+//! - [`monotonic_timestamp`] guards locally *minted* commit timestamps so an
+//!   edit made after observing another commit always outranks it under
+//!   [`BothModified::KeepNewest`], without ever rewriting received content
+//!   (timestamps are part of the commit hash).
+//!
+//! [`MergeOutcome::graph`]: crate::merge::MergeOutcome::graph
+//! [`BothModified::KeepNewest`]: crate::merge::BothModified::KeepNewest
+
+use crate::{
+    CaHash, Commit, CommitAddr, GraphAddr, Timestamp, commit_addr, graph_addr,
+    history::{self, MergeAnalysis},
+    registry::{Commits, Registry},
+};
+use petgraph::visit::{Data, GraphBase, IntoEdgeReferences, IntoNodeReferences, NodeIndexable};
+use std::{
+    collections::{BTreeMap, HashSet, VecDeque},
+    fmt,
+    hash::Hash,
+    time::Duration,
+};
+
+/// How a local tip is brought up to date with a remote one.
+///
+/// Produced by [`plan_sync_step`]. Applying the step is the caller's job;
+/// every variant that moves the tip does so identically on all peers.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SyncStep {
+    /// The remote tip is already in the local tip's ancestry (or is the local
+    /// tip itself): nothing to do.
+    UpToDate,
+    /// The local tip is an ancestor of the remote: move to the remote tip, no
+    /// commit required.
+    FastForward(CommitAddr),
+    /// The tips diverged but their commits point at the same graph:
+    /// deterministically adopt the winner (max by `(timestamp, addr)`), no
+    /// commit required. When the winner is the local tip there is nothing to
+    /// do - the remote peer adopts ours.
+    Adopt(CommitAddr),
+    /// The tips truly diverged: merge `(first, second)` in canonical
+    /// orientation (see [`canonical_tips`]) and commit the outcome via
+    /// [`Registry::commit_merge_canonical`].
+    Merge {
+        first: CommitAddr,
+        second: CommitAddr,
+    },
+    /// The tips share no common ancestor. How to proceed is an application
+    /// decision (e.g. rename the local graph aside), never automatic.
+    Unrelated,
+}
+
+/// A fetched object whose recomputed content address does not match the
+/// address it was claimed under.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum VerifyError {
+    /// The commit's recomputed address differs from the claimed one.
+    Commit {
+        claimed: CommitAddr,
+        actual: CommitAddr,
+    },
+    /// The graph's recomputed address differs from the claimed one.
+    Graph {
+        claimed: GraphAddr,
+        actual: GraphAddr,
+    },
+}
+
+/// An error preventing a [`Staged`] set from being applied to a registry.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ApplyError {
+    /// A strictly staged commit references a parent that is neither in the
+    /// registry nor staged - a protocol violation for live deltas (snapshot
+    /// commits detach instead, see [`Applied::truncated`]).
+    MissingParent {
+        commit: CommitAddr,
+        parent: CommitAddr,
+    },
+    /// A staged commit's graph is neither in the registry nor staged.
+    MissingGraph {
+        commit: CommitAddr,
+        graph: GraphAddr,
+    },
+}
+
+/// Objects still required before a tip's closure is complete.
+///
+/// See [`Staged::missing`]. Both vecs are in discovery (breadth-first) order
+/// and free of duplicates.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Missing {
+    pub commits: Vec<CommitAddr>,
+    pub graphs: Vec<GraphAddr>,
+}
+
+/// The result of applying a [`Staged`] set to a registry.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Applied {
+    /// The commits applied, oldest-first (parents before children).
+    pub commits: Vec<CommitAddr>,
+    /// The graphs applied.
+    pub graphs: Vec<GraphAddr>,
+    /// The number of snapshot commits whose absent parents were detached on
+    /// insert because the sender truncated history below them (the same
+    /// semantic a local [`Registry::prune_unreachable`] leaves behind).
+    pub truncated: usize,
+}
+
+/// A staging area validating fetched objects before they touch a registry.
+///
+/// Live-delta commits are staged with [`insert_commit`](Self::insert_commit)
+/// (strict: content must hash to the claimed address); join-snapshot commits
+/// with [`insert_commit_grandfathered`](Self::insert_commit_grandfathered)
+/// (a mismatch is tolerated and recorded, as senders legitimately hold
+/// hash-inconsistent history after pruning). Graphs are always strict.
+///
+/// [`missing`](Self::missing) drives a fetch loop until
+/// [`is_complete`](Self::is_complete), after which
+/// [`apply`](Self::apply) inserts everything oldest-first under claimed keys.
+#[derive(Clone, Debug)]
+pub struct Staged<G> {
+    commits: BTreeMap<CommitAddr, StagedCommit>,
+    graphs: BTreeMap<GraphAddr, G>,
+    grandfathered: Vec<CommitAddr>,
+}
+
+/// A staged commit alongside whether it arrived via a snapshot (tolerant
+/// validation) or a live delta (strict).
+#[derive(Clone, Debug)]
+struct StagedCommit {
+    commit: Commit,
+    snapshot: bool,
+}
+
+/// The smallest timestamp increment: used to derive strictly-newer
+/// deterministic timestamps.
+const NANO: Duration = Duration::from_nanos(1);
+
+impl Missing {
+    /// `true` when no commits or graphs are missing.
+    pub fn is_empty(&self) -> bool {
+        self.commits.is_empty() && self.graphs.is_empty()
+    }
+}
+
+impl<G> Staged<G> {
+    /// An empty staging area.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Stage a live-delta commit, verifying that its content hashes to the
+    /// claimed address.
+    pub fn insert_commit(
+        &mut self,
+        claimed: CommitAddr,
+        commit: Commit,
+    ) -> Result<(), VerifyError> {
+        let actual = commit_addr(&commit);
+        if actual != claimed {
+            return Err(VerifyError::Commit { claimed, actual });
+        }
+        let staged = StagedCommit {
+            commit,
+            snapshot: false,
+        };
+        self.commits.insert(claimed, staged);
+        Ok(())
+    }
+
+    /// Stage a join-snapshot commit under its claimed address.
+    ///
+    /// An address mismatch is tolerated and recorded (see
+    /// [`grandfathered`](Self::grandfathered)): a sender that has pruned
+    /// history legitimately holds commits whose parents were detached in
+    /// place under their original keys, so their content no longer re-hashes
+    /// to the key. This defends DAG bookkeeping only - content honesty is the
+    /// graph check, which is always strict.
+    pub fn insert_commit_grandfathered(&mut self, claimed: CommitAddr, commit: Commit) {
+        if commit_addr(&commit) != claimed {
+            self.grandfathered.push(claimed);
+        }
+        let staged = StagedCommit {
+            commit,
+            snapshot: true,
+        };
+        self.commits.insert(claimed, staged);
+    }
+
+    /// The staged commits whose content did not re-hash to their claimed
+    /// address (accepted via
+    /// [`insert_commit_grandfathered`](Self::insert_commit_grandfathered)).
+    pub fn grandfathered(&self) -> &[CommitAddr] {
+        &self.grandfathered
+    }
+
+    /// Stage a graph, verifying that its content hashes to the claimed
+    /// address.
+    ///
+    /// Always strict: graph content is compiled to executed code, so a graph
+    /// that does not hash to the address it was requested under is rejected.
+    pub fn insert_graph(&mut self, claimed: GraphAddr, graph: G) -> Result<(), VerifyError>
+    where
+        G: Data + NodeIndexable,
+        G::EdgeWeight: CaHash + Ord,
+        G::NodeWeight: CaHash,
+        G::NodeId: Eq + Hash + Ord,
+        for<'a> &'a G: Data<EdgeWeight = G::EdgeWeight, NodeWeight = G::NodeWeight>
+            + GraphBase<NodeId = G::NodeId, EdgeId = G::EdgeId>
+            + IntoNodeReferences
+            + IntoEdgeReferences,
+    {
+        let actual = graph_addr(&graph);
+        if actual != claimed {
+            return Err(VerifyError::Graph { claimed, actual });
+        }
+        self.graphs.insert(claimed, graph);
+        Ok(())
+    }
+
+    /// The commits and graphs still required to complete `tip`'s closure,
+    /// walking ancestry through the staged set and the registry.
+    ///
+    /// The walk stops at commits already in the registry, relying on the
+    /// registry invariant that its commits are parent-closed (absent parents
+    /// are detached on insert and prune) and graph-complete.
+    pub fn missing(&self, reg: &Registry<G>, tip: CommitAddr) -> Missing {
+        let mut missing = Missing::default();
+        let mut missing_graphs: HashSet<GraphAddr> = HashSet::new();
+        let mut queue: VecDeque<CommitAddr> = VecDeque::from([tip]);
+        let mut visited: HashSet<CommitAddr> = HashSet::from([tip]);
+        while let Some(ca) = queue.pop_front() {
+            let Some(staged) = self.commits.get(&ca) else {
+                if !reg.commits().contains_key(&ca) {
+                    missing.commits.push(ca);
+                }
+                continue;
+            };
+            let graph = staged.commit.graph;
+            if !reg.graphs().contains_key(&graph)
+                && !self.graphs.contains_key(&graph)
+                && missing_graphs.insert(graph)
+            {
+                missing.graphs.push(graph);
+            }
+            for parent in staged.commit.parents() {
+                if visited.insert(parent) {
+                    queue.push_back(parent);
+                }
+            }
+        }
+        missing
+    }
+
+    /// `true` when `tip`'s closure is complete and the staged set is ready to
+    /// [`apply`](Self::apply).
+    pub fn is_complete(&self, reg: &Registry<G>, tip: CommitAddr) -> bool {
+        self.missing(reg, tip).is_empty()
+    }
+
+    /// Apply the staged set to the registry: graphs first, then commits
+    /// oldest-first (parents before children), each under its claimed key.
+    ///
+    /// All validation happens before the registry is touched, so an `Err`
+    /// leaves it unchanged. Strict commits must have every parent present
+    /// (registry or staged); snapshot commits with absent parents are
+    /// detached on insert and counted in [`Applied::truncated`], mirroring
+    /// the local post-prune semantic.
+    pub fn apply(self, reg: &mut Registry<G>) -> Result<Applied, ApplyError> {
+        for (&ca, staged) in &self.commits {
+            let graph = staged.commit.graph;
+            if !reg.graphs().contains_key(&graph) && !self.graphs.contains_key(&graph) {
+                return Err(ApplyError::MissingGraph { commit: ca, graph });
+            }
+            if !staged.snapshot {
+                for parent in staged.commit.parents() {
+                    if !reg.commits().contains_key(&parent) && !self.commits.contains_key(&parent) {
+                        return Err(ApplyError::MissingParent { commit: ca, parent });
+                    }
+                }
+            }
+        }
+        let order = topo_order(&self.commits);
+        let mut applied = Applied::default();
+        for (ga, graph) in self.graphs {
+            reg.insert_graph_at(ga, graph);
+            applied.graphs.push(ga);
+        }
+        let mut commits = self.commits;
+        for ca in order {
+            let Some(staged) = commits.remove(&ca) else {
+                continue;
+            };
+            let mut commit = staged.commit;
+            if staged.snapshot {
+                let mut detached = false;
+                if commit
+                    .parent
+                    .is_some_and(|p| !reg.commits().contains_key(&p))
+                {
+                    commit.parent = None;
+                    detached = true;
+                }
+                let n = commit.merge_parents.len();
+                commit
+                    .merge_parents
+                    .retain(|p| reg.commits().contains_key(p));
+                detached |= commit.merge_parents.len() != n;
+                if detached {
+                    applied.truncated += 1;
+                }
+            }
+            reg.insert_commit_at(ca, commit);
+            applied.commits.push(ca);
+        }
+        Ok(applied)
+    }
+}
+
+impl<G> Default for Staged<G> {
+    fn default() -> Self {
+        Self {
+            commits: BTreeMap::new(),
+            graphs: BTreeMap::new(),
+            grandfathered: Vec::new(),
+        }
+    }
+}
+
+impl fmt::Display for VerifyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Commit { claimed, actual } => {
+                write!(f, "commit claimed as {claimed} hashes to {actual}")
+            }
+            Self::Graph { claimed, actual } => {
+                write!(f, "graph claimed as {claimed} hashes to {actual}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VerifyError {}
+
+impl fmt::Display for ApplyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingParent { commit, parent } => {
+                write!(f, "commit {commit} references missing parent {parent}")
+            }
+            Self::MissingGraph { commit, graph } => {
+                write!(f, "commit {commit} references missing graph {graph}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ApplyError {}
+
+/// Order two diverged tips canonically: ascending by `(timestamp, addr)`.
+///
+/// The order is a pure function of commit content, so every peer derives the
+/// same orientation for the same pair - the prerequisite for identical merge
+/// outcomes, as the merged graph's node order depends on which side plays
+/// "ours" (see [`MergeOutcome::graph`](crate::merge::MergeOutcome::graph)).
+pub fn canonical_tips(commits: &Commits, a: CommitAddr, b: CommitAddr) -> (CommitAddr, CommitAddr) {
+    let key = |ca: CommitAddr| (commits.get(&ca).map(|c| c.timestamp), ca);
+    if key(a) <= key(b) { (a, b) } else { (b, a) }
+}
+
+/// The timestamp for a canonical merge commit: strictly newer than both tips
+/// (`max + 1ns`), and a pure function of the two tips so every peer mints the
+/// identical merge commit.
+///
+/// Being strictly newer also means chain-tracked edit times through the merge
+/// never tie against pre-merge edits.
+pub fn merge_timestamp(commits: &Commits, first: CommitAddr, second: CommitAddr) -> Timestamp {
+    let ts = |ca: CommitAddr| commits.get(&ca).map(|c| c.timestamp).unwrap_or_default();
+    ts(first).max(ts(second)).saturating_add(NANO)
+}
+
+/// A locally minted commit's timestamp, guarded for session causality: at
+/// least one nanosecond newer than the newest commit observed in the session.
+///
+/// This keeps "last edit wins" honest under clock skew - an edit made *after*
+/// seeing a remote commit always outranks it - without touching received
+/// content. Truly concurrent blind edits still race wall clocks, which is
+/// exactly the case where last-edit-wins is arbitrary anyway.
+pub fn monotonic_timestamp(now: Timestamp, newest_seen: Timestamp) -> Timestamp {
+    now.max(newest_seen.saturating_add(NANO))
+}
+
+/// Classify how the local tip should be brought up to date with a remote tip.
+///
+/// Both tips (and the history connecting them to their base) are expected to
+/// be present in `commits` - i.e. the remote tip's closure has been fetched
+/// and applied. Every branch of the decision is a pure, side-independent
+/// function of commit content, so two peers planning opposite directions of
+/// the same pair reach complementary steps that converge on the same tip.
+pub fn plan_sync_step(commits: &Commits, local: CommitAddr, remote: CommitAddr) -> SyncStep {
+    if local == remote {
+        return SyncStep::UpToDate;
+    }
+    match history::analyze(commits, local, remote) {
+        MergeAnalysis::Unrelated => SyncStep::Unrelated,
+        MergeAnalysis::AlreadyUpToDate => SyncStep::UpToDate,
+        MergeAnalysis::FastForward => SyncStep::FastForward(remote),
+        MergeAnalysis::Diverged(_) => {
+            let graph = |ca: CommitAddr| commits.get(&ca).map(|c| c.graph);
+            match (graph(local), graph(remote)) {
+                // Twin commits: same graph reached independently (concurrent
+                // identical edits, concurrent resyncs). Adopt the winner
+                // rather than minting a pointless merge commit.
+                (Some(gl), Some(gr)) if gl == gr => {
+                    let key = |ca: CommitAddr| (commits.get(&ca).map(|c| c.timestamp), ca);
+                    let winner = if key(local) >= key(remote) {
+                        local
+                    } else {
+                        remote
+                    };
+                    SyncStep::Adopt(winner)
+                }
+                _ => {
+                    let (first, second) = canonical_tips(commits, local, remote);
+                    SyncStep::Merge { first, second }
+                }
+            }
+        }
+    }
+}
+
+/// Topologically order the staged commits oldest-first (parents before
+/// children), following only parent edges within the staged set.
+///
+/// Iteration over the `BTreeMap` keeps the order deterministic. A parent
+/// cycle (only forgeable via grandfathered claimed keys) cannot occur in
+/// honestly hashed content and degrades gracefully: the visited set breaks
+/// the cycle and the out-of-order parent is later detached on apply.
+fn topo_order(staged: &BTreeMap<CommitAddr, StagedCommit>) -> Vec<CommitAddr> {
+    let mut order = Vec::with_capacity(staged.len());
+    let mut visited: HashSet<CommitAddr> = HashSet::new();
+    for &start in staged.keys() {
+        if visited.contains(&start) {
+            continue;
+        }
+        let mut stack = vec![(start, false)];
+        while let Some((ca, expanded)) = stack.pop() {
+            if expanded {
+                order.push(ca);
+                continue;
+            }
+            if !visited.insert(ca) {
+                continue;
+            }
+            stack.push((ca, true));
+            if let Some(staged_commit) = staged.get(&ca) {
+                for parent in staged_commit.commit.parents() {
+                    if staged.contains_key(&parent) && !visited.contains(&parent) {
+                        stack.push((parent, false));
+                    }
+                }
+            }
+        }
+    }
+    order
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ContentAddr, Head};
+    use petgraph::Directed;
+
+    type Graph = petgraph::graph::Graph<String, u32, Directed, usize>;
+    type Reg = Registry<Graph>;
+
+    fn graph(nodes: &[&str]) -> Graph {
+        let mut g = Graph::default();
+        for n in nodes {
+            g.add_node(n.to_string());
+        }
+        g
+    }
+
+    fn graph_addr_raw(n: u8) -> GraphAddr {
+        GraphAddr::from(ContentAddr::from([n; 32]))
+    }
+
+    /// Add a commit to the map, returning its address.
+    fn add(commits: &mut Commits, secs: u64, parent: Option<CommitAddr>, g: u8) -> CommitAddr {
+        let commit = Commit::new(Duration::from_secs(secs), parent, graph_addr_raw(g));
+        let ca = commit_addr(&commit);
+        commits.insert(ca, commit);
+        ca
+    }
+
+    #[test]
+    fn canonical_tips_is_order_independent() {
+        let mut commits = Commits::default();
+        let root = add(&mut commits, 1, None, 1);
+        let a = add(&mut commits, 2, Some(root), 2);
+        let b = add(&mut commits, 3, Some(root), 3);
+        assert_eq!(canonical_tips(&commits, a, b), (a, b));
+        assert_eq!(canonical_tips(&commits, b, a), (a, b));
+    }
+
+    #[test]
+    fn canonical_tips_tie_breaks_on_addr() {
+        let mut commits = Commits::default();
+        let root = add(&mut commits, 1, None, 1);
+        // Same timestamp, different graphs: only the addr differentiates.
+        let a = add(&mut commits, 2, Some(root), 2);
+        let b = add(&mut commits, 2, Some(root), 3);
+        let expected = if a < b { (a, b) } else { (b, a) };
+        assert_eq!(canonical_tips(&commits, a, b), expected);
+        assert_eq!(canonical_tips(&commits, b, a), expected);
+    }
+
+    #[test]
+    fn merge_timestamp_is_strictly_newer_than_both_tips() {
+        let mut commits = Commits::default();
+        let root = add(&mut commits, 1, None, 1);
+        let a = add(&mut commits, 2, Some(root), 2);
+        let b = add(&mut commits, 5, Some(root), 3);
+        let ts = merge_timestamp(&commits, a, b);
+        assert_eq!(ts, Duration::from_secs(5) + NANO);
+        assert_eq!(ts, merge_timestamp(&commits, b, a));
+    }
+
+    #[test]
+    fn monotonic_timestamp_guards_causality() {
+        let now = Duration::from_secs(10);
+        let behind = Duration::from_secs(5);
+        let ahead = Duration::from_secs(20);
+        // A clock ahead of everything observed passes through.
+        assert_eq!(monotonic_timestamp(now, behind), now);
+        // A clock behind an observed commit is bumped strictly past it.
+        assert_eq!(monotonic_timestamp(now, ahead), ahead + NANO);
+    }
+
+    #[test]
+    fn plan_up_to_date_and_fast_forward() {
+        let mut commits = Commits::default();
+        let root = add(&mut commits, 1, None, 1);
+        let tip = add(&mut commits, 2, Some(root), 2);
+        assert_eq!(plan_sync_step(&commits, tip, tip), SyncStep::UpToDate);
+        assert_eq!(plan_sync_step(&commits, tip, root), SyncStep::UpToDate);
+        assert_eq!(
+            plan_sync_step(&commits, root, tip),
+            SyncStep::FastForward(tip)
+        );
+    }
+
+    #[test]
+    fn plan_unrelated() {
+        let mut commits = Commits::default();
+        let a = add(&mut commits, 1, None, 1);
+        let b = add(&mut commits, 2, None, 2);
+        assert_eq!(plan_sync_step(&commits, a, b), SyncStep::Unrelated);
+    }
+
+    #[test]
+    fn plan_adopts_twin_commits_without_merging() {
+        let mut commits = Commits::default();
+        let root = add(&mut commits, 1, None, 1);
+        // Two peers independently commit the same graph at different times.
+        let a = add(&mut commits, 2, Some(root), 2);
+        let b = add(&mut commits, 3, Some(root), 2);
+        // Both directions adopt the same winner: the newer commit.
+        assert_eq!(plan_sync_step(&commits, a, b), SyncStep::Adopt(b));
+        assert_eq!(plan_sync_step(&commits, b, a), SyncStep::Adopt(b));
+    }
+
+    #[test]
+    fn plan_merges_diverged_graphs_in_canonical_orientation() {
+        let mut commits = Commits::default();
+        let root = add(&mut commits, 1, None, 1);
+        let a = add(&mut commits, 2, Some(root), 2);
+        let b = add(&mut commits, 3, Some(root), 3);
+        let expected = SyncStep::Merge {
+            first: a,
+            second: b,
+        };
+        // The orientation is the same regardless of which side plans.
+        assert_eq!(plan_sync_step(&commits, a, b), expected);
+        assert_eq!(plan_sync_step(&commits, b, a), expected);
+    }
+
+    #[test]
+    fn commit_merge_canonical_mints_identical_commit_on_both_peers() {
+        // Two registries with identical content merge the same diverged pair
+        // from opposite orientations.
+        let build = || {
+            let mut reg = Reg::default();
+            let base = graph(&["base"]);
+            let base_ca = crate::graph_addr(&base);
+            let root = reg.commit_graph(Duration::from_secs(1), None, base_ca, || base);
+            let ga = graph(&["base", "a"]);
+            let ga_ca = crate::graph_addr(&ga);
+            let a = reg.commit_graph(Duration::from_secs(2), Some(root), ga_ca, || ga);
+            let gb = graph(&["base", "b"]);
+            let gb_ca = crate::graph_addr(&gb);
+            let b = reg.commit_graph(Duration::from_secs(3), Some(root), gb_ca, || gb);
+            (reg, a, b)
+        };
+        let (mut reg_1, a, b) = build();
+        let (mut reg_2, a_2, b_2) = build();
+        assert_eq!((a, b), (a_2, b_2));
+        let merged = graph(&["base", "a", "b"]);
+        let merged_ca = crate::graph_addr(&merged);
+        // Peer 1's head is on `a` and merges in `b`; peer 2 vice versa.
+        let mut head_1 = Head::Commit(a);
+        let mut head_2 = Head::Commit(b);
+        let m_1 = reg_1.commit_merge_canonical(a, b, merged_ca, || merged.clone(), &mut head_1);
+        let m_2 = reg_2.commit_merge_canonical(b, a, merged_ca, || merged.clone(), &mut head_2);
+        assert_eq!(m_1, m_2);
+        assert_eq!(head_1, Head::Commit(m_1));
+        assert_eq!(head_2, Head::Commit(m_1));
+        let commit = &reg_1.commits()[&m_1];
+        // Canonical orientation: `a` (older) is the first parent on both.
+        assert_eq!(commit.parent, Some(a));
+        assert_eq!(commit.merge_parents, vec![b]);
+        assert_eq!(commit, &reg_2.commits()[&m_2]);
+    }
+
+    #[test]
+    fn staged_rejects_forged_commit_addr() {
+        let mut staged = Staged::<Graph>::new();
+        let commit = Commit::new(Duration::from_secs(1), None, graph_addr_raw(1));
+        let forged = CommitAddr::from(ContentAddr::from([9; 32]));
+        let err = staged.insert_commit(forged, commit.clone()).unwrap_err();
+        assert_eq!(
+            err,
+            VerifyError::Commit {
+                claimed: forged,
+                actual: commit_addr(&commit),
+            }
+        );
+        // The honest address is accepted.
+        staged.insert_commit(commit_addr(&commit), commit).unwrap();
+    }
+
+    #[test]
+    fn staged_rejects_forged_graph_addr() {
+        let mut staged = Staged::<Graph>::new();
+        let g = graph(&["a"]);
+        let forged = graph_addr_raw(9);
+        let err = staged.insert_graph(forged, g.clone()).unwrap_err();
+        assert_eq!(
+            err,
+            VerifyError::Graph {
+                claimed: forged,
+                actual: crate::graph_addr(&g),
+            }
+        );
+        staged.insert_graph(crate::graph_addr(&g), g).unwrap();
+    }
+
+    #[test]
+    fn staged_grandfathered_accepts_and_records_mismatch() {
+        let mut staged = Staged::<Graph>::new();
+        // A post-prune commit: parent detached in place under its original
+        // key, so the content no longer hashes to the key.
+        let parent = CommitAddr::from(ContentAddr::from([7; 32]));
+        let original = Commit::new(Duration::from_secs(2), Some(parent), graph_addr_raw(1));
+        let original_ca = commit_addr(&original);
+        let detached = Commit::new(Duration::from_secs(2), None, graph_addr_raw(1));
+        staged.insert_commit_grandfathered(original_ca, detached);
+        assert_eq!(staged.grandfathered(), &[original_ca]);
+        // A consistent snapshot commit records nothing.
+        let ok = Commit::new(Duration::from_secs(3), None, graph_addr_raw(1));
+        staged.insert_commit_grandfathered(commit_addr(&ok), ok);
+        assert_eq!(staged.grandfathered().len(), 1);
+    }
+
+    #[test]
+    fn missing_reports_unfetched_parents_and_graphs() {
+        let reg = Reg::default();
+        let mut staged = Staged::<Graph>::new();
+        let g = graph(&["a"]);
+        let g_ca = crate::graph_addr(&g);
+        let root = Commit::new(Duration::from_secs(1), None, g_ca);
+        let root_ca = commit_addr(&root);
+        let tip = Commit::new(Duration::from_secs(2), Some(root_ca), g_ca);
+        let tip_ca = commit_addr(&tip);
+        // Nothing staged: the tip itself is missing.
+        assert_eq!(staged.missing(&reg, tip_ca).commits, vec![tip_ca]);
+        staged.insert_commit(tip_ca, tip).unwrap();
+        // The tip is staged: its parent and graph are missing.
+        let missing = staged.missing(&reg, tip_ca);
+        assert_eq!(missing.commits, vec![root_ca]);
+        assert_eq!(missing.graphs, vec![g_ca]);
+        staged.insert_commit(root_ca, root).unwrap();
+        staged.insert_graph(g_ca, g).unwrap();
+        assert!(staged.is_complete(&reg, tip_ca));
+    }
+
+    #[test]
+    fn missing_stops_at_registry_commits() {
+        let mut reg = Reg::default();
+        let base = graph(&["base"]);
+        let base_ca = crate::graph_addr(&base);
+        let root = reg.commit_graph(Duration::from_secs(1), None, base_ca, || base);
+        let mut staged = Staged::<Graph>::new();
+        let g = graph(&["base", "a"]);
+        let g_ca = crate::graph_addr(&g);
+        let tip = Commit::new(Duration::from_secs(2), Some(root), g_ca);
+        let tip_ca = commit_addr(&tip);
+        staged.insert_commit(tip_ca, tip).unwrap();
+        staged.insert_graph(g_ca, g).unwrap();
+        // The parent is already in the registry: closure is complete.
+        assert!(staged.is_complete(&reg, tip_ca));
+    }
+
+    #[test]
+    fn apply_preserves_addresses_add_commit_would_rewrite() {
+        // A chain staged out of order applies parents-first under claimed
+        // keys, unlike `Registry::add_commit` which re-parents-then-hashes.
+        let mut reg = Reg::default();
+        let mut staged = Staged::<Graph>::new();
+        let g = graph(&["a"]);
+        let g_ca = crate::graph_addr(&g);
+        let root = Commit::new(Duration::from_secs(1), None, g_ca);
+        let root_ca = commit_addr(&root);
+        let mid = Commit::new(Duration::from_secs(2), Some(root_ca), g_ca);
+        let mid_ca = commit_addr(&mid);
+        let tip = Commit::new(Duration::from_secs(3), Some(mid_ca), g_ca);
+        let tip_ca = commit_addr(&tip);
+        // Stage newest-first, as a fetch loop discovers them.
+        staged.insert_commit(tip_ca, tip).unwrap();
+        staged.insert_commit(mid_ca, mid).unwrap();
+        staged.insert_commit(root_ca, root).unwrap();
+        staged.insert_graph(g_ca, g).unwrap();
+        let applied = staged.apply(&mut reg).unwrap();
+        assert_eq!(applied.commits.len(), 3);
+        assert_eq!(applied.truncated, 0);
+        // Parents precede children in the applied order.
+        let pos = |ca| applied.commits.iter().position(|&c| c == ca).unwrap();
+        assert!(pos(root_ca) < pos(mid_ca));
+        assert!(pos(mid_ca) < pos(tip_ca));
+        // Every commit re-hashes to its key: no address was rewritten.
+        for (&ca, commit) in reg.commits() {
+            assert_eq!(ca, commit_addr(commit));
+        }
+        assert_eq!(reg.commits()[&tip_ca].parent, Some(mid_ca));
+    }
+
+    #[test]
+    fn apply_errors_on_strict_missing_parent() {
+        let mut reg = Reg::default();
+        let mut staged = Staged::<Graph>::new();
+        let g = graph(&["a"]);
+        let g_ca = crate::graph_addr(&g);
+        let absent = CommitAddr::from(ContentAddr::from([7; 32]));
+        let tip = Commit::new(Duration::from_secs(2), Some(absent), g_ca);
+        let tip_ca = commit_addr(&tip);
+        staged.insert_commit(tip_ca, tip).unwrap();
+        staged.insert_graph(g_ca, g).unwrap();
+        let err = staged.apply(&mut reg).unwrap_err();
+        assert_eq!(
+            err,
+            ApplyError::MissingParent {
+                commit: tip_ca,
+                parent: absent,
+            }
+        );
+        // The registry was left untouched.
+        assert!(reg.commits().is_empty());
+        assert!(reg.graphs().is_empty());
+    }
+
+    #[test]
+    fn apply_errors_on_missing_graph() {
+        let mut reg = Reg::default();
+        let mut staged = Staged::<Graph>::new();
+        let tip = Commit::new(Duration::from_secs(1), None, graph_addr_raw(1));
+        let tip_ca = commit_addr(&tip);
+        staged.insert_commit(tip_ca, tip).unwrap();
+        let err = staged.apply(&mut reg).unwrap_err();
+        assert_eq!(
+            err,
+            ApplyError::MissingGraph {
+                commit: tip_ca,
+                graph: graph_addr_raw(1),
+            }
+        );
+        assert!(reg.commits().is_empty());
+    }
+
+    #[test]
+    fn apply_detaches_truncated_snapshot_parents() {
+        // The oldest snapshot commit references a parent below the history
+        // depth cutoff: it applies detached, mirroring post-prune semantics.
+        let mut reg = Reg::default();
+        let mut staged = Staged::<Graph>::new();
+        let g = graph(&["a"]);
+        let g_ca = crate::graph_addr(&g);
+        let below_cutoff = CommitAddr::from(ContentAddr::from([7; 32]));
+        let oldest = Commit::new(Duration::from_secs(1), Some(below_cutoff), g_ca);
+        let oldest_ca = commit_addr(&oldest);
+        let tip = Commit::new(Duration::from_secs(2), Some(oldest_ca), g_ca);
+        let tip_ca = commit_addr(&tip);
+        staged.insert_commit_grandfathered(oldest_ca, oldest);
+        staged.insert_commit_grandfathered(tip_ca, tip);
+        staged.insert_graph(g_ca, g).unwrap();
+        let applied = staged.apply(&mut reg).unwrap();
+        assert_eq!(applied.truncated, 1);
+        assert_eq!(reg.commits()[&oldest_ca].parent, None);
+        assert_eq!(reg.commits()[&tip_ca].parent, Some(oldest_ca));
+    }
+}

--- a/crates/gantz_ca/tests/sync_convergence.rs
+++ b/crates/gantz_ca/tests/sync_convergence.rs
@@ -1,0 +1,535 @@
+//! Simulated-peer convergence tests for `gantz_ca::sync`.
+//!
+//! Each test drives a small fleet of in-process peers exchanging tip
+//! announcements over a network with a controllable (seeded, adversarial)
+//! delivery order. No real networking: "fetching" reads the sender's
+//! registry through the same `Staged` validate-then-apply path a live
+//! protocol would use.
+//!
+//! The property under test: after the network drains, every peer holds the
+//! *identical* tip commit address (not merely an equivalent graph), with no
+//! further announcements pending - the definition of convergence for #286.
+
+use gantz_ca::{
+    BothModified, CommitAddr, EditOrDelete, Head, Registry, Resolutions, SyncStep, commit_addr,
+    graph_addr, history, merge::MergeResolution, merge_commits, monotonic_timestamp,
+    plan_sync_step, sync::Staged,
+};
+use petgraph::{Directed, visit::EdgeRef};
+use std::time::Duration;
+
+type Graph = petgraph::graph::Graph<String, u32, Directed, usize>;
+type Reg = Registry<Graph>;
+
+/// A peer's view of the shared session: its registry, its tip on the shared
+/// graph, and the session bookkeeping a live peer would hold.
+struct Peer {
+    reg: Reg,
+    tip: CommitAddr,
+    /// The newest commit timestamp observed (minted or received): feeds
+    /// `monotonic_timestamp` when minting.
+    newest_seen: Duration,
+    /// Echo suppression: the tip most recently announced.
+    last_announced: Option<CommitAddr>,
+    /// Merge commits this peer minted itself.
+    minted_merges: usize,
+    /// Conflicts flagged by the most recent merge this peer performed.
+    last_conflicts: usize,
+    /// Announcements that planned as `Unrelated` (surfaced, never automatic).
+    unrelated: usize,
+}
+
+/// A tip announcement in flight from one peer to another.
+#[derive(Clone, Copy)]
+struct Msg {
+    from: usize,
+    to: usize,
+    tip: CommitAddr,
+}
+
+/// The in-flight message set. Delivery order is chosen by the test's `Rng`,
+/// so any interleaving (including per-link reordering) is reachable.
+#[derive(Default)]
+struct Net {
+    queue: Vec<Msg>,
+}
+
+/// A tiny deterministic LCG: adversarial delivery orders from a seed without
+/// pulling in a rand dependency.
+struct Rng(u64);
+
+/// The fixed session policy: last edit wins, edits beat deletes.
+const RESOLUTIONS: Resolutions = Resolutions {
+    both_modified: BothModified::KeepNewest,
+    delete_modify: EditOrDelete::KeepEdit,
+};
+
+impl Peer {
+    fn graph(&self) -> &Graph {
+        self.reg
+            .commit_graph_ref(&self.tip)
+            .expect("peer tip must resolve to a graph")
+    }
+
+    /// Make a local edit at wall-clock `now`, committing to the tip and
+    /// returning the new tip for announcement.
+    fn edit(&mut self, now: Duration, f: impl FnOnce(&mut Graph)) -> CommitAddr {
+        let mut graph = self.graph().clone();
+        f(&mut graph);
+        let ts = monotonic_timestamp(now, self.newest_seen);
+        let graph_ca = graph_addr(&graph);
+        let mut head = Head::Commit(self.tip);
+        let ca = self
+            .reg
+            .commit_graph_to_head(ts, graph_ca, || graph, &mut head);
+        self.newest_seen = self.newest_seen.max(ts);
+        self.tip = ca;
+        ca
+    }
+
+    /// Receive an announced tip: fetch its closure from the sender via the
+    /// strict `Staged` path, then apply the planned sync step. Returns the
+    /// new tip when this peer *minted* a commit (which must be announced);
+    /// fast-forwards and adoptions of received tips are never re-announced.
+    fn receive(&mut self, sender: &Reg, tip: CommitAddr) -> Option<CommitAddr> {
+        let mut staged = Staged::new();
+        loop {
+            let missing = staged.missing(&self.reg, tip);
+            if missing.is_empty() {
+                break;
+            }
+            for ca in missing.commits {
+                let commit = sender
+                    .commits()
+                    .get(&ca)
+                    .expect("sender must hold the announced closure")
+                    .clone();
+                staged
+                    .insert_commit(ca, commit)
+                    .expect("honest sender content must verify");
+            }
+            for ga in missing.graphs {
+                let graph = sender
+                    .graphs()
+                    .get(&ga)
+                    .expect("sender must hold the announced closure")
+                    .clone();
+                staged
+                    .insert_graph(ga, graph)
+                    .expect("honest sender content must verify");
+            }
+        }
+        let applied = staged.apply(&mut self.reg).expect("closure is complete");
+        for ca in &applied.commits {
+            self.newest_seen = self.newest_seen.max(self.reg.commits()[ca].timestamp);
+        }
+        match plan_sync_step(self.reg.commits(), self.tip, tip) {
+            SyncStep::UpToDate => None,
+            SyncStep::FastForward(t) | SyncStep::Adopt(t) => {
+                self.tip = t;
+                None
+            }
+            SyncStep::Merge { first, second } => {
+                let resolution = merge_commits(&self.reg, first, second, RESOLUTIONS)
+                    .expect("planned merge tips must be related");
+                let MergeResolution::Diverged { outcome, .. } = resolution else {
+                    panic!("planned merge must be diverged");
+                };
+                self.last_conflicts = outcome.conflicts.len();
+                let graph_ca = graph_addr(&outcome.graph);
+                let mut head = Head::Commit(self.tip);
+                let graph = outcome.graph;
+                let m =
+                    self.reg
+                        .commit_merge_canonical(first, second, graph_ca, || graph, &mut head);
+                self.newest_seen = self.newest_seen.max(self.reg.commits()[&m].timestamp);
+                self.tip = m;
+                self.minted_merges += 1;
+                Some(m)
+            }
+            SyncStep::Unrelated => {
+                self.unrelated += 1;
+                None
+            }
+        }
+    }
+}
+
+impl Rng {
+    fn pick(&mut self, n: usize) -> usize {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((self.0 >> 33) as usize) % n
+    }
+}
+
+/// Peers sharing a common root commit whose graph holds the given nodes.
+fn peers_with_base(n: usize, base_nodes: &[&str]) -> (Vec<Peer>, Net) {
+    let mut graph = Graph::default();
+    for node in base_nodes {
+        graph.add_node(node.to_string());
+    }
+    let mut reg = Reg::default();
+    let graph_ca = graph_addr(&graph);
+    let root = reg.commit_graph(Duration::from_secs(1), None, graph_ca, || graph);
+    let peers = (0..n)
+        .map(|_| Peer {
+            reg: reg.clone(),
+            tip: root,
+            newest_seen: Duration::from_secs(1),
+            last_announced: None,
+            minted_merges: 0,
+            last_conflicts: 0,
+            unrelated: 0,
+        })
+        .collect();
+    (peers, Net::default())
+}
+
+/// Broadcast `from`'s tip to every other peer, suppressing re-announcement
+/// of an unchanged tip.
+fn announce(peers: &mut [Peer], net: &mut Net, from: usize) {
+    let tip = peers[from].tip;
+    if peers[from].last_announced == Some(tip) {
+        return;
+    }
+    peers[from].last_announced = Some(tip);
+    for to in 0..peers.len() {
+        if to != from {
+            net.queue.push(Msg { from, to, tip });
+        }
+    }
+}
+
+/// Deliver messages in the order chosen by `seed` until the network drains,
+/// announcing every minted commit. Returns the number of deliveries.
+fn run(peers: &mut [Peer], net: &mut Net, seed: u64) -> usize {
+    let mut rng = Rng(seed);
+    let mut steps = 0;
+    while !net.queue.is_empty() {
+        steps += 1;
+        assert!(steps < 10_000, "sync failed to quiesce");
+        let i = rng.pick(net.queue.len());
+        let Msg { from, to, tip } = net.queue.swap_remove(i);
+        let sender_reg = peers[from].reg.clone();
+        if peers[to].receive(&sender_reg, tip).is_some() {
+            announce(peers, net, to);
+        }
+    }
+    steps
+}
+
+/// Assert all peers hold the identical tip, graph address, and graph value
+/// (node order included), returning the converged tip.
+fn assert_converged(peers: &[Peer]) -> CommitAddr {
+    let tip = peers[0].tip;
+    for (i, peer) in peers.iter().enumerate() {
+        assert_eq!(peer.tip, tip, "peer {i} tip diverged");
+        assert_eq!(peer.unrelated, 0, "peer {i} saw unrelated announcements");
+    }
+    let graph_ca = peers[0].reg.commits()[&tip].graph;
+    let value = graph_value(peers[0].graph());
+    for (i, peer) in peers.iter().enumerate().skip(1) {
+        assert_eq!(
+            peer.reg.commits()[&tip].graph,
+            graph_ca,
+            "peer {i} graph addr"
+        );
+        assert_eq!(graph_value(peer.graph()), value, "peer {i} graph value");
+    }
+    tip
+}
+
+/// A graph's node weights in index order plus its sorted edge triples:
+/// equality here is stronger than address equality (it pins node indices,
+/// which cross-peer layout coherence relies on).
+fn graph_value(g: &Graph) -> (Vec<String>, Vec<(usize, usize, u32)>) {
+    let nodes = g.node_weights().cloned().collect();
+    let mut edges: Vec<_> = g
+        .edge_references()
+        .map(|e| (e.source().index(), e.target().index(), *e.weight()))
+        .collect();
+    edges.sort();
+    (nodes, edges)
+}
+
+/// The node weights of a peer's converged graph.
+fn node_set(peer: &Peer) -> Vec<String> {
+    let mut nodes: Vec<String> = peer.graph().node_weights().cloned().collect();
+    nodes.sort();
+    nodes
+}
+
+/// Distinct merge commits reachable from `tip`.
+fn reachable_merge_commits(reg: &Reg, tip: CommitAddr) -> usize {
+    history::ancestors(reg.commits(), tip)
+        .filter(|ca| !reg.commits()[ca].merge_parents.is_empty())
+        .count()
+}
+
+#[test]
+fn two_peers_disjoint_adds_converge_with_one_merge() {
+    let (mut peers, mut net) = peers_with_base(2, &["base"]);
+    peers[0].edit(Duration::from_secs(10), |g| {
+        g.add_node("a".to_string());
+    });
+    announce(&mut peers, &mut net, 0);
+    peers[1].edit(Duration::from_secs(20), |g| {
+        g.add_node("b".to_string());
+    });
+    announce(&mut peers, &mut net, 1);
+    run(&mut peers, &mut net, 42);
+    let tip = assert_converged(&peers);
+    assert_eq!(node_set(&peers[0]), ["a", "b", "base"]);
+    // Both peers minted the merge independently, yet exactly one distinct
+    // merge commit exists: they minted the identical commit.
+    assert_eq!(peers[0].minted_merges + peers[1].minted_merges, 2);
+    assert_eq!(reachable_merge_commits(&peers[0].reg, tip), 1);
+}
+
+#[test]
+fn convergence_is_delivery_order_independent() {
+    // The same two-peer scenario must converge on the same tip regardless of
+    // delivery order (here trivially, but the harness honours the seed).
+    let converged_tip = |seed: u64| {
+        let (mut peers, mut net) = peers_with_base(2, &["base"]);
+        peers[0].edit(Duration::from_secs(10), |g| {
+            g.add_node("a".to_string());
+        });
+        announce(&mut peers, &mut net, 0);
+        peers[1].edit(Duration::from_secs(20), |g| {
+            g.add_node("b".to_string());
+        });
+        announce(&mut peers, &mut net, 1);
+        run(&mut peers, &mut net, seed);
+        assert_converged(&peers)
+    };
+    let tips: Vec<_> = (0..8).map(converged_tip).collect();
+    assert!(tips.windows(2).all(|w| w[0] == w[1]));
+}
+
+#[test]
+fn both_modified_resolves_to_newest_edit() {
+    let (mut peers, mut net) = peers_with_base(2, &["n"]);
+    // Both peers modify the same base node; peer 1's edit is newer.
+    peers[0].edit(Duration::from_secs(10), |g| {
+        g[petgraph::graph::NodeIndex::new(0)] = "n-old".to_string();
+    });
+    announce(&mut peers, &mut net, 0);
+    peers[1].edit(Duration::from_secs(20), |g| {
+        g[petgraph::graph::NodeIndex::new(0)] = "n-new".to_string();
+    });
+    announce(&mut peers, &mut net, 1);
+    run(&mut peers, &mut net, 7);
+    assert_converged(&peers);
+    // Last edit wins. At least one peer performed the merge and saw the
+    // conflict; a peer may instead fast-forward onto the other's (identical)
+    // merge commit without merging itself.
+    assert_eq!(node_set(&peers[0]), ["n-new"]);
+    assert!(peers[0].last_conflicts + peers[1].last_conflicts >= 1);
+}
+
+#[test]
+fn delete_vs_modify_keeps_the_edit() {
+    let (mut peers, mut net) = peers_with_base(2, &["base", "n"]);
+    peers[0].edit(Duration::from_secs(10), |g| {
+        g.remove_node(petgraph::graph::NodeIndex::new(1));
+    });
+    announce(&mut peers, &mut net, 0);
+    peers[1].edit(Duration::from_secs(20), |g| {
+        g[petgraph::graph::NodeIndex::new(1)] = "n-edited".to_string();
+    });
+    announce(&mut peers, &mut net, 1);
+    run(&mut peers, &mut net, 7);
+    assert_converged(&peers);
+    // KeepEdit: the modified node survives the delete, flagged as a conflict
+    // on whichever peer(s) performed the merge.
+    assert_eq!(node_set(&peers[0]), ["base", "n-edited"]);
+    assert!(peers[0].last_conflicts + peers[1].last_conflicts >= 1);
+}
+
+#[test]
+fn three_peers_converge_under_arbitrary_delivery_orders() {
+    for seed in 0..40 {
+        let (mut peers, mut net) = peers_with_base(3, &["base"]);
+        for (i, (name, secs)) in [("a", 10), ("b", 20), ("c", 30)].iter().enumerate() {
+            peers[i].edit(Duration::from_secs(*secs), |g| {
+                g.add_node(name.to_string());
+            });
+            announce(&mut peers, &mut net, i);
+        }
+        run(&mut peers, &mut net, seed);
+        assert_converged(&peers);
+        assert_eq!(
+            node_set(&peers[0]),
+            ["a", "b", "base", "c"],
+            "seed {seed}: all edits present"
+        );
+    }
+}
+
+#[test]
+fn twin_commits_adopt_without_merging() {
+    let (mut peers, mut net) = peers_with_base(2, &["base"]);
+    // Both peers make the identical edit concurrently (e.g. two resync
+    // passes): same graph, different timestamps.
+    peers[0].edit(Duration::from_secs(10), |g| {
+        g.add_node("x".to_string());
+    });
+    announce(&mut peers, &mut net, 0);
+    peers[1].edit(Duration::from_secs(20), |g| {
+        g.add_node("x".to_string());
+    });
+    announce(&mut peers, &mut net, 1);
+    run(&mut peers, &mut net, 3);
+    let tip = assert_converged(&peers);
+    // Adoption, not merging: zero merge commits anywhere.
+    assert_eq!(reachable_merge_commits(&peers[0].reg, tip), 0);
+    assert_eq!(peers[0].minted_merges + peers[1].minted_merges, 0);
+}
+
+#[test]
+fn fast_forwards_are_not_reannounced() {
+    let (mut peers, mut net) = peers_with_base(2, &["base"]);
+    peers[0].edit(Duration::from_secs(10), |g| {
+        g.add_node("a".to_string());
+    });
+    announce(&mut peers, &mut net, 0);
+    // A single delivery: peer 1 fast-forwards and must stay silent.
+    let steps = run(&mut peers, &mut net, 0);
+    assert_eq!(steps, 1);
+    assert_converged(&peers);
+    assert_eq!(peers[1].minted_merges, 0);
+}
+
+#[test]
+fn redelivery_is_idempotent() {
+    let (mut peers, mut net) = peers_with_base(2, &["base"]);
+    peers[0].edit(Duration::from_secs(10), |g| {
+        g.add_node("a".to_string());
+    });
+    announce(&mut peers, &mut net, 0);
+    peers[1].edit(Duration::from_secs(20), |g| {
+        g.add_node("b".to_string());
+    });
+    announce(&mut peers, &mut net, 1);
+    run(&mut peers, &mut net, 42);
+    let tip = assert_converged(&peers);
+    let commit_counts: Vec<_> = peers.iter().map(|p| p.reg.commits().len()).collect();
+    // Re-deliver every peer's tip to everyone, bypassing suppression (a lost
+    // ack / anti-entropy repeat).
+    for from in 0..peers.len() {
+        let t = peers[from].tip;
+        for to in 0..peers.len() {
+            if to != from {
+                net.queue.push(Msg { from, to, tip: t });
+            }
+        }
+    }
+    run(&mut peers, &mut net, 43);
+    assert_eq!(assert_converged(&peers), tip);
+    let after: Vec<_> = peers.iter().map(|p| p.reg.commits().len()).collect();
+    assert_eq!(commit_counts, after, "redelivery minted nothing");
+}
+
+#[test]
+fn slow_clock_edits_stay_causally_ordered() {
+    let (mut peers, mut net) = peers_with_base(2, &["n"]);
+    // Peer 0 edits at t=100; peer 1's wall clock is far behind (t=51).
+    peers[0].edit(Duration::from_secs(100), |g| {
+        g[petgraph::graph::NodeIndex::new(0)] = "n-first".to_string();
+    });
+    announce(&mut peers, &mut net, 0);
+    run(&mut peers, &mut net, 0);
+    assert_converged(&peers);
+    // Peer 1 edits *after observing* the t=100 commit, with its slow clock.
+    let tip = peers[1].edit(Duration::from_secs(51), |g| {
+        g[petgraph::graph::NodeIndex::new(0)] = "n-after".to_string();
+    });
+    // The monotonic guard orders the edit strictly after everything observed,
+    // so "last edit wins" respects causality despite the skew.
+    let ts = peers[1].reg.commits()[&tip].timestamp;
+    assert!(ts > Duration::from_secs(100));
+    announce(&mut peers, &mut net, 1);
+    run(&mut peers, &mut net, 0);
+    assert_converged(&peers);
+    assert_eq!(node_set(&peers[0]), ["n-after"]);
+}
+
+#[test]
+fn join_snapshot_tolerates_pruned_history() {
+    // A host with pruned history: the surviving tip was detached in place, so
+    // its content no longer hashes to its key.
+    let (mut host_peers, _) = peers_with_base(1, &["base"]);
+    let mut host = host_peers.remove(0);
+    host.edit(Duration::from_secs(10), |g| {
+        g.add_node("a".to_string());
+    });
+    host.edit(Duration::from_secs(20), |g| {
+        g.add_node("b".to_string());
+    });
+    let tip = host.tip;
+    host.reg.prune_unreachable(&[tip].into_iter().collect());
+    assert_ne!(
+        commit_addr(&host.reg.commits()[&tip]),
+        tip,
+        "tip is detached"
+    );
+
+    // The joiner applies the host's snapshot through the grandfathered path.
+    let mut reg = Reg::default();
+    let mut staged = Staged::new();
+    for ca in history::ancestors(host.reg.commits(), tip) {
+        staged.insert_commit_grandfathered(ca, host.reg.commits()[&ca].clone());
+    }
+    for (&ga, g) in host.reg.graphs() {
+        staged.insert_graph(ga, g.clone()).unwrap();
+    }
+    assert_eq!(staged.grandfathered(), &[tip]);
+    let applied = staged.apply(&mut reg).unwrap();
+    assert_eq!(applied.truncated, 0, "the host already detached the parent");
+    let joiner = Peer {
+        reg,
+        tip,
+        newest_seen: Duration::from_secs(20),
+        last_announced: None,
+        minted_merges: 0,
+        last_conflicts: 0,
+        unrelated: 0,
+    };
+
+    // Live sync continues over the pruned base: concurrent edits still merge.
+    let mut peers = vec![host, joiner];
+    let mut net = Net::default();
+    peers[0].edit(Duration::from_secs(30), |g| {
+        g.add_node("host-edit".to_string());
+    });
+    announce(&mut peers, &mut net, 0);
+    peers[1].edit(Duration::from_secs(40), |g| {
+        g.add_node("joiner-edit".to_string());
+    });
+    announce(&mut peers, &mut net, 1);
+    run(&mut peers, &mut net, 5);
+    assert_converged(&peers);
+    assert_eq!(
+        node_set(&peers[0]),
+        ["a", "b", "base", "host-edit", "joiner-edit"]
+    );
+}
+
+#[test]
+fn unrelated_announcements_are_surfaced_not_applied() {
+    // Two peers with no shared history: the announcement is recorded as
+    // unrelated and the local tip is untouched (the app decides what to do).
+    let (mut a_peers, _) = peers_with_base(1, &["a"]);
+    let (mut b_peers, _) = peers_with_base(1, &["b"]);
+    let mut a = a_peers.remove(0);
+    let b = b_peers.remove(0);
+    let a_tip = a.tip;
+    let minted = a.receive(&b.reg, b.tip);
+    assert_eq!(minted, None);
+    assert_eq!(a.tip, a_tip);
+    assert_eq!(a.unrelated, 1);
+}


### PR DESCRIPTION
## Summary

This branch introduces two major subsystems:

1. **Content-addressed sync/convergence primitives** (`gantz_ca`) for safe concurrent editing and multi-peer collaboration.
2. **DSP instance composition** (`gantz_plyphon`) for efficient multi-instance synthesis, plus a `size_sync` module to keep node sizes consistent across synced graphs.


## Content-addressed sync & convergence (`gantz_ca`)

Enables multiple peers (or sessions) to collaboratively edit the same graph and converge to an identical tip without conflicts:

- **`Staged`** - validates fetched commits and graphs against their claimed content addresses before they touch a registry. Graph content is recomputed and rejected on mismatch. Commits apply oldest-first under their claimed keys, preserving addresses.
- **`plan_sync_step`** - classifies a `(local_tip, remote_tip)` pair into `UpToDate`, `FastForward`, `Adopt` (twin commits differing only in timestamp), `Merge` (canonical orientation), or `Unrelated`. Every decision is a pure, side-independent function of commit content, so all peers converge identically.
- **Canonical merge orientation** - diverged tips are merged in a deterministic `(first, second)` order, guaranteeing every peer produces the same merged graph and merge commit.
- **Criss-cross history handling** - when peers repeatedly merge each other's tips (multiple best common ancestors), candidates are recursively merged into a *virtual base* up to 5 levels deep, preventing duplicate changes from different merge paths.
- **Monotonic timestamps** - locally minted commit timestamps are guarded so edits observed after another commit always outrank it under `KeepNewest`, without rewriting received content.
- **Refactor: `merge_base` -> `merge_bases`** - the history module now returns all best common ancestors, canonically sorted. The old `merge_base` is preserved as a convenience wrapping `.last()`.


## DSP instance composition (`gantz_plyphon`)

Adds multi-instance support for the DSP compilation pipeline:

- **`instance.rs`** - full instance derivation: template-based synthesis with recursive instantiation, shared definition registration (install once, spawn many), refcounted shared defs, and bus/scope/fade wiring.
- **Instancing is the default lowering** for DSP refs in the Bevy runtime.
- **Transient spawn retry** - retries transient spawn failures on the next frame rather than failing hard.
- New tests covering instance derivation, flattening, and ref extension.


## UI & UX improvements

- **`size_sync` module** (`gantz_egui/src/node/size_sync.rs`) - keeps node sizes consistent across synced/branched graphs. `size_sync` begin/store operations absorb the shared frame plumbing.
- **Comment node** - size sync begin/store, interaction-only size discipline.
- **Plot node** - interaction-only size discipline.
- **State preservation** - node state is now preserved across undo/redo and head navigation.
- **Layout persistence** - live layout is carried forward on viewless navigation.
- **Web paste fix** - browser paste events are allowed through in the WASM build.


## Other

- **`base_graph` helper** - owns the merge-base ladder in the merge module, providing a single shared utility for constructing virtual merge bases.
- **`commit_layout`** - layout-only commits for undo/redo history.
- **VM state preservation** - same-graph navigation no longer resets VM state.