### PR TITLE
feat(gantz_ui): declarative UI tree model, codecs, and diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3455,6 +3455,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gantz_ui"
+version = "0.1.0"
+dependencies = [
+ "gantz_core",
+ "steel-core",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ gantz_nodetag = { version = "0.1.0", path = "crates/gantz_nodetag" }
 gantz_nodetag_derive = { version = "0.1.0", path = "crates/gantz_nodetag_derive" }
 gantz_plyphon = { version = "0.1.0", path = "crates/gantz_plyphon" }
 gantz_std = { version = "0.3.0", path = "crates/gantz_std" }
+gantz_ui = { version = "0.1.0", path = "crates/gantz_ui" }
 hex = "0.4"
 humantime = "2.3"
 log = { version = "0.4", features = ["serde"] }

--- a/crates/gantz_ui/Cargo.toml
+++ b/crates/gantz_ui/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "gantz_ui"
+version = "0.1.0"
+description = "Declarative UI tree model and value codecs for user-defined gantz GUIs."
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+
+[features]
+default = ["steel"]
+steel = ["dep:steel-core"]
+datum = ["dep:gantz_core"]
+
+[dependencies]
+gantz_core = { workspace = true, optional = true }
+steel-core = { workspace = true, optional = true }
+thiserror.workspace = true

--- a/crates/gantz_ui/src/codec.rs
+++ b/crates/gantz_ui/src/codec.rs
@@ -6,5 +6,7 @@
 //! Adding a backend means writing one small total lowering, the model,
 //! decoder and encoder are shared.
 
+#[cfg(feature = "datum")]
+pub mod datum;
 #[cfg(feature = "steel")]
 pub mod steel;

--- a/crates/gantz_ui/src/codec.rs
+++ b/crates/gantz_ui/src/codec.rs
@@ -1,0 +1,10 @@
+//! Per-runtime codecs between the abstract value model and value types.
+//!
+//! Each codec is four total free functions: `lower` maps a runtime value
+//! into [`crate::sexpr::SExpr`], `raise` maps an `SExpr` back, and
+//! `decode`/`encode` compose them with the shared decoder and encoder.
+//! Adding a backend means writing one small total lowering, the model,
+//! decoder and encoder are shared.
+
+#[cfg(feature = "steel")]
+pub mod steel;

--- a/crates/gantz_ui/src/codec/datum.rs
+++ b/crates/gantz_ui/src/codec/datum.rs
@@ -1,0 +1,110 @@
+//! The `Datum` codec, the storage and interchange encoding of the tree.
+//!
+//! `Datum` has no symbol variant, so identifiers and strings both map to
+//! [`Datum::Str`]: the decoder's ident-or-string tolerance rule exists for
+//! exactly this. Raising is therefore not injective, a datum round trip
+//! normalizes identifiers to strings while decoding to the same tree.
+//! Nulls, characters, byte buffers and maps lower to [`SExpr::Other`] so the
+//! decoder can report them by name.
+
+use crate::decode::{Decoded, Limits};
+use crate::elem::Element;
+use crate::sexpr::SExpr;
+use gantz_core::datum::Datum;
+
+/// Lower a datum into the abstract model. Total.
+pub fn lower(datum: &Datum) -> SExpr {
+    match datum {
+        Datum::Bool(b) => SExpr::Bool(*b),
+        Datum::I64(i) => SExpr::Int(*i),
+        Datum::U64(u) => match i64::try_from(*u) {
+            Ok(i) => SExpr::Int(i),
+            Err(_) => SExpr::Other("an out-of-range integer".to_string()),
+        },
+        Datum::F64(f) if f.is_finite() => SExpr::Float(*f),
+        Datum::F64(_) => SExpr::Other("a non-finite number".to_string()),
+        Datum::Str(s) => SExpr::Str(s.clone()),
+        Datum::Seq(items) => SExpr::List(items.iter().map(lower).collect()),
+        Datum::Null => SExpr::Other("null".to_string()),
+        Datum::Char(_) => SExpr::Other("a character".to_string()),
+        Datum::Bytes(_) => SExpr::Other("a byte buffer".to_string()),
+        Datum::Map(_) => SExpr::Other("a map".to_string()),
+    }
+}
+
+/// Raise an abstract value into a datum.
+///
+/// Total. Identifiers and strings both become [`Datum::Str`], and `Other`
+/// (which never comes out of the encoder) becomes its description string.
+pub fn raise(expr: &SExpr) -> Datum {
+    match expr {
+        SExpr::Ident(s) | SExpr::Str(s) => Datum::Str(s.clone()),
+        SExpr::Bool(b) => Datum::Bool(*b),
+        SExpr::Int(i) => Datum::I64(*i),
+        SExpr::Float(f) => Datum::F64(*f),
+        SExpr::List(items) => Datum::Seq(items.iter().map(raise).collect()),
+        SExpr::Other(s) => Datum::Str(s.clone()),
+    }
+}
+
+/// Decode a UI tree from a datum. Total, see [`crate::decode::decode`].
+pub fn decode(datum: &Datum, limits: &Limits) -> Decoded {
+    crate::decode::decode(lower(datum), limits)
+}
+
+/// Encode an element as a datum in canonical form, see
+/// [`crate::encode::encode`].
+pub fn encode(elem: &Element) -> Datum {
+    raise(&crate::encode::encode(elem))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lower_maps_atoms() {
+        assert_eq!(lower(&Datum::Bool(true)), SExpr::Bool(true));
+        assert_eq!(lower(&Datum::I64(-3)), SExpr::Int(-3));
+        assert_eq!(lower(&Datum::U64(3)), SExpr::Int(3));
+        assert_eq!(
+            lower(&Datum::U64(u64::MAX)),
+            SExpr::Other("an out-of-range integer".to_string())
+        );
+        assert_eq!(lower(&Datum::F64(1.5)), SExpr::Float(1.5));
+        assert_eq!(
+            lower(&Datum::Str("hi".into())),
+            SExpr::Str("hi".to_string())
+        );
+        assert_eq!(lower(&Datum::Null), SExpr::Other("null".to_string()));
+        assert_eq!(
+            lower(&Datum::Char('x')),
+            SExpr::Other("a character".to_string())
+        );
+        assert_eq!(
+            lower(&Datum::Bytes(vec![1])),
+            SExpr::Other("a byte buffer".to_string())
+        );
+        assert_eq!(
+            lower(&Datum::Map(vec![])),
+            SExpr::Other("a map".to_string())
+        );
+    }
+
+    #[test]
+    fn raise_normalizes_identifiers_to_strings() {
+        assert_eq!(
+            raise(&SExpr::Ident("col".to_string())),
+            Datum::Str("col".to_string())
+        );
+        assert_eq!(
+            raise(&SExpr::Str("col".to_string())),
+            Datum::Str("col".to_string())
+        );
+        let expr = SExpr::List(vec![SExpr::Ident("gap".to_string()), SExpr::Int(4)]);
+        assert_eq!(
+            lower(&raise(&expr)),
+            SExpr::List(vec![SExpr::Str("gap".to_string()), SExpr::Int(4)])
+        );
+    }
+}

--- a/crates/gantz_ui/src/codec/steel.rs
+++ b/crates/gantz_ui/src/codec/steel.rs
@@ -1,0 +1,108 @@
+//! The Steel runtime codec, the v1 backend encoding of the tree.
+//!
+//! Symbols lower to identifiers, strings to strings, and Steel lists and
+//! vectors both lower to lists, matching how the rest of gantz treats the
+//! two interchangeably. Non-finite numbers and values outside the abstract
+//! model lower to [`SExpr::Other`] so the decoder can report them by name.
+
+use crate::decode::{Decoded, Limits};
+use crate::elem::Element;
+use crate::sexpr::SExpr;
+use steel::SteelVal;
+
+/// Lower a Steel value into the abstract model. Total.
+pub fn lower(val: &SteelVal) -> SExpr {
+    match val {
+        SteelVal::SymbolV(s) => SExpr::Ident(s.to_string()),
+        SteelVal::StringV(s) => SExpr::Str(s.to_string()),
+        SteelVal::BoolV(b) => SExpr::Bool(*b),
+        SteelVal::IntV(i) => SExpr::Int(*i as i64),
+        SteelVal::NumV(f) if f.is_finite() => SExpr::Float(*f),
+        SteelVal::NumV(_) => SExpr::Other("a non-finite number".to_string()),
+        SteelVal::ListV(items) => SExpr::List(items.iter().map(lower).collect()),
+        SteelVal::VectorV(items) => SExpr::List(items.iter().map(lower).collect()),
+        SteelVal::CharV(_) => SExpr::Other("a character".to_string()),
+        SteelVal::Void => SExpr::Other("void".to_string()),
+        SteelVal::HashMapV(_) => SExpr::Other("a hash map".to_string()),
+        SteelVal::HashSetV(_) => SExpr::Other("a hash set".to_string()),
+        SteelVal::FuncV(_) | SteelVal::MutFunc(_) | SteelVal::BoxedFunction(_) => {
+            SExpr::Other("a function".to_string())
+        }
+        SteelVal::Closure(_) => SExpr::Other("a function".to_string()),
+        _ => SExpr::Other("an unsupported runtime value".to_string()),
+    }
+}
+
+/// Raise an abstract value into a Steel value.
+///
+/// Total. `Other` never comes out of the encoder, it raises to its
+/// description string for completeness. Integers saturate to the `isize`
+/// range on 32 bit targets.
+pub fn raise(expr: &SExpr) -> SteelVal {
+    match expr {
+        SExpr::Ident(s) => SteelVal::SymbolV(s.as_str().into()),
+        SExpr::Bool(b) => SteelVal::BoolV(*b),
+        SExpr::Int(i) => {
+            let i = isize::try_from(*i).unwrap_or(if *i < 0 { isize::MIN } else { isize::MAX });
+            SteelVal::IntV(i)
+        }
+        SExpr::Float(f) => SteelVal::NumV(*f),
+        SExpr::Str(s) => SteelVal::StringV(s.as_str().into()),
+        SExpr::List(items) => SteelVal::ListV(items.iter().map(raise).collect()),
+        SExpr::Other(s) => SteelVal::StringV(s.as_str().into()),
+    }
+}
+
+/// Decode a UI tree from a Steel value. Total, see [`crate::decode::decode`].
+pub fn decode(val: &SteelVal, limits: &Limits) -> Decoded {
+    crate::decode::decode(lower(val), limits)
+}
+
+/// Encode an element as a Steel value in canonical form, see
+/// [`crate::encode::encode`].
+pub fn encode(elem: &Element) -> SteelVal {
+    raise(&crate::encode::encode(elem))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lower_maps_atoms() {
+        assert_eq!(
+            lower(&SteelVal::SymbolV("col".into())),
+            SExpr::Ident("col".to_string())
+        );
+        assert_eq!(
+            lower(&SteelVal::StringV("hi".into())),
+            SExpr::Str("hi".to_string())
+        );
+        assert_eq!(lower(&SteelVal::BoolV(true)), SExpr::Bool(true));
+        assert_eq!(lower(&SteelVal::IntV(3)), SExpr::Int(3));
+        assert_eq!(lower(&SteelVal::NumV(1.5)), SExpr::Float(1.5));
+        assert_eq!(
+            lower(&SteelVal::NumV(f64::NAN)),
+            SExpr::Other("a non-finite number".to_string())
+        );
+        assert_eq!(
+            lower(&SteelVal::CharV('x')),
+            SExpr::Other("a character".to_string())
+        );
+    }
+
+    #[test]
+    fn raise_then_lower_is_identity_on_the_model() {
+        let exprs = [
+            SExpr::Ident("col".to_string()),
+            SExpr::Bool(false),
+            SExpr::Int(-7),
+            SExpr::Float(2.25),
+            SExpr::Str("hi".to_string()),
+            SExpr::List(vec![SExpr::Ident("gap".to_string()), SExpr::Int(4)]),
+        ];
+        for expr in exprs {
+            assert_eq!(lower(&raise(&expr)), expr);
+        }
+    }
+}

--- a/crates/gantz_ui/src/decode.rs
+++ b/crates/gantz_ui/src/decode.rs
@@ -1,0 +1,1479 @@
+//! The total decoder from the abstract value model to the typed tree.
+//!
+//! [`decode`] never fails. Malformed subtrees become inline
+//! [`Element::Error`] nodes at their slot in the tree so hosts render an
+//! error chip while siblings render normally, and recoverable issues become
+//! [`Warning`]s (see [`crate::diag`] for the boundary rule). Unknown
+//! attributes are ignored for forward compatibility, unknown tags are
+//! visible errors, never silently blank.
+//!
+//! One tolerance rule spans every codec: `Datum` has no symbol variant, so
+//! identifier positions (tags, attribute names, enum-like attribute values)
+//! also accept strings, and text positions also accept identifiers.
+
+use crate::diag::{ErrorReason, TreePath, Warning, WarningKind};
+use crate::elem::{
+    ATTRS_MARKER, Align, BindPath, Button, Col, Dialer, DialerStyle, Element, ErrorElem, Frame,
+    Grid, Key, Label, Matrix, Plot, PlotMode, PlotStyle, RESERVED_TAGS, RefGui, Rgba, Row, Scope,
+    Sep, Space, Toggle, Value,
+};
+use crate::sexpr::{self, SExpr};
+
+/// Caps bounding pathological computed trees. Generous by default: a
+/// hand-authored GUI never meets them, a runaway computed one stays visible
+/// as an inline error instead of stalling the host.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Limits {
+    /// The maximum nesting depth, with the root element at depth zero.
+    pub max_depth: usize,
+    /// The maximum total number of elements.
+    pub max_elements: usize,
+}
+
+/// The result of a total decode.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Decoded {
+    /// The decoded tree.
+    pub root: Element,
+    /// Recoverable issues encountered along the way.
+    pub warnings: Vec<Warning>,
+}
+
+/// Decode state threaded through the recursion.
+struct Ctx<'a> {
+    limits: &'a Limits,
+    remaining: usize,
+    warnings: Vec<Warning>,
+}
+
+/// The attribute entries of one element, consumed by name.
+struct AttrSet {
+    entries: Vec<(String, Option<SExpr>)>,
+}
+
+/// Typed attribute extraction for one element, warning on mismatches and
+/// falling back to defaults.
+struct Attrs<'a, 'b> {
+    ctx: &'a mut Ctx<'b>,
+    path: &'a [usize],
+    tag: &'a str,
+    set: AttrSet,
+}
+
+/// Every tag of the v1 vocabulary.
+const KNOWN_TAGS: &[&str] = &[
+    "col", "row", "grid", "frame", "sep", "space", "scope", "dialer", "toggle", "button", "matrix",
+    "label", "value", "plot", "ref-gui",
+];
+
+impl Ctx<'_> {
+    fn warn(&mut self, path: &[usize], kind: WarningKind) {
+        let path = TreePath(path.to_vec());
+        self.warnings.push(Warning { path, kind });
+    }
+}
+
+impl AttrSet {
+    fn empty() -> Self {
+        AttrSet {
+            entries: Vec::new(),
+        }
+    }
+
+    fn take(&mut self, name: &str) -> Option<SExpr> {
+        self.entries
+            .iter_mut()
+            .find(|(n, v)| n == name && v.is_some())
+            .and_then(|(_, v)| v.take())
+    }
+
+    fn present(&self, name: &str) -> bool {
+        self.entries.iter().any(|(n, _)| n == name)
+    }
+}
+
+impl<'a, 'b> Attrs<'a, 'b> {
+    fn new(ctx: &'a mut Ctx<'b>, path: &'a [usize], tag: &'a str, set: AttrSet) -> Self {
+        Attrs {
+            ctx,
+            path,
+            tag,
+            set,
+        }
+    }
+
+    /// Consume the attribute `name`, parse it, and warn with a fallback to
+    /// the field default on a mismatch.
+    fn take<T>(
+        &mut self,
+        name: &str,
+        expected: &'static str,
+        parse: impl Fn(&SExpr) -> Option<T>,
+    ) -> Option<T> {
+        let v = self.set.take(name)?;
+        let parsed = parse(&v);
+        if parsed.is_none() {
+            let kind = WarningKind::InvalidAttrValue {
+                tag: self.tag.to_string(),
+                attr: name.to_string(),
+                expected,
+                found: sexpr::summary(&v),
+            };
+            self.ctx.warn(self.path, kind);
+        }
+        parsed
+    }
+
+    fn f32(&mut self, name: &str) -> Option<f32> {
+        self.take(name, "a number", as_f32)
+    }
+
+    fn f64(&mut self, name: &str) -> Option<f64> {
+        self.take(name, "a number", as_f64)
+    }
+
+    fn u8(&mut self, name: &str) -> Option<u8> {
+        self.take(name, "an integer in 0..=255", as_u8)
+    }
+
+    fn bool_or(&mut self, name: &str, default: bool) -> bool {
+        self.take(name, "a boolean", as_bool).unwrap_or(default)
+    }
+
+    fn string(&mut self, name: &str) -> Option<String> {
+        self.take(name, "a string", text)
+    }
+
+    fn color(&mut self, name: &str) -> Option<Rgba> {
+        self.take(name, "a colour string like \"#rrggbb\"", |v| {
+            text(v).as_deref().and_then(Rgba::parse)
+        })
+    }
+
+    fn key(&mut self) -> Option<Key> {
+        self.take("key", "a string or an integer", as_key)
+    }
+
+    fn bind(&mut self) -> Option<BindPath> {
+        self.take("bind", "a list of node ids", as_bind)
+    }
+
+    /// The required `cols` attribute of `grid`: substitutes 1 with a warning
+    /// when absent.
+    fn cols(&mut self) -> u32 {
+        if self.set.present("cols") {
+            self.take("cols", "a positive integer", as_cols)
+                .unwrap_or(1)
+        } else {
+            let kind = WarningKind::MissingAttr {
+                tag: self.tag.to_string(),
+                attr: "cols".to_string(),
+                default: "1".to_string(),
+            };
+            self.ctx.warn(self.path, kind);
+            1
+        }
+    }
+
+    /// Warn for every attribute never consumed.
+    fn finish(self) {
+        let Attrs {
+            ctx,
+            path,
+            tag,
+            set,
+            ..
+        } = self;
+        for (name, v) in set.entries {
+            if v.is_some() {
+                let kind = WarningKind::UnknownAttr {
+                    tag: tag.to_string(),
+                    attr: name,
+                };
+                ctx.warn(path, kind);
+            }
+        }
+    }
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Limits {
+            max_depth: 64,
+            max_elements: 10_000,
+        }
+    }
+}
+
+/// Decode a UI tree from the abstract value model.
+///
+/// Total: this never fails. Malformed subtrees become inline
+/// [`Element::Error`] nodes preserving their slot in the tree, recoverable
+/// issues become [`Warning`]s and the element renders with documented
+/// defaults.
+pub fn decode(expr: SExpr, limits: &Limits) -> Decoded {
+    let mut ctx = Ctx {
+        limits,
+        remaining: limits.max_elements,
+        warnings: Vec::new(),
+    };
+    let mut path = Vec::new();
+    let root = elem(&mut ctx, &mut path, 0, expr);
+    Decoded {
+        root,
+        warnings: ctx.warnings,
+    }
+}
+
+fn error_at(path: &[usize], reason: ErrorReason) -> Element {
+    Element::Error(ErrorElem {
+        path: TreePath(path.to_vec()),
+        reason,
+    })
+}
+
+/// Decode one element form.
+fn elem(ctx: &mut Ctx, path: &mut Vec<usize>, depth: usize, expr: SExpr) -> Element {
+    if ctx.remaining == 0 {
+        return error_at(path, ErrorReason::ElementLimit(ctx.limits.max_elements));
+    }
+    if depth > ctx.limits.max_depth {
+        return error_at(path, ErrorReason::DepthLimit(ctx.limits.max_depth));
+    }
+    ctx.remaining -= 1;
+
+    let SExpr::List(items) = expr else {
+        let found = sexpr::summary(&expr);
+        return error_at(path, ErrorReason::NotAnElement { found });
+    };
+    let mut items = items.into_iter();
+    let Some(head) = items.next() else {
+        let found = "an empty list".to_string();
+        return error_at(path, ErrorReason::NotAnElement { found });
+    };
+    let Some(tag) = text(&head) else {
+        let found = format!("a list headed by {}", sexpr::summary(&head));
+        return error_at(path, ErrorReason::NotAnElement { found });
+    };
+    if tag == ATTRS_MARKER {
+        return error_at(path, ErrorReason::MisplacedAttrs);
+    }
+    if RESERVED_TAGS.contains(&tag.as_str()) {
+        return error_at(path, ErrorReason::ReservedTag(tag));
+    }
+    if !KNOWN_TAGS.contains(&tag.as_str()) {
+        return error_at(path, ErrorReason::UnknownTag(tag));
+    }
+
+    let (attr_entries, rest) = split_attrs(items.collect());
+    let set = match attr_entries {
+        Some(entries) => parse_attrs(ctx, path, &tag, entries),
+        None => AttrSet::empty(),
+    };
+
+    match tag.as_str() {
+        "col" | "row" => {
+            let mut a = Attrs::new(ctx, path, &tag, set);
+            let gap = a.f32("gap");
+            let align = a.take("align", "one of start, center, end", |v| {
+                text(v).as_deref().and_then(Align::from_name)
+            });
+            let key = a.key();
+            a.finish();
+            let children = children(ctx, path, depth, rest);
+            match tag.as_str() {
+                "col" => Element::Col(Col {
+                    gap,
+                    align,
+                    key,
+                    children,
+                }),
+                _ => Element::Row(Row {
+                    gap,
+                    align,
+                    key,
+                    children,
+                }),
+            }
+        }
+        "grid" => {
+            let mut a = Attrs::new(ctx, path, &tag, set);
+            let cols = a.cols();
+            let gap = a.f32("gap");
+            let key = a.key();
+            a.finish();
+            let children = children(ctx, path, depth, rest);
+            Element::Grid(Grid {
+                cols,
+                gap,
+                key,
+                children,
+            })
+        }
+        "frame" => {
+            let mut a = Attrs::new(ctx, path, &tag, set);
+            let title = a.string("title");
+            let key = a.key();
+            a.finish();
+            let children = children(ctx, path, depth, rest);
+            Element::Frame(Frame {
+                title,
+                key,
+                children,
+            })
+        }
+        "sep" => {
+            let mut a = Attrs::new(ctx, path, &tag, set);
+            let key = a.key();
+            a.finish();
+            warn_ignored(ctx, path, &tag, rest.len());
+            Element::Sep(Sep { key })
+        }
+        "space" => {
+            let mut a = Attrs::new(ctx, path, &tag, set);
+            let key = a.key();
+            a.finish();
+            let mut items = rest.into_iter();
+            let amount = match items.next() {
+                None => None,
+                Some(v) => match as_f32(&v) {
+                    Some(f) => Some(f),
+                    None => {
+                        let kind = WarningKind::InvalidArg {
+                            tag: tag.clone(),
+                            what: "a numeric amount",
+                            found: sexpr::summary(&v),
+                        };
+                        ctx.warn(path, kind);
+                        None
+                    }
+                },
+            };
+            warn_ignored(ctx, path, &tag, items.count());
+            Element::Space(Space { amount, key })
+        }
+        "scope" => {
+            let mut a = Attrs::new(ctx, path, &tag, set);
+            let key = a.key();
+            a.finish();
+            let mut items = rest.into_iter();
+            let id = match node_id_arg(&tag, items.next()) {
+                Ok(id) => id,
+                Err(reason) => return error_at(path, reason),
+            };
+            let children = children(ctx, path, depth, items.collect());
+            Element::Scope(Scope { id, key, children })
+        }
+        "dialer" => {
+            let mut a = Attrs::new(ctx, path, &tag, set);
+            let bind = a.bind();
+            let min = a.f64("min");
+            let max = a.f64("max");
+            let step = a.f64("step");
+            let precision = a.u8("precision");
+            let label = a.string("label");
+            let push = a.bool_or("push", true);
+            let style = a.take("style", "one of slider, knob", |v| {
+                text(v).as_deref().and_then(DialerStyle::from_name)
+            });
+            let key = a.key();
+            a.finish();
+            warn_ignored(ctx, path, &tag, rest.len());
+            Element::Dialer(Dialer {
+                bind,
+                min,
+                max,
+                step,
+                precision,
+                label,
+                push,
+                style,
+                key,
+            })
+        }
+        "toggle" => {
+            let mut a = Attrs::new(ctx, path, &tag, set);
+            let bind = a.bind();
+            let label = a.string("label");
+            let push = a.bool_or("push", true);
+            let key = a.key();
+            a.finish();
+            warn_ignored(ctx, path, &tag, rest.len());
+            Element::Toggle(Toggle {
+                bind,
+                label,
+                push,
+                key,
+            })
+        }
+        "button" => {
+            let mut a = Attrs::new(ctx, path, &tag, set);
+            let bind = a.bind();
+            let label = a.string("label");
+            let key = a.key();
+            a.finish();
+            warn_ignored(ctx, path, &tag, rest.len());
+            Element::Button(Button { bind, label, key })
+        }
+        "matrix" => {
+            let mut a = Attrs::new(ctx, path, &tag, set);
+            let bind = a.bind();
+            let cell_size = a.f32("cell-size");
+            let push = a.bool_or("push", true);
+            let key = a.key();
+            a.finish();
+            warn_ignored(ctx, path, &tag, rest.len());
+            Element::Matrix(Matrix {
+                bind,
+                cell_size,
+                push,
+                key,
+            })
+        }
+        "label" => {
+            let mut a = Attrs::new(ctx, path, &tag, set);
+            let size = a.f32("size");
+            let color = a.color("color");
+            let key = a.key();
+            a.finish();
+            let mut items = rest.into_iter();
+            let text_arg = match items.next() {
+                None => {
+                    let kind = WarningKind::MissingText {
+                        tag: tag.clone(),
+                        what: "a text string",
+                    };
+                    ctx.warn(path, kind);
+                    String::new()
+                }
+                Some(v) => match text(&v) {
+                    Some(t) => t,
+                    None => {
+                        let kind = WarningKind::InvalidArg {
+                            tag: tag.clone(),
+                            what: "a text string",
+                            found: sexpr::summary(&v),
+                        };
+                        ctx.warn(path, kind);
+                        String::new()
+                    }
+                },
+            };
+            warn_ignored(ctx, path, &tag, items.count());
+            Element::Label(Label {
+                text: text_arg,
+                size,
+                color,
+                key,
+            })
+        }
+        "value" => {
+            let mut a = Attrs::new(ctx, path, &tag, set);
+            let bind = a.bind();
+            let wrap = a.bool_or("wrap", false);
+            let key = a.key();
+            a.finish();
+            warn_ignored(ctx, path, &tag, rest.len());
+            Element::Value(Value { bind, wrap, key })
+        }
+        "plot" => {
+            let mut a = Attrs::new(ctx, path, &tag, set);
+            let bind = a.bind();
+            let mode = a.take("mode", "one of scope, signal", |v| {
+                text(v).as_deref().and_then(PlotMode::from_name)
+            });
+            let style = a.take("style", "one of bars, line", |v| {
+                text(v).as_deref().and_then(PlotStyle::from_name)
+            });
+            let color = a.color("color");
+            let grid = a.bool_or("grid", false);
+            let axes = a.bool_or("axes", false);
+            let y_min = a.f32("y-min");
+            let y_max = a.f32("y-max");
+            let w = a.f32("w");
+            let h = a.f32("h");
+            let key = a.key();
+            a.finish();
+            warn_ignored(ctx, path, &tag, rest.len());
+            Element::Plot(Plot {
+                bind,
+                mode,
+                style,
+                color,
+                grid,
+                axes,
+                y_min,
+                y_max,
+                w,
+                h,
+                key,
+            })
+        }
+        "ref-gui" => {
+            let mut a = Attrs::new(ctx, path, &tag, set);
+            let key = a.key();
+            a.finish();
+            let mut items = rest.into_iter();
+            let id = match node_id_arg(&tag, items.next()) {
+                Ok(id) => id,
+                Err(reason) => return error_at(path, reason),
+            };
+            warn_ignored(ctx, path, &tag, items.count());
+            Element::RefGui(RefGui { id, key })
+        }
+        // Unreachable: membership in KNOWN_TAGS is checked above.
+        _ => error_at(path, ErrorReason::UnknownTag(tag)),
+    }
+}
+
+/// Decode the child elements of a container, dropping remaining siblings
+/// behind a single visible error once the element budget is spent.
+fn children(ctx: &mut Ctx, path: &mut Vec<usize>, depth: usize, items: Vec<SExpr>) -> Vec<Element> {
+    let mut elems = Vec::with_capacity(items.len());
+    for (ix, item) in items.into_iter().enumerate() {
+        path.push(ix);
+        if ctx.remaining == 0 {
+            elems.push(error_at(
+                path,
+                ErrorReason::ElementLimit(ctx.limits.max_elements),
+            ));
+            path.pop();
+            break;
+        }
+        elems.push(elem(ctx, path, depth + 1, item));
+        path.pop();
+    }
+    elems
+}
+
+/// Split a leading attribute block from an element's remaining items.
+fn split_attrs(rest: Vec<SExpr>) -> (Option<Vec<SExpr>>, Vec<SExpr>) {
+    let mut iter = rest.into_iter();
+    match iter.next() {
+        Some(SExpr::List(entries)) if entries.first().is_some_and(is_attrs_marker) => {
+            (Some(entries), iter.collect())
+        }
+        Some(first) => (None, std::iter::once(first).chain(iter).collect()),
+        None => (None, Vec::new()),
+    }
+}
+
+/// Whether the value is the reserved `@` marker.
+fn is_attrs_marker(expr: &SExpr) -> bool {
+    matches!(expr, SExpr::Ident(s) | SExpr::Str(s) if s == ATTRS_MARKER)
+}
+
+/// Parse the entries of an attribute block (marker included) into an
+/// [`AttrSet`], warning for malformed entries and duplicates.
+fn parse_attrs(ctx: &mut Ctx, path: &[usize], tag: &str, entries: Vec<SExpr>) -> AttrSet {
+    let mut parsed: Vec<(String, Option<SExpr>)> = Vec::new();
+    for entry in entries.into_iter().skip(1) {
+        match entry {
+            SExpr::List(pair) => match <[SExpr; 2]>::try_from(pair) {
+                Ok([name_expr, value]) => match text(&name_expr) {
+                    Some(name) if parsed.iter().any(|(n, _)| *n == name) => {
+                        let kind = WarningKind::DuplicateAttr {
+                            tag: tag.to_string(),
+                            attr: name,
+                        };
+                        ctx.warn(path, kind);
+                    }
+                    Some(name) => parsed.push((name, Some(value))),
+                    None => {
+                        let kind = WarningKind::MalformedAttr {
+                            tag: tag.to_string(),
+                            found: sexpr::summary(&name_expr),
+                        };
+                        ctx.warn(path, kind);
+                    }
+                },
+                Err(pair) => {
+                    let kind = WarningKind::MalformedAttr {
+                        tag: tag.to_string(),
+                        found: sexpr::summary(&SExpr::List(pair)),
+                    };
+                    ctx.warn(path, kind);
+                }
+            },
+            other => {
+                let kind = WarningKind::MalformedAttr {
+                    tag: tag.to_string(),
+                    found: sexpr::summary(&other),
+                };
+                ctx.warn(path, kind);
+            }
+        }
+    }
+    AttrSet { entries: parsed }
+}
+
+/// Extract the required leading node id argument of `scope` and `ref-gui`.
+fn node_id_arg(tag: &str, arg: Option<SExpr>) -> Result<usize, ErrorReason> {
+    let missing = |found: String| ErrorReason::MissingArg {
+        tag: tag.to_string(),
+        what: "a node id",
+        found,
+    };
+    match arg {
+        None => Err(missing("nothing".to_string())),
+        Some(v) => as_node_id(&v).ok_or_else(|| missing(sexpr::summary(&v))),
+    }
+}
+
+fn warn_ignored(ctx: &mut Ctx, path: &[usize], tag: &str, count: usize) {
+    if count > 0 {
+        let kind = WarningKind::IgnoredChildren {
+            tag: tag.to_string(),
+            count,
+        };
+        ctx.warn(path, kind);
+    }
+}
+
+/// The contents of an identifier or string.
+///
+/// This is the tolerance rule in one place: identifier positions accept
+/// strings and text positions accept identifiers, because `Datum` encodes
+/// identifiers as strings.
+fn text(expr: &SExpr) -> Option<String> {
+    match expr {
+        SExpr::Ident(s) | SExpr::Str(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// A number. Integers widen to floats, never the reverse.
+fn as_f64(expr: &SExpr) -> Option<f64> {
+    match expr {
+        SExpr::Float(f) => Some(*f),
+        SExpr::Int(i) => Some(*i as f64),
+        _ => None,
+    }
+}
+
+fn as_f32(expr: &SExpr) -> Option<f32> {
+    as_f64(expr).map(|f| f as f32)
+}
+
+fn as_u8(expr: &SExpr) -> Option<u8> {
+    match expr {
+        SExpr::Int(i) => u8::try_from(*i).ok(),
+        _ => None,
+    }
+}
+
+/// A grid column count: a positive integer.
+fn as_cols(expr: &SExpr) -> Option<u32> {
+    match expr {
+        SExpr::Int(i) if *i >= 1 => u32::try_from(*i).ok(),
+        _ => None,
+    }
+}
+
+fn as_bool(expr: &SExpr) -> Option<bool> {
+    match expr {
+        SExpr::Bool(b) => Some(*b),
+        _ => None,
+    }
+}
+
+fn as_key(expr: &SExpr) -> Option<Key> {
+    match expr {
+        SExpr::Ident(s) | SExpr::Str(s) => Some(Key::Str(s.clone())),
+        SExpr::Int(i) => Some(Key::Int(*i)),
+        _ => None,
+    }
+}
+
+/// A node id: a non-negative integer.
+fn as_node_id(expr: &SExpr) -> Option<usize> {
+    match expr {
+        SExpr::Int(i) => usize::try_from(*i).ok(),
+        _ => None,
+    }
+}
+
+/// A binding path: a list of node ids. Machine produced, so no bare integer
+/// sugar.
+fn as_bind(expr: &SExpr) -> Option<BindPath> {
+    match expr {
+        SExpr::List(items) => items
+            .iter()
+            .map(as_node_id)
+            .collect::<Option<Vec<_>>>()
+            .map(BindPath),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ident(s: &str) -> SExpr {
+        SExpr::Ident(s.to_string())
+    }
+
+    fn str_(s: &str) -> SExpr {
+        SExpr::Str(s.to_string())
+    }
+
+    fn int(i: i64) -> SExpr {
+        SExpr::Int(i)
+    }
+
+    fn float(f: f64) -> SExpr {
+        SExpr::Float(f)
+    }
+
+    fn list(items: Vec<SExpr>) -> SExpr {
+        SExpr::List(items)
+    }
+
+    fn attr(name: &str, value: SExpr) -> SExpr {
+        list(vec![ident(name), value])
+    }
+
+    fn attrs(entries: Vec<SExpr>) -> SExpr {
+        let mut items = vec![ident(ATTRS_MARKER)];
+        items.extend(entries);
+        list(items)
+    }
+
+    fn dec(expr: SExpr) -> Decoded {
+        decode(expr, &Limits::default())
+    }
+
+    fn error_reason(elem: &Element) -> &ErrorReason {
+        match elem {
+            Element::Error(e) => &e.reason,
+            other => panic!("expected an error element, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn col_and_row_decode_with_attrs_and_children() {
+        let d = dec(list(vec![
+            ident("col"),
+            attrs(vec![attr("gap", int(4)), attr("align", ident("center"))]),
+            list(vec![ident("row"), list(vec![ident("sep")])]),
+        ]));
+        let expected = Element::Col(Col {
+            gap: Some(4.0),
+            align: Some(Align::Center),
+            key: None,
+            children: vec![Element::Row(Row {
+                children: vec![Element::Sep(Sep::default())],
+                ..Default::default()
+            })],
+        });
+        assert_eq!(d.root, expected);
+        assert_eq!(d.warnings, vec![]);
+    }
+
+    #[test]
+    fn every_control_decodes_fully_attributed() {
+        let d = dec(list(vec![
+            ident("dialer"),
+            attrs(vec![
+                attr("bind", list(vec![int(0), int(2)])),
+                attr("min", float(0.0)),
+                attr("max", float(1.0)),
+                attr("step", float(0.1)),
+                attr("precision", int(3)),
+                attr("label", str_("cutoff")),
+                attr("push", SExpr::Bool(false)),
+                attr("style", ident("knob")),
+                attr("key", str_("k")),
+            ]),
+        ]));
+        let expected = Element::Dialer(Dialer {
+            bind: Some(BindPath(vec![0, 2])),
+            min: Some(0.0),
+            max: Some(1.0),
+            step: Some(0.1),
+            precision: Some(3),
+            label: Some("cutoff".to_string()),
+            push: false,
+            style: Some(DialerStyle::Knob),
+            key: Some(Key::Str("k".to_string())),
+        });
+        assert_eq!(d.root, expected);
+        assert_eq!(d.warnings, vec![]);
+
+        let d = dec(list(vec![
+            ident("toggle"),
+            attrs(vec![
+                attr("bind", list(vec![int(5)])),
+                attr("label", str_("drive")),
+            ]),
+        ]));
+        let expected = Element::Toggle(Toggle {
+            bind: Some(BindPath(vec![5])),
+            label: Some("drive".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(d.root, expected);
+
+        let d = dec(list(vec![
+            ident("button"),
+            attrs(vec![attr("bind", list(vec![int(7)]))]),
+        ]));
+        let expected = Element::Button(Button {
+            bind: Some(BindPath(vec![7])),
+            ..Default::default()
+        });
+        assert_eq!(d.root, expected);
+
+        let d = dec(list(vec![
+            ident("matrix"),
+            attrs(vec![
+                attr("bind", list(vec![int(1)])),
+                attr("cell-size", int(12)),
+                attr("push", SExpr::Bool(false)),
+            ]),
+        ]));
+        let expected = Element::Matrix(Matrix {
+            bind: Some(BindPath(vec![1])),
+            cell_size: Some(12.0),
+            push: false,
+            key: None,
+        });
+        assert_eq!(d.root, expected);
+    }
+
+    #[test]
+    fn controls_apply_documented_defaults() {
+        assert_eq!(
+            dec(list(vec![ident("dialer")])).root,
+            Element::Dialer(Dialer::default())
+        );
+        assert_eq!(
+            dec(list(vec![ident("toggle")])).root,
+            Element::Toggle(Toggle::default())
+        );
+        assert_eq!(
+            dec(list(vec![ident("value")])).root,
+            Element::Value(Value::default())
+        );
+        assert_eq!(
+            dec(list(vec![ident("plot")])).root,
+            Element::Plot(Plot::default())
+        );
+    }
+
+    #[test]
+    fn display_elements_decode() {
+        let d = dec(list(vec![
+            ident("label"),
+            attrs(vec![
+                attr("size", float(18.0)),
+                attr("color", str_("#ff0080")),
+            ]),
+            str_("hello"),
+        ]));
+        let expected = Element::Label(Label {
+            text: "hello".to_string(),
+            size: Some(18.0),
+            color: Some(Rgba([255, 0, 128, 255])),
+            key: None,
+        });
+        assert_eq!(d.root, expected);
+        assert_eq!(d.warnings, vec![]);
+
+        let d = dec(list(vec![
+            ident("value"),
+            attrs(vec![
+                attr("bind", list(vec![int(3)])),
+                attr("wrap", SExpr::Bool(true)),
+            ]),
+        ]));
+        let expected = Element::Value(Value {
+            bind: Some(BindPath(vec![3])),
+            wrap: true,
+            key: None,
+        });
+        assert_eq!(d.root, expected);
+
+        let d = dec(list(vec![
+            ident("plot"),
+            attrs(vec![
+                attr("bind", list(vec![int(4)])),
+                attr("mode", ident("scope")),
+                attr("style", ident("line")),
+                attr("color", str_("#00ff0080")),
+                attr("grid", SExpr::Bool(true)),
+                attr("axes", SExpr::Bool(true)),
+                attr("y-min", float(-1.0)),
+                attr("y-max", float(1.0)),
+                attr("w", int(120)),
+                attr("h", int(80)),
+            ]),
+        ]));
+        let expected = Element::Plot(Plot {
+            bind: Some(BindPath(vec![4])),
+            mode: Some(PlotMode::Scope),
+            style: Some(PlotStyle::Line),
+            color: Some(Rgba([0, 255, 0, 128])),
+            grid: true,
+            axes: true,
+            y_min: Some(-1.0),
+            y_max: Some(1.0),
+            w: Some(120.0),
+            h: Some(80.0),
+            key: None,
+        });
+        assert_eq!(d.root, expected);
+        assert_eq!(d.warnings, vec![]);
+    }
+
+    #[test]
+    fn frame_and_grid_decode() {
+        let d = dec(list(vec![
+            ident("frame"),
+            attrs(vec![attr("title", str_("filter"))]),
+            list(vec![ident("sep")]),
+        ]));
+        let expected = Element::Frame(Frame {
+            title: Some("filter".to_string()),
+            key: None,
+            children: vec![Element::Sep(Sep::default())],
+        });
+        assert_eq!(d.root, expected);
+
+        let d = dec(list(vec![
+            ident("grid"),
+            attrs(vec![attr("cols", int(3)), attr("gap", int(2))]),
+            list(vec![ident("sep")]),
+        ]));
+        let expected = Element::Grid(Grid {
+            cols: 3,
+            gap: Some(2.0),
+            key: None,
+            children: vec![Element::Sep(Sep::default())],
+        });
+        assert_eq!(d.root, expected);
+        assert_eq!(d.warnings, vec![]);
+    }
+
+    #[test]
+    fn grid_without_cols_defaults_with_warning() {
+        let d = dec(list(vec![ident("grid")]));
+        assert_eq!(d.root, Element::Grid(Grid::default()));
+        assert_eq!(
+            d.warnings,
+            vec![Warning {
+                path: TreePath(vec![]),
+                kind: WarningKind::MissingAttr {
+                    tag: "grid".to_string(),
+                    attr: "cols".to_string(),
+                    default: "1".to_string(),
+                },
+            }]
+        );
+    }
+
+    #[test]
+    fn space_amount_variants() {
+        assert_eq!(
+            dec(list(vec![ident("space"), int(8)])).root,
+            Element::Space(Space {
+                amount: Some(8.0),
+                key: None,
+            })
+        );
+        assert_eq!(
+            dec(list(vec![ident("space"), float(8.5)])).root,
+            Element::Space(Space {
+                amount: Some(8.5),
+                key: None,
+            })
+        );
+        assert_eq!(
+            dec(list(vec![ident("space")])).root,
+            Element::Space(Space::default())
+        );
+        let d = dec(list(vec![ident("space"), str_("wide")]));
+        assert_eq!(d.root, Element::Space(Space::default()));
+        assert!(matches!(d.warnings[0].kind, WarningKind::InvalidArg { .. }));
+    }
+
+    #[test]
+    fn scope_decodes_and_prefixes_children() {
+        let d = dec(list(vec![ident("scope"), int(3), list(vec![ident("sep")])]));
+        let expected = Element::Scope(Scope {
+            id: 3,
+            key: None,
+            children: vec![Element::Sep(Sep::default())],
+        });
+        assert_eq!(d.root, expected);
+        assert_eq!(d.warnings, vec![]);
+    }
+
+    #[test]
+    fn scope_and_ref_gui_require_a_node_id() {
+        let d = dec(list(vec![ident("scope")]));
+        assert!(matches!(
+            error_reason(&d.root),
+            ErrorReason::MissingArg { tag, .. } if tag == "scope"
+        ));
+
+        let d = dec(list(vec![ident("scope"), str_("nope")]));
+        assert!(matches!(
+            error_reason(&d.root),
+            ErrorReason::MissingArg { .. }
+        ));
+
+        let d = dec(list(vec![ident("ref-gui"), int(-1)]));
+        assert!(matches!(
+            error_reason(&d.root),
+            ErrorReason::MissingArg { .. }
+        ));
+
+        let d = dec(list(vec![ident("ref-gui"), int(9)]));
+        assert_eq!(d.root, Element::RefGui(RefGui { id: 9, key: None }));
+    }
+
+    #[test]
+    fn unknown_attr_warns_and_is_ignored() {
+        let d = dec(list(vec![
+            ident("dialer"),
+            attrs(vec![attr("wobble", int(1))]),
+        ]));
+        assert_eq!(d.root, Element::Dialer(Dialer::default()));
+        assert_eq!(
+            d.warnings,
+            vec![Warning {
+                path: TreePath(vec![]),
+                kind: WarningKind::UnknownAttr {
+                    tag: "dialer".to_string(),
+                    attr: "wobble".to_string(),
+                },
+            }]
+        );
+    }
+
+    #[test]
+    fn duplicate_attr_keeps_first_and_warns() {
+        let d = dec(list(vec![
+            ident("dialer"),
+            attrs(vec![attr("min", float(1.0)), attr("min", float(9.0))]),
+        ]));
+        let Element::Dialer(dialer) = &d.root else {
+            panic!("expected a dialer");
+        };
+        assert_eq!(dialer.min, Some(1.0));
+        assert!(matches!(
+            d.warnings[0].kind,
+            WarningKind::DuplicateAttr { .. }
+        ));
+    }
+
+    #[test]
+    fn invalid_attr_value_falls_back_with_warning() {
+        let d = dec(list(vec![
+            ident("dialer"),
+            attrs(vec![attr("min", str_("low")), attr("push", int(1))]),
+        ]));
+        assert_eq!(d.root, Element::Dialer(Dialer::default()));
+        assert_eq!(d.warnings.len(), 2);
+        assert!(
+            d.warnings
+                .iter()
+                .all(|w| matches!(w.kind, WarningKind::InvalidAttrValue { .. }))
+        );
+    }
+
+    #[test]
+    fn ints_widen_to_float_attrs_but_floats_never_narrow() {
+        let d = dec(list(vec![
+            ident("dialer"),
+            attrs(vec![attr("min", int(2)), attr("precision", float(2.5))]),
+        ]));
+        let Element::Dialer(dialer) = &d.root else {
+            panic!("expected a dialer");
+        };
+        assert_eq!(dialer.min, Some(2.0));
+        assert_eq!(dialer.precision, None);
+        assert!(matches!(
+            d.warnings[0].kind,
+            WarningKind::InvalidAttrValue { ref attr, .. } if attr == "precision"
+        ));
+
+        let d = dec(list(vec![
+            ident("grid"),
+            attrs(vec![attr("cols", float(2.5))]),
+        ]));
+        let Element::Grid(grid) = &d.root else {
+            panic!("expected a grid");
+        };
+        assert_eq!(grid.cols, 1);
+    }
+
+    #[test]
+    fn malformed_attr_entries_warn_and_skip() {
+        let d = dec(list(vec![
+            ident("dialer"),
+            attrs(vec![
+                int(3),
+                list(vec![ident("min")]),
+                list(vec![int(1), int(2)]),
+                attr("max", float(1.0)),
+            ]),
+        ]));
+        let Element::Dialer(dialer) = &d.root else {
+            panic!("expected a dialer");
+        };
+        assert_eq!(dialer.max, Some(1.0));
+        assert_eq!(d.warnings.len(), 3);
+        assert!(
+            d.warnings
+                .iter()
+                .all(|w| matches!(w.kind, WarningKind::MalformedAttr { .. }))
+        );
+    }
+
+    #[test]
+    fn keys_accept_string_and_int() {
+        let d = dec(list(vec![
+            ident("sep"),
+            attrs(vec![attr("key", str_("a"))]),
+        ]));
+        assert_eq!(
+            d.root,
+            Element::Sep(Sep {
+                key: Some(Key::Str("a".to_string())),
+            })
+        );
+        let d = dec(list(vec![ident("sep"), attrs(vec![attr("key", int(7))])]));
+        assert_eq!(
+            d.root,
+            Element::Sep(Sep {
+                key: Some(Key::Int(7)),
+            })
+        );
+        let d = dec(list(vec![
+            ident("sep"),
+            attrs(vec![attr("key", SExpr::Bool(true))]),
+        ]));
+        assert_eq!(d.root, Element::Sep(Sep::default()));
+        assert!(matches!(
+            d.warnings[0].kind,
+            WarningKind::InvalidAttrValue { .. }
+        ));
+    }
+
+    #[test]
+    fn bind_requires_a_list_of_node_ids() {
+        let ok = dec(list(vec![
+            ident("value"),
+            attrs(vec![attr("bind", list(vec![int(1), int(2)]))]),
+        ]));
+        let Element::Value(value) = &ok.root else {
+            panic!("expected a value");
+        };
+        assert_eq!(value.bind, Some(BindPath(vec![1, 2])));
+
+        for bad in [
+            attr("bind", int(1)),
+            attr("bind", list(vec![int(-1)])),
+            attr("bind", list(vec![str_("x")])),
+        ] {
+            let d = dec(list(vec![ident("value"), attrs(vec![bad])]));
+            let Element::Value(value) = &d.root else {
+                panic!("expected a value");
+            };
+            assert_eq!(value.bind, None);
+            assert!(matches!(
+                d.warnings[0].kind,
+                WarningKind::InvalidAttrValue { ref attr, .. } if attr == "bind"
+            ));
+        }
+    }
+
+    #[test]
+    fn bad_colors_warn_and_fall_back() {
+        for bad in ["ff0080", "#ff008", "#gg0080"] {
+            let d = dec(list(vec![
+                ident("label"),
+                attrs(vec![attr("color", str_(bad))]),
+                str_("x"),
+            ]));
+            let Element::Label(label) = &d.root else {
+                panic!("expected a label");
+            };
+            assert_eq!(label.color, None);
+            assert!(matches!(
+                d.warnings[0].kind,
+                WarningKind::InvalidAttrValue { ref attr, .. } if attr == "color"
+            ));
+        }
+    }
+
+    #[test]
+    fn identifier_positions_accept_strings_and_vice_versa() {
+        // A tag as a string, an enum value as a string, text as an ident.
+        let d = dec(list(vec![
+            str_("col"),
+            attrs(vec![attr("align", str_("center"))]),
+            list(vec![str_("label"), ident("hi")]),
+        ]));
+        let expected = Element::Col(Col {
+            align: Some(Align::Center),
+            children: vec![Element::Label(Label {
+                text: "hi".to_string(),
+                ..Default::default()
+            })],
+            ..Default::default()
+        });
+        assert_eq!(d.root, expected);
+        assert_eq!(d.warnings, vec![]);
+    }
+
+    #[test]
+    fn label_text_variants() {
+        let d = dec(list(vec![ident("label")]));
+        assert_eq!(d.root, Element::Label(Label::default()));
+        assert!(matches!(
+            d.warnings[0].kind,
+            WarningKind::MissingText { .. }
+        ));
+
+        let d = dec(list(vec![ident("label"), int(3)]));
+        assert_eq!(d.root, Element::Label(Label::default()));
+        assert!(matches!(d.warnings[0].kind, WarningKind::InvalidArg { .. }));
+
+        let d = dec(list(vec![ident("label"), str_("x"), str_("y")]));
+        assert!(matches!(
+            d.warnings[0].kind,
+            WarningKind::IgnoredChildren { count: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn leaves_ignore_children_with_a_warning() {
+        let d = dec(list(vec![ident("sep"), list(vec![ident("sep")]), int(2)]));
+        assert_eq!(d.root, Element::Sep(Sep::default()));
+        assert_eq!(
+            d.warnings,
+            vec![Warning {
+                path: TreePath(vec![]),
+                kind: WarningKind::IgnoredChildren {
+                    tag: "sep".to_string(),
+                    count: 2,
+                },
+            }]
+        );
+    }
+
+    #[test]
+    fn unknown_tag_errors_at_its_path() {
+        let d = dec(list(vec![
+            ident("col"),
+            list(vec![ident("sep")]),
+            list(vec![ident("bogus"), int(1)]),
+        ]));
+        let Element::Col(col) = &d.root else {
+            panic!("expected a col");
+        };
+        assert_eq!(col.children[0], Element::Sep(Sep::default()));
+        assert_eq!(
+            col.children[1],
+            Element::Error(ErrorElem {
+                path: TreePath(vec![1]),
+                reason: ErrorReason::UnknownTag("bogus".to_string()),
+            })
+        );
+    }
+
+    #[test]
+    fn every_reserved_tag_errors() {
+        for tag in RESERVED_TAGS {
+            let d = dec(list(vec![ident(tag)]));
+            assert_eq!(
+                *error_reason(&d.root),
+                ErrorReason::ReservedTag(tag.to_string()),
+            );
+        }
+    }
+
+    #[test]
+    fn siblings_survive_a_malformed_child() {
+        let d = dec(list(vec![
+            ident("col"),
+            list(vec![ident("dialer")]),
+            list(vec![ident("bogus")]),
+            list(vec![ident("toggle")]),
+        ]));
+        let Element::Col(col) = &d.root else {
+            panic!("expected a col");
+        };
+        assert_eq!(col.children.len(), 3);
+        assert_eq!(col.children[0], Element::Dialer(Dialer::default()));
+        assert!(matches!(col.children[1], Element::Error(_)));
+        assert_eq!(col.children[2], Element::Toggle(Toggle::default()));
+        assert_eq!(d.warnings, vec![]);
+    }
+
+    #[test]
+    fn nested_error_paths_are_exact() {
+        let d = dec(list(vec![
+            ident("col"),
+            list(vec![ident("sep")]),
+            list(vec![
+                ident("row"),
+                list(vec![ident("sep")]),
+                list(vec![ident("frame"), int(5)]),
+            ]),
+        ]));
+        let Element::Col(col) = &d.root else {
+            panic!("expected a col");
+        };
+        let Element::Row(row) = &col.children[1] else {
+            panic!("expected a row");
+        };
+        let Element::Frame(frame) = &row.children[1] else {
+            panic!("expected a frame");
+        };
+        assert_eq!(
+            frame.children[0],
+            Element::Error(ErrorElem {
+                path: TreePath(vec![1, 1, 0]),
+                reason: ErrorReason::NotAnElement {
+                    found: "the integer `5`".to_string(),
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn misplaced_attr_blocks_error() {
+        // An attribute block in child position.
+        let d = dec(list(vec![
+            ident("col"),
+            list(vec![ident("sep")]),
+            attrs(vec![attr("gap", int(4))]),
+        ]));
+        let Element::Col(col) = &d.root else {
+            panic!("expected a col");
+        };
+        assert_eq!(*error_reason(&col.children[1]), ErrorReason::MisplacedAttrs);
+
+        // An attribute block as the root form.
+        let d = dec(attrs(vec![attr("gap", int(4))]));
+        assert_eq!(*error_reason(&d.root), ErrorReason::MisplacedAttrs);
+
+        // The marker as a string still counts.
+        let d = dec(list(vec![str_("@"), attr("gap", int(4))]));
+        assert_eq!(*error_reason(&d.root), ErrorReason::MisplacedAttrs);
+    }
+
+    #[test]
+    fn non_element_roots_error() {
+        assert!(matches!(
+            error_reason(&dec(int(3)).root),
+            ErrorReason::NotAnElement { .. }
+        ));
+        assert!(matches!(
+            error_reason(&dec(list(vec![])).root),
+            ErrorReason::NotAnElement { .. }
+        ));
+        let d = dec(list(vec![list(vec![ident("col")])]));
+        assert!(matches!(
+            error_reason(&d.root),
+            ErrorReason::NotAnElement { .. }
+        ));
+    }
+
+    #[test]
+    fn foreign_values_error_with_their_summary() {
+        let d = dec(list(vec![
+            ident("col"),
+            SExpr::Other("a closure".to_string()),
+        ]));
+        let Element::Col(col) = &d.root else {
+            panic!("expected a col");
+        };
+        assert_eq!(
+            *error_reason(&col.children[0]),
+            ErrorReason::NotAnElement {
+                found: "a closure".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn depth_limit_replaces_the_offending_subtree() {
+        let limits = Limits {
+            max_depth: 2,
+            ..Default::default()
+        };
+        let at_limit = list(vec![
+            ident("col"),
+            list(vec![ident("col"), list(vec![ident("sep")])]),
+        ]);
+        let d = decode(at_limit, &limits);
+        assert_eq!(d.warnings, vec![]);
+        assert!(!tree_has_error(&d.root));
+
+        let past_limit = list(vec![
+            ident("col"),
+            list(vec![
+                ident("col"),
+                list(vec![ident("col"), list(vec![ident("sep")])]),
+            ]),
+        ]);
+        let d = decode(past_limit, &limits);
+        let Element::Col(c0) = &d.root else {
+            panic!("expected a col");
+        };
+        let Element::Col(c1) = &c0.children[0] else {
+            panic!("expected a col");
+        };
+        let Element::Col(c2) = &c1.children[0] else {
+            panic!("expected a col");
+        };
+        assert_eq!(
+            c2.children[0],
+            Element::Error(ErrorElem {
+                path: TreePath(vec![0, 0, 0]),
+                reason: ErrorReason::DepthLimit(2),
+            })
+        );
+    }
+
+    #[test]
+    fn element_limit_truncates_visibly() {
+        let limits = Limits {
+            max_elements: 3,
+            ..Default::default()
+        };
+        let d = decode(
+            list(vec![
+                ident("col"),
+                list(vec![ident("sep")]),
+                list(vec![ident("sep")]),
+                list(vec![ident("sep")]),
+                list(vec![ident("sep")]),
+            ]),
+            &limits,
+        );
+        let Element::Col(col) = &d.root else {
+            panic!("expected a col");
+        };
+        assert_eq!(col.children.len(), 3);
+        assert_eq!(col.children[0], Element::Sep(Sep::default()));
+        assert_eq!(col.children[1], Element::Sep(Sep::default()));
+        assert_eq!(
+            col.children[2],
+            Element::Error(ErrorElem {
+                path: TreePath(vec![2]),
+                reason: ErrorReason::ElementLimit(3),
+            })
+        );
+    }
+
+    fn tree_has_error(elem: &Element) -> bool {
+        matches!(elem, Element::Error(_)) || elem.children().iter().any(tree_has_error)
+    }
+}

--- a/crates/gantz_ui/src/diag.rs
+++ b/crates/gantz_ui/src/diag.rs
@@ -1,0 +1,147 @@
+//! Decode diagnostics.
+//!
+//! Decoding is total and never silently blank. Issues fall on one of two
+//! sides of a single boundary rule:
+//!
+//! - An **error element** ([`ErrorReason`], carried by
+//!   [`crate::elem::ErrorElem`]) means the subtree cannot render
+//!   meaningfully. The element's slot in the tree is preserved so a host can
+//!   render an inline error chip while siblings render normally.
+//! - A **warning** ([`Warning`]) means the element still renders after
+//!   recovering, for example by ignoring an unknown attribute or falling
+//!   back to a documented default.
+
+use thiserror::Error;
+
+/// A path of child element indices from the tree root.
+///
+/// Indices address the `children` vectors of decoded elements, so they count
+/// element positions after the tag, any attribute block and any positional
+/// arguments of the parent form.
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+pub struct TreePath(pub Vec<usize>);
+
+/// A non-fatal decode note attached to the element at `path`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Warning {
+    /// The element the note is attached to.
+    pub path: TreePath,
+    /// What was recovered from and how.
+    pub kind: WarningKind,
+}
+
+/// A recoverable decode issue. The element renders regardless.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum WarningKind {
+    /// An attribute the element does not know. Ignored for forward
+    /// compatibility.
+    #[error("unknown attribute `{attr}` on `{tag}`")]
+    UnknownAttr {
+        /// The element's tag.
+        tag: String,
+        /// The unknown attribute's name.
+        attr: String,
+    },
+    /// An attribute value of the wrong shape. The field falls back to its
+    /// default.
+    #[error("attribute `{attr}` on `{tag}` expects {expected}, found {found}")]
+    InvalidAttrValue {
+        /// The element's tag.
+        tag: String,
+        /// The attribute's name.
+        attr: String,
+        /// What the attribute accepts.
+        expected: &'static str,
+        /// A summary of the value found.
+        found: String,
+    },
+    /// The same attribute given more than once. The first value wins.
+    #[error("duplicate attribute `{attr}` on `{tag}`, first value wins")]
+    DuplicateAttr {
+        /// The element's tag.
+        tag: String,
+        /// The duplicated attribute's name.
+        attr: String,
+    },
+    /// An attribute entry that is not a `(name value)` pair. Skipped.
+    #[error("malformed attribute entry on `{tag}`, expected a (name value) pair, found {found}")]
+    MalformedAttr {
+        /// The element's tag.
+        tag: String,
+        /// A summary of the entry found.
+        found: String,
+    },
+    /// A required attribute was absent and a default was substituted.
+    #[error("`{tag}` expects attribute `{attr}`, defaulting to {default}")]
+    MissingAttr {
+        /// The element's tag.
+        tag: String,
+        /// The missing attribute's name.
+        attr: String,
+        /// The substituted default, rendered for the message.
+        default: String,
+    },
+    /// A positional argument of the wrong shape. A default was substituted.
+    #[error("`{tag}` expects {what}, found {found}")]
+    InvalidArg {
+        /// The element's tag.
+        tag: String,
+        /// What the argument accepts.
+        what: &'static str,
+        /// A summary of the value found.
+        found: String,
+    },
+    /// Items given to an element that takes no children. Ignored.
+    #[error("`{tag}` takes no children, ignored {count}")]
+    IgnoredChildren {
+        /// The element's tag.
+        tag: String,
+        /// How many items were ignored.
+        count: usize,
+    },
+    /// Text expected but absent. An empty string was substituted.
+    #[error("`{tag}` expects {what}, none found")]
+    MissingText {
+        /// The element's tag.
+        tag: String,
+        /// What kind of text was expected.
+        what: &'static str,
+    },
+}
+
+/// Why a subtree decoded to an inline error element.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum ErrorReason {
+    /// A tag outside the vocabulary.
+    #[error("unknown element `{0}`")]
+    UnknownTag(String),
+    /// A tag claimed by the vocabulary for a future version.
+    #[error("`{0}` is reserved for a future version")]
+    ReservedTag(String),
+    /// A value in element position that is not an element form.
+    #[error("expected an element list, found {found}")]
+    NotAnElement {
+        /// A summary of the value found.
+        found: String,
+    },
+    /// An attribute block anywhere other than immediately after the tag.
+    #[error("an attribute block is only valid immediately after the tag")]
+    MisplacedAttrs,
+    /// A required positional argument absent or of the wrong shape.
+    #[error("`{tag}` requires {what}, found {found}")]
+    MissingArg {
+        /// The element's tag.
+        tag: String,
+        /// What the argument accepts.
+        what: &'static str,
+        /// A summary of what was found, or "nothing".
+        found: String,
+    },
+    /// Nesting deeper than the decoder's depth limit.
+    #[error("depth limit of {0} exceeded")]
+    DepthLimit(usize),
+    /// More elements than the decoder's element limit. The remaining
+    /// siblings of the slot holding this error were dropped.
+    #[error("element limit of {0} exceeded, remaining siblings dropped")]
+    ElementLimit(usize),
+}

--- a/crates/gantz_ui/src/elem.rs
+++ b/crates/gantz_ui/src/elem.rs
@@ -1,0 +1,626 @@
+//! The typed UI tree model.
+//!
+//! [`Element`] is the canonical, closed representation of the v1 vocabulary.
+//! Unknown or malformed forms never fail a decode, they become
+//! [`Element::Error`] nodes in place (see [`crate::diag`]).
+//!
+//! The `Default` impl of each element struct is the single source of truth
+//! for attribute defaults: the decoder falls back to it and the encoder
+//! omits attributes equal to it.
+
+use crate::diag::{ErrorReason, TreePath};
+use std::fmt;
+
+/// A node path relative to the graph the tree was defined in.
+///
+/// Segments match `gantz_core::node::Id` (a plain `usize`), stated as
+/// `usize` here so the model stays runtime free. Paths are machine produced
+/// at codegen time, never hand authored in the normal flow.
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+pub struct BindPath(pub Vec<usize>);
+
+/// An explicit identity override, `(key <string|int>)`.
+///
+/// Keys are required for children whose order can change at runtime so that
+/// host widget memory follows the child rather than its position.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum Key {
+    /// A string key.
+    Str(String),
+    /// An integer key.
+    Int(i64),
+}
+
+/// An RGBA colour parsed from `"#rrggbb"` or `"#rrggbbaa"`.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct Rgba(pub [u8; 4]);
+
+/// Cross axis alignment for `col` and `row`.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Align {
+    /// Align children to the start of the cross axis.
+    Start,
+    /// Center children on the cross axis.
+    Center,
+    /// Align children to the end of the cross axis.
+    End,
+}
+
+/// The rendering style of a `dialer`. Reserved: the v1 host renders every
+/// dialer as a drag value regardless.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum DialerStyle {
+    /// A linear slider.
+    Slider,
+    /// A rotary knob.
+    Knob,
+}
+
+/// What a `plot` displays.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum PlotMode {
+    /// A rolling history buffer.
+    Scope,
+    /// The bound value itself as a signal frame.
+    Signal,
+}
+
+/// How a `plot` draws its samples.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum PlotStyle {
+    /// One bar per sample.
+    Bars,
+    /// A connected line.
+    Line,
+}
+
+/// One node of the decoded UI tree.
+///
+/// The model is closed: unknown tags decode to [`Element::Error`] so they
+/// stay visible, never silently blank.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Element {
+    /// A vertical stack, `(col ...)`.
+    Col(Col),
+    /// A horizontal stack, `(row ...)`.
+    Row(Row),
+    /// A row-major grid, `(grid (@ (cols n)) ...)`.
+    Grid(Grid),
+    /// A labelled group box, `(frame ...)`.
+    Frame(Frame),
+    /// A separator line, `(sep)`.
+    Sep(Sep),
+    /// Empty space, `(space n)`.
+    Space(Space),
+    /// A binding path prefix for a subtree, `(scope id ...)`.
+    Scope(Scope),
+    /// A numeric control, `(dialer)`.
+    Dialer(Dialer),
+    /// A boolean control, `(toggle)`.
+    Toggle(Toggle),
+    /// A trigger control, `(button)`.
+    Button(Button),
+    /// A grid of bool or number cells, `(matrix)`.
+    Matrix(Matrix),
+    /// Static text, `(label "text")`.
+    Label(Label),
+    /// A read-only value readout, `(value)`.
+    Value(Value),
+    /// A plotted view of bound state, `(plot)`.
+    Plot(Plot),
+    /// A host resolved embed of a child instance's GUI, `(ref-gui id)`.
+    RefGui(RefGui),
+    /// A subtree that could not be decoded, rendered as an inline error.
+    Error(ErrorElem),
+}
+
+/// A vertical stack of children.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Col {
+    /// Spacing between children, host default when absent.
+    pub gap: Option<f32>,
+    /// Cross axis alignment, host default when absent.
+    pub align: Option<Align>,
+    /// Identity override.
+    pub key: Option<Key>,
+    /// Child elements.
+    pub children: Vec<Element>,
+}
+
+/// A horizontal stack of children.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Row {
+    /// Spacing between children, host default when absent.
+    pub gap: Option<f32>,
+    /// Cross axis alignment, host default when absent.
+    pub align: Option<Align>,
+    /// Identity override.
+    pub key: Option<Key>,
+    /// Child elements.
+    pub children: Vec<Element>,
+}
+
+/// A grid filled row-major.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Grid {
+    /// The number of columns, at least 1. Required: decoding substitutes 1
+    /// with a warning when absent.
+    pub cols: u32,
+    /// Spacing between cells, host default when absent.
+    pub gap: Option<f32>,
+    /// Identity override.
+    pub key: Option<Key>,
+    /// Child elements.
+    pub children: Vec<Element>,
+}
+
+/// A labelled group box.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Frame {
+    /// The group box title.
+    pub title: Option<String>,
+    /// Identity override.
+    pub key: Option<Key>,
+    /// Child elements.
+    pub children: Vec<Element>,
+}
+
+/// A separator line.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Sep {
+    /// Identity override.
+    pub key: Option<Key>,
+}
+
+/// Empty space along the parent's main axis.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Space {
+    /// The amount of space, host default when absent. Positional:
+    /// `(space 8)`.
+    pub amount: Option<f32>,
+    /// Identity override.
+    pub key: Option<Key>,
+}
+
+/// Prefixes the binding paths of a subtree with a node id.
+///
+/// Never hand written in the normal flow: codegen inserts it where a child
+/// graph's exported GUI crosses into a parent expression, and hosts apply it
+/// implicitly when rendering a referenced graph at an instance path.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Scope {
+    /// The node id pushed onto the binding path prefix. Positional:
+    /// `(scope 3 ...)`.
+    pub id: usize,
+    /// Identity override.
+    pub key: Option<Key>,
+    /// Child elements, rendered with the prefixed scope.
+    pub children: Vec<Element>,
+}
+
+/// A numeric control bound to number state.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Dialer {
+    /// The bound node path.
+    pub bind: Option<BindPath>,
+    /// Lower bound.
+    pub min: Option<f64>,
+    /// Upper bound.
+    pub max: Option<f64>,
+    /// Drag step.
+    pub step: Option<f64>,
+    /// Displayed decimal places.
+    pub precision: Option<u8>,
+    /// An inline label.
+    pub label: Option<String>,
+    /// Whether a `set` also queues a push eval at the bound node.
+    pub push: bool,
+    /// Rendering style, reserved.
+    pub style: Option<DialerStyle>,
+    /// Identity override.
+    pub key: Option<Key>,
+}
+
+/// A boolean control bound to bool state.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Toggle {
+    /// The bound node path.
+    pub bind: Option<BindPath>,
+    /// An inline label.
+    pub label: Option<String>,
+    /// Whether a `set` also queues a push eval at the bound node.
+    pub push: bool,
+    /// Identity override.
+    pub key: Option<Key>,
+}
+
+/// A trigger control. Holds no state, a press queues a push eval at the
+/// bound node (bang semantics stay in the node's expression).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Button {
+    /// The bound node path.
+    pub bind: Option<BindPath>,
+    /// An inline label.
+    pub label: Option<String>,
+    /// Identity override.
+    pub key: Option<Key>,
+}
+
+/// A grid of bool or number cells bound to list-of-rows state.
+///
+/// Rows and columns come from the bound state's shape, not from attributes:
+/// a dynamic collection is one widget bound to one structured value.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Matrix {
+    /// The bound node path.
+    pub bind: Option<BindPath>,
+    /// The size of one cell, host default when absent. Attribute
+    /// `cell-size`.
+    pub cell_size: Option<f32>,
+    /// Whether a `set` also queues a push eval at the bound node.
+    pub push: bool,
+    /// Identity override.
+    pub key: Option<Key>,
+}
+
+/// Static text. The text is positional: `(label "text")`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Label {
+    /// The text to display.
+    pub text: String,
+    /// Font size, host default when absent.
+    pub size: Option<f32>,
+    /// Text colour, host default when absent.
+    pub color: Option<Rgba>,
+    /// Identity override.
+    pub key: Option<Key>,
+}
+
+/// A read-only readout of the bound state's representation.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Value {
+    /// The bound node path.
+    pub bind: Option<BindPath>,
+    /// Whether long output wraps.
+    pub wrap: bool,
+    /// Identity override.
+    pub key: Option<Key>,
+}
+
+/// A plotted view of bound state (a scope buffer or a signal, a list of
+/// lists renders as stacked channels).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Plot {
+    /// The bound node path.
+    pub bind: Option<BindPath>,
+    /// What is displayed, host default when absent.
+    pub mode: Option<PlotMode>,
+    /// How samples draw, host default when absent.
+    pub style: Option<PlotStyle>,
+    /// Plot colour, theme default when absent.
+    pub color: Option<Rgba>,
+    /// Whether a grid draws behind the samples.
+    pub grid: bool,
+    /// Whether axes draw.
+    pub axes: bool,
+    /// A fixed lower value axis bound. Attribute `y-min`.
+    pub y_min: Option<f32>,
+    /// A fixed upper value axis bound. Attribute `y-max`.
+    pub y_max: Option<f32>,
+    /// Width, host default when absent.
+    pub w: Option<f32>,
+    /// Height, host default when absent.
+    pub h: Option<f32>,
+    /// Identity override.
+    pub key: Option<Key>,
+}
+
+/// A host resolved embed of a child instance's GUI.
+///
+/// The id is the instance's node id in the defining graph. The host resolves
+/// the instance's body marker (else its auto GUI, else a label) and renders
+/// it at the instance path inside an implicit scope.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RefGui {
+    /// The child instance's node id. Positional: `(ref-gui 9)`.
+    pub id: usize,
+    /// Identity override.
+    pub key: Option<Key>,
+}
+
+/// A subtree that failed to decode, preserved in place so hosts render an
+/// inline error chip while siblings render normally.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ErrorElem {
+    /// Where in the tree the failure sits.
+    pub path: TreePath,
+    /// What went wrong.
+    pub reason: ErrorReason,
+}
+
+/// Tag names claimed by the vocabulary but not yet implemented. Decoding one
+/// yields an [`ErrorReason::ReservedTag`] element.
+pub const RESERVED_TAGS: &[&str] = &[
+    "tabs",
+    "page",
+    "canvas",
+    "paint",
+    "image",
+    "dropdown",
+    "text-input",
+    "xy-pad",
+    "meter",
+];
+
+/// The reserved attribute block marker, invalid as a user tag.
+pub const ATTRS_MARKER: &str = "@";
+
+impl Element {
+    /// The element's tag name (`"error"` for [`Element::Error`]).
+    pub fn tag(&self) -> &'static str {
+        match self {
+            Element::Col(_) => "col",
+            Element::Row(_) => "row",
+            Element::Grid(_) => "grid",
+            Element::Frame(_) => "frame",
+            Element::Sep(_) => "sep",
+            Element::Space(_) => "space",
+            Element::Scope(_) => "scope",
+            Element::Dialer(_) => "dialer",
+            Element::Toggle(_) => "toggle",
+            Element::Button(_) => "button",
+            Element::Matrix(_) => "matrix",
+            Element::Label(_) => "label",
+            Element::Value(_) => "value",
+            Element::Plot(_) => "plot",
+            Element::RefGui(_) => "ref-gui",
+            Element::Error(_) => "error",
+        }
+    }
+
+    /// The element's children, empty for leaves.
+    pub fn children(&self) -> &[Element] {
+        match self {
+            Element::Col(e) => &e.children,
+            Element::Row(e) => &e.children,
+            Element::Grid(e) => &e.children,
+            Element::Frame(e) => &e.children,
+            Element::Scope(e) => &e.children,
+            _ => &[],
+        }
+    }
+
+    /// The element's explicit identity key, if any.
+    pub fn key(&self) -> Option<&Key> {
+        match self {
+            Element::Col(e) => e.key.as_ref(),
+            Element::Row(e) => e.key.as_ref(),
+            Element::Grid(e) => e.key.as_ref(),
+            Element::Frame(e) => e.key.as_ref(),
+            Element::Sep(e) => e.key.as_ref(),
+            Element::Space(e) => e.key.as_ref(),
+            Element::Scope(e) => e.key.as_ref(),
+            Element::Dialer(e) => e.key.as_ref(),
+            Element::Toggle(e) => e.key.as_ref(),
+            Element::Button(e) => e.key.as_ref(),
+            Element::Matrix(e) => e.key.as_ref(),
+            Element::Label(e) => e.key.as_ref(),
+            Element::Value(e) => e.key.as_ref(),
+            Element::Plot(e) => e.key.as_ref(),
+            Element::RefGui(e) => e.key.as_ref(),
+            Element::Error(_) => None,
+        }
+    }
+}
+
+impl Align {
+    /// The identifier for this alignment in the tree form.
+    pub fn name(self) -> &'static str {
+        match self {
+            Align::Start => "start",
+            Align::Center => "center",
+            Align::End => "end",
+        }
+    }
+
+    /// Parse an alignment from its identifier.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "start" => Some(Align::Start),
+            "center" => Some(Align::Center),
+            "end" => Some(Align::End),
+            _ => None,
+        }
+    }
+}
+
+impl DialerStyle {
+    /// The identifier for this style in the tree form.
+    pub fn name(self) -> &'static str {
+        match self {
+            DialerStyle::Slider => "slider",
+            DialerStyle::Knob => "knob",
+        }
+    }
+
+    /// Parse a style from its identifier.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "slider" => Some(DialerStyle::Slider),
+            "knob" => Some(DialerStyle::Knob),
+            _ => None,
+        }
+    }
+}
+
+impl PlotMode {
+    /// The identifier for this mode in the tree form.
+    pub fn name(self) -> &'static str {
+        match self {
+            PlotMode::Scope => "scope",
+            PlotMode::Signal => "signal",
+        }
+    }
+
+    /// Parse a mode from its identifier.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "scope" => Some(PlotMode::Scope),
+            "signal" => Some(PlotMode::Signal),
+            _ => None,
+        }
+    }
+}
+
+impl PlotStyle {
+    /// The identifier for this style in the tree form.
+    pub fn name(self) -> &'static str {
+        match self {
+            PlotStyle::Bars => "bars",
+            PlotStyle::Line => "line",
+        }
+    }
+
+    /// Parse a style from its identifier.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "bars" => Some(PlotStyle::Bars),
+            "line" => Some(PlotStyle::Line),
+            _ => None,
+        }
+    }
+}
+
+impl Rgba {
+    /// Parse `"#rrggbb"` or `"#rrggbbaa"`, case insensitive.
+    pub fn parse(s: &str) -> Option<Self> {
+        let hex = s.strip_prefix('#')?;
+        if hex.len() != 6 && hex.len() != 8 {
+            return None;
+        }
+        if !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+            return None;
+        }
+        let byte = |ix: usize| u8::from_str_radix(hex.get(ix..ix + 2)?, 16).ok();
+        let r = byte(0)?;
+        let g = byte(2)?;
+        let b = byte(4)?;
+        let a = if hex.len() == 8 { byte(6)? } else { 255 };
+        Some(Rgba([r, g, b, a]))
+    }
+}
+
+impl Default for Grid {
+    fn default() -> Self {
+        Grid {
+            cols: 1,
+            gap: None,
+            key: None,
+            children: Vec::new(),
+        }
+    }
+}
+
+impl Default for Dialer {
+    fn default() -> Self {
+        Dialer {
+            bind: None,
+            min: None,
+            max: None,
+            step: None,
+            precision: None,
+            label: None,
+            push: true,
+            style: None,
+            key: None,
+        }
+    }
+}
+
+impl Default for Toggle {
+    fn default() -> Self {
+        Toggle {
+            bind: None,
+            label: None,
+            push: true,
+            key: None,
+        }
+    }
+}
+
+impl Default for Matrix {
+    fn default() -> Self {
+        Matrix {
+            bind: None,
+            cell_size: None,
+            push: true,
+            key: None,
+        }
+    }
+}
+
+impl fmt::Display for Rgba {
+    /// Formats lowercase, `#rrggbb` when fully opaque, else `#rrggbbaa`.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let Rgba([r, g, b, a]) = *self;
+        match a {
+            255 => write!(f, "#{r:02x}{g:02x}{b:02x}"),
+            _ => write!(f, "#{r:02x}{g:02x}{b:02x}{a:02x}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rgba_parses_rgb_and_rgba() {
+        assert_eq!(Rgba::parse("#ff0080"), Some(Rgba([255, 0, 128, 255])));
+        assert_eq!(Rgba::parse("#FF0080"), Some(Rgba([255, 0, 128, 255])));
+        assert_eq!(Rgba::parse("#ff008040"), Some(Rgba([255, 0, 128, 64])));
+    }
+
+    #[test]
+    fn rgba_rejects_malformed() {
+        assert_eq!(Rgba::parse("ff0080"), None);
+        assert_eq!(Rgba::parse("#ff008"), None);
+        assert_eq!(Rgba::parse("#gg0080"), None);
+        assert_eq!(Rgba::parse("#+f0080"), None);
+        assert_eq!(Rgba::parse("#ff00800"), None);
+    }
+
+    #[test]
+    fn rgba_displays_minimal_form() {
+        assert_eq!(Rgba([255, 0, 128, 255]).to_string(), "#ff0080");
+        assert_eq!(Rgba([255, 0, 128, 64]).to_string(), "#ff008040");
+        assert_eq!(Rgba::parse("#ff008040").unwrap().to_string(), "#ff008040");
+    }
+
+    #[test]
+    fn enum_names_round_trip() {
+        for align in [Align::Start, Align::Center, Align::End] {
+            assert_eq!(Align::from_name(align.name()), Some(align));
+        }
+        for style in [DialerStyle::Slider, DialerStyle::Knob] {
+            assert_eq!(DialerStyle::from_name(style.name()), Some(style));
+        }
+        for mode in [PlotMode::Scope, PlotMode::Signal] {
+            assert_eq!(PlotMode::from_name(mode.name()), Some(mode));
+        }
+        for style in [PlotStyle::Bars, PlotStyle::Line] {
+            assert_eq!(PlotStyle::from_name(style.name()), Some(style));
+        }
+    }
+
+    #[test]
+    fn control_defaults_push() {
+        assert!(Dialer::default().push);
+        assert!(Toggle::default().push);
+        assert!(Matrix::default().push);
+        assert_eq!(Grid::default().cols, 1);
+        assert!(!Value::default().wrap);
+        assert!(!Plot::default().grid);
+        assert!(!Plot::default().axes);
+    }
+}

--- a/crates/gantz_ui/src/encode.rs
+++ b/crates/gantz_ui/src/encode.rs
@@ -1,0 +1,509 @@
+//! The canonical encoder from the typed tree to the abstract value model.
+//!
+//! Canonical form keeps stored GUI values minimal and stable, mirroring the
+//! ext conventions elsewhere in gantz:
+//!
+//! - Tags and attribute names emit as identifiers.
+//! - Only attributes differing from the element's `Default` emit. Required
+//!   attributes (`cols` on `grid`) and positional arguments (`scope` and
+//!   `ref-gui` ids, `label` text) always emit.
+//! - Attributes emit in field declaration order with `key` last, and the
+//!   attribute block is omitted entirely when empty.
+//!
+//! For any tree that decodes without errors and without warnings,
+//! [`crate::decode::decode`] of the encoding yields the tree unchanged.
+
+use crate::elem::{ATTRS_MARKER, BindPath, Element, Key, Rgba};
+use crate::sexpr::SExpr;
+
+/// Encode an element into the abstract value model in canonical form.
+///
+/// Total. [`Element::Error`] encodes as `(error (@ (reason "...")))`, and
+/// since `error` is not a vocabulary tag it decodes back to an unknown-tag
+/// error element: error elements are decode artifacts that stay visible
+/// after a store and reload, they are excluded from the round trip law.
+pub fn encode(elem: &Element) -> SExpr {
+    match elem {
+        Element::Col(e) => {
+            let mut attrs = Vec::new();
+            push_f32(&mut attrs, "gap", e.gap);
+            push_ident(&mut attrs, "align", e.align.map(|a| a.name()));
+            push_key(&mut attrs, &e.key);
+            form("col", attrs, Vec::new(), &e.children)
+        }
+        Element::Row(e) => {
+            let mut attrs = Vec::new();
+            push_f32(&mut attrs, "gap", e.gap);
+            push_ident(&mut attrs, "align", e.align.map(|a| a.name()));
+            push_key(&mut attrs, &e.key);
+            form("row", attrs, Vec::new(), &e.children)
+        }
+        Element::Grid(e) => {
+            let mut attrs = vec![entry("cols", SExpr::Int(i64::from(e.cols)))];
+            push_f32(&mut attrs, "gap", e.gap);
+            push_key(&mut attrs, &e.key);
+            form("grid", attrs, Vec::new(), &e.children)
+        }
+        Element::Frame(e) => {
+            let mut attrs = Vec::new();
+            push_string(&mut attrs, "title", &e.title);
+            push_key(&mut attrs, &e.key);
+            form("frame", attrs, Vec::new(), &e.children)
+        }
+        Element::Sep(e) => {
+            let mut attrs = Vec::new();
+            push_key(&mut attrs, &e.key);
+            form("sep", attrs, Vec::new(), &[])
+        }
+        Element::Space(e) => {
+            let mut attrs = Vec::new();
+            push_key(&mut attrs, &e.key);
+            let positional = e
+                .amount
+                .map(|f| SExpr::Float(f64::from(f)))
+                .into_iter()
+                .collect();
+            form("space", attrs, positional, &[])
+        }
+        Element::Scope(e) => {
+            let mut attrs = Vec::new();
+            push_key(&mut attrs, &e.key);
+            form("scope", attrs, vec![node_id(e.id)], &e.children)
+        }
+        Element::Dialer(e) => {
+            let mut attrs = Vec::new();
+            push_bind(&mut attrs, &e.bind);
+            push_f64(&mut attrs, "min", e.min);
+            push_f64(&mut attrs, "max", e.max);
+            push_f64(&mut attrs, "step", e.step);
+            push_int(&mut attrs, "precision", e.precision.map(i64::from));
+            push_string(&mut attrs, "label", &e.label);
+            push_bool(&mut attrs, "push", e.push, true);
+            push_ident(&mut attrs, "style", e.style.map(|s| s.name()));
+            push_key(&mut attrs, &e.key);
+            form("dialer", attrs, Vec::new(), &[])
+        }
+        Element::Toggle(e) => {
+            let mut attrs = Vec::new();
+            push_bind(&mut attrs, &e.bind);
+            push_string(&mut attrs, "label", &e.label);
+            push_bool(&mut attrs, "push", e.push, true);
+            push_key(&mut attrs, &e.key);
+            form("toggle", attrs, Vec::new(), &[])
+        }
+        Element::Button(e) => {
+            let mut attrs = Vec::new();
+            push_bind(&mut attrs, &e.bind);
+            push_string(&mut attrs, "label", &e.label);
+            push_key(&mut attrs, &e.key);
+            form("button", attrs, Vec::new(), &[])
+        }
+        Element::Matrix(e) => {
+            let mut attrs = Vec::new();
+            push_bind(&mut attrs, &e.bind);
+            push_f32(&mut attrs, "cell-size", e.cell_size);
+            push_bool(&mut attrs, "push", e.push, true);
+            push_key(&mut attrs, &e.key);
+            form("matrix", attrs, Vec::new(), &[])
+        }
+        Element::Label(e) => {
+            let mut attrs = Vec::new();
+            push_f32(&mut attrs, "size", e.size);
+            push_color(&mut attrs, "color", e.color);
+            push_key(&mut attrs, &e.key);
+            form("label", attrs, vec![SExpr::Str(e.text.clone())], &[])
+        }
+        Element::Value(e) => {
+            let mut attrs = Vec::new();
+            push_bind(&mut attrs, &e.bind);
+            push_bool(&mut attrs, "wrap", e.wrap, false);
+            push_key(&mut attrs, &e.key);
+            form("value", attrs, Vec::new(), &[])
+        }
+        Element::Plot(e) => {
+            let mut attrs = Vec::new();
+            push_bind(&mut attrs, &e.bind);
+            push_ident(&mut attrs, "mode", e.mode.map(|m| m.name()));
+            push_ident(&mut attrs, "style", e.style.map(|s| s.name()));
+            push_color(&mut attrs, "color", e.color);
+            push_bool(&mut attrs, "grid", e.grid, false);
+            push_bool(&mut attrs, "axes", e.axes, false);
+            push_f32(&mut attrs, "y-min", e.y_min);
+            push_f32(&mut attrs, "y-max", e.y_max);
+            push_f32(&mut attrs, "w", e.w);
+            push_f32(&mut attrs, "h", e.h);
+            push_key(&mut attrs, &e.key);
+            form("plot", attrs, Vec::new(), &[])
+        }
+        Element::RefGui(e) => {
+            let mut attrs = Vec::new();
+            push_key(&mut attrs, &e.key);
+            form("ref-gui", attrs, vec![node_id(e.id)], &[])
+        }
+        Element::Error(e) => {
+            let attrs = vec![entry("reason", SExpr::Str(e.reason.to_string()))];
+            form("error", attrs, Vec::new(), &[])
+        }
+    }
+}
+
+/// Assemble `(tag attrs? positional ... child ...)`, omitting the attribute
+/// block when empty.
+fn form(tag: &str, attrs: Vec<SExpr>, positional: Vec<SExpr>, children: &[Element]) -> SExpr {
+    let mut items = vec![ident(tag)];
+    if !attrs.is_empty() {
+        let mut block = vec![ident(ATTRS_MARKER)];
+        block.extend(attrs);
+        items.push(SExpr::List(block));
+    }
+    items.extend(positional);
+    items.extend(children.iter().map(encode));
+    SExpr::List(items)
+}
+
+fn ident(s: &str) -> SExpr {
+    SExpr::Ident(s.to_string())
+}
+
+/// A `(name value)` attribute entry.
+fn entry(name: &str, value: SExpr) -> SExpr {
+    SExpr::List(vec![ident(name), value])
+}
+
+/// A node id as an integer. Ids never approach the `i64` range in practice,
+/// saturation keeps the encoder total regardless.
+fn node_id(id: usize) -> SExpr {
+    SExpr::Int(i64::try_from(id).unwrap_or(i64::MAX))
+}
+
+fn push_f32(attrs: &mut Vec<SExpr>, name: &str, v: Option<f32>) {
+    if let Some(f) = v {
+        attrs.push(entry(name, SExpr::Float(f64::from(f))));
+    }
+}
+
+fn push_f64(attrs: &mut Vec<SExpr>, name: &str, v: Option<f64>) {
+    if let Some(f) = v {
+        attrs.push(entry(name, SExpr::Float(f)));
+    }
+}
+
+fn push_int(attrs: &mut Vec<SExpr>, name: &str, v: Option<i64>) {
+    if let Some(i) = v {
+        attrs.push(entry(name, SExpr::Int(i)));
+    }
+}
+
+fn push_string(attrs: &mut Vec<SExpr>, name: &str, v: &Option<String>) {
+    if let Some(s) = v {
+        attrs.push(entry(name, SExpr::Str(s.clone())));
+    }
+}
+
+fn push_ident(attrs: &mut Vec<SExpr>, name: &str, v: Option<&'static str>) {
+    if let Some(s) = v {
+        attrs.push(entry(name, ident(s)));
+    }
+}
+
+fn push_color(attrs: &mut Vec<SExpr>, name: &str, v: Option<Rgba>) {
+    if let Some(c) = v {
+        attrs.push(entry(name, SExpr::Str(c.to_string())));
+    }
+}
+
+/// Emit a boolean attribute only when it differs from its default.
+fn push_bool(attrs: &mut Vec<SExpr>, name: &str, v: bool, default: bool) {
+    if v != default {
+        attrs.push(entry(name, SExpr::Bool(v)));
+    }
+}
+
+fn push_key(attrs: &mut Vec<SExpr>, key: &Option<Key>) {
+    if let Some(k) = key {
+        let v = match k {
+            Key::Str(s) => SExpr::Str(s.clone()),
+            Key::Int(i) => SExpr::Int(*i),
+        };
+        attrs.push(entry("key", v));
+    }
+}
+
+fn push_bind(attrs: &mut Vec<SExpr>, bind: &Option<BindPath>) {
+    if let Some(BindPath(ids)) = bind {
+        let items = ids.iter().map(|&id| node_id(id)).collect();
+        attrs.push(entry("bind", SExpr::List(items)));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decode::{Decoded, Limits, decode};
+    use crate::diag::{ErrorReason, TreePath};
+    use crate::elem::{
+        Align, Button, Col, Dialer, DialerStyle, ErrorElem, Frame, Grid, Label, Matrix, Plot,
+        PlotMode, PlotStyle, RefGui, Row, Scope, Sep, Space, Toggle, Value,
+    };
+
+    fn roundtrips(elem: Element) {
+        let d = decode(encode(&elem), &Limits::default());
+        assert_eq!(
+            d,
+            Decoded {
+                root: elem,
+                warnings: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn default_leaves_encode_with_no_attr_block() {
+        assert_eq!(
+            encode(&Element::Dialer(Dialer::default())),
+            SExpr::List(vec![ident("dialer")])
+        );
+        assert_eq!(
+            encode(&Element::Sep(Sep::default())),
+            SExpr::List(vec![ident("sep")])
+        );
+        assert_eq!(
+            encode(&Element::Space(Space::default())),
+            SExpr::List(vec![ident("space")])
+        );
+    }
+
+    #[test]
+    fn required_forms_always_emit() {
+        // The required cols attribute.
+        assert_eq!(
+            encode(&Element::Grid(Grid::default())),
+            SExpr::List(vec![
+                ident("grid"),
+                SExpr::List(vec![ident(ATTRS_MARKER), entry("cols", SExpr::Int(1)),]),
+            ])
+        );
+        // The positional label text, even when empty.
+        assert_eq!(
+            encode(&Element::Label(Label::default())),
+            SExpr::List(vec![ident("label"), SExpr::Str(String::new())])
+        );
+    }
+
+    #[test]
+    fn attrs_emit_in_declaration_order_with_key_last() {
+        let dialer = Element::Dialer(Dialer {
+            bind: Some(BindPath(vec![2])),
+            min: Some(0.0),
+            max: Some(1.0),
+            push: false,
+            key: Some(Key::Int(1)),
+            ..Default::default()
+        });
+        let expected = SExpr::List(vec![
+            ident("dialer"),
+            SExpr::List(vec![
+                ident(ATTRS_MARKER),
+                entry("bind", SExpr::List(vec![SExpr::Int(2)])),
+                entry("min", SExpr::Float(0.0)),
+                entry("max", SExpr::Float(1.0)),
+                entry("push", SExpr::Bool(false)),
+                entry("key", SExpr::Int(1)),
+            ]),
+        ]);
+        assert_eq!(encode(&dialer), expected);
+    }
+
+    #[test]
+    fn error_elements_encode_visibly_but_do_not_round_trip() {
+        let err = Element::Error(ErrorElem {
+            path: TreePath(vec![1]),
+            reason: ErrorReason::UnknownTag("bogus".to_string()),
+        });
+        let encoded = encode(&err);
+        let SExpr::List(items) = &encoded else {
+            panic!("expected a list");
+        };
+        assert_eq!(items[0], ident("error"));
+        let d = decode(encoded, &Limits::default());
+        assert!(matches!(
+            d.root,
+            Element::Error(ErrorElem {
+                reason: ErrorReason::UnknownTag(ref tag),
+                ..
+            }) if tag == "error"
+        ));
+    }
+
+    #[test]
+    fn every_element_round_trips_fully_populated() {
+        roundtrips(Element::Col(Col {
+            gap: Some(4.0),
+            align: Some(Align::Center),
+            key: Some(Key::Str("c".to_string())),
+            children: vec![Element::Sep(Sep::default())],
+        }));
+        roundtrips(Element::Row(Row {
+            gap: Some(2.5),
+            align: Some(Align::End),
+            key: None,
+            children: vec![Element::Space(Space {
+                amount: Some(8.0),
+                key: None,
+            })],
+        }));
+        roundtrips(Element::Grid(Grid {
+            cols: 3,
+            gap: Some(1.0),
+            key: Some(Key::Int(2)),
+            children: vec![Element::Sep(Sep::default())],
+        }));
+        roundtrips(Element::Frame(Frame {
+            title: Some("filter".to_string()),
+            key: None,
+            children: vec![Element::Button(Button {
+                bind: Some(BindPath(vec![7])),
+                label: Some("ping".to_string()),
+                key: None,
+            })],
+        }));
+        roundtrips(Element::Scope(Scope {
+            id: 3,
+            key: None,
+            children: vec![Element::Toggle(Toggle {
+                bind: Some(BindPath(vec![5])),
+                label: Some("drive".to_string()),
+                push: false,
+                key: None,
+            })],
+        }));
+        roundtrips(Element::Dialer(Dialer {
+            bind: Some(BindPath(vec![0, 2])),
+            min: Some(20.0),
+            max: Some(20_000.0),
+            step: Some(0.5),
+            precision: Some(2),
+            label: Some("cutoff".to_string()),
+            push: false,
+            style: Some(DialerStyle::Knob),
+            key: Some(Key::Str("k".to_string())),
+        }));
+        roundtrips(Element::Matrix(Matrix {
+            bind: Some(BindPath(vec![1])),
+            cell_size: Some(12.0),
+            push: false,
+            key: None,
+        }));
+        roundtrips(Element::Label(Label {
+            text: "hello".to_string(),
+            size: Some(18.0),
+            color: Some(Rgba([255, 0, 128, 64])),
+            key: None,
+        }));
+        roundtrips(Element::Value(Value {
+            bind: Some(BindPath(vec![3])),
+            wrap: true,
+            key: None,
+        }));
+        roundtrips(Element::Plot(Plot {
+            bind: Some(BindPath(vec![4])),
+            mode: Some(PlotMode::Scope),
+            style: Some(PlotStyle::Line),
+            color: Some(Rgba([0, 255, 0, 255])),
+            grid: true,
+            axes: true,
+            y_min: Some(-1.0),
+            y_max: Some(1.0),
+            w: Some(120.0),
+            h: Some(80.0),
+            key: None,
+        }));
+        roundtrips(Element::RefGui(RefGui {
+            id: 9,
+            key: Some(Key::Int(4)),
+        }));
+    }
+
+    #[test]
+    fn every_element_round_trips_at_defaults() {
+        roundtrips(Element::Col(Col::default()));
+        roundtrips(Element::Row(Row::default()));
+        roundtrips(Element::Grid(Grid::default()));
+        roundtrips(Element::Frame(Frame::default()));
+        roundtrips(Element::Sep(Sep::default()));
+        roundtrips(Element::Space(Space::default()));
+        roundtrips(Element::Dialer(Dialer::default()));
+        roundtrips(Element::Toggle(Toggle::default()));
+        roundtrips(Element::Button(Button::default()));
+        roundtrips(Element::Matrix(Matrix::default()));
+        roundtrips(Element::Label(Label::default()));
+        roundtrips(Element::Value(Value::default()));
+        roundtrips(Element::Plot(Plot::default()));
+        roundtrips(Element::Scope(Scope {
+            id: 0,
+            key: None,
+            children: vec![],
+        }));
+        roundtrips(Element::RefGui(RefGui { id: 0, key: None }));
+    }
+
+    #[test]
+    fn a_deep_mixed_tree_round_trips() {
+        let tree = Element::Col(Col {
+            gap: Some(4.0),
+            align: None,
+            key: None,
+            children: vec![
+                Element::Frame(Frame {
+                    title: Some("filter".to_string()),
+                    key: None,
+                    children: vec![Element::Row(Row {
+                        children: vec![
+                            Element::Dialer(Dialer {
+                                bind: Some(BindPath(vec![2])),
+                                min: Some(20.0),
+                                max: Some(20_000.0),
+                                label: Some("cutoff".to_string()),
+                                ..Default::default()
+                            }),
+                            Element::Dialer(Dialer {
+                                bind: Some(BindPath(vec![3])),
+                                min: Some(0.1),
+                                max: Some(4.0),
+                                label: Some("q".to_string()),
+                                ..Default::default()
+                            }),
+                        ],
+                        ..Default::default()
+                    })],
+                }),
+                Element::Row(Row {
+                    children: vec![
+                        Element::Toggle(Toggle {
+                            bind: Some(BindPath(vec![5])),
+                            label: Some("drive".to_string()),
+                            ..Default::default()
+                        }),
+                        Element::Button(Button {
+                            bind: Some(BindPath(vec![7])),
+                            label: Some("ping".to_string()),
+                            key: None,
+                        }),
+                    ],
+                    ..Default::default()
+                }),
+                Element::Scope(Scope {
+                    id: 9,
+                    key: None,
+                    children: vec![Element::Plot(Plot {
+                        bind: Some(BindPath(vec![1])),
+                        mode: Some(PlotMode::Scope),
+                        ..Default::default()
+                    })],
+                }),
+                Element::RefGui(RefGui { id: 9, key: None }),
+            ],
+        });
+        roundtrips(tree);
+    }
+}

--- a/crates/gantz_ui/src/lib.rs
+++ b/crates/gantz_ui/src/lib.rs
@@ -19,6 +19,7 @@ pub use elem::{
 pub use encode::encode;
 pub use sexpr::{SExpr, summary};
 
+pub mod codec;
 pub mod decode;
 pub mod diag;
 pub mod elem;

--- a/crates/gantz_ui/src/lib.rs
+++ b/crates/gantz_ui/src/lib.rs
@@ -1,0 +1,14 @@
+//! The declarative UI tree model for user-defined gantz GUIs.
+//!
+//! A graph's GUI is a value: a tree of plain data that the graph itself
+//! produces, interpreted by a host every frame. This crate defines the
+//! canonical typed model of that tree along with per-runtime codecs. It is
+//! deliberately free of any GUI toolkit and, at its core, free of any
+//! runtime.
+//!
+//! The full v1 vocabulary reference lives here at the crate level and grows
+//! alongside the modules below.
+
+pub use sexpr::{SExpr, summary};
+
+pub mod sexpr;

--- a/crates/gantz_ui/src/lib.rs
+++ b/crates/gantz_ui/src/lib.rs
@@ -9,6 +9,14 @@
 //! The full v1 vocabulary reference lives here at the crate level and grows
 //! alongside the modules below.
 
+pub use diag::{ErrorReason, TreePath, Warning, WarningKind};
+pub use elem::{
+    ATTRS_MARKER, Align, BindPath, Button, Col, Dialer, DialerStyle, Element, ErrorElem, Frame,
+    Grid, Key, Label, Matrix, Plot, PlotMode, PlotStyle, RESERVED_TAGS, RefGui, Rgba, Row, Scope,
+    Sep, Space, Toggle, Value,
+};
 pub use sexpr::{SExpr, summary};
 
+pub mod diag;
+pub mod elem;
 pub mod sexpr;

--- a/crates/gantz_ui/src/lib.rs
+++ b/crates/gantz_ui/src/lib.rs
@@ -16,9 +16,11 @@ pub use elem::{
     Grid, Key, Label, Matrix, Plot, PlotMode, PlotStyle, RESERVED_TAGS, RefGui, Rgba, Row, Scope,
     Sep, Space, Toggle, Value,
 };
+pub use encode::encode;
 pub use sexpr::{SExpr, summary};
 
 pub mod decode;
 pub mod diag;
 pub mod elem;
+pub mod encode;
 pub mod sexpr;

--- a/crates/gantz_ui/src/lib.rs
+++ b/crates/gantz_ui/src/lib.rs
@@ -9,6 +9,7 @@
 //! The full v1 vocabulary reference lives here at the crate level and grows
 //! alongside the modules below.
 
+pub use decode::{Decoded, Limits, decode};
 pub use diag::{ErrorReason, TreePath, Warning, WarningKind};
 pub use elem::{
     ATTRS_MARKER, Align, BindPath, Button, Col, Dialer, DialerStyle, Element, ErrorElem, Frame,
@@ -17,6 +18,7 @@ pub use elem::{
 };
 pub use sexpr::{SExpr, summary};
 
+pub mod decode;
 pub mod diag;
 pub mod elem;
 pub mod sexpr;

--- a/crates/gantz_ui/src/lib.rs
+++ b/crates/gantz_ui/src/lib.rs
@@ -1,13 +1,161 @@
 //! The declarative UI tree model for user-defined gantz GUIs.
 //!
-//! A graph's GUI is a value: a tree of plain data that the graph itself
-//! produces, interpreted by a host every frame. This crate defines the
-//! canonical typed model of that tree along with per-runtime codecs. It is
-//! deliberately free of any GUI toolkit and, at its core, free of any
-//! runtime.
+//! **A graph's GUI is a value.** A tree of plain data that the graph itself
+//! produces, bound to node state by path, interpreted by a host every frame.
+//! This crate defines the canonical typed model of that tree ([`Element`]),
+//! a total decoder with inline diagnostics, a canonical encoder, and
+//! per-runtime codecs. It is deliberately free of any GUI toolkit and, with
+//! no features enabled, free of any runtime.
 //!
-//! The full v1 vocabulary reference lives here at the crate level and grows
-//! alongside the modules below.
+//! # The form
+//!
+//! The vocabulary is specified over an abstract data model ([`SExpr`]):
+//! identifier atoms, booleans, integers, floats, strings and lists. Written
+//! in s-expression reference syntax:
+//!
+//! ```text
+//! element  := (tag attrs? arg ... child ...)
+//! attrs    := (@ (name value) ...)
+//! tag,name := identifier
+//! value    := bool | int | float | string | list
+//! ```
+//!
+//! `@` is the reserved attribute marker and invalid as a user tag. A small
+//! example:
+//!
+//! ```text
+//! (col
+//!   (frame (@ (title "filter"))
+//!     (row (dialer (@ (bind (2)) (min 20.0) (max 20000.0) (label "cutoff")))
+//!          (dialer (@ (bind (3)) (min 0.1) (max 4.0) (label "q")))))
+//!   (row (toggle (@ (bind (5)) (label "drive")))
+//!        (button (@ (bind (7)) (label "ping"))))
+//!   (ref-gui 9))
+//! ```
+//!
+//! Each runtime encodes the model in its own value type through a codec
+//! (see [`codec`]). The Steel encoding writes tags and names as symbols, the
+//! `Datum` encoding writes them as strings, and the decoder treats
+//! identifiers and strings as interchangeable in identifier and text
+//! positions so both agree.
+//!
+//! # Principles
+//!
+//! 1. The tree is inert data. No callbacks, no code. The graph produces it
+//!    on change, the host interprets it per frame.
+//! 2. Bindings are structural and machine produced. Paths are baked by
+//!    codegen or the host, never hand authored in the normal flow.
+//! 3. State granularity beats binding splicing. A dynamic collection is one
+//!    widget bound to one structured state value, not many spliced bindings.
+//! 4. Restore never fires. Widgets emit events only from user interaction.
+//! 5. Unknown attributes are ignored (forward compatibility), unknown tags
+//!    are visible inline errors, never silently blank.
+//!
+//! # Element catalog
+//!
+//! Every element accepts a `key` attribute, a string or integer identity
+//! override for children whose order can change at runtime (see
+//! [Identity](#identity-and-keys)).
+//!
+//! ## Layout
+//!
+//! | element | children | attrs |
+//! |---|---|---|
+//! | `(col ...)` / `(row ...)` | elements | `gap` (number), `align` (`start`/`center`/`end`) |
+//! | `(grid (@ (cols n)) ...)` | elements, row-major | `cols` (required positive int), `gap` |
+//! | `(frame ...)` | elements | `title` (string) |
+//! | `(sep)` | none | |
+//! | `(space n)` | none | positional numeric amount, optional |
+//! | `(scope id ...)` | elements | positional node id, required. Prefixes binding paths, see below |
+//!
+//! ## Controls
+//!
+//! Controls bind to node state and emit events (a `set` writes the bound
+//! state, and when the `push` attribute is on it also queues a push eval at
+//! the bound node).
+//!
+//! | element | state shape | attrs |
+//! |---|---|---|
+//! | `(dialer)` | number | `bind`, `min`, `max`, `step` (numbers), `precision` (int), `label` (string), `push` (bool, default `#t`), `style` (reserved: `slider`/`knob`) |
+//! | `(toggle)` | bool | `bind`, `label`, `push` (default `#t`) |
+//! | `(button)` | none | `bind`, `label`. A press queues a push eval, bang semantics stay in the node's expression |
+//! | `(matrix)` | list of rows of bool or number cells | `bind`, `cell-size` (number), `push` (default `#t`). Rows and columns come from the state shape, not attrs |
+//!
+//! ## Display
+//!
+//! | element | state shape | attrs |
+//! |---|---|---|
+//! | `(label "text")` | none | positional text (required), `size` (number), `color` (`"#rrggbb"` or `"#rrggbbaa"`) |
+//! | `(value)` | any, rendered as its representation | `bind`, `wrap` (bool, default `#f`) |
+//! | `(plot)` | scope buffer or signal, a list of lists renders as stacked channels | `bind`, `mode` (`scope`/`signal`), `style` (`bars`/`line`), `color`, `grid`, `axes` (bools, default `#f`), `y-min`, `y-max`, `w`, `h` (numbers) |
+//!
+//! ## Embedding
+//!
+//! `(ref-gui id)` is a host resolved embed of a child instance's GUI: the
+//! host resolves the instance's body marker (else its auto GUI, else a
+//! label) and renders it at the instance path inside an implicit scope. The
+//! required positional id is the instance's node id in the defining graph.
+//!
+//! ## Reserved
+//!
+//! Tag names claimed for later tiers decode as visible errors today:
+//! `tabs`, `page`, `canvas`, `paint`, `image`, `dropdown`, `text-input`,
+//! `xy-pad`, `meter` ([`RESERVED_TAGS`]).
+//!
+//! # Binding model
+//!
+//! A `bind` attribute holds a list of non-negative integers, a node path
+//! relative to the graph the tree was defined in ([`BindPath`], matching
+//! `gantz_core::node::Id` paths). Hosts resolve a binding as
+//! `instance prefix ++ scope prefixes ++ bind path`, reading and writing VM
+//! runtime state at that path. `(scope id ...)` pushes `id` onto the prefix
+//! for its subtree. Neither is hand authored in the normal flow: widget
+//! fragments bake their own node id at codegen and hosts insert scopes where
+//! a child's GUI crosses into a parent.
+//!
+//! # Identity and keys
+//!
+//! Host widget identity derives from the render root, accumulated scope
+//! prefixes and structural tree position, with the `key` attribute as the
+//! override. Keys are required for children whose order can change at
+//! runtime, otherwise widget memory (focus, drag state) follows the position
+//! rather than the child. Label text never contributes to identity, so
+//! relabelling never resets widget state.
+//!
+//! # Diagnostics and totality
+//!
+//! [`decode()`] is total. One boundary rule (see [`diag`]):
+//!
+//! - A subtree that cannot render meaningfully becomes an inline
+//!   [`Element::Error`] preserving its slot: unknown or reserved tags,
+//!   non-element values in element position, a misplaced `@` block, a
+//!   missing required positional argument, an exceeded limit. Siblings
+//!   decode independently.
+//! - Everything recoverable is a [`Warning`] and the element still renders:
+//!   unknown attributes are ignored, mistyped attribute values fall back to
+//!   their defaults, duplicates keep the first value, extra children of leaf
+//!   elements are dropped.
+//!
+//! [`Limits`] caps nesting depth and element count so a pathological
+//! computed tree stays a visible inline error rather than a stalled host.
+//!
+//! # Codecs and features
+//!
+//! - `steel` (default): [`codec::steel`], the v1 backend encoding over
+//!   `SteelVal`. Symbols are identifiers, Steel lists and vectors both read
+//!   as lists.
+//! - `datum`: [`codec::datum`], the storage and interchange encoding over
+//!   `gantz_core::datum::Datum`. `Datum` has no symbol variant, so
+//!   identifiers normalize to strings on a store and reload while decoding
+//!   to the identical tree.
+//!
+//! With no features enabled the crate is the pure model: [`SExpr`],
+//! [`Element`], [`decode()`] and [`encode()`].
+//!
+//! The canonical encoding ([`encode()`]) emits the minimal form: only
+//! attributes differing from an element's `Default` (required attributes and
+//! positional arguments always emit), in field declaration order, `key`
+//! last.
 
 pub use decode::{Decoded, Limits, decode};
 pub use diag::{ErrorReason, TreePath, Warning, WarningKind};

--- a/crates/gantz_ui/src/sexpr.rs
+++ b/crates/gantz_ui/src/sexpr.rs
@@ -1,0 +1,94 @@
+//! The abstract data model of the UI tree form.
+//!
+//! The vocabulary is specified over this model rather than over any one
+//! runtime's value type: identifier atoms, booleans, integers, floats,
+//! strings and lists. Each runtime codec lowers its own value type into
+//! [`SExpr`] totally, so the decoder is written once and every backend
+//! shares it. Values outside the model (closures, maps, byte buffers and so
+//! on) lower to [`SExpr::Other`] carrying a short description so diagnostics
+//! can name what was found.
+
+/// A runtime neutral s-expression value, the seam every codec lowers into.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SExpr {
+    /// An identifier atom (a symbol in Steel, a string in `Datum`).
+    Ident(String),
+    /// A boolean.
+    Bool(bool),
+    /// An integer.
+    Int(i64),
+    /// A float. Codecs only produce finite floats and lower non-finite
+    /// numbers to [`SExpr::Other`].
+    Float(f64),
+    /// A string.
+    Str(String),
+    /// A list of values.
+    List(Vec<SExpr>),
+    /// A runtime value outside the abstract model, carrying a short human
+    /// readable description for diagnostics.
+    Other(String),
+}
+
+/// A short human readable description of a value for use in diagnostics,
+/// phrased to follow "expected ..., found".
+pub fn summary(expr: &SExpr) -> String {
+    match expr {
+        SExpr::Ident(s) => format!("the identifier `{s}`"),
+        SExpr::Bool(true) => "the boolean `#t`".to_string(),
+        SExpr::Bool(false) => "the boolean `#f`".to_string(),
+        SExpr::Int(i) => format!("the integer `{i}`"),
+        SExpr::Float(f) => format!("the float `{f}`"),
+        SExpr::Str(s) => format!("the string {:?}", truncated(s)),
+        SExpr::List(items) if items.is_empty() => "an empty list".to_string(),
+        SExpr::List(items) if items.len() == 1 => "a list of 1 item".to_string(),
+        SExpr::List(items) => format!("a list of {} items", items.len()),
+        SExpr::Other(s) => s.clone(),
+    }
+}
+
+/// Cap a string for inclusion in a diagnostic message.
+fn truncated(s: &str) -> String {
+    const MAX: usize = 24;
+    if s.chars().count() <= MAX {
+        s.to_string()
+    } else {
+        let head: String = s.chars().take(MAX).collect();
+        format!("{head}...")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn summaries_name_each_kind() {
+        assert_eq!(summary(&SExpr::Ident("col".into())), "the identifier `col`");
+        assert_eq!(summary(&SExpr::Bool(true)), "the boolean `#t`");
+        assert_eq!(summary(&SExpr::Bool(false)), "the boolean `#f`");
+        assert_eq!(summary(&SExpr::Int(42)), "the integer `42`");
+        assert_eq!(summary(&SExpr::Float(1.5)), "the float `1.5`");
+        assert_eq!(summary(&SExpr::Str("hi".into())), "the string \"hi\"");
+        assert_eq!(summary(&SExpr::Other("a closure".into())), "a closure");
+    }
+
+    #[test]
+    fn list_summaries_count_items() {
+        assert_eq!(summary(&SExpr::List(vec![])), "an empty list");
+        assert_eq!(
+            summary(&SExpr::List(vec![SExpr::Int(1)])),
+            "a list of 1 item"
+        );
+        assert_eq!(
+            summary(&SExpr::List(vec![SExpr::Int(1), SExpr::Int(2)])),
+            "a list of 2 items"
+        );
+    }
+
+    #[test]
+    fn long_strings_truncate() {
+        let long = "x".repeat(100);
+        let s = summary(&SExpr::Str(long));
+        assert_eq!(s, format!("the string \"{}...\"", "x".repeat(24)));
+    }
+}

--- a/crates/gantz_ui/tests/cross_codec.rs
+++ b/crates/gantz_ui/tests/cross_codec.rs
@@ -1,0 +1,140 @@
+//! Both codecs agree: one tree, two runtimes, the same decode.
+
+#![cfg(all(feature = "steel", feature = "datum"))]
+
+use gantz_ui::elem::{
+    Align, BindPath, Button, Col, Dialer, DialerStyle, Element, Frame, Grid, Key, Label, Matrix,
+    Plot, PlotMode, PlotStyle, RefGui, Rgba, Row, Scope, Sep, Space, Toggle, Value,
+};
+use gantz_ui::{Decoded, Limits, SExpr, codec};
+
+/// One tree exercising every vocabulary element and attribute.
+fn full_tree() -> Element {
+    Element::Col(Col {
+        gap: Some(4.0),
+        align: Some(Align::Start),
+        key: Some(Key::Str("root".to_string())),
+        children: vec![
+            Element::Frame(Frame {
+                title: Some("filter".to_string()),
+                key: None,
+                children: vec![Element::Row(Row {
+                    gap: Some(2.0),
+                    align: Some(Align::Center),
+                    key: None,
+                    children: vec![
+                        Element::Dialer(Dialer {
+                            bind: Some(BindPath(vec![0, 2])),
+                            min: Some(20.0),
+                            max: Some(20_000.0),
+                            step: Some(0.5),
+                            precision: Some(2),
+                            label: Some("cutoff".to_string()),
+                            push: false,
+                            style: Some(DialerStyle::Knob),
+                            key: Some(Key::Int(1)),
+                        }),
+                        Element::Toggle(Toggle {
+                            bind: Some(BindPath(vec![5])),
+                            label: Some("drive".to_string()),
+                            push: false,
+                            key: None,
+                        }),
+                        Element::Button(Button {
+                            bind: Some(BindPath(vec![7])),
+                            label: Some("ping".to_string()),
+                            key: None,
+                        }),
+                    ],
+                })],
+            }),
+            Element::Grid(Grid {
+                cols: 4,
+                gap: Some(1.0),
+                key: None,
+                children: vec![
+                    Element::Matrix(Matrix {
+                        bind: Some(BindPath(vec![8])),
+                        cell_size: Some(12.0),
+                        push: false,
+                        key: None,
+                    }),
+                    Element::Sep(Sep::default()),
+                    Element::Space(Space {
+                        amount: Some(8.0),
+                        key: None,
+                    }),
+                    Element::Value(Value {
+                        bind: Some(BindPath(vec![3])),
+                        wrap: true,
+                        key: None,
+                    }),
+                ],
+            }),
+            Element::Label(Label {
+                text: "hello".to_string(),
+                size: Some(18.0),
+                color: Some(Rgba([255, 0, 128, 64])),
+                key: None,
+            }),
+            Element::Plot(Plot {
+                bind: Some(BindPath(vec![4])),
+                mode: Some(PlotMode::Signal),
+                style: Some(PlotStyle::Bars),
+                color: Some(Rgba([0, 255, 0, 255])),
+                grid: true,
+                axes: true,
+                y_min: Some(-1.0),
+                y_max: Some(1.0),
+                w: Some(120.0),
+                h: Some(80.0),
+                key: None,
+            }),
+            Element::Scope(Scope {
+                id: 9,
+                key: None,
+                children: vec![Element::RefGui(RefGui {
+                    id: 9,
+                    key: Some(Key::Str("child".to_string())),
+                })],
+            }),
+        ],
+    })
+}
+
+/// Identifiers and strings are interchangeable, so normalizing identifiers
+/// away yields the codec-independent form.
+fn normalized(expr: SExpr) -> SExpr {
+    match expr {
+        SExpr::Ident(s) => SExpr::Str(s),
+        SExpr::List(items) => SExpr::List(items.into_iter().map(normalized).collect()),
+        other => other,
+    }
+}
+
+#[test]
+fn both_codecs_decode_the_same_tree_identically() {
+    let tree = full_tree();
+    let limits = Limits::default();
+
+    let steel_val = codec::steel::encode(&tree);
+    let datum = codec::datum::encode(&tree);
+
+    let via_steel = codec::steel::decode(&steel_val, &limits);
+    let via_datum = codec::datum::decode(&datum, &limits);
+
+    let expected = Decoded {
+        root: tree,
+        warnings: vec![],
+    };
+    assert_eq!(via_steel, expected);
+    assert_eq!(via_datum, expected);
+}
+
+#[test]
+fn both_encodings_agree_modulo_identifier_normalization() {
+    let tree = full_tree();
+    let steel_lowered = codec::steel::lower(&codec::steel::encode(&tree));
+    let datum_lowered = codec::datum::lower(&codec::datum::encode(&tree));
+    assert_eq!(normalized(steel_lowered), datum_lowered);
+}

--- a/crates/gantz_ui/tests/roundtrip_datum.rs
+++ b/crates/gantz_ui/tests/roundtrip_datum.rs
@@ -1,0 +1,167 @@
+//! Datum codec integration tests: the storage-side encoding.
+
+#![cfg(feature = "datum")]
+
+use gantz_core::datum::Datum;
+use gantz_ui::codec::datum::{decode, encode};
+use gantz_ui::{
+    BindPath, Col, Decoded, Dialer, Element, ErrorReason, Frame, Label, Limits, Rgba, Sep, Toggle,
+    WarningKind,
+};
+
+fn s(text: &str) -> Datum {
+    Datum::Str(text.to_string())
+}
+
+fn seq(items: Vec<Datum>) -> Datum {
+    Datum::Seq(items)
+}
+
+fn attr(name: &str, value: Datum) -> Datum {
+    seq(vec![s(name), value])
+}
+
+#[test]
+fn string_keyed_trees_decode() {
+    // Tags, attribute names and enum values all arrive as strings from
+    // Datum. The tolerance rule makes this identical to the symbol form.
+    let tree = seq(vec![
+        s("col"),
+        seq(vec![s("@"), attr("gap", Datum::I64(4))]),
+        seq(vec![
+            s("dialer"),
+            seq(vec![
+                s("@"),
+                attr("bind", seq(vec![Datum::I64(0), Datum::I64(2)])),
+                attr("min", Datum::F64(0.0)),
+                attr("label", s("cutoff")),
+            ]),
+        ]),
+        seq(vec![s("label"), s("filter")]),
+    ]);
+    let d = decode(&tree, &Limits::default());
+    let expected = Element::Col(Col {
+        gap: Some(4.0),
+        align: None,
+        key: None,
+        children: vec![
+            Element::Dialer(Dialer {
+                bind: Some(BindPath(vec![0, 2])),
+                min: Some(0.0),
+                label: Some("cutoff".to_string()),
+                ..Default::default()
+            }),
+            Element::Label(Label {
+                text: "filter".to_string(),
+                ..Default::default()
+            }),
+        ],
+    });
+    assert_eq!(
+        d,
+        Decoded {
+            root: expected,
+            warnings: vec![],
+        }
+    );
+}
+
+#[test]
+fn u64_edges() {
+    let in_range = seq(vec![
+        s("dialer"),
+        seq(vec![s("@"), attr("precision", Datum::U64(3))]),
+    ]);
+    let d = decode(&in_range, &Limits::default());
+    let Element::Dialer(dialer) = &d.root else {
+        panic!("expected a dialer");
+    };
+    assert_eq!(dialer.precision, Some(3));
+    assert_eq!(d.warnings, vec![]);
+
+    let out_of_range = seq(vec![
+        s("dialer"),
+        seq(vec![s("@"), attr("min", Datum::U64(u64::MAX))]),
+    ]);
+    let d = decode(&out_of_range, &Limits::default());
+    assert!(matches!(
+        d.warnings[0].kind,
+        WarningKind::InvalidAttrValue { ref found, .. } if found == "an out-of-range integer"
+    ));
+
+    let as_child = seq(vec![s("col"), Datum::U64(u64::MAX)]);
+    let d = decode(&as_child, &Limits::default());
+    let Element::Col(col) = &d.root else {
+        panic!("expected a col");
+    };
+    assert!(matches!(
+        col.children[0],
+        Element::Error(ref e)
+            if matches!(&e.reason, ErrorReason::NotAnElement { found } if found == "an out-of-range integer")
+    ));
+}
+
+#[test]
+fn foreign_datum_kinds_are_reported_by_name() {
+    for (datum, name) in [
+        (Datum::Null, "null"),
+        (Datum::Char('x'), "a character"),
+        (Datum::Bytes(vec![1, 2]), "a byte buffer"),
+        (Datum::Map(vec![("k".to_string(), Datum::I64(1))]), "a map"),
+    ] {
+        let tree = seq(vec![s("col"), datum]);
+        let d = decode(&tree, &Limits::default());
+        let Element::Col(col) = &d.root else {
+            panic!("expected a col");
+        };
+        assert!(matches!(
+            col.children[0],
+            Element::Error(ref e)
+                if matches!(&e.reason, ErrorReason::NotAnElement { found } if found == name)
+        ));
+    }
+}
+
+#[test]
+fn a_full_tree_round_trips_through_datum() {
+    let tree = Element::Frame(Frame {
+        title: Some("filter".to_string()),
+        key: None,
+        children: vec![
+            Element::Dialer(Dialer {
+                bind: Some(BindPath(vec![2])),
+                min: Some(20.0),
+                max: Some(20_000.0),
+                precision: Some(1),
+                label: Some("cutoff".to_string()),
+                push: false,
+                ..Default::default()
+            }),
+            Element::Sep(Sep::default()),
+            Element::Toggle(Toggle {
+                bind: Some(BindPath(vec![5])),
+                label: Some("drive".to_string()),
+                ..Default::default()
+            }),
+            Element::Label(Label {
+                text: "hello".to_string(),
+                color: Some(Rgba([255, 0, 128, 255])),
+                ..Default::default()
+            }),
+        ],
+    });
+    let datum = encode(&tree);
+    // Tags normalize to strings at the datum level.
+    let Datum::Seq(items) = &datum else {
+        panic!("expected a seq");
+    };
+    assert_eq!(items[0], s("frame"));
+    let d = decode(&datum, &Limits::default());
+    assert_eq!(
+        d,
+        Decoded {
+            root: tree,
+            warnings: vec![],
+        }
+    );
+}

--- a/crates/gantz_ui/tests/roundtrip_steel.rs
+++ b/crates/gantz_ui/tests/roundtrip_steel.rs
@@ -1,0 +1,178 @@
+//! Steel codec integration tests driving the real reader.
+
+#![cfg(feature = "steel")]
+
+use gantz_ui::codec::steel::{decode, encode, lower};
+use gantz_ui::{
+    Align, BindPath, Col, Decoded, Dialer, Element, ErrorReason, Frame, Label, Limits, Row, SExpr,
+    Sep, Toggle, WarningKind,
+};
+use steel::SteelVal;
+use steel::gc::Gc;
+use steel::steel_vm::engine::Engine;
+
+fn run(src: &str) -> SteelVal {
+    Engine::new_base()
+        .run(src.to_string())
+        .unwrap()
+        .last()
+        .cloned()
+        .expect("no value")
+}
+
+fn sym(s: &str) -> SteelVal {
+    SteelVal::SymbolV(s.into())
+}
+
+fn slist(items: Vec<SteelVal>) -> SteelVal {
+    SteelVal::ListV(items.into_iter().collect())
+}
+
+fn svec(items: Vec<SteelVal>) -> SteelVal {
+    let v: steel::Vector<SteelVal> = items.into_iter().collect();
+    SteelVal::VectorV(Gc::new(v).into())
+}
+
+#[test]
+fn reader_output_decodes() {
+    let val = run(r#"'(col (@ (gap 4) (align center))
+             (row (dialer (@ (bind (0 2)) (min 0.0) (max 20000.0) (label "cutoff")))
+                  (toggle (@ (bind (5)) (label "drive") (push #f))))
+             (label "filter"))"#);
+    let d = decode(&val, &Limits::default());
+    let expected = Element::Col(Col {
+        gap: Some(4.0),
+        align: Some(Align::Center),
+        key: None,
+        children: vec![
+            Element::Row(Row {
+                children: vec![
+                    Element::Dialer(Dialer {
+                        bind: Some(BindPath(vec![0, 2])),
+                        min: Some(0.0),
+                        max: Some(20_000.0),
+                        label: Some("cutoff".to_string()),
+                        ..Default::default()
+                    }),
+                    Element::Toggle(Toggle {
+                        bind: Some(BindPath(vec![5])),
+                        label: Some("drive".to_string()),
+                        push: false,
+                        key: None,
+                    }),
+                ],
+                ..Default::default()
+            }),
+            Element::Label(Label {
+                text: "filter".to_string(),
+                ..Default::default()
+            }),
+        ],
+    });
+    assert_eq!(
+        d,
+        Decoded {
+            root: expected,
+            warnings: vec![],
+        }
+    );
+}
+
+#[test]
+fn string_tags_decode_like_symbol_tags() {
+    let strings = run(r#"'("col" ("sep"))"#);
+    let symbols = run("'(col (sep))");
+    let limits = Limits::default();
+    assert_eq!(decode(&strings, &limits), decode(&symbols, &limits));
+}
+
+#[test]
+fn vectors_decode_like_lists() {
+    let as_list = run("'(col (sep) (sep))");
+    let sep = svec(vec![sym("sep")]);
+    let as_vec = svec(vec![sym("col"), sep.clone(), sep]);
+    let limits = Limits::default();
+    assert_eq!(decode(&as_vec, &limits), decode(&as_list, &limits));
+}
+
+#[test]
+fn intv_edge_values_lower_losslessly() {
+    assert_eq!(
+        lower(&SteelVal::IntV(isize::MAX)),
+        SExpr::Int(isize::MAX as i64)
+    );
+    assert_eq!(
+        lower(&SteelVal::IntV(isize::MIN)),
+        SExpr::Int(isize::MIN as i64)
+    );
+}
+
+#[test]
+fn non_finite_numbers_warn_as_attr_values() {
+    let tree = slist(vec![
+        sym("dialer"),
+        slist(vec![
+            sym("@"),
+            slist(vec![sym("min"), SteelVal::NumV(f64::NAN)]),
+        ]),
+    ]);
+    let d = decode(&tree, &Limits::default());
+    assert_eq!(d.root, Element::Dialer(Dialer::default()));
+    assert!(matches!(
+        d.warnings[0].kind,
+        WarningKind::InvalidAttrValue { ref found, .. } if found == "a non-finite number"
+    ));
+}
+
+#[test]
+fn foreign_values_in_element_position_error() {
+    let closure = run("(lambda (x) x)");
+    let tree = slist(vec![sym("col"), closure]);
+    let d = decode(&tree, &Limits::default());
+    let Element::Col(col) = &d.root else {
+        panic!("expected a col");
+    };
+    let Element::Error(err) = &col.children[0] else {
+        panic!("expected an error element");
+    };
+    assert!(matches!(err.reason, ErrorReason::NotAnElement { .. }));
+}
+
+#[test]
+fn a_full_tree_round_trips_through_steel() {
+    let tree = Element::Frame(Frame {
+        title: Some("filter".to_string()),
+        key: None,
+        children: vec![
+            Element::Dialer(Dialer {
+                bind: Some(BindPath(vec![2])),
+                min: Some(20.0),
+                max: Some(20_000.0),
+                precision: Some(1),
+                label: Some("cutoff".to_string()),
+                ..Default::default()
+            }),
+            Element::Sep(Sep::default()),
+            Element::Toggle(Toggle {
+                bind: Some(BindPath(vec![5])),
+                label: Some("drive".to_string()),
+                push: false,
+                key: None,
+            }),
+        ],
+    });
+    let val = encode(&tree);
+    // Canonical encoding uses symbols for tags and attribute names.
+    let SteelVal::ListV(items) = &val else {
+        panic!("expected a list");
+    };
+    assert_eq!(items.iter().next(), Some(&sym("frame")));
+    let d = decode(&val, &Limits::default());
+    assert_eq!(
+        d,
+        Decoded {
+            root: tree,
+            warnings: vec![],
+        }
+    );
+}


### PR DESCRIPTION
## Summary

Introduces `gantz_ui` - a toolkit-agnostic, declarative UI tree model for user-defined gantz GUIs. A graph's GUI is a value: a tree of plain data the graph produces, bound to node state by path, and interpreted by a host every frame.

The first part of #318.

## Changes

### New crate: `crates/gantz_ui`

| Module | Description |
|--------|-------------|
| `sexpr.rs` | Abstract S-expr data model (atoms, bools, ints, floats, strings, lists) |
| `elem.rs` | Closed, typed element model - the canonical v1 vocabulary |
| `decode.rs` | Total decoder from `SExpr` -> typed `Element` with inline diagnostics |
| `encode.rs` | Canonical encoder back to `SExpr` with attribute omission for defaults |
| `diag.rs` | Diagnostics: `ErrorReason`, `Warning`, and tree path tracking |
| `codec/steel.rs` | Steel value codec (tags/names as symbols) |
| `codec/datum.rs` | Datum codec (tags/names as strings, for storage) |

### Vocabulary

The model covers a complete widget set: `col`, `row`, `frame`, `grid`, `dialer`, `toggle`, `button`, `plot`, `label`, `space`, `sep`, `scope`, `matrix`, `ref-gui`. Each element accepts a `key` attribute for stable identity across runtime reorderings.

### Decoding principles

- **Never fails** - malformed or unknown subtrees become `Element::Error` nodes in place. Siblings render normally.
- **Forward compatible** - unknown attributes are silently ignored.
- **Visible errors** - unknown tags surface as inline error chips, never silently blank.
- **Bounded** - configurable nesting depth and element count limits prevent runaway computed trees.
- **Codec-agnostic tolerance** - identifier positions also accept strings (Datum has no symbol variant).