### PR TITLE
feat: Audio-rate FM via hybrid `~sinosc` freq input

### DIFF
--- a/crates/bevy_gantz_plyphon/examples/custom_unit.rs
+++ b/crates/bevy_gantz_plyphon/examples/custom_unit.rs
@@ -108,7 +108,12 @@ impl NodeDsp for SawNode {
         1
     }
 
-    fn ugens(&self, _path: &[usize], _inputs: &[Signal], b: &mut DspBuilder) -> Vec<Signal> {
+    fn ugens(
+        &self,
+        _path: &[usize],
+        _inputs: &[Option<Signal>],
+        b: &mut DspBuilder,
+    ) -> Vec<Signal> {
         // Name our custom unit. Freq is a baked constant (see ~sinosc for a param).
         let unit = b.push_unit(UnitSpec::new(
             "Saw",

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -773,6 +773,52 @@ mod tests {
         );
     }
 
+    /// The hybrid side of `~sinosc`'s freq input: a *dsp* source pushed through
+    /// it must NOT touch the param state - dsp placeholder outputs are
+    /// non-numeric by contract, so the `number?` guard skips the write. (The
+    /// derived def reads the wire instead, so a queued update would have no
+    /// param to drain into and `pending` would grow unboundedly.)
+    #[test]
+    fn dsp_wire_into_freq_leaves_param_state_untouched() {
+        use gantz_core::compile::push_pull_entrypoints;
+        use gantz_core::edge::Edge;
+        use gantz_core::node::graph::Graph;
+        use gantz_core::steel::SteelVal;
+        type G = Graph<Box<dyn Node>>;
+
+        // number -> ~lag (dsp input) -> ~sinosc.freq: pushing the number fires
+        // the whole chain, so the lag's placeholder reaches the freq input.
+        let mut g: G = Graph::default();
+        let num = g.add_node(Box::new(gantz_std::Number::default()) as Box<dyn Node>);
+        let lag = g.add_node(Box::new(gantz_plyphon::Lag::default()) as Box<dyn Node>);
+        let sine = g.add_node(Box::new(gantz_plyphon::SinOsc::default()) as Box<dyn Node>);
+        g.add_edge(num, lag, Edge::new(0.into(), 0.into()));
+        g.add_edge(lag, sine, Edge::new(0.into(), 0.into()));
+
+        let get_node = |_: &gantz_ca::ContentAddr| -> Option<&dyn gantz_core::Node> { None };
+        let config = gantz_core::compile::Config::default();
+        let eps = push_pull_entrypoints(&get_node, &g);
+        let (mut vm, _compiled) = gantz_core::vm::init(&get_node, &g, &eps, &config)
+            .expect("compile number -> ~lag -> ~sinosc");
+
+        vm.update_value(gantz_core::ARGS, gantz_core::args::time(1.25));
+        gantz_core::node::state::update_value(&mut vm, &[num.index()], SteelVal::NumV(440.0))
+            .expect("set number state");
+        fire_push(&mut vm, &eps, num.index());
+
+        let (value, pending) = gantz_plyphon::param::drain_param(&mut vm, &[sine.index()])
+            .expect("~sinosc param state present");
+        assert_eq!(
+            value,
+            f64::from(gantz_plyphon::SinOsc::DEFAULT_FREQ),
+            "a dsp wire must not overwrite the param value",
+        );
+        assert!(
+            pending.is_empty(),
+            "a dsp wire must not queue param updates",
+        );
+    }
+
     /// `~scopeout`'s control side: firing its trigger input outputs the per-channel
     /// ring-buffer state (which the dsp driver fills) as a list of rings on
     /// output 0, and the channel count - the number of rings - on output 1. Here

--- a/crates/gantz_plyphon/src/compile.rs
+++ b/crates/gantz_plyphon/src/compile.rs
@@ -133,9 +133,13 @@ pub struct Derived {
 /// falls outside the traversal - it is a Steel/state concern, not part of the dsp
 /// signal graph. The same rule applies at *interior* nodes: only nodes that feed a
 /// sink transitively through dsp inputs contribute units, so a dsp chain wired into
-/// a control input (e.g. a `~lag` into `~sinosc`'s freq) emits nothing rather than
-/// dead units whose params the driver would drive and whose presence would force
-/// spurious respawns (they'd land in [`structural_sig`]).
+/// a control input emits nothing rather than dead units whose params the driver
+/// would drive and whose presence would force spurious respawns (they'd land in
+/// [`structural_sig`]). A *hybrid* dsp input (e.g. `~sinosc`'s freq, see
+/// [`NodeDsp::n_dsp_inputs`](crate::NodeDsp::n_dsp_inputs)) IS part of the
+/// traversal: a dsp chain wired into it emits units and drives the input
+/// directly (audio-rate FM), and the input's fallback param is only baked while
+/// no dsp source is connected.
 ///
 /// Nested graphs are supported via a pre-derivation pass: [`flatten`](crate::flatten())
 /// resolves graph refs and splices their nodes into a single flat graph (each

--- a/crates/gantz_plyphon/src/compile.rs
+++ b/crates/gantz_plyphon/src/compile.rs
@@ -180,15 +180,17 @@ where
         let Some(dsp) = graph[n].to_node_dsp() else {
             continue;
         };
-        let inputs: Vec<Signal> = sources[&n]
+        let inputs: Vec<Option<Signal>> = sources[&n]
             .iter()
             .map(|summands| {
                 let sigs: Vec<Signal> = summands
                     .iter()
                     .filter_map(|&(s, port)| outputs.get(&s).and_then(|o| o.get(port)).cloned())
                     .collect();
-                // An unconnected input sums to mono silence.
-                sum_signals(&mut builder, &sigs)
+                // `None` iff no summand materialized a signal (unconnected, or
+                // e.g. a dangling `~unpack` port), so hybrid inputs fall back
+                // to their param exactly when the Steel side keeps it driven.
+                (!sigs.is_empty()).then(|| sum_signals(&mut builder, &sigs))
             })
             .collect();
         let outs = dsp.ugens(&graph[n].node_path(n.index()), &inputs, &mut builder);
@@ -552,7 +554,7 @@ where
             };
             // Each input sums its summands: a plain summand wires directly, a
             // boundary summand lowers to its buses - in-region wires or `In`s.
-            let mut inputs: Vec<Signal> = Vec::with_capacity(sources[&n].len());
+            let mut inputs: Vec<Option<Signal>> = Vec::with_capacity(sources[&n].len());
             for summands in &sources[&n] {
                 let mut sigs: Vec<Signal> = Vec::new();
                 for &(s, port) in summands {
@@ -592,18 +594,16 @@ where
                                     .clone();
                                 sigs.push(sig);
                             }
-                            _ => sigs.push(
-                                outputs
-                                    .get(&src)
-                                    .and_then(|o| o.get(sport))
-                                    .cloned()
-                                    .unwrap_or_else(|| Signal::silent(1)),
-                            ),
+                            // A dangling port materializes nothing.
+                            _ => sigs.extend(outputs.get(&src).and_then(|o| o.get(sport)).cloned()),
                         }
                     }
                 }
-                // An unconnected (or unsourced-boundary) input sums to silence.
-                inputs.push(sum_signals(&mut builder, &sigs));
+                // `None` iff no summand materialized a signal (unconnected, an
+                // unsourced boundary, or a dangling port), so hybrid inputs
+                // fall back to their param exactly when the Steel side keeps
+                // it driven.
+                inputs.push((!sigs.is_empty()).then(|| sum_signals(&mut builder, &sigs)));
             }
             let outs = dsp.ugens(&graph[n].node_path(n.index()), &inputs, &mut builder);
             debug_assert_eq!(

--- a/crates/gantz_plyphon/src/dsp.rs
+++ b/crates/gantz_plyphon/src/dsp.rs
@@ -173,13 +173,16 @@ pub trait NodeDsp {
     /// `path` is the node's path within the graph (e.g. `[2]` for the node at
     /// index 2 of a flat graph). Use it to name any control [`Param`]s
     /// uniquely within the synthdef (see [`param_name`](crate::param::param_name)).
-    /// `inputs` has length [`n_dsp_inputs`](Self::n_dsp_inputs), each input
-    /// arriving pre-summed (a multi-edge input is the unity-gain mix of its
-    /// summands, [`sum_signals`]). An unconnected
-    /// input is [`Signal::silent`]`(1)` (mono silence). Params should broadcast
-    /// across an input's channels (e.g. `~lag` emits one `Lag` unit per channel,
-    /// all sharing the one `dur` param).
-    fn ugens(&self, path: &[usize], inputs: &[Signal], b: &mut DspBuilder) -> Vec<Signal>;
+    /// `inputs` has length [`n_dsp_inputs`](Self::n_dsp_inputs). A connected
+    /// input arrives pre-summed as `Some` (a multi-edge input is the unity-gain
+    /// mix of its summands, [`sum_signals`]). `None` means no dsp summand
+    /// materialized a signal: the input is unconnected, or fed only by
+    /// signal-less sources (e.g. a dangling `~unpack` port). A node may treat
+    /// `None` as mono silence ([`input_or_silent`]) or fall back to a control
+    /// param (a *hybrid* input). Params should broadcast across an input's
+    /// channels (e.g. `~lag` emits one `Lag` unit per channel, all sharing the
+    /// one `dur` param).
+    fn ugens(&self, path: &[usize], inputs: &[Option<Signal>], b: &mut DspBuilder) -> Vec<Signal>;
 }
 
 /// A downcast hook so the synthdef compiler and the audio driver can find
@@ -435,6 +438,17 @@ pub fn node_dsp_of(any: &dyn std::any::Any) -> Option<&dyn NodeDsp> {
         .or_else(|| probe::<crate::Sum>(any))
         .or_else(|| probe::<crate::Unpack>(any))
         .or_else(|| probe::<crate::Bus>(any))
+}
+
+/// The signal at dsp input `i` of a [`NodeDsp::ugens`] `inputs` slice, or mono
+/// silence when no signal materialized there - the common fallback for a
+/// non-hybrid input.
+pub fn input_or_silent(inputs: &[Option<Signal>], i: usize) -> Signal {
+    inputs
+        .get(i)
+        .cloned()
+        .flatten()
+        .unwrap_or_else(|| Signal::silent(1))
 }
 
 /// Sum channel groups into one group: the unity-gain mix of every summand.

--- a/crates/gantz_plyphon/src/dsp.rs
+++ b/crates/gantz_plyphon/src/dsp.rs
@@ -129,6 +129,15 @@ pub trait NodeDsp {
     /// inputs, a purely Steel/state concern (a connected control value is written
     /// into the node's param state by its `expr`), and are ignored by the
     /// synthdef compiler.
+    ///
+    /// A dsp input may also be *hybrid*: backed by a control param it falls
+    /// back to when no dsp source is connected (e.g. `~sinosc`'s freq). The two
+    /// sides compose without coordination: the synthdef compiler only wires dsp
+    /// sources (a connected number materializes no signal, so
+    /// [`ugens`](Self::ugens) sees `None` and bakes the param), while the
+    /// node's Steel `expr` ([`control_input_expr`](crate::param::control_input_expr))
+    /// writes connected numbers into the param state and ignores dsp
+    /// placeholders via its `number?` guard.
     fn n_dsp_inputs(&self) -> usize {
         0
     }

--- a/crates/gantz_plyphon/src/dsp.rs
+++ b/crates/gantz_plyphon/src/dsp.rs
@@ -114,6 +114,14 @@ impl FromIterator<InputRef> for Signal {
 /// the synthdef under construction. A node is "DSP" simply by implementing this
 /// trait (and being discoverable via [`ToNodeDsp`]). The same gantz graph is
 /// compiled by both backends independently.
+///
+/// **Steel placeholder contract:** a dsp node's `Node::expr` output for a dsp
+/// output port must not evaluate to a number (use `'()` or similar). Hybrid
+/// control inputs ([`control_input_expr`](crate::param::control_input_expr))
+/// distinguish a control value from an inert dsp edge with a `number?` guard, so
+/// a numeric placeholder would be mistaken for a control value and stomp the
+/// downstream node's param state. Nodes with no dsp outputs (e.g. `~scopeout`)
+/// are exempt - their Steel outputs never feed a dsp edge.
 pub trait NodeDsp {
     /// The number of DSP (signal) input *ports* - the leading inputs that carry
     /// signals, wired into the synthdef. A node's [`gantz_core::Node::n_inputs`]

--- a/crates/gantz_plyphon/src/egui/node/sin_osc.rs
+++ b/crates/gantz_plyphon/src/egui/node/sin_osc.rs
@@ -68,8 +68,9 @@ impl NodeUi for SinOsc {
 
     fn socket_doc(&self, _: &dyn Registry, kind: SocketKind, ix: usize) -> Option<SocketDoc> {
         match (kind, ix) {
-            (SocketKind::Input, 0) => Some(SocketDoc::ty("number").with_description(
-                "frequency (Hz) control; overrides the inspector value while connected",
+            (SocketKind::Input, 0) => Some(SocketDoc::ty("signal | number").with_description(
+                "frequency (Hz): a connected signal drives it directly (audio-rate FM), \
+                 a connected number overrides the inspector value",
             )),
             (SocketKind::Output, _) => Some(SocketDoc::ty("signal").with_description(
                 "sine signal at the configured frequency (and the configured ar/kr rate)",

--- a/crates/gantz_plyphon/src/instance.rs
+++ b/crates/gantz_plyphon/src/instance.rs
@@ -1113,17 +1113,19 @@ where
         };
         let path = graph[n].path();
         // Each input sums its summands' resolved signals.
-        let mut inputs: Vec<Signal> = Vec::with_capacity(srcs[&n].len());
+        let mut inputs: Vec<Option<Signal>> = Vec::with_capacity(srcs[&n].len());
         for summands in &srcs[&n] {
             let mut sigs: Vec<Signal> = Vec::new();
             for &src in summands {
                 for f in feeds(src, at, out_summands) {
                     let sig = match f {
-                        Feed::Wire(s, port) => outputs
-                            .get(&s)
-                            .and_then(|o| o.get(port))
-                            .cloned()
-                            .unwrap_or_else(|| Signal::silent(1)),
+                        // A dangling port materializes nothing.
+                        Feed::Wire(s, port) => {
+                            let Some(sig) = outputs.get(&s).and_then(|o| o.get(port)) else {
+                                continue;
+                            };
+                            sig.clone()
+                        }
                         Feed::Read { key, param_at, .. } => in_signals
                             .entry(key.clone())
                             .or_insert_with(|| {
@@ -1152,8 +1154,10 @@ where
                     sigs.push(sig);
                 }
             }
-            // An unconnected (or unsourced-boundary) input sums to silence.
-            inputs.push(sum_signals(&mut builder, &sigs));
+            // `None` iff no summand materialized a signal (e.g. an unconnected
+            // inlet), so hybrid inputs fall back to their param exactly when
+            // the Steel side keeps it driven.
+            inputs.push((!sigs.is_empty()).then(|| sum_signals(&mut builder, &sigs)));
         }
         let outs = dsp.ugens(path, &inputs, &mut builder);
         debug_assert_eq!(

--- a/crates/gantz_plyphon/src/node/bus.rs
+++ b/crates/gantz_plyphon/src/node/bus.rs
@@ -5,7 +5,7 @@ use gantz_core::node::{ExprCtx, ExprResult, MetaCtx};
 use gantz_nodetag::NodeTag;
 use serde::{Deserialize, Serialize};
 
-use crate::dsp::{DspBuilder, NodeDsp, Signal, ToNodeDsp};
+use crate::dsp::{DspBuilder, NodeDsp, Signal, ToNodeDsp, input_or_silent};
 
 /// A synthdef *boundary*: drop it on a signal wire to cut the derived synthdef
 /// there. The upstream region ends in an `Out` to a driver-allocated private
@@ -62,11 +62,16 @@ impl NodeDsp for Bus {
         true
     }
 
-    fn ugens(&self, _path: &[usize], inputs: &[Signal], _b: &mut DspBuilder) -> Vec<Signal> {
+    fn ugens(
+        &self,
+        _path: &[usize],
+        inputs: &[Option<Signal>],
+        _b: &mut DspBuilder,
+    ) -> Vec<Signal> {
         // Only reached when both sides share a region (the boundary was not a
         // cut): a plain wire. The cut case is lowered by the compiler itself
         // (`derive_synthdefs`), which emits the bus `Out`/`In` pair.
-        vec![inputs.first().cloned().unwrap_or_else(|| Signal::silent(1))]
+        vec![input_or_silent(inputs, 0)]
     }
 }
 

--- a/crates/gantz_plyphon/src/node/bus.rs
+++ b/crates/gantz_plyphon/src/node/bus.rs
@@ -43,8 +43,9 @@ impl gantz_core::Node for Bus {
 
     fn expr(&self, _ctx: ExprCtx<'_, '_>) -> ExprResult {
         // Steel-inert: the boundary exists only at synthdef derivation. A
-        // placeholder output feeds the inert dsp output edge.
-        gantz_core::node::parse_expr("0")
+        // non-numeric placeholder output feeds the inert dsp output edge (see
+        // the `NodeDsp` docs).
+        gantz_core::node::parse_expr("'()")
     }
 }
 

--- a/crates/gantz_plyphon/src/node/lag.rs
+++ b/crates/gantz_plyphon/src/node/lag.rs
@@ -70,9 +70,9 @@ impl gantz_core::Node for Lag {
 
     fn expr(&self, _ctx: ExprCtx<'_, '_>) -> ExprResult {
         // Steel-inert: the audio engine smooths the signal; the duration lives in
-        // state and is applied via `set_control`. A placeholder output feeds the
-        // inert dsp output edge.
-        gantz_core::node::parse_expr("0")
+        // state and is applied via `set_control`. A non-numeric placeholder
+        // output feeds the inert dsp output edge (see the `NodeDsp` docs).
+        gantz_core::node::parse_expr("'()")
     }
 }
 

--- a/crates/gantz_plyphon/src/node/lag.rs
+++ b/crates/gantz_plyphon/src/node/lag.rs
@@ -6,7 +6,7 @@ use gantz_nodetag::NodeTag;
 use plyphon::synthdef::{InputRef, UnitSpec};
 use serde::{Deserialize, Serialize};
 
-use crate::dsp::{DspBuilder, NodeDsp, NodeRate, Signal, ToNodeDsp, cahash_rate};
+use crate::dsp::{DspBuilder, NodeDsp, NodeRate, Signal, ToNodeDsp, cahash_rate, input_or_silent};
 use crate::param::{param_name, param_state, plyphon_param};
 
 /// A one-pole lag (smoother). Emits a `Lag` UGen per input channel at the
@@ -85,8 +85,8 @@ impl NodeDsp for Lag {
         1
     }
 
-    fn ugens(&self, path: &[usize], inputs: &[Signal], b: &mut DspBuilder) -> Vec<Signal> {
-        let signal = inputs.first().cloned().unwrap_or_else(|| Signal::silent(1));
+    fn ugens(&self, path: &[usize], inputs: &[Option<Signal>], b: &mut DspBuilder) -> Vec<Signal> {
+        let signal = input_or_silent(inputs, 0);
         // The lag time is a settable control param (nominal default here; the
         // driver applies the live state value via `set_control`), shared by every
         // channel's `Lag` unit (params broadcast across the group).

--- a/crates/gantz_plyphon/src/node/out.rs
+++ b/crates/gantz_plyphon/src/node/out.rs
@@ -9,7 +9,7 @@ use plyphon::Rate;
 use plyphon::synthdef::{InputRef, UnitSpec};
 use serde::{Deserialize, Serialize};
 
-use crate::dsp::{DspBuilder, NodeDsp, Signal, ToNodeDsp};
+use crate::dsp::{DspBuilder, NodeDsp, Signal, ToNodeDsp, input_or_silent};
 use crate::param::{cahash_lag, control_input_expr, param_name, param_state, plyphon_param};
 
 /// The audio output sink. Applies a master `gain` to its input signal and writes
@@ -112,8 +112,8 @@ impl NodeDsp for Out {
         true
     }
 
-    fn ugens(&self, path: &[usize], inputs: &[Signal], b: &mut DspBuilder) -> Vec<Signal> {
-        let sig = inputs.first().cloned().unwrap_or_else(|| Signal::silent(1));
+    fn ugens(&self, path: &[usize], inputs: &[Option<Signal>], b: &mut DspBuilder) -> Vec<Signal> {
+        let sig = input_or_silent(inputs, 0);
         let out_channels = b.out_channels();
         // The output level = gain x fade, multiplied once at control rate:
         // `gain` is the settable (smoothed) control param (the driver applies

--- a/crates/gantz_plyphon/src/node/pack.rs
+++ b/crates/gantz_plyphon/src/node/pack.rs
@@ -5,7 +5,7 @@ use gantz_core::node::{ExprCtx, ExprResult, MetaCtx};
 use gantz_nodetag::NodeTag;
 use serde::{Deserialize, Serialize};
 
-use crate::dsp::{DspBuilder, NodeDsp, Signal, ToNodeDsp};
+use crate::dsp::{DspBuilder, NodeDsp, Signal, ToNodeDsp, input_or_silent};
 
 /// Concatenate `count` input signals into one channel group (like Max's
 /// `mc.pack~` or a VCV merge): the output's width is the sum of the input
@@ -79,10 +79,17 @@ impl NodeDsp for Pack {
         1
     }
 
-    fn ugens(&self, _path: &[usize], inputs: &[Signal], _b: &mut DspBuilder) -> Vec<Signal> {
+    fn ugens(
+        &self,
+        _path: &[usize],
+        inputs: &[Option<Signal>],
+        _b: &mut DspBuilder,
+    ) -> Vec<Signal> {
         // Pure re-grouping: no units, just the concatenation of every input's
-        // channels (unconnected inputs are already mono silence).
-        vec![Signal::concat(inputs.iter().cloned())]
+        // channels (an unconnected input contributes mono silence).
+        vec![Signal::concat(
+            (0..inputs.len()).map(|i| input_or_silent(inputs, i)),
+        )]
     }
 }
 

--- a/crates/gantz_plyphon/src/node/pack.rs
+++ b/crates/gantz_plyphon/src/node/pack.rs
@@ -63,9 +63,10 @@ impl gantz_core::Node for Pack {
     }
 
     fn expr(&self, _ctx: ExprCtx<'_, '_>) -> ExprResult {
-        // Steel-inert: the packing happens at synthdef derivation. A placeholder
-        // output feeds the inert dsp output edge.
-        gantz_core::node::parse_expr("0")
+        // Steel-inert: the packing happens at synthdef derivation. A non-numeric
+        // placeholder output feeds the inert dsp output edge (see the `NodeDsp`
+        // docs).
+        gantz_core::node::parse_expr("'()")
     }
 }
 

--- a/crates/gantz_plyphon/src/node/scope_out.rs
+++ b/crates/gantz_plyphon/src/node/scope_out.rs
@@ -9,7 +9,7 @@ use plyphon::Rate;
 use plyphon::synthdef::{InputRef, UnitSpec};
 use serde::{Deserialize, Serialize};
 
-use crate::dsp::{DspBuilder, NodeDsp, Signal, ToNodeDsp};
+use crate::dsp::{DspBuilder, NodeDsp, Signal, ToNodeDsp, input_or_silent};
 
 /// A signal *tap*: streams every sample of its input signal into per-channel
 /// ring buffers held in VM state (the audio driver writes them, draining a
@@ -127,14 +127,14 @@ impl NodeDsp for ScopeOut {
         true
     }
 
-    fn ugens(&self, path: &[usize], inputs: &[Signal], b: &mut DspBuilder) -> Vec<Signal> {
+    fn ugens(&self, path: &[usize], inputs: &[Option<Signal>], b: &mut DspBuilder) -> Vec<Signal> {
         // `ScopeOut.ar(bufnum, ch0, ch1, …)`: stream *every* sample of each of the
         // input signal's channels (interleaved) off the audio thread into a cued
         // scope stream the driver drains into this node's per-channel rings - the
         // channel count is the input's width. `bufnum` is a no-lag control param;
         // the driver allocates a globally-unique cued index and sets it via
         // `set_control` after spawning (no def mutation).
-        let signal = inputs.first().cloned().unwrap_or_else(|| Signal::silent(1));
+        let signal = input_or_silent(inputs, 0);
         let bufnum = b.push_control_param(path, "bufnum");
         let mut scope_inputs = Vec::with_capacity(signal.width() + 1);
         scope_inputs.push(InputRef::Param(bufnum));

--- a/crates/gantz_plyphon/src/node/sin_osc.rs
+++ b/crates/gantz_plyphon/src/node/sin_osc.rs
@@ -11,8 +11,13 @@ use serde::{Deserialize, Serialize};
 use crate::dsp::{DspBuilder, NodeDsp, NodeRate, Signal, ToNodeDsp, cahash_rate};
 use crate::param::{cahash_lag, control_input_expr, param_name, param_state, plyphon_param};
 
-/// A sine oscillator. Emits a single `SinOsc` UGen at the configured `rate`
-/// (audio by default; control rate for modulator duty).
+/// A sine oscillator. Emits one `SinOsc` UGen per freq channel at the
+/// configured `rate` (audio by default; control rate for modulator duty).
+///
+/// The freq input is *hybrid* (see [`NodeDsp::n_dsp_inputs`]): a connected dsp
+/// signal drives the oscillator's frequency directly - audio-rate FM when the
+/// wire is audio rate - while an unconnected input falls back to the smoothed
+/// `freq` control param.
 ///
 /// The `freq` (Hz) *value* lives in the node's VM state (path-keyed, like
 /// `number`), so editing it does not churn the graph's content address; the audio
@@ -79,7 +84,8 @@ impl CaHash for SinOsc {
 
 impl gantz_core::Node for SinOsc {
     fn n_inputs(&self, _ctx: MetaCtx) -> usize {
-        // A single control input: the frequency. (No dsp signal inputs.)
+        // A single hybrid input: the frequency (dsp signal when connected,
+        // control param fallback otherwise).
         1
     }
 
@@ -100,33 +106,63 @@ impl gantz_core::Node for SinOsc {
     }
 
     fn expr(&self, ctx: ExprCtx<'_, '_>) -> ExprResult {
-        // The audio engine reads the freq from state; this node is otherwise
-        // Steel-inert. When its control input is connected, write the incoming
-        // value into state (the audio driver applies it via `set_control`). The
-        // placeholder output (the freq) feeds the inert dsp output edge.
-        control_input_expr(&ctx, self.n_dsp_inputs(), "state")
+        // The audio engine reads the freq from a connected dsp wire or from
+        // state; this node is otherwise Steel-inert. Input 0 is hybrid: a
+        // connected *number* is written into state (the audio driver applies it
+        // via `set_control`), while a dsp source's non-numeric placeholder is
+        // ignored by the `number?` guard. The placeholder output (the state)
+        // feeds the inert dsp output edge.
+        control_input_expr(&ctx, 0, "state")
     }
 }
 
 impl NodeDsp for SinOsc {
+    fn n_dsp_inputs(&self) -> usize {
+        // The hybrid freq input.
+        1
+    }
+
     fn n_dsp_outputs(&self) -> usize {
         1
     }
 
-    fn ugens(&self, path: &[usize], _inputs: &[Option<Signal>], b: &mut DspBuilder) -> Vec<Signal> {
-        // `freq` is a settable control param (a nominal default here; the driver
-        // applies the live state value via `set_control`).
-        let freq = b.push_param(
-            path,
-            plyphon_param(param_name(path, "freq"), Self::DEFAULT_FREQ, self.freq_lag),
-        );
-        let unit = b.push_unit(UnitSpec::new(
-            "SinOsc",
-            self.rate.to_plyphon(),
-            vec![InputRef::Param(freq), InputRef::Constant(0.0)],
-            1,
-        ));
-        vec![Signal::mono(InputRef::Unit { unit, output: 0 })]
+    fn ugens(&self, path: &[usize], inputs: &[Option<Signal>], b: &mut DspBuilder) -> Vec<Signal> {
+        match inputs.first().cloned().flatten() {
+            // A connected signal drives the frequency directly (audio-rate FM
+            // when the wire is audio rate; `freq_lag` is inert while wired).
+            // One `SinOsc` per freq channel: width N in -> width N out.
+            Some(freq) => {
+                let oscs = freq
+                    .channels()
+                    .map(|ch| {
+                        let unit = b.push_unit(UnitSpec::new(
+                            "SinOsc",
+                            self.rate.to_plyphon(),
+                            vec![ch, InputRef::Constant(0.0)],
+                            1,
+                        ));
+                        InputRef::Unit { unit, output: 0 }
+                    })
+                    .collect();
+                vec![oscs]
+            }
+            // Unconnected: `freq` falls back to the settable control param (a
+            // nominal default here; the driver applies the live state value via
+            // `set_control`).
+            None => {
+                let freq = b.push_param(
+                    path,
+                    plyphon_param(param_name(path, "freq"), Self::DEFAULT_FREQ, self.freq_lag),
+                );
+                let unit = b.push_unit(UnitSpec::new(
+                    "SinOsc",
+                    self.rate.to_plyphon(),
+                    vec![InputRef::Param(freq), InputRef::Constant(0.0)],
+                    1,
+                ));
+                vec![Signal::mono(InputRef::Unit { unit, output: 0 })]
+            }
+        }
     }
 }
 

--- a/crates/gantz_plyphon/src/node/sin_osc.rs
+++ b/crates/gantz_plyphon/src/node/sin_osc.rs
@@ -113,7 +113,7 @@ impl NodeDsp for SinOsc {
         1
     }
 
-    fn ugens(&self, path: &[usize], _inputs: &[Signal], b: &mut DspBuilder) -> Vec<Signal> {
+    fn ugens(&self, path: &[usize], _inputs: &[Option<Signal>], b: &mut DspBuilder) -> Vec<Signal> {
         // `freq` is a settable control param (a nominal default here; the driver
         // applies the live state value via `set_control`).
         let freq = b.push_param(

--- a/crates/gantz_plyphon/src/node/sum.rs
+++ b/crates/gantz_plyphon/src/node/sum.rs
@@ -77,9 +77,10 @@ impl NodeDsp for Sum {
         1
     }
 
-    fn ugens(&self, _path: &[usize], inputs: &[Signal], b: &mut DspBuilder) -> Vec<Signal> {
-        // Unconnected inputs are already mono silence, which folds away.
-        vec![sum_signals(b, inputs)]
+    fn ugens(&self, _path: &[usize], inputs: &[Option<Signal>], b: &mut DspBuilder) -> Vec<Signal> {
+        // Unconnected inputs contribute nothing (silence would fold away).
+        let sigs: Vec<Signal> = inputs.iter().flatten().cloned().collect();
+        vec![sum_signals(b, &sigs)]
     }
 }
 

--- a/crates/gantz_plyphon/src/node/sum.rs
+++ b/crates/gantz_plyphon/src/node/sum.rs
@@ -61,9 +61,10 @@ impl gantz_core::Node for Sum {
     }
 
     fn expr(&self, _ctx: ExprCtx<'_, '_>) -> ExprResult {
-        // Steel-inert: the summing happens at synthdef derivation. A placeholder
-        // output feeds the inert dsp output edge.
-        gantz_core::node::parse_expr("0")
+        // Steel-inert: the summing happens at synthdef derivation. A non-numeric
+        // placeholder output feeds the inert dsp output edge (see the `NodeDsp`
+        // docs).
+        gantz_core::node::parse_expr("'()")
     }
 }
 

--- a/crates/gantz_plyphon/src/node/unpack.rs
+++ b/crates/gantz_plyphon/src/node/unpack.rs
@@ -5,7 +5,7 @@ use gantz_core::node::{ExprCtx, ExprResult, MetaCtx};
 use gantz_nodetag::NodeTag;
 use serde::{Deserialize, Serialize};
 
-use crate::dsp::{DspBuilder, NodeDsp, Signal, ToNodeDsp};
+use crate::dsp::{DspBuilder, NodeDsp, Signal, ToNodeDsp, input_or_silent};
 
 /// Split a channel group into `count` mono outputs (like Max's `mc.unpack~` or
 /// a VCV split): output `i` carries the input's channel `i`, or silence past
@@ -87,10 +87,15 @@ impl NodeDsp for Unpack {
         self.count
     }
 
-    fn ugens(&self, _path: &[usize], inputs: &[Signal], _b: &mut DspBuilder) -> Vec<Signal> {
+    fn ugens(
+        &self,
+        _path: &[usize],
+        inputs: &[Option<Signal>],
+        _b: &mut DspBuilder,
+    ) -> Vec<Signal> {
         // Pure re-grouping: no units, output `i` = the input's channel `i` (or
         // mono silence past the input's width).
-        let signal = inputs.first().cloned().unwrap_or_else(|| Signal::silent(1));
+        let signal = input_or_silent(inputs, 0);
         (0..self.count)
             .map(|i| {
                 signal

--- a/crates/gantz_plyphon/src/node/unpack.rs
+++ b/crates/gantz_plyphon/src/node/unpack.rs
@@ -66,12 +66,13 @@ impl gantz_core::Node for Unpack {
     }
 
     fn expr(&self, _ctx: ExprCtx<'_, '_>) -> ExprResult {
-        // Steel-inert: the splitting happens at synthdef derivation. Placeholder
-        // outputs feed the inert dsp output edges - a single value for one
-        // output, a list of values otherwise (the multi-output expr contract).
+        // Steel-inert: the splitting happens at synthdef derivation. Non-numeric
+        // placeholder outputs feed the inert dsp output edges (see the `NodeDsp`
+        // docs) - a single value for one output, a list of values otherwise (the
+        // multi-output expr contract).
         let src = match self.count {
-            1 => "0".to_string(),
-            n => format!("(list {})", vec!["0"; n].join(" ")),
+            1 => "'()".to_string(),
+            n => format!("(list {})", vec!["'()"; n].join(" ")),
         };
         gantz_core::node::parse_expr(&src)
     }

--- a/crates/gantz_plyphon/src/param.rs
+++ b/crates/gantz_plyphon/src/param.rs
@@ -43,6 +43,14 @@ pub fn plyphon_param(name: impl Into<String>, default: f32, lag: f32) -> Param {
 /// inspector edits. The expr always evaluates to `output`: the node's placeholder
 /// dsp output (`"state"` for a source like `~sinosc`, `"'()"` for a sink like
 /// `~out`). DSP nodes are otherwise Steel-inert.
+///
+/// The `number?` guard is what makes a *hybrid* input work (a dsp input that
+/// falls back to a control param, e.g. `~sinosc`'s freq - see
+/// [`NodeDsp::n_dsp_inputs`](crate::NodeDsp::n_dsp_inputs)): a connected dsp
+/// source's placeholder output is non-numeric by contract and is ignored here,
+/// as is the list a multi-edge input evaluates to. So while any dsp wire shares
+/// the input the wire wins - numbers are not queued, matching the derived def,
+/// where the param is absent and nothing would drain the queue.
 pub fn control_input_expr(ctx: &ExprCtx<'_, '_>, control_ix: usize, output: &str) -> ExprResult {
     let expr = match ctx.inputs().get(control_ix) {
         Some(Some(val)) => {

--- a/crates/gantz_plyphon/tests/derive_regions.rs
+++ b/crates/gantz_plyphon/tests/derive_regions.rs
@@ -250,6 +250,52 @@ fn two_buses_between_the_same_regions() {
 }
 
 #[test]
+fn fm_across_a_bus_boundary() {
+    // `~sinosc -> ~bus -> ~sinosc.freq -> ~out`: the modulator crosses the
+    // boundary, so the reader region's carrier reads its freq from the bus `In`
+    // wire and bakes no freq fallback param (the writer's own freq param is
+    // unaffected).
+    let mut g = Graph::<N>::default();
+    let m = g.add_node(N::SinOsc(SinOsc::default()));
+    let b = g.add_node(N::Bus(Bus::default()));
+    let c = g.add_node(N::SinOsc(SinOsc::default()));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(m, b, Edge::new(0.into(), 0.into()));
+    g.add_edge(b, c, Edge::new(0.into(), 0.into()));
+    g.add_edge(c, o, Edge::new(0.into(), 0.into()));
+
+    let regions = derive_synthdefs(&g, 1, "head").expect("derive");
+    assert_eq!(regions.len(), 2, "modulator region + carrier region");
+    let (writer, reader) = (&regions[0], &regions[1]);
+    assert!(
+        writer
+            .derived
+            .def
+            .params
+            .iter()
+            .any(|p| p.name.ends_with("/freq")),
+        "the modulator keeps its own freq param",
+    );
+    let rdef = &reader.derived.def;
+    assert_eq!(reader.bus_reads.len(), 1);
+    let in_unit = reader.bus_reads[0].unit;
+    assert_eq!(rdef.units[in_unit].name, "In");
+    let osc = rdef
+        .units
+        .iter()
+        .find(|u| u.name == "SinOsc")
+        .expect("carrier SinOsc");
+    assert!(
+        matches!(osc.inputs[0], InputRef::Unit { unit, .. } if unit as usize == in_unit),
+        "the carrier's freq reads the bus In wire",
+    );
+    assert!(
+        !rdef.params.iter().any(|p| p.name.ends_with("/freq")),
+        "the wired carrier bakes no freq param",
+    );
+}
+
+#[test]
 fn bus_cycle_is_rejected() {
     // Two regions reading each other's buses: no writer-before-reader order
     // exists, so derivation reports the cycle (deliberate feedback is a planned

--- a/crates/gantz_plyphon/tests/derive_synthdef.rs
+++ b/crates/gantz_plyphon/tests/derive_synthdef.rs
@@ -332,7 +332,7 @@ fn scopeout_taps_a_multichannel_signal() {
         InputRef::Unit { unit: 7, output: 0 },
         InputRef::Unit { unit: 8, output: 0 },
     );
-    let outs = ScopeOut::default().ugens(&[2], &[sig], &mut b);
+    let outs = ScopeOut::default().ugens(&[2], &[Some(sig)], &mut b);
     assert!(outs.is_empty(), "a tap sink has no dsp outputs");
 
     let (def, _params, monitors, _gains) = b.finish("t");
@@ -358,7 +358,7 @@ fn lag_smooths_each_channel() {
     // single `dur` param (params broadcast across the group); width in = width out.
     let mut b = DspBuilder::new(1);
     let sig = stereo(InputRef::Constant(0.25), InputRef::Constant(0.5));
-    let outs = Lag::default().ugens(&[0], &[sig], &mut b);
+    let outs = Lag::default().ugens(&[0], &[Some(sig)], &mut b);
     assert_eq!(outs.len(), 1, "one dsp output port");
     assert_eq!(outs[0].width(), 2, "width flows through");
 
@@ -382,7 +382,7 @@ fn out_writes_multichannel_channel_per_bus() {
     // fan-out - the two written wires stay distinct).
     let mut b = DspBuilder::new(2);
     let sig = stereo(InputRef::Constant(0.25), InputRef::Constant(0.5));
-    let outs = Out::default().ugens(&[0], &[sig], &mut b);
+    let outs = Out::default().ugens(&[0], &[Some(sig)], &mut b);
     assert!(outs.is_empty());
 
     let (def, ..) = b.finish("t");
@@ -425,7 +425,7 @@ fn out_drops_excess_channels() {
         Signal::mono(InputRef::Constant(0.2)),
         Signal::mono(InputRef::Constant(0.3)),
     ]);
-    Out::default().ugens(&[0], &[sig], &mut b);
+    Out::default().ugens(&[0], &[Some(sig)], &mut b);
 
     let (def, ..) = b.finish("t");
     let n_muls = def

--- a/crates/gantz_plyphon/tests/derive_synthdef.rs
+++ b/crates/gantz_plyphon/tests/derive_synthdef.rs
@@ -231,31 +231,211 @@ fn control_edge_on_root_does_not_panic() {
 }
 
 #[test]
-fn dsp_chain_into_control_input_emits_no_units() {
-    // `~lag -> ~sinosc`'s freq (a *control* input - sinosc has no dsp inputs) with
-    // `~sinosc -> ~out`: the lag feeds no sink through dsp inputs, so it must not
-    // land in the def. Interior nodes are pull-traversed over ALL incoming edges,
-    // so without the dsp-reachable intersection the lag would emit a dead `Lag`
-    // unit (wasted audio CPU) with a live `dur` param (driven by the driver, and
-    // hashed into `structural_sig` - a spurious respawn on control-wiring edits).
+fn dsp_wire_into_freq_drives_fm() {
+    // `~lag -> ~sinosc.freq -> ~out`: freq is a *hybrid* dsp input, so the
+    // connected chain emits units and the `Lag`'s output wire drives the
+    // oscillator's freq input directly. The freq fallback param must NOT be
+    // baked - the wire wins, and an undriven param would land in the def (and
+    // `structural_sig`) with nothing draining its state.
     let mut g = Graph::<N>::default();
     let l = g.add_node(N::Lag(Lag::default()));
     let s = g.add_node(N::SinOsc(SinOsc::default()));
     let o = g.add_node(N::Out(Out::default()));
-    g.add_edge(l, s, Edge::new(0.into(), 0.into())); // ~lag -> sinosc freq (control)
+    g.add_edge(l, s, Edge::new(0.into(), 0.into())); // ~lag -> sinosc freq (dsp)
     g.add_edge(s, o, Edge::new(0.into(), 0.into())); // sinosc -> ~out (dsp)
 
     let derived = derive_synthdef(&g, 1, "t").expect("derive");
-    assert_eq!(
-        derived.def.units.len(),
-        4,
-        "SinOsc + level/channel muls + Out, no Lag"
-    );
-    assert!(derived.def.units.iter().all(|u| u.name != "Lag"));
+    let def = &derived.def;
+    // Units: Lag(0), SinOsc(1), level-mul, channel-mul, Out.
+    assert_eq!(def.units.len(), 5);
+    assert_eq!(def.units[0].name, "Lag");
+    assert_eq!(def.units[1].name, "SinOsc");
     assert!(
-        derived.def.params.iter().all(|p| !p.name.ends_with("/dur")),
-        "the unreachable lag's dur param must not be driven",
+        matches!(
+            def.units[1].inputs[0],
+            InputRef::Unit { unit: 0, output: 0 }
+        ),
+        "the SinOsc freq input reads the lag's output wire",
     );
+    assert!(
+        def.params.iter().all(|p| !p.name.ends_with("/freq")),
+        "a wired freq bakes no fallback param",
+    );
+    assert!(
+        derived
+            .params
+            .iter()
+            .all(|b| b.node_path != vec![s.index()]),
+        "no binding drives the wired sinosc",
+    );
+    // The lag's own dur param is unaffected.
+    assert!(def.params.iter().any(|p| p.name.ends_with("/dur")));
+}
+
+#[test]
+fn kr_modulator_fm_keeps_its_own_freq_param() {
+    // `~sinosc(kr) -> ~sinosc.freq -> ~out` (vibrato duty): the modulator's own
+    // freq input is unconnected so it keeps its fallback param, while the
+    // carrier's freq is the kr wire (no param).
+    let mut modulator = SinOsc::default();
+    modulator.set_rate(NodeRate::Control);
+    let mut g = Graph::<N>::default();
+    let m = g.add_node(N::SinOsc(modulator));
+    let c = g.add_node(N::SinOsc(SinOsc::default()));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(m, c, Edge::new(0.into(), 0.into()));
+    g.add_edge(c, o, Edge::new(0.into(), 0.into()));
+
+    let derived = derive_synthdef(&g, 1, "t").expect("derive");
+    let def = &derived.def;
+    let oscs: Vec<_> = def.units.iter().filter(|u| u.name == "SinOsc").collect();
+    assert_eq!(oscs.len(), 2);
+    assert!(matches!(oscs[0].rate, Rate::Control));
+    assert!(
+        matches!(oscs[0].inputs[0], InputRef::Param(_)),
+        "the modulator's freq falls back to its param",
+    );
+    assert!(matches!(oscs[1].rate, Rate::Audio));
+    assert!(
+        matches!(oscs[1].inputs[0], InputRef::Unit { .. }),
+        "the carrier's freq reads the kr wire",
+    );
+    assert_eq!(
+        def.params
+            .iter()
+            .filter(|p| p.name.ends_with("/freq"))
+            .count(),
+        1,
+        "one freq param: the modulator's",
+    );
+    assert_eq!(
+        derived
+            .params
+            .iter()
+            .filter(|b| b.node_path == vec![m.index()])
+            .count(),
+        1,
+        "the freq binding maps to the modulator",
+    );
+}
+
+#[test]
+fn multichannel_freq_expands_an_osc_per_channel() {
+    // `~pack`(2) (unconnected: a 2-wide silent group) -> `~sinosc.freq` -> `~out`
+    // on a 2-channel device: the oscillator expands to one SinOsc per freq
+    // channel and its output group is 2 wide.
+    let mut g = Graph::<N>::default();
+    let pk = g.add_node(N::Pack(Pack::default()));
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(pk, s, Edge::new(0.into(), 0.into()));
+    g.add_edge(s, o, Edge::new(0.into(), 0.into()));
+
+    let def = derive_synthdef(&g, 2, "t").expect("derive").def;
+    let oscs: Vec<_> = def.units.iter().filter(|u| u.name == "SinOsc").collect();
+    assert_eq!(oscs.len(), 2, "one SinOsc per freq channel");
+    assert!(
+        oscs.iter()
+            .all(|u| matches!(u.inputs[0], InputRef::Constant(c) if c == 0.0)),
+        "each osc reads its own (silent) freq channel",
+    );
+    assert!(def.params.iter().all(|p| !p.name.ends_with("/freq")));
+    let out = def.units.iter().find(|u| u.name == "Out").expect("Out");
+    assert_eq!(
+        out.inputs.len(),
+        1 + 2,
+        "the 2-wide group reaches both device channels",
+    );
+}
+
+#[test]
+fn freq_wire_changes_structural_sig() {
+    // Connecting a dsp wire into freq swaps the freq param for the wire (and
+    // pulls the modulator chain into the def), so the structural sig changes
+    // and the driver respawns (crossfaded).
+    let def = |fm: bool| {
+        let mut g = Graph::<N>::default();
+        let m = g.add_node(N::SinOsc(SinOsc::default()));
+        let s = g.add_node(N::SinOsc(SinOsc::default()));
+        let o = g.add_node(N::Out(Out::default()));
+        if fm {
+            g.add_edge(m, s, Edge::new(0.into(), 0.into()));
+        }
+        g.add_edge(s, o, Edge::new(0.into(), 0.into()));
+        derive_synthdef(&g, 1, "t").expect("derive").def
+    };
+    assert_ne!(
+        structural_sig(&def(false)),
+        structural_sig(&def(true)),
+        "a freq connect/disconnect must change the structural signature",
+    );
+}
+
+#[test]
+fn dangling_unpack_port_into_freq_keeps_the_param() {
+    // A stale `~unpack` edge (output 1 of a count-1 unpack) into `~sinosc.freq`:
+    // the summand materializes no signal, so freq must fall back to its param.
+    // (The Steel side cannot see the port is dangling and keeps queueing state
+    // updates; only a def-present param is drained by the driver.)
+    let mut unpack = Unpack::default();
+    unpack.set_count(1);
+    let mut g = Graph::<N>::default();
+    let src = g.add_node(N::SinOsc(SinOsc::default()));
+    let up = g.add_node(N::Unpack(unpack));
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(src, up, Edge::new(0.into(), 0.into()));
+    g.add_edge(up, s, Edge::new(1.into(), 0.into())); // stale: output 1 of 1
+    g.add_edge(s, o, Edge::new(0.into(), 0.into()));
+
+    let derived = derive_synthdef(&g, 1, "t").expect("derive");
+    let def = &derived.def;
+    // Both the upstream source's and the carrier's freq params are baked.
+    assert_eq!(
+        def.params
+            .iter()
+            .filter(|p| p.name.ends_with("/freq"))
+            .count(),
+        2,
+        "the dangling-port freq falls back to its param",
+    );
+    // The carrier (emitted after the source) reads a param, not a wire.
+    let carrier = def
+        .units
+        .iter()
+        .filter(|u| u.name == "SinOsc")
+        .last()
+        .expect("carrier SinOsc");
+    assert!(matches!(carrier.inputs[0], InputRef::Param(_)));
+}
+
+#[test]
+fn scopeout_output_into_freq_keeps_the_param() {
+    // `~scopeout` output 1 (its Steel channel-count output - the node has NO dsp
+    // outputs) wired into `~sinosc.freq`: the summand materializes no signal, so
+    // freq must fall back to its param. Guards the "None iff nothing
+    // materialized" rule: keying on raw summands would bake silence here while
+    // the node's Steel expr queues the (numeric) channel count into a param
+    // absent from the def, growing `pending` unboundedly.
+    let mut g = Graph::<N>::default();
+    let t = g.add_node(N::ScopeOut(ScopeOut::default()));
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(t, s, Edge::new(1.into(), 0.into())); // scope channel count -> freq
+    g.add_edge(s, o, Edge::new(0.into(), 0.into()));
+
+    let derived = derive_synthdef(&g, 1, "t").expect("derive");
+    let def = &derived.def;
+    assert!(
+        def.params.iter().any(|p| p.name.ends_with("/freq")),
+        "freq falls back to its param",
+    );
+    let osc = def
+        .units
+        .iter()
+        .find(|u| u.name == "SinOsc")
+        .expect("SinOsc");
+    assert!(matches!(osc.inputs[0], InputRef::Param(_)));
 }
 
 #[test]
@@ -781,6 +961,52 @@ fn derived_synth_plays_expected_tone() {
     assert!(
         m220 > 5.0 * m440,
         "expected 220 Hz dominant: m220={m220}, m440={m440}"
+    );
+}
+
+#[test]
+fn audio_rate_fm_renders_through_the_wire() {
+    // `~sinosc(ar) -> ~sinosc.freq -> ~out` rendered offline: the carrier's freq
+    // is the modulator's raw [-1, 1] Hz signal, so the output is the faint
+    // phase-wobble tone at the modulator's 220 Hz (the carrier's own 220 Hz
+    // *param* default must NOT sound - the wire wins). Proves the audio-rate
+    // freq path end to end through the real engine.
+    let mut g = Graph::<N>::default();
+    let m = g.add_node(N::SinOsc(SinOsc::default()));
+    let s = g.add_node(N::SinOsc(SinOsc::default()));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(m, s, Edge::new(0.into(), 0.into()));
+    g.add_edge(s, o, Edge::new(0.into(), 0.into()));
+    let derived = derive_synthdef(&g, 1, "t").expect("derive");
+
+    let (mut controller, _nrt, mut world) = engine(Options {
+        sample_rate: SR as f64,
+        output_channels: 1,
+        ..Options::default()
+    });
+    controller.add_synthdef(derived.def);
+    let node = controller
+        .synth_new("t", ROOT_GROUP_ID, AddAction::Tail)
+        .expect("synth_new");
+    {
+        let mut backend = Embedded::new(&mut controller);
+        for gain in &derived.gains {
+            backend.set_control(node, gain.index, 1.0).expect("fade in");
+        }
+    }
+
+    let a = render(&mut world, SR as usize / 2);
+    assert!(
+        a.iter().all(|s| s.is_finite() && s.abs() <= 1.001),
+        "output must stay finite and within full scale",
+    );
+    // A ±1 Hz freq wobbles the phase by ~1/(2*pi*220), so the tone at 220 Hz has
+    // a tiny but clearly-detectable magnitude - and 330 Hz carries nothing.
+    let (m220, m330) = (goertzel(&a, 220.0), goertzel(&a, 330.0));
+    assert!(m220 > 1e-6, "expected the 220 Hz wobble: m220={m220}");
+    assert!(
+        m220 > 5.0 * m330,
+        "220 Hz must dominate: m220={m220}, m330={m330}",
     );
 }
 

--- a/crates/gantz_plyphon/tests/instance.rs
+++ b/crates/gantz_plyphon/tests/instance.rs
@@ -345,6 +345,77 @@ fn unconnected_inlet_bakes_silence() {
 }
 
 #[test]
+fn instance_inlet_drives_hybrid_freq() {
+    // A child `inlet -> ~sinosc.freq -> ~out` (an FM voice whose modulation
+    // input is the interface inlet). Fed variant: the carrier reads its freq
+    // from the interface `In` wire and bakes no freq param. Unfed variant: the
+    // freq falls back to its param - a distinct `VariantKey` (inlet
+    // connectivity is part of the key), so the two defs never collide in the
+    // cache.
+    let mut child = Graph::<N>::default();
+    let i = child.add_node(N::Inlet);
+    let s = child.add_node(N::SinOsc(SinOsc::default()));
+    let o = child.add_node(N::Out(Out::default()));
+    child.add_edge(i, s, Edge::new(0.into(), 0.into()));
+    child.add_edge(s, o, Edge::new(0.into(), 0.into()));
+    let map = HashMap::from([(ca(1), child)]);
+
+    // Fed: a parent modulator wired into the instance's inlet.
+    let mut g = Graph::<N>::default();
+    let m = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::Ref(ca(1), 1, 0));
+    g.add_edge(m, r, Edge::new(0.into(), 0.into()));
+    let (template, cache) = derive(&g, &map).expect("derive");
+    let inst = &instances(&template)[0];
+    assert_eq!(inst.variant.inlets, vec![vec![1]]);
+    let child = cache.get(&inst.variant).expect("cached child");
+    let child_region = &regions(&child)[0];
+    let in_read = child_region
+        .bus_reads
+        .iter()
+        .find(|b| matches!(b.key, BusKey::IfaceIn { inlet: 0, .. }))
+        .expect("the child's In reads its interface inlet");
+    let osc = child_region
+        .def
+        .units
+        .iter()
+        .find(|u| u.name == "SinOsc")
+        .expect("carrier SinOsc");
+    assert!(
+        matches!(osc.inputs[0], plyphon::synthdef::InputRef::Unit { unit, .. }
+            if unit as usize == in_read.unit),
+        "the carrier's freq reads the inlet In wire",
+    );
+    assert!(
+        !child_region
+            .def
+            .params
+            .iter()
+            .any(|p| p.name.ends_with("/freq")),
+        "the wired carrier bakes no freq param",
+    );
+
+    // Unfed: the same child with nothing into the inlet.
+    let mut g2 = Graph::<N>::default();
+    let _r = g2.add_node(N::Ref(ca(1), 1, 0));
+    let (template2, cache2) = derive(&g2, &map).expect("derive");
+    let inst2 = &instances(&template2)[0];
+    assert_ne!(
+        inst.variant, inst2.variant,
+        "inlet connectivity keys the variant",
+    );
+    let child2 = cache2.get(&inst2.variant).expect("cached child");
+    assert!(
+        regions(&child2)[0]
+            .def
+            .params
+            .iter()
+            .any(|p| p.name.ends_with("/freq")),
+        "an unfed inlet leaves the freq param baked",
+    );
+}
+
+#[test]
 fn consumed_outlet_mask_keys_the_variant() {
     // A child with two outlets, only the second consumed: the variant records
     // `[false, true]` and the child def writes exactly one outlet bus.


### PR DESCRIPTION
## Summary

Introduce **hybrid inputs** to the `NodeDsp` API - dsp inputs that fall back to a control param when unconnected - and implement the first one: `~sinosc`'s `freq` input. This unlocks **audio-rate FM** by wiring an audio-rate signal into `freq` directly, while preserving the original param-driven behaviour when the port is left dangling.

Closes #322