### PR TITLE
feat: Allow domains to extend "panes". Add a dedicated pane with DSP derivation diagnostics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3930,6 +3930,7 @@ dependencies = [
  "plyphon",
  "ron 0.10.1",
  "serde",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -149,6 +149,7 @@ where
             .init_resource::<Demos>()
             .init_resource::<WindowedPanesRequested>()
             .init_resource::<SettingsTabs>()
+            .init_resource::<ExtPanes>()
             .init_resource::<RefExtUis>()
             // GUI state observers
             .add_observer(on_head_opened::<N>)
@@ -205,11 +206,16 @@ where
     }
 }
 
-/// Empty the domain-provided GUI collections ([`SettingsTabs`],
+/// Empty the domain-provided GUI collections ([`SettingsTabs`], [`ExtPanes`],
 /// [`RefExtUis`]) so domain providers refill them with fresh snapshots each
 /// frame (see the resource docs for the schedule contract).
-fn clear_ui_providers(mut tabs: ResMut<SettingsTabs>, mut ref_ext_uis: ResMut<RefExtUis>) {
+fn clear_ui_providers(
+    mut tabs: ResMut<SettingsTabs>,
+    mut ext_panes: ResMut<ExtPanes>,
+    mut ref_ext_uis: ResMut<RefExtUis>,
+) {
     tabs.0.clear();
+    ext_panes.0.clear();
     ref_ext_uis.0.clear();
 }
 
@@ -300,6 +306,16 @@ pub struct ImportTask(bevy_tasks::Task<Option<Vec<u8>>>);
 /// payloads its tab emitted on the previous frame.
 #[derive(Default, Resource)]
 pub struct SettingsTabs(pub Vec<Box<dyn gantz_egui::widget::SettingsTab + Send + Sync>>);
+
+/// Top-level panes contributed by domains (see
+/// [`ExtPane`][gantz_egui::widget::ExtPane]).
+///
+/// Same provider contract as [`SettingsTabs`]: cleared each frame in `First`,
+/// refilled by domain provider systems in `PreUpdate`, consumed by both GUI
+/// render paths. A provider typically pushes a fresh snapshot of its domain's
+/// per-head data.
+#[derive(Default, Resource)]
+pub struct ExtPanes(pub Vec<Box<dyn gantz_egui::widget::ExtPane + Send + Sync>>);
 
 /// `NamedRef` inspector extensions contributed by domains (see
 /// [`RefExtUi`][gantz_egui::node::RefExtUi]).
@@ -1779,6 +1795,7 @@ pub fn update<N>(
         mut compile_config,
         mut change_validation,
         mut settings_tabs,
+        mut ext_panes,
         ref_ext_uis,
         mut requested,
         host_native,
@@ -1791,6 +1808,7 @@ pub fn update<N>(
         ResMut<CompileConfig>,
         ResMut<bevy_gantz::ValidateCommitted>,
         ResMut<SettingsTabs>,
+        ResMut<ExtPanes>,
         Res<RefExtUis>,
         ResMut<WindowedPanesRequested>,
         Option<Res<HostNativePaneWindows>>,
@@ -1872,6 +1890,11 @@ where
                 .iter_mut()
                 .map(|t| &mut **t as &mut dyn gantz_egui::widget::SettingsTab)
                 .collect();
+            let mut panes: Vec<&mut dyn gantz_egui::widget::ExtPane> = ext_panes
+                .0
+                .iter_mut()
+                .map(|p| &mut **p as &mut dyn gantz_egui::widget::ExtPane)
+                .collect();
             let exts: Vec<&dyn gantz_egui::node::RefExtUi> = ref_ext_uis
                 .0
                 .iter()
@@ -1886,6 +1909,7 @@ where
                 .perf_captures(&mut perf_vm.0, &mut perf_gui.0)
                 .pane_window_mode(pane_window_mode)
                 .settings_tabs(&mut tabs)
+                .ext_panes(&mut panes)
                 .ref_ext_uis(&exts);
             // Base-source authoring context, present only where the
             // per-source write-back runs (`update-base` inserts ExportPaths),

--- a/crates/bevy_gantz_egui/src/pane_window.rs
+++ b/crates/bevy_gantz_egui/src/pane_window.rs
@@ -18,7 +18,7 @@
 //! `egui::Window`s instead.
 
 use crate::{
-    BaseImmutable, BaseNames, BuiltinNodes, CompileConfig, Demos, GuiState, HeadAccess,
+    BaseImmutable, BaseNames, BuiltinNodes, CompileConfig, Demos, ExtPanes, GuiState, HeadAccess,
     HostNativePaneWindows, ImportTask, OpenHeadViews, PerfGui, PerfVm, RefExtUis, Registry,
     ResponseDispatchers, SettingsTabs, TraceCapture, WindowedPanesRequested, handle_gantz_response,
     head, registry_ref,
@@ -192,6 +192,7 @@ fn render_windowed_panes<N: PaneNode>(
         mut compile_config,
         mut change_validation,
         mut settings_tabs,
+        mut ext_panes,
         ref_ext_uis,
         mut demos,
         dispatchers,
@@ -204,6 +205,7 @@ fn render_windowed_panes<N: PaneNode>(
         ResMut<CompileConfig>,
         ResMut<bevy_gantz::ValidateCommitted>,
         ResMut<SettingsTabs>,
+        ResMut<ExtPanes>,
         Res<RefExtUis>,
         ResMut<Demos>,
         Res<ResponseDispatchers>,
@@ -256,6 +258,11 @@ fn render_windowed_panes<N: PaneNode>(
                 .iter_mut()
                 .map(|t| &mut **t as &mut dyn gantz_egui::widget::SettingsTab)
                 .collect();
+            let mut panes: Vec<&mut dyn gantz_egui::widget::ExtPane> = ext_panes
+                .0
+                .iter_mut()
+                .map(|p| &mut **p as &mut dyn gantz_egui::widget::ExtPane)
+                .collect();
             let exts: Vec<&dyn gantz_egui::node::RefExtUi> = ref_ext_uis
                 .0
                 .iter()
@@ -269,6 +276,7 @@ fn render_windowed_panes<N: PaneNode>(
                 .trace_capture(trace_capture.0.clone(), level)
                 .perf_captures(&mut perf_vm.0, &mut perf_gui.0)
                 .settings_tabs(&mut tabs)
+                .ext_panes(&mut panes)
                 .ref_ext_uis(&exts);
             // Base-source authoring context (mirrors `update`).
             if let Some(paths) = &export_paths {

--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -53,8 +53,11 @@ type UnitRegistrar = Box<dyn Fn(&mut plyphon::UnitRegistry) + Send + Sync>;
 
 use bevy_gantz::head::{HeadRef, HeadVms, OpenHead, WorkingGraph};
 use bevy_gantz::{EntrypointSet, EvalEpoch, Registry, VmSet};
-use bevy_gantz_egui::{RefExtUis, RegisterResponseExt, SettingsTabs};
-use gantz_plyphon::{Config, DspRefExtUi, DspSettingsTab, Status, dsp_commits};
+use bevy_gantz_egui::{ExtPanes, RefExtUis, RegisterResponseExt, SettingsTabs};
+use gantz_plyphon::{
+    Config, DeriveStatus, DspPane, DspPaneHead, DspRefExtUi, DspSettingsTab, Status,
+    describe_parts, dsp_commits,
+};
 
 /// Editable DSP settings: the domain's [`Config`] as a bevy resource.
 /// Runtime-only - not persisted, so it resets to the defaults each session.
@@ -70,6 +73,21 @@ pub struct DspStatus(pub Status);
 /// [`Config`]), buffered for the settings-sync system to apply next frame.
 #[derive(Message)]
 pub struct DspSettingsChanged(pub Config);
+
+/// Per-head DSP derive status plus a readable rendering of the derived
+/// program - the DSP analogue of `bevy_gantz`'s `Module`/`Diagnostics` head
+/// components. Written by the synth driver on each structural sync, i.e. only
+/// when the head's committed graph changes. Heads the driver never reaches
+/// (no dsp engine) carry no `DspHead`; readers treat a missing component as
+/// [`DeriveStatus::Pending`].
+#[derive(Clone, Component, Debug, Default)]
+pub struct DspHead {
+    /// The most recent derivation's outcome.
+    pub status: DeriveStatus,
+    /// The derived program rendered as text ([`describe_parts`]), or the
+    /// failure message.
+    pub view: std::sync::Arc<str>,
+}
 
 /// OSC/NTP fixed-point units per second (OSC time is 32.32 fixed point: 2^32).
 const OSC_UNITS_PER_SEC: f64 = 4_294_967_296.0;
@@ -181,10 +199,18 @@ where
         // `init_resource` calls are idempotent and keep the providers valid
         // without the egui plugin.
         app.init_resource::<SettingsTabs>()
+            .init_resource::<ExtPanes>()
             .init_resource::<RefExtUis>()
             .add_message::<DspSettingsChanged>()
             .register_response_with::<Config>(dispatch_dsp_settings)
-            .add_systems(PreUpdate, (sync_dsp_settings, provide_dsp_ref_ext::<N>));
+            .add_systems(
+                PreUpdate,
+                (
+                    sync_dsp_settings,
+                    provide_dsp_pane,
+                    provide_dsp_ref_ext::<N>,
+                ),
+            );
         // The DSP domain's base graphs (see `bevy_gantz_egui::base`).
         app.world_mut()
             .get_resource_or_init::<bevy_gantz_egui::base::BaseSources>()
@@ -522,14 +548,50 @@ fn sync_dsp_settings(
     mut msgs: MessageReader<DspSettingsChanged>,
     mut config: ResMut<DspConfig>,
     status: Res<DspStatus>,
+    tab_order: Res<bevy_gantz::head::HeadTabOrder>,
+    heads: Query<(&HeadRef, Option<&DspHead>), With<OpenHead>>,
     mut tabs: ResMut<SettingsTabs>,
 ) {
     if let Some(msg) = msgs.read().last() {
         config.0 = msg.0.clone();
     }
+    let heads = tab_order
+        .iter()
+        .filter_map(|&e| heads.get(e).ok())
+        .map(|(head_ref, dsp)| {
+            let status = dsp.map(|d| d.status.clone()).unwrap_or_default();
+            (head_ref.0.to_string(), status)
+        })
+        .collect();
     tabs.0.push(Box::new(DspSettingsTab {
         config: config.0.clone(),
         status: status.0.clone(),
+        heads,
+    }));
+}
+
+/// Provide this frame's DSP pane: each open head's [`DspHead`] snapshot plus
+/// the engine's presence (see [`ExtPanes`] for the First/PreUpdate schedule
+/// contract). Heads without a [`DspHead`] read as [`DeriveStatus::Pending`].
+fn provide_dsp_pane(
+    status: Res<DspStatus>,
+    heads: Query<(&HeadRef, Option<&DspHead>), With<OpenHead>>,
+    mut panes: ResMut<ExtPanes>,
+) {
+    let heads = heads
+        .iter()
+        .map(|(head_ref, dsp)| {
+            let dsp = dsp.cloned().unwrap_or_default();
+            let head = DspPaneHead {
+                status: dsp.status,
+                view: dsp.view,
+            };
+            (head_ref.0.clone(), head)
+        })
+        .collect();
+    panes.0.push(Box::new(DspPane {
+        present: status.0.present,
+        heads,
     }));
 }
 
@@ -578,6 +640,7 @@ fn drive_synths<N>(
     state: NonSendMut<HeadSynths>,
     mut vms: NonSendMut<HeadVms>,
     heads: Query<(Entity, &HeadRef, &WorkingGraph<N>), With<OpenHead>>,
+    mut cmds: Commands,
 ) where
     N: 'static + ToNodeDsp + gantz_core::Node + AsRefNode + Clone + Send + Sync,
 {
@@ -623,6 +686,7 @@ fn drive_synths<N>(
         // flatten error (a ref cycle or an unresolvable ref, both forbidden
         // upstream): keep the previous synths, parking the head at this graph
         // address so the error logs once per commit rather than every frame.
+        // Either way the outcome lands on the head as a `DspHead` for the GUI.
         let stale = state
             .heads
             .get(&entity)
@@ -632,7 +696,7 @@ fn drive_synths<N>(
                 let children = flatten_instance_children(&flat, &registry)?;
                 Ok((flat, children))
             });
-            match flat_children {
+            let dsp_head = match flat_children {
                 Ok((flat, children)) => structural_sync(
                     &mut dsp.controller,
                     state,
@@ -645,12 +709,17 @@ fn drive_synths<N>(
                 ),
                 Err(e) => {
                     log::error!(
-                        "bevy_gantz_plyphon: flattening nested graphs failed ({e:?}), \
+                        "bevy_gantz_plyphon: flattening nested graphs failed ({e}), \
                          keeping the previous synths"
                     );
                     park_head(state, entity, graph_ca);
+                    DspHead {
+                        status: DeriveStatus::FlattenError(e.to_string()),
+                        view: format!("{e} - keeping the previous synths").into(),
+                    }
                 }
-            }
+            };
+            cmds.entity(entity).insert(dsp_head);
         }
 
         // Param sync: drain each param's queued control updates and schedule
@@ -803,6 +872,8 @@ fn park_head(state: &mut HeadSynths, entity: Entity, graph_ca: ca::GraphAddr) {
 /// later in topo order (bus readers hear only writers computed earlier in the
 /// node tree), else at the tail. On install/spawn failure the old synth is left
 /// playing - strictly better than going silent.
+///
+/// Returns the sync's outcome as the head's [`DspHead`], for the GUI.
 fn structural_sync<N>(
     controller: &mut Controller,
     state: &mut HeadSynths,
@@ -812,7 +883,8 @@ fn structural_sync<N>(
     children: &HashMap<gantz_ca::ContentAddr, Graph<gantz_plyphon::Flat<N>>>,
     out_channels: usize,
     sample_rate: f64,
-) where
+) -> DspHead
+where
     N: ToNodeDsp,
 {
     let now = Instant::now();
@@ -843,26 +915,29 @@ fn structural_sync<N>(
                     parts: Vec::new(),
                 },
             );
-            return;
+            return DspHead {
+                status: DeriveStatus::Silent,
+                view: "no dsp sink (`~out` / `~scopeout`) - silent".into(),
+            };
         }
-        // A cycle between parts (`~bus` regions or instances) has no runnable
-        // writer-before-reader order: keep the previous synths, recording the
-        // graph address so the error logs once per commit rather than every
-        // frame.
-        Err(gantz_plyphon::DeriveError::BusCycle) => {
-            log::error!("bevy_gantz_plyphon: bus cycle between parts, keeping the previous synths");
+        // A part cycle (`~bus` regions or instances with no runnable
+        // writer-before-reader order) or an instanced-reference failure: keep
+        // the previous synths, parking the head so the error logs once per
+        // commit rather than every frame.
+        Err(e) => {
+            log::error!("bevy_gantz_plyphon: {e}, keeping the previous synths");
             park_head(state, entity, graph_ca);
-            return;
-        }
-        // Instanced-reference failures: keep the previous synths, parking the
-        // head so the error logs once per commit rather than every frame.
-        Err(e @ gantz_plyphon::DeriveError::Unresolved(_))
-        | Err(e @ gantz_plyphon::DeriveError::RefCycle(_)) => {
-            log::error!("bevy_gantz_plyphon: {e:?}, keeping the previous synths");
-            park_head(state, entity, graph_ca);
-            return;
+            return DspHead {
+                status: DeriveStatus::DeriveError(e.to_string()),
+                view: format!("{e} - keeping the previous synths").into(),
+            };
         }
     };
+
+    // The GUI's readable rendering, taken before the planning loop below
+    // consumes `derived`.
+    let view: std::sync::Arc<str> = describe_parts(&derived).into();
+    let n_parts = derived.len();
 
     // Release bus runs whose keys are gone from the derivation.
     let live_buses: HashSet<BusKey> = derived
@@ -986,6 +1061,11 @@ fn structural_sync<N>(
             parts,
         },
     );
+
+    DspHead {
+        status: DeriveStatus::Ok { parts: n_parts },
+        view,
+    }
 }
 
 /// Why a part failed to spawn.

--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -1041,6 +1041,7 @@ fn spawn_part(
         gains,
         bus_writes,
         bus_reads,
+        shapes: _,
     } = part;
 
     // Allocate buses and cue scope streams up front so their indices are known

--- a/crates/gantz_egui/src/widget.rs
+++ b/crates/gantz_egui/src/widget.rs
@@ -2,6 +2,7 @@
 use time::{OffsetDateTime, UtcOffset, format_description};
 
 pub use checkbox_enabled::CheckboxEnabled;
+pub use ext_pane::ExtPane;
 pub use gantz::{
     AlignConfig, BaseSourcesCtx, Gantz, GantzState, GridConfig, LayoutConfig, NodeViewPane, Pane,
     PaneWindowGeometry, PaneWindowMode, SceneConfig, SnapConfig, SnapMode, WindowedPane,
@@ -28,6 +29,7 @@ pub use style_config::style_config;
 pub use tab::{Tab, TabResponse};
 
 pub mod checkbox_enabled;
+pub mod ext_pane;
 pub mod gantz;
 pub mod global_config;
 pub mod graph_config;

--- a/crates/gantz_egui/src/widget.rs
+++ b/crates/gantz_egui/src/widget.rs
@@ -2,7 +2,7 @@
 use time::{OffsetDateTime, UtcOffset, format_description};
 
 pub use checkbox_enabled::CheckboxEnabled;
-pub use ext_pane::ExtPane;
+pub use ext_pane::{ExtPane, ExtPaneCtx, ExtPaneEntry};
 pub use gantz::{
     AlignConfig, BaseSourcesCtx, Gantz, GantzState, GridConfig, LayoutConfig, NodeViewPane, Pane,
     PaneWindowGeometry, PaneWindowMode, SceneConfig, SnapConfig, SnapMode, WindowedPane,

--- a/crates/gantz_egui/src/widget/ext_pane.rs
+++ b/crates/gantz_egui/src/widget/ext_pane.rs
@@ -1,0 +1,37 @@
+//! Application-supplied top-level panes (see [`ExtPane`]).
+
+use crate::Responses;
+
+/// An application-supplied top-level pane - the pane analogue of
+/// [`SettingsTab`][super::SettingsTab].
+///
+/// Domains contribute their own panes by supplying implementations to the
+/// [`Gantz`][super::Gantz] widget via
+/// [`Gantz::ext_panes`][super::Gantz::ext_panes]. A pane typically holds a
+/// per-frame snapshot of its domain's data, and reports changes by pushing
+/// typed payloads into the returned [`Responses`] for the host to apply.
+///
+/// A supplied pane's tile is inserted into the tray on first sight of its
+/// [`key`][Self::key] and persists in the tile tree from then on. While no
+/// provider supplies the key (e.g. the owning domain is disabled), the tile
+/// renders a placeholder. Visibility defaults to hidden, toggled via
+/// Settings -> Panes like the built-in tray panes.
+pub trait ExtPane {
+    /// The pane's stable identity: persisted in the tile tree and keying its
+    /// pop-out window geometry. Unique among the supplied panes and stable
+    /// across sessions.
+    fn key(&self) -> &str;
+
+    /// The tab label. Suffixed with the focused head in the tab title, like
+    /// the built-in Steel pane.
+    fn title(&self) -> &str;
+
+    /// Hover text for the pane's Settings -> Panes visibility checkbox.
+    fn description(&self) -> &str {
+        ""
+    }
+
+    /// Render the pane's contents given the currently focused head (if any),
+    /// returning any change payloads.
+    fn ui(&mut self, focused: Option<&gantz_ca::Head>, ui: &mut egui::Ui) -> Responses;
+}

--- a/crates/gantz_egui/src/widget/ext_pane.rs
+++ b/crates/gantz_egui/src/widget/ext_pane.rs
@@ -1,6 +1,7 @@
 //! Application-supplied top-level panes (see [`ExtPane`]).
 
 use crate::Responses;
+use gantz_core::node;
 
 /// An application-supplied top-level pane - the pane analogue of
 /// [`SettingsTab`][super::SettingsTab].
@@ -31,7 +32,33 @@ pub trait ExtPane {
         ""
     }
 
-    /// Render the pane's contents given the currently focused head (if any),
-    /// returning any change payloads.
-    fn ui(&mut self, focused: Option<&gantz_ca::Head>, ui: &mut egui::Ui) -> Responses;
+    /// Render the pane's contents, returning any change payloads.
+    fn ui(&mut self, cx: ExtPaneCtx, ui: &mut egui::Ui) -> Responses;
+}
+
+/// The context handed to [`ExtPane::ui`] - what the widget knows about the
+/// focused head that a pane might want to follow (the built-in Steel pane's
+/// inputs, roughly).
+///
+/// `#[non_exhaustive]` so future context reaches panes without breaking
+/// implementors: only the widget constructs one.
+#[non_exhaustive]
+pub struct ExtPaneCtx<'a> {
+    /// The currently focused head, if any.
+    pub focused: Option<&'a gantz_ca::Head>,
+    /// The focused head's selected nodes (root-level indices), sorted.
+    pub selection: &'a [node::Id],
+}
+
+/// One supplied extension pane's identity and labels, for the pane-visibility
+/// checkbox UIs (Settings -> Panes and the graph-area context menu's "panes"
+/// submenu - see [`panes_config`][super::panes_config()]).
+#[derive(Clone, Debug)]
+pub struct ExtPaneEntry {
+    /// The pane's stable identity ([`ExtPane::key`]).
+    pub key: String,
+    /// The checkbox label ([`ExtPane::title`]).
+    pub title: String,
+    /// The checkbox hover text ([`ExtPane::description`]).
+    pub description: String,
 }

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -1447,6 +1447,9 @@ where
             // We'll use this to position the floating sidebar toggle.
             let rect = ui.available_rect_before_wrap();
 
+            // Extension-pane toggle entries for the graph-area context menu.
+            let ext_panes = ext_pane_entries(gantz);
+
             // Retrieve the inner graph tree from persistent storage, or create empty.
             let graph_tree_id = egui::Id::new(GRAPH_TREE_ID);
             let mut graph_tree: egui_tiles::Tree<GraphPane> =
@@ -1477,6 +1480,7 @@ where
                 reindexes: &mut gantz_response.node_view_reindexes,
                 base_names,
                 base_immutable: gantz.base_immutable,
+                ext_panes: &ext_panes,
             };
             graph_tree.ui(&mut graph_behaviour, ui);
 
@@ -1836,17 +1840,7 @@ where
         Pane::Settings => {
             let compile_config = gantz.compile_config;
             let validate_change_tracking = gantz.validate_change_tracking;
-            let ext_panes: Vec<(String, String, String)> = gantz
-                .ext_panes
-                .iter()
-                .map(|p| {
-                    (
-                        p.key().to_string(),
-                        p.title().to_string(),
-                        p.description().to_string(),
-                    )
-                })
-                .collect();
+            let ext_panes = ext_pane_entries(gantz);
             let ext_tabs = &mut *gantz.settings_tabs;
             let res = pane_ui(ui, |ui| {
                 widget::settings(
@@ -1904,6 +1898,9 @@ where
     reindexes: &'a mut Vec<(gantz_ca::Head, crate::ops::Reindex)>,
     base_names: &'a gantz_ca::registry::Names,
     base_immutable: bool,
+    /// Extension-pane toggle entries for the scene's "Panes" context submenu
+    /// (see [`ext_pane_entries`]).
+    ext_panes: &'a [(String, String, String)],
 }
 
 impl<'a, Access> egui_tiles::Behavior<GraphPane> for GraphTreeBehaviour<'a, Access>
@@ -2120,6 +2117,7 @@ where
                 pane_head,
                 head_state,
                 view_toggles,
+                self.ext_panes,
                 data.view,
                 layout_params,
                 scene_config,
@@ -2646,6 +2644,24 @@ fn linear_child_points(
     (total > 0.0).then(|| available * l.shares[child] / total)
 }
 
+/// The supplied extension panes as `(key, title, description)` entries - the
+/// single source both pane-toggle UIs (Settings -> Panes and the graph-area
+/// context menu's "panes" submenu) render their checkboxes from, so a new
+/// pane cannot appear in one and not the other.
+fn ext_pane_entries(gantz: &Gantz) -> Vec<(String, String, String)> {
+    gantz
+        .ext_panes
+        .iter()
+        .map(|p| {
+            (
+                p.key().to_string(),
+                p.title().to_string(),
+                p.description().to_string(),
+            )
+        })
+        .collect()
+}
+
 /// Whether a tab's pane can be hidden via its right-click menu. The main graph
 /// scene is not hideable; node views are closed (removed), not hidden.
 fn pane_is_hideable(pane: &Pane) -> bool {
@@ -3049,6 +3065,7 @@ fn graph_scene<N>(
     head: &gantz_ca::Head,
     head_state: &mut OpenHeadState,
     view_toggles: &mut ViewToggles,
+    ext_panes: &[(String, String, String)],
     head_view: &mut crate::SceneView,
     layout_params: egui_graph::LayoutParams,
     scene_config: SceneConfig,
@@ -3096,6 +3113,7 @@ where
         .scene_config(scene_config)
         .immutable(immutable)
         .view_toggles(view_toggles)
+        .ext_panes(ext_panes)
         .show(head_view, &mut head_state.scene, vm, ui);
 
     graph_scene::paint_diagnostics(diagnostics, &[], &response, ui);

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use gantz_core::{Node, node};
 use petgraph::visit::{IntoNodeReferences, NodeRef};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use steel::steel_vm::engine::Engine;
 
 /// A file dropped onto a gantz pane.
@@ -63,6 +63,7 @@ pub struct Gantz<'a> {
     compile_config: Option<gantz_core::compile::Config>,
     validate_change_tracking: Option<bool>,
     settings_tabs: &'a mut [&'a mut dyn widget::SettingsTab],
+    ext_panes: &'a mut [&'a mut dyn widget::ExtPane],
     ref_ext_uis: &'a [&'a dyn crate::node::RefExtUi],
     base_sources: Option<BaseSourcesCtx<'a>>,
     pane_window_mode: PaneWindowMode,
@@ -390,6 +391,10 @@ impl SceneConfig {
 /// A pane within the outer tree.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub enum Pane {
+    /// An application-supplied pane, identified by its provider's stable key
+    /// (see [`ExtPane::key`][widget::ExtPane::key]). Renders a placeholder
+    /// while no provider supplies the key.
+    Ext(String),
     GraphConfig,
     /// Contains the inner graph tree with all open graph tabs.
     GraphScene,
@@ -670,6 +675,10 @@ pub struct ViewToggles {
     pub perf_vm: bool,
     pub steel: bool,
     pub graph_config: bool,
+    /// Per-[`Pane::Ext`] visibility, keyed by the provider key. A missing
+    /// entry means hidden (matching the tray panes' default). Keys of
+    /// long-gone providers linger harmlessly.
+    pub ext: BTreeMap<String, bool>,
 }
 
 impl Default for ViewToggles {
@@ -689,6 +698,7 @@ impl Default for ViewToggles {
             perf_vm: false,
             steel: false,
             graph_config: true,
+            ext: BTreeMap::new(),
         }
     }
 }
@@ -779,6 +789,7 @@ impl<'a> Gantz<'a> {
             compile_config: None,
             validate_change_tracking: None,
             settings_tabs: &mut [],
+            ext_panes: &mut [],
             ref_ext_uis: &[],
             base_sources: None,
             pane_window_mode: PaneWindowMode::default(),
@@ -820,6 +831,14 @@ impl<'a> Gantz<'a> {
     /// [`GantzResponse::responses`].
     pub fn settings_tabs(mut self, tabs: &'a mut [&'a mut dyn widget::SettingsTab]) -> Self {
         self.settings_tabs = tabs;
+        self
+    }
+
+    /// Provide extension top-level panes (see [`ExtPane`][widget::ExtPane]).
+    /// One tray tile appears per entry, and any payloads a pane emits are
+    /// reported via [`GantzResponse::responses`] tagged with the focused head.
+    pub fn ext_panes(mut self, panes: &'a mut [&'a mut dyn widget::ExtPane]) -> Self {
+        self.ext_panes = panes;
         self
     }
 
@@ -919,6 +938,10 @@ impl<'a> Gantz<'a> {
 
         // The set of panes popped out into windows, persisted alongside the tree.
         let mut windowed: Vec<Pane> = load_ron(ui.ctx(), windowed_panes_id()).unwrap_or_default();
+
+        // Ensure every supplied extension pane has a tile.
+        let ext_keys: Vec<&str> = self.ext_panes.iter().map(|p| p.key()).collect();
+        sync_ext_panes(&mut tree, &ext_keys);
 
         // Check the `view_toggles` match the pane visibility.
         set_tile_visibility(&mut tree, &state.view_toggles);
@@ -1320,6 +1343,23 @@ where
         response: gantz_response,
     } = cx;
     match pane {
+        Pane::Ext(key) => {
+            let focused = access.heads().get(*focused_head).cloned();
+            match gantz.ext_panes.iter_mut().find(|p| p.key() == *key) {
+                Some(p) => {
+                    let res = pane_ui(ui, |ui| p.ui(focused.as_ref(), ui));
+                    let mut ext_responses = res.inner;
+                    gantz_response
+                        .responses
+                        .extend(focused.as_ref(), ext_responses.drain().map(|(_, d)| d));
+                }
+                None => {
+                    ui.centered_and_justified(|ui| {
+                        ui.weak(format!("'{key}' pane unavailable (no provider)"));
+                    });
+                }
+            }
+        }
         Pane::GraphConfig => match access.heads().get(*focused_head).cloned() {
             Some(head) => {
                 let merge_resolutions = &mut state.merge_resolutions;
@@ -1796,6 +1836,17 @@ where
         Pane::Settings => {
             let compile_config = gantz.compile_config;
             let validate_change_tracking = gantz.validate_change_tracking;
+            let ext_panes: Vec<(String, String, String)> = gantz
+                .ext_panes
+                .iter()
+                .map(|p| {
+                    (
+                        p.key().to_string(),
+                        p.title().to_string(),
+                        p.description().to_string(),
+                    )
+                })
+                .collect();
             let ext_tabs = &mut *gantz.settings_tabs;
             let res = pane_ui(ui, |ui| {
                 widget::settings(
@@ -1806,6 +1857,7 @@ where
                     &mut state.scene_config,
                     &mut state.keymap,
                     ext_tabs,
+                    &ext_panes,
                     ui,
                 )
             });
@@ -2141,6 +2193,10 @@ where
         None => label.to_string(),
     };
     match pane {
+        Pane::Ext(key) => match gantz.ext_panes.iter().find(|p| p.key() == *key) {
+            Some(p) => with_head(p.title()),
+            None => key.clone(),
+        },
         Pane::GraphConfig => with_head("Graph"),
         Pane::GraphScene => "Graphs".to_string(),
         Pane::Graphs => "Graphs".to_string(),
@@ -2301,6 +2357,28 @@ fn add_node_view_pane(
     match container {
         Some(c) => tree.move_tile_to_container(pane_id, c, usize::MAX, true),
         None => tree.root = Some(pane_id),
+    }
+}
+
+/// Ensure a [`Pane::Ext`] tile exists for each supplied provider key, adding
+/// missing ones to the tray (hidden until toggled, like Logs/Steel). Tiles
+/// whose provider is absent are left in place: they render a placeholder and
+/// keep their spot in the layout for when the provider returns.
+fn sync_ext_panes(tree: &mut egui_tiles::Tree<Pane>, keys: &[&str]) {
+    for &key in keys {
+        let exists = tree
+            .tiles
+            .iter()
+            .any(|(_, tile)| matches!(tile, egui_tiles::Tile::Pane(Pane::Ext(k)) if k == key));
+        if exists {
+            continue;
+        }
+        let pane_id = tree.tiles.insert_pane(Pane::Ext(key.to_string()));
+        let container = layout_anchors(tree).map(|a| a.tray).or_else(|| tree.root());
+        match container {
+            Some(c) => tree.move_tile_to_container(pane_id, c, usize::MAX, true),
+            None => tree.root = Some(pane_id),
+        }
     }
 }
 
@@ -2577,6 +2655,9 @@ fn pane_is_hideable(pane: &Pane) -> bool {
 /// Set a pane's visibility toggle. No-op for panes without one.
 fn set_pane_visible(view: &mut ViewToggles, pane: &Pane, visible: bool) {
     match pane {
+        Pane::Ext(key) => {
+            view.ext.insert(key.clone(), visible);
+        }
         Pane::Graphs => view.graphs = visible,
         Pane::History => view.history = visible,
         Pane::Settings => view.settings = visible,
@@ -2595,6 +2676,7 @@ fn set_pane_visible(view: &mut ViewToggles, pane: &Pane, visible: bool) {
 /// (the graph scene and node views) are always considered visible.
 fn pane_is_visible(view: &ViewToggles, pane: &Pane) -> bool {
     match pane {
+        Pane::Ext(key) => view.ext.get(key).copied().unwrap_or(false),
         Pane::Graphs => view.graphs,
         Pane::History => view.history,
         Pane::Settings => view.settings,
@@ -2621,6 +2703,7 @@ fn pane_is_poppable(pane: &Pane) -> bool {
 /// ([`GantzState::windowed_geometry`]) by the same identity.
 pub fn pane_key(pane: &Pane) -> String {
     match pane {
+        Pane::Ext(key) => format!("ext:{key}"),
         Pane::GraphConfig => "graph-config".to_string(),
         Pane::GraphScene => "graph-scene".to_string(),
         Pane::Graphs => "graphs".to_string(),
@@ -2774,6 +2857,7 @@ fn set_tile_visibility(tree: &mut egui_tiles::Tree<Pane>, view: &ViewToggles) {
         if let Some(pane) = tree.tiles.get_pane(&id) {
             match pane {
                 Pane::GraphScene => (),
+                Pane::Ext(key) => tree.set_visible(id, view.ext.get(key).copied().unwrap_or(false)),
                 Pane::Settings => tree.set_visible(id, open && view.settings),
                 Pane::GraphConfig => tree.set_visible(id, open && view.graph_config),
                 Pane::Graphs => tree.set_visible(id, open && view.graphs),

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -1345,9 +1345,29 @@ where
     match pane {
         Pane::Ext(key) => {
             let focused = access.heads().get(*focused_head).cloned();
+            // The focused head's selection, as sorted root-level node ids
+            // (mirroring the Steel pane's span-highlight input).
+            let mut selection: Vec<node::Id> = focused
+                .as_ref()
+                .and_then(|h| state.open_heads.get(h))
+                .map(|hs| {
+                    hs.scene
+                        .interaction
+                        .selection
+                        .nodes
+                        .iter()
+                        .map(|n| n.index())
+                        .collect()
+                })
+                .unwrap_or_default();
+            selection.sort_unstable();
             match gantz.ext_panes.iter_mut().find(|p| p.key() == *key) {
                 Some(p) => {
-                    let res = pane_ui(ui, |ui| p.ui(focused.as_ref(), ui));
+                    let cx = widget::ExtPaneCtx {
+                        focused: focused.as_ref(),
+                        selection: &selection,
+                    };
+                    let res = pane_ui(ui, |ui| p.ui(cx, ui));
                     let mut ext_responses = res.inner;
                     gantz_response
                         .responses
@@ -1900,7 +1920,7 @@ where
     base_immutable: bool,
     /// Extension-pane toggle entries for the scene's "Panes" context submenu
     /// (see [`ext_pane_entries`]).
-    ext_panes: &'a [(String, String, String)],
+    ext_panes: &'a [widget::ExtPaneEntry],
 }
 
 impl<'a, Access> egui_tiles::Behavior<GraphPane> for GraphTreeBehaviour<'a, Access>
@@ -2644,20 +2664,18 @@ fn linear_child_points(
     (total > 0.0).then(|| available * l.shares[child] / total)
 }
 
-/// The supplied extension panes as `(key, title, description)` entries - the
-/// single source both pane-toggle UIs (Settings -> Panes and the graph-area
-/// context menu's "panes" submenu) render their checkboxes from, so a new
-/// pane cannot appear in one and not the other.
-fn ext_pane_entries(gantz: &Gantz) -> Vec<(String, String, String)> {
+/// The supplied extension panes' checkbox entries - the single source both
+/// pane-toggle UIs (Settings -> Panes and the graph-area context menu's
+/// "panes" submenu) render from, so a new pane cannot appear in one and not
+/// the other.
+fn ext_pane_entries(gantz: &Gantz) -> Vec<widget::ExtPaneEntry> {
     gantz
         .ext_panes
         .iter()
-        .map(|p| {
-            (
-                p.key().to_string(),
-                p.title().to_string(),
-                p.description().to_string(),
-            )
+        .map(|p| widget::ExtPaneEntry {
+            key: p.key().to_string(),
+            title: p.title().to_string(),
+            description: p.description().to_string(),
         })
         .collect()
 }
@@ -3065,7 +3083,7 @@ fn graph_scene<N>(
     head: &gantz_ca::Head,
     head_state: &mut OpenHeadState,
     view_toggles: &mut ViewToggles,
-    ext_panes: &[(String, String, String)],
+    ext_panes: &[widget::ExtPaneEntry],
     head_view: &mut crate::SceneView,
     layout_params: egui_graph::LayoutParams,
     scene_config: SceneConfig,

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -68,6 +68,9 @@ pub struct GraphScene<'a, N> {
     /// When set, the background context menu gains a "Panes" submenu of
     /// pane-visibility checkboxes.
     view_toggles: Option<&'a mut crate::widget::gantz::ViewToggles>,
+    /// The supplied extension panes as `(key, title, description)`, for the
+    /// "Panes" submenu's checkboxes (see [`panes_config`][super::panes_config()]).
+    ext_panes: &'a [(String, String, String)],
 }
 
 /// State associated with the [`GraphScene`] widget that can be useful to access
@@ -126,6 +129,7 @@ where
             scene_config: Default::default(),
             immutable: false,
             view_toggles: None,
+            ext_panes: &[],
         }
     }
 
@@ -170,6 +174,14 @@ where
     /// background (graph-area) context menu. Available even in immutable mode.
     pub fn view_toggles(mut self, view_toggles: &'a mut crate::widget::gantz::ViewToggles) -> Self {
         self.view_toggles = Some(view_toggles);
+        self
+    }
+
+    /// Provide the extension-pane entries (`(key, title, description)`) so the
+    /// "Panes" context submenu lists them alongside the built-in panes,
+    /// matching Settings -> Panes.
+    pub fn ext_panes(mut self, ext_panes: &'a [(String, String, String)]) -> Self {
+        self.ext_panes = ext_panes;
         self
     }
 
@@ -310,6 +322,7 @@ where
         // submenu for toggling pane visibility (available even when immutable).
         let immutable = self.immutable;
         let view_toggles = self.view_toggles;
+        let ext_panes = self.ext_panes;
         let mut reset_layout = false;
         let mut request_layout = false;
         let mut request_center = false;
@@ -357,9 +370,7 @@ where
                 }
                 if let Some(view) = view_toggles {
                     ui.menu_button("panes", |ui| {
-                        // Extension panes are toggled from Settings -> Panes;
-                        // the scene widget has no access to the supplied list.
-                        crate::widget::panes_config(view, &[], ui);
+                        crate::widget::panes_config(view, ext_panes, ui);
                         ui.separator();
                         if crate::widget::reset_layout_button(ui) {
                             reset_layout = true;

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -357,7 +357,9 @@ where
                 }
                 if let Some(view) = view_toggles {
                     ui.menu_button("panes", |ui| {
-                        crate::widget::panes_config(view, ui);
+                        // Extension panes are toggled from Settings -> Panes;
+                        // the scene widget has no access to the supplied list.
+                        crate::widget::panes_config(view, &[], ui);
                         ui.separator();
                         if crate::widget::reset_layout_button(ui) {
                             reset_layout = true;

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -68,9 +68,9 @@ pub struct GraphScene<'a, N> {
     /// When set, the background context menu gains a "Panes" submenu of
     /// pane-visibility checkboxes.
     view_toggles: Option<&'a mut crate::widget::gantz::ViewToggles>,
-    /// The supplied extension panes as `(key, title, description)`, for the
-    /// "Panes" submenu's checkboxes (see [`panes_config`][super::panes_config()]).
-    ext_panes: &'a [(String, String, String)],
+    /// The supplied extension panes, for the "Panes" submenu's checkboxes
+    /// (see [`panes_config`][super::panes_config()]).
+    ext_panes: &'a [crate::widget::ExtPaneEntry],
 }
 
 /// State associated with the [`GraphScene`] widget that can be useful to access
@@ -177,10 +177,9 @@ where
         self
     }
 
-    /// Provide the extension-pane entries (`(key, title, description)`) so the
-    /// "Panes" context submenu lists them alongside the built-in panes,
-    /// matching Settings -> Panes.
-    pub fn ext_panes(mut self, ext_panes: &'a [(String, String, String)]) -> Self {
+    /// Provide the extension-pane entries so the "Panes" context submenu
+    /// lists them alongside the built-in panes, matching Settings -> Panes.
+    pub fn ext_panes(mut self, ext_panes: &'a [crate::widget::ExtPaneEntry]) -> Self {
         self.ext_panes = ext_panes;
         self
     }

--- a/crates/gantz_egui/src/widget/panes_config.rs
+++ b/crates/gantz_egui/src/widget/panes_config.rs
@@ -5,7 +5,11 @@
 use super::gantz::ViewToggles;
 
 /// Render the per-pane visibility checkboxes.
-pub fn panes_config(view: &mut ViewToggles, ui: &mut egui::Ui) {
+///
+/// `ext` lists the supplied extension panes as `(key, title, description)`
+/// (see [`ExtPane`][super::ExtPane]) - one checkbox per entry after the
+/// built-in tray panes.
+pub fn panes_config(view: &mut ViewToggles, ext: &[(String, String, String)], ui: &mut egui::Ui) {
     // Sidebar panes: enabling one also opens the sidebar if it is closed, so
     // the toggle has a visible effect (e.g. from the graph-area context menu).
     sidebar_pane(
@@ -62,6 +66,11 @@ pub fn panes_config(view: &mut ViewToggles, ui: &mut egui::Ui) {
         .on_hover_text("Log output from the running graphs.");
     ui.checkbox(&mut view.steel, "Steel")
         .on_hover_text("The compiled Steel code for the focused graph.");
+    for (key, title, description) in ext {
+        let on = view.ext.entry(key.clone()).or_insert(false);
+        ui.checkbox(on, title.as_str())
+            .on_hover_text(description.as_str());
+    }
 }
 
 /// Render the "reset all" layout button. Returns `true` when clicked.

--- a/crates/gantz_egui/src/widget/panes_config.rs
+++ b/crates/gantz_egui/src/widget/panes_config.rs
@@ -6,10 +6,9 @@ use super::gantz::ViewToggles;
 
 /// Render the per-pane visibility checkboxes.
 ///
-/// `ext` lists the supplied extension panes as `(key, title, description)`
-/// (see [`ExtPane`][super::ExtPane]) - one checkbox per entry after the
-/// built-in tray panes.
-pub fn panes_config(view: &mut ViewToggles, ext: &[(String, String, String)], ui: &mut egui::Ui) {
+/// `ext` lists the supplied extension panes (see [`ExtPane`][super::ExtPane])
+/// - one checkbox per entry after the built-in tray panes.
+pub fn panes_config(view: &mut ViewToggles, ext: &[super::ExtPaneEntry], ui: &mut egui::Ui) {
     // Sidebar panes: enabling one also opens the sidebar if it is closed, so
     // the toggle has a visible effect (e.g. from the graph-area context menu).
     sidebar_pane(
@@ -66,10 +65,10 @@ pub fn panes_config(view: &mut ViewToggles, ext: &[(String, String, String)], ui
         .on_hover_text("Log output from the running graphs.");
     ui.checkbox(&mut view.steel, "Steel")
         .on_hover_text("The compiled Steel code for the focused graph.");
-    for (key, title, description) in ext {
-        let on = view.ext.entry(key.clone()).or_insert(false);
-        ui.checkbox(on, title.as_str())
-            .on_hover_text(description.as_str());
+    for entry in ext {
+        let on = view.ext.entry(entry.key.clone()).or_insert(false);
+        ui.checkbox(on, entry.title.as_str())
+            .on_hover_text(entry.description.as_str());
     }
 }
 

--- a/crates/gantz_egui/src/widget/settings.rs
+++ b/crates/gantz_egui/src/widget/settings.rs
@@ -51,6 +51,10 @@ pub struct SettingsResponse {
 
 /// Render the Settings pane: a subtab selector over Global / Style / Keybinds /
 /// Panes and any supplied extension subtabs.
+///
+/// `ext_panes` lists the supplied extension panes as
+/// `(key, title, description)` for the Panes subtab's visibility checkboxes
+/// (see [`panes_config`][super::panes_config]).
 pub fn settings(
     view: &mut ViewToggles,
     compile_config: Option<gantz_core::compile::Config>,
@@ -59,6 +63,7 @@ pub fn settings(
     scene_config: &mut SceneConfig,
     keymap: &mut Keymap,
     ext_tabs: &mut [&mut dyn SettingsTab],
+    ext_panes: &[(String, String, String)],
     ui: &mut egui::Ui,
 ) -> SettingsResponse {
     let id = ui.id().with("settings_subtab");
@@ -120,7 +125,7 @@ pub fn settings(
                 .show_inside(ui, |ui| {
                     egui::ScrollArea::vertical()
                         .auto_shrink([false, false])
-                        .show(ui, |ui| super::panes_config(view, ui));
+                        .show(ui, |ui| super::panes_config(view, ext_panes, ui));
                 });
         }
         SubTab::Style => {

--- a/crates/gantz_egui/src/widget/settings.rs
+++ b/crates/gantz_egui/src/widget/settings.rs
@@ -54,7 +54,7 @@ pub struct SettingsResponse {
 ///
 /// `ext_panes` lists the supplied extension panes as
 /// `(key, title, description)` for the Panes subtab's visibility checkboxes
-/// (see [`panes_config`][super::panes_config]).
+/// (see [`panes_config`][super::panes_config()]).
 pub fn settings(
     view: &mut ViewToggles,
     compile_config: Option<gantz_core::compile::Config>,

--- a/crates/gantz_egui/src/widget/settings.rs
+++ b/crates/gantz_egui/src/widget/settings.rs
@@ -52,9 +52,8 @@ pub struct SettingsResponse {
 /// Render the Settings pane: a subtab selector over Global / Style / Keybinds /
 /// Panes and any supplied extension subtabs.
 ///
-/// `ext_panes` lists the supplied extension panes as
-/// `(key, title, description)` for the Panes subtab's visibility checkboxes
-/// (see [`panes_config`][super::panes_config()]).
+/// `ext_panes` lists the supplied extension panes for the Panes subtab's
+/// visibility checkboxes (see [`panes_config`][super::panes_config()]).
 pub fn settings(
     view: &mut ViewToggles,
     compile_config: Option<gantz_core::compile::Config>,
@@ -63,7 +62,7 @@ pub fn settings(
     scene_config: &mut SceneConfig,
     keymap: &mut Keymap,
     ext_tabs: &mut [&mut dyn SettingsTab],
-    ext_panes: &[(String, String, String)],
+    ext_panes: &[super::ExtPaneEntry],
     ui: &mut egui::Ui,
 ) -> SettingsResponse {
     let id = ui.id().with("settings_subtab");

--- a/crates/gantz_plyphon/Cargo.toml
+++ b/crates/gantz_plyphon/Cargo.toml
@@ -28,6 +28,7 @@ log.workspace = true
 petgraph.workspace = true
 plyphon.workspace = true
 serde.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 petgraph.workspace = true

--- a/crates/gantz_plyphon/src/compile.rs
+++ b/crates/gantz_plyphon/src/compile.rs
@@ -18,19 +18,23 @@ use crate::dsp::{
 };
 
 /// An error deriving a synthdef from a graph.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum DeriveError {
     /// The graph has no dsp *sink* (no `~out` output and no `~scopeout` monitor), so
     /// there is nothing to root a synthdef at.
+    #[error("no dsp sink (no `~out` output and no `~scopeout` monitor)")]
     NoSink,
     /// The `~bus` boundaries form a cycle between regions, so there is no
     /// writer-before-reader order to derive (or run) them in. Deliberate
     /// cross-region feedback (an `InFeedback`-based bus) is a planned follow-up.
+    #[error("`~bus`/instance boundaries form a cycle between parts")]
     BusCycle,
     /// An instanced reference's target graph could not be resolved.
+    #[error("unresolved instanced reference: {0}")]
     Unresolved(gantz_ca::ContentAddr),
     /// Instanced references form a cycle (a graph transitively instancing
     /// itself), so there is no finite template to derive.
+    #[error("instanced references form a cycle through {0}")]
     RefCycle(gantz_ca::ContentAddr),
 }
 

--- a/crates/gantz_plyphon/src/compile.rs
+++ b/crates/gantz_plyphon/src/compile.rs
@@ -14,7 +14,8 @@ use gantz_core::node::Conns;
 use gantz_core::node::graph::{Graph, NodeIx};
 
 use crate::dsp::{
-    DspBuilder, GainRef, ParamBinding, ScopeOutBinding, Signal, ToNodeDsp, sum_signals,
+    DspBuilder, GainRef, ParamBinding, PortShapes, ScopeOutBinding, Signal, ToNodeDsp,
+    record_port_shapes, sum_signals,
 };
 
 /// An error deriving a synthdef from a graph.
@@ -109,6 +110,8 @@ pub struct Derived {
     /// The params that gate the def's whole output (e.g. `~out`'s gain), which
     /// the driver fades through on a crossfaded replacement.
     pub gains: Vec<GainRef>,
+    /// The width and rate each dsp output port carried, for diagnostics.
+    pub shapes: PortShapes,
 }
 
 /// Derive a [`SynthDef`] named `name` from a graph's DSP subgraph, fanning the
@@ -183,6 +186,7 @@ where
     // Each processed node's per-port output signals, for its consumers to
     // reference. A whole channel group flows across an edge.
     let mut outputs: HashMap<NodeIx, Vec<Signal>> = HashMap::new();
+    let mut shapes = PortShapes::new();
 
     for n in order {
         let Some(dsp) = graph[n].to_node_dsp() else {
@@ -201,12 +205,14 @@ where
                 (!sigs.is_empty()).then(|| sum_signals(&mut builder, &sigs))
             })
             .collect();
-        let outs = dsp.ugens(&graph[n].node_path(n.index()), &inputs, &mut builder);
+        let path = graph[n].node_path(n.index());
+        let outs = dsp.ugens(&path, &inputs, &mut builder);
         debug_assert_eq!(
             outs.len(),
             dsp.n_dsp_outputs(),
             "a node must return one Signal per dsp output port",
         );
+        record_port_shapes(&mut shapes, &builder, &path, &outs);
         outputs.insert(n, outs);
     }
 
@@ -216,6 +222,7 @@ where
         params,
         monitors,
         gains,
+        shapes,
     })
 }
 
@@ -552,6 +559,7 @@ where
 
         let mut builder = DspBuilder::new(out_channels);
         let mut outputs: HashMap<NodeIx, Vec<Signal>> = HashMap::new();
+        let mut shapes = PortShapes::new();
         let mut bus_reads: Vec<BusBinding> = Vec::new();
         // One `In` per bus read, shared by every consumer in the region.
         let mut in_signals: HashMap<RegionBus, Signal> = HashMap::new();
@@ -613,12 +621,14 @@ where
                 // it driven.
                 inputs.push((!sigs.is_empty()).then(|| sum_signals(&mut builder, &sigs)));
             }
-            let outs = dsp.ugens(&graph[n].node_path(n.index()), &inputs, &mut builder);
+            let path = graph[n].node_path(n.index());
+            let outs = dsp.ugens(&path, &inputs, &mut builder);
             debug_assert_eq!(
                 outs.len(),
                 dsp.n_dsp_outputs(),
                 "a node must return one Signal per dsp output port",
             );
+            record_port_shapes(&mut shapes, &builder, &path, &outs);
             outputs.insert(n, outs);
         }
 
@@ -694,6 +704,7 @@ where
                 params,
                 monitors,
                 gains,
+                shapes,
             },
             bus_writes,
             bus_reads,

--- a/crates/gantz_plyphon/src/config.rs
+++ b/crates/gantz_plyphon/src/config.rs
@@ -19,6 +19,34 @@ pub struct Config {
     pub enabled: bool,
 }
 
+/// The outcome of a head's most recent DSP derivation, written by the DSP
+/// runtime for the GUI to display (the per-head analogue of [`Status`]).
+///
+/// The error variants carry the rendered error message rather than the error
+/// value, keeping the type cheap to clone and the GUI decoupled from the
+/// error enums.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum DeriveStatus {
+    /// Nothing has been derived for the head yet (or no DSP engine is
+    /// running).
+    #[default]
+    Pending,
+    /// The graph has no dsp sink, so it is intentionally silent - not an
+    /// error.
+    Silent,
+    /// Derived and running.
+    Ok {
+        /// The number of resolved parts (synths) the head derived to.
+        parts: usize,
+    },
+    /// Flattening the head's nested graphs failed
+    /// (a rendered [`FlattenError`][crate::FlattenError]).
+    FlattenError(String),
+    /// Deriving the synthdef template failed
+    /// (a rendered [`DeriveError`][crate::DeriveError]).
+    DeriveError(String),
+}
+
 /// Read-only DSP status, written by the DSP runtime for the GUI to display.
 #[derive(Clone, Debug, Default)]
 pub struct Status {

--- a/crates/gantz_plyphon/src/describe.rs
+++ b/crates/gantz_plyphon/src/describe.rs
@@ -1,0 +1,168 @@
+//! A readable text rendering of a resolved DSP program, for diagnostics
+//! surfacing (the GUI's "DSP" pane).
+
+use std::fmt::Write;
+
+use plyphon::Rate;
+use plyphon::synthdef::{InputRef, UnitSpec};
+
+use crate::instance::{BusKey, ResolvedBus, ResolvedPart};
+
+/// Render a head's resolved DSP program - the parts the audio driver spawns,
+/// in part order - as readable text.
+///
+/// Per part: the def name and identity, its params (with bound node paths),
+/// its units, its monitors, the buses it writes and reads, and the width/rate
+/// each dsp output port carried at derive time
+/// ([`shapes`][ResolvedPart::shapes]).
+pub fn describe_parts(parts: &[ResolvedPart]) -> String {
+    let mut s = String::new();
+    for (i, part) in parts.iter().enumerate() {
+        if i > 0 {
+            s.push('\n');
+        }
+        describe_part(&mut s, i, part);
+    }
+    s
+}
+
+/// Render one part into `s`.
+fn describe_part(s: &mut String, i: usize, part: &ResolvedPart) {
+    let _ = writeln!(s, "part {i}: {}", part.def.name);
+    let _ = writeln!(s, "  key {:016x}  sig {:016x}", part.key, part.sig);
+
+    if !part.def.params.is_empty() {
+        let _ = writeln!(s, "  params:");
+        for (p, param) in part.def.params.iter().enumerate() {
+            let bound = part
+                .params
+                .iter()
+                .find(|b| b.index == p)
+                .map(|b| format!("  <- {:?}", b.node_path));
+            let fade = part.gains.iter().any(|g| g.index == p);
+            let trig = param.is_trig.then_some("  trig");
+            let lag = param.lag.map(|l| format!("  lag {l}"));
+            let _ = writeln!(
+                s,
+                "    p{p} {} = {} {}{}{}{}",
+                param.name,
+                param.default,
+                rate_token(param.rate),
+                trig.unwrap_or(""),
+                lag.as_deref().unwrap_or(""),
+                bound
+                    .as_deref()
+                    .unwrap_or(if fade { "  (driver fade)" } else { "" }),
+            );
+        }
+    }
+
+    let _ = writeln!(s, "  units:");
+    for (u, unit) in part.def.units.iter().enumerate() {
+        let _ = writeln!(s, "    u{u} {}", unit_str(unit));
+    }
+
+    for m in &part.monitors {
+        let _ = writeln!(
+            s,
+            "  monitor {:?}: {}ch ring {}",
+            m.node_path, m.channels, m.size,
+        );
+    }
+    for b in &part.bus_writes {
+        let _ = writeln!(s, "  writes {}", bus_str(b));
+    }
+    for b in &part.bus_reads {
+        let _ = writeln!(s, "  reads {}", bus_str(b));
+    }
+
+    if !part.shapes.is_empty() {
+        let _ = writeln!(s, "  ports:");
+        for ((path, port), shape) in &part.shapes {
+            let _ = writeln!(
+                s,
+                "    {path:?}.{port}: {}ch {}",
+                shape.width,
+                rate_token(shape.rate),
+            );
+        }
+    }
+}
+
+/// One unit as `Name rate (inputs) -> n_outs`, decoding a binary op's
+/// selector (e.g. `BinaryOpUGen[mul]`).
+fn unit_str(unit: &UnitSpec) -> String {
+    let op = match (unit.name.as_str(), unit.special_index) {
+        (_, 0) => String::new(),
+        ("BinaryOpUGen", i) => format!("[{}]", binary_op(i)),
+        (_, i) => format!("[{i}]"),
+    };
+    let inputs = unit
+        .inputs
+        .iter()
+        .map(input_str)
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "{}{op} {} ({inputs}) -> {}",
+        unit.name,
+        rate_token(unit.rate),
+        unit.num_outputs,
+    )
+}
+
+/// One input wire, compactly: a bare literal, `p2` (param) or `u3.0`
+/// (unit output).
+fn input_str(input: &InputRef) -> String {
+    match input {
+        InputRef::Constant(c) => format!("{c}"),
+        InputRef::Param(p) => format!("p{p}"),
+        InputRef::Unit { unit, output } => format!("u{unit}.{output}"),
+    }
+}
+
+/// One bus binding as `<key> Nch (u<unit>, p<param>)`.
+fn bus_str(b: &ResolvedBus) -> String {
+    format!(
+        "{} {}ch (u{}, p{})",
+        bus_key_str(&b.key),
+        b.channels,
+        b.unit,
+        b.param,
+    )
+}
+
+/// A bus key, compactly (absolute paths).
+fn bus_key_str(key: &BusKey) -> String {
+    match key {
+        BusKey::Bus(path) => format!("~bus {path:?}"),
+        BusKey::Src { path, output } => format!("src {path:?}.{output}"),
+        BusKey::InstOut {
+            path,
+            outlet,
+            summand,
+        } => format!("inst {path:?} outlet {outlet} summand {summand}"),
+        BusKey::IfaceIn { inlet, summand } => format!("inlet {inlet} summand {summand}"),
+    }
+}
+
+/// The display token of a [`Rate`]: `ar`/`kr`/`ir`/`dr`.
+fn rate_token(rate: Rate) -> &'static str {
+    match rate {
+        Rate::Audio => "ar",
+        Rate::Control => "kr",
+        Rate::Scalar => "ir",
+        Rate::Demand => "dr",
+    }
+}
+
+/// SC's `BinaryOpUGen` selector names (the ones derivation emits).
+fn binary_op(special_index: i16) -> String {
+    match special_index {
+        0 => "add".to_string(),
+        1 => "sub".to_string(),
+        2 => "mul".to_string(),
+        4 => "div".to_string(),
+        i => format!("op{i}"),
+    }
+}

--- a/crates/gantz_plyphon/src/dsp.rs
+++ b/crates/gantz_plyphon/src/dsp.rs
@@ -107,6 +107,24 @@ impl FromIterator<InputRef> for Signal {
     }
 }
 
+/// The channel width and rate a dsp output port's [`Signal`] carried at derive
+/// time (see [`PortShapes`]).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PortShape {
+    /// The number of channels the port carries.
+    pub width: usize,
+    /// The port's rate (see [`signal_rate`]).
+    pub rate: Rate,
+}
+
+/// Per-port shapes recorded during derivation, keyed by
+/// `(node path, dsp output port)`.
+///
+/// Covers exactly the ports derivation materialized a [`Signal`] for
+/// (dsp-reachable nodes) - a port with no entry contributed nothing to the
+/// derived program. A `BTreeMap` keeps any rendering of it deterministic.
+pub type PortShapes = std::collections::BTreeMap<(Vec<usize>, usize), PortShape>;
+
 /// A gantz node that contributes one or more plyphon UGens to a synthdef.
 ///
 /// This is the audio/DSP analogue of [`gantz_core::Node`]: where `Node::expr`
@@ -458,6 +476,39 @@ pub fn input_or_silent(inputs: &[Option<Signal>], i: usize) -> Signal {
         .cloned()
         .flatten()
         .unwrap_or_else(|| Signal::silent(1))
+}
+
+/// The rate of a channel group: audio if any channel is audio, else control
+/// if any is control, else scalar (a constant-only signal, e.g. baked
+/// silence).
+pub fn signal_rate(b: &DspBuilder, sig: &Signal) -> Rate {
+    let any = |rate: Rate| sig.channels().any(|ch| b.input_rate(&ch) == rate);
+    if any(Rate::Audio) {
+        Rate::Audio
+    } else if any(Rate::Control) {
+        Rate::Control
+    } else {
+        Rate::Scalar
+    }
+}
+
+/// Record one [`PortShape`] per output port of the node at `path` (with output
+/// [`Signal`]s `outs`) into `shapes`.
+pub(crate) fn record_port_shapes(
+    shapes: &mut PortShapes,
+    b: &DspBuilder,
+    path: &[usize],
+    outs: &[Signal],
+) {
+    let shape = |sig| PortShape {
+        width: Signal::width(sig),
+        rate: signal_rate(b, sig),
+    };
+    let entries = outs
+        .iter()
+        .enumerate()
+        .map(|(port, sig)| ((path.to_vec(), port), shape(sig)));
+    shapes.extend(entries);
 }
 
 /// Sum channel groups into one group: the unity-gain mix of every summand.

--- a/crates/gantz_plyphon/src/egui/mod.rs
+++ b/crates/gantz_plyphon/src/egui/mod.rs
@@ -8,10 +8,12 @@
 //! of the crate is headless by construction, so new UI code cannot
 //! accidentally leak egui into a `--no-default-features` build.
 
+pub use pane::{DSP_PANE_KEY, DspPane, DspPaneHead};
 pub use ref_ext::DspRefExtUi;
 pub use settings::DspSettingsTab;
 
 pub mod node;
+pub mod pane;
 pub mod param;
 pub mod ref_ext;
 pub mod settings;

--- a/crates/gantz_plyphon/src/egui/pane.rs
+++ b/crates/gantz_plyphon/src/egui/pane.rs
@@ -49,14 +49,14 @@ impl gantz_egui::widget::ExtPane for DspPane {
         "The focused graph's DSP derive status and derived program."
     }
 
-    fn ui(&mut self, focused: Option<&gantz_ca::Head>, ui: &mut egui::Ui) -> Responses {
+    fn ui(&mut self, cx: gantz_egui::widget::ExtPaneCtx, ui: &mut egui::Ui) -> Responses {
         if !self.present {
             ui.colored_label(
                 ui.visuals().warn_fg_color,
                 "No DSP output device - running silent.",
             );
         }
-        let Some(head) = focused else {
+        let Some(head) = cx.focused else {
             ui.weak("no focused graph");
             return Responses::default();
         };

--- a/crates/gantz_plyphon/src/egui/pane.rs
+++ b/crates/gantz_plyphon/src/egui/pane.rs
@@ -1,0 +1,100 @@
+//! The "DSP" top-level pane: the focused head's derive status and a readable
+//! rendering of its derived program (see
+//! [`describe_parts`][crate::describe_parts]).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use gantz_egui::Responses;
+
+use crate::DeriveStatus;
+
+/// The "DSP" pane's stable [`ExtPane::key`][gantz_egui::widget::ExtPane::key].
+pub const DSP_PANE_KEY: &str = "dsp";
+
+/// The "DSP" top-level pane, the domain's analogue of the built-in Steel
+/// pane: the focused head's derive status, with the derived program rendered
+/// as text on success.
+///
+/// Holds a per-frame snapshot of every open head's status so the pane follows
+/// whichever head is focused. Supplied to the
+/// [`Gantz`][gantz_egui::widget::Gantz] widget via
+/// [`ExtPane`][gantz_egui::widget::ExtPane].
+pub struct DspPane {
+    /// Whether a DSP output device is present (else the app runs silent).
+    pub present: bool,
+    /// Each open head's snapshot.
+    pub heads: HashMap<gantz_ca::Head, DspPaneHead>,
+}
+
+/// One head's snapshot within [`DspPane`].
+#[derive(Clone, Debug, Default)]
+pub struct DspPaneHead {
+    /// The most recent derivation's outcome.
+    pub status: DeriveStatus,
+    /// The derived program rendered as text, or the failure message.
+    pub view: Arc<str>,
+}
+
+impl gantz_egui::widget::ExtPane for DspPane {
+    fn key(&self) -> &str {
+        DSP_PANE_KEY
+    }
+
+    fn title(&self) -> &str {
+        "DSP"
+    }
+
+    fn description(&self) -> &str {
+        "The focused graph's DSP derive status and derived program."
+    }
+
+    fn ui(&mut self, focused: Option<&gantz_ca::Head>, ui: &mut egui::Ui) -> Responses {
+        if !self.present {
+            ui.colored_label(
+                ui.visuals().warn_fg_color,
+                "No DSP output device - running silent.",
+            );
+        }
+        let Some(head) = focused else {
+            ui.weak("no focused graph");
+            return Responses::default();
+        };
+        let snapshot = self.heads.get(head).cloned().unwrap_or_default();
+        derive_status_label(&snapshot.status, ui);
+        if let DeriveStatus::Ok { .. } = snapshot.status {
+            ui.separator();
+            egui::ScrollArea::both()
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    ui.add(
+                        egui::Label::new(egui::RichText::new(&*snapshot.view).monospace()).extend(),
+                    );
+                });
+        }
+        Responses::default()
+    }
+}
+
+/// One line summarising a [`DeriveStatus`]: weak for pending/silent, plain
+/// for ok, error-coloured (with the full message) for failures. Shared by
+/// the DSP pane and the settings tab's per-head grid.
+pub(crate) fn derive_status_label(status: &DeriveStatus, ui: &mut egui::Ui) {
+    match status {
+        DeriveStatus::Pending => {
+            ui.weak("pending - nothing derived yet");
+        }
+        DeriveStatus::Silent => {
+            ui.weak("silent - no dsp sink (~out / ~scopeout)");
+        }
+        DeriveStatus::Ok { parts } => {
+            ui.label(format!("ok - {parts} part(s)"));
+        }
+        DeriveStatus::FlattenError(e) | DeriveStatus::DeriveError(e) => {
+            // Truncated to the available width (errors can be long); the full
+            // message is on hover.
+            let text = egui::RichText::new(e).color(ui.visuals().error_fg_color);
+            ui.add(egui::Label::new(text).truncate()).on_hover_text(e);
+        }
+    }
+}

--- a/crates/gantz_plyphon/src/egui/settings.rs
+++ b/crates/gantz_plyphon/src/egui/settings.rs
@@ -1,11 +1,12 @@
 //! The DSP settings subtab: the dsp runtime's status plus a couple of live
 //! knobs (scheduling lead and mute).
 
-use crate::{Config, Status};
+use crate::{Config, DeriveStatus, Status};
 use gantz_egui::Responses;
 
-/// The DSP settings subtab: a read-only status readout plus a live
-/// scheduling-lead control and an enable/mute toggle.
+/// The DSP settings subtab: a read-only status readout, a live
+/// scheduling-lead control and an enable/mute toggle, plus each open head's
+/// derive status.
 ///
 /// Holds a per-frame snapshot of the domain's [`Config`] and [`Status`].
 /// Edits apply to the snapshot in place, and the full updated [`Config`] is
@@ -16,6 +17,8 @@ pub struct DspSettingsTab {
     pub config: Config,
     /// The read-only runtime status snapshot.
     pub status: Status,
+    /// Each open head's display name and derive status, in tab order.
+    pub heads: Vec<(String, DeriveStatus)>,
 }
 
 impl gantz_egui::widget::SettingsTab for DspSettingsTab {
@@ -88,6 +91,23 @@ impl gantz_egui::widget::SettingsTab for DspSettingsTab {
                 responses.push(None, self.config.clone());
             }
         });
+
+        // Each open head's derive status (the DSP pane shows the focused
+        // head's in full).
+        if !self.heads.is_empty() {
+            ui.separator();
+            ui.label("Graphs:");
+            egui::Grid::new("dsp_heads_grid")
+                .num_columns(2)
+                .spacing([12.0, 4.0])
+                .show(ui, |ui| {
+                    for (name, status) in &self.heads {
+                        ui.label(name);
+                        super::pane::derive_status_label(status, ui);
+                        ui.end_row();
+                    }
+                });
+        }
 
         responses
     }

--- a/crates/gantz_plyphon/src/flatten.rs
+++ b/crates/gantz_plyphon/src/flatten.rs
@@ -122,11 +122,13 @@ impl<N> Flat<N> {
 /// Both cases are defensive: the editor refuses to create ref cycles and the
 /// registry holds a committed graph for every ref it hands out, so neither
 /// should be reachable through the application.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum FlattenError {
     /// A graph ref (transitively) resolves through itself.
+    #[error("graph reference resolves through itself: {0}")]
     RefCycle(ContentAddr),
     /// A graph ref whose target graph could not be found.
+    #[error("unresolved graph reference: {0}")]
     Unresolved(ContentAddr),
 }
 

--- a/crates/gantz_plyphon/src/instance.rs
+++ b/crates/gantz_plyphon/src/instance.rs
@@ -76,7 +76,8 @@ use crate::compile::{
     DeriveError, content_def_name, derive_synthdefs, dsp_sinks, merged_pull_order, structural_sig,
 };
 use crate::dsp::{
-    DspBuilder, GainRef, ParamBinding, ScopeOutBinding, Signal, ToNodeDsp, sum_signals,
+    DspBuilder, GainRef, ParamBinding, PortShapes, ScopeOutBinding, Signal, ToNodeDsp,
+    record_port_shapes, sum_signals,
 };
 use crate::flatten::Flat;
 
@@ -182,6 +183,9 @@ pub struct TemplateRegion {
     pub bus_writes: Vec<TemplateBus>,
     /// The buses this region's def reads.
     pub bus_reads: Vec<TemplateBus>,
+    /// The width and rate each dsp output port carried (template-relative
+    /// node paths), for diagnostics.
+    pub shapes: PortShapes,
 }
 
 /// One part of a [`GraphTemplate`].
@@ -281,6 +285,9 @@ pub struct ResolvedPart {
     pub bus_writes: Vec<ResolvedBus>,
     /// The buses this part's synth reads (absolute keys).
     pub bus_reads: Vec<ResolvedBus>,
+    /// The width and rate each dsp output port carried (absolute node paths),
+    /// for diagnostics.
+    pub shapes: PortShapes,
 }
 
 /// A [`TemplateBus`] with its key made absolute.
@@ -478,6 +485,7 @@ where
                     gains: r.derived.gains,
                     bus_writes: r.bus_writes.into_iter().map(to_template).collect(),
                     bus_reads: r.bus_reads.into_iter().map(to_template).collect(),
+                    shapes: r.derived.shapes,
                 })
             })
             .collect();
@@ -1099,6 +1107,7 @@ where
 
     let mut builder = DspBuilder::new(out_channels);
     let mut outputs: HashMap<NodeIx, Vec<Signal>> = HashMap::new();
+    let mut shapes = PortShapes::new();
     let mut bus_reads: Vec<TemplateBus> = Vec::new();
     // One `In` per read key, shared by every consumer in the region.
     let mut in_signals: HashMap<BusKey, Signal> = HashMap::new();
@@ -1165,6 +1174,7 @@ where
             dsp.n_dsp_outputs(),
             "a node must return one Signal per dsp output port",
         );
+        record_port_shapes(&mut shapes, &builder, path, &outs);
         outputs.insert(n, outs);
     }
 
@@ -1239,6 +1249,7 @@ where
         gains,
         bus_writes,
         bus_reads,
+        shapes,
     })
 }
 
@@ -1460,6 +1471,11 @@ fn instantiate_into(
                     gains: r.gains.clone(),
                     bus_writes: r.bus_writes.iter().map(abs_bus).collect(),
                     bus_reads: r.bus_reads.iter().map(abs_bus).collect(),
+                    shapes: r
+                        .shapes
+                        .iter()
+                        .map(|((path, port), shape)| ((prefixed(path), *port), *shape))
+                        .collect(),
                 });
             }
             Part::Instance(ip) => {

--- a/crates/gantz_plyphon/src/lib.rs
+++ b/crates/gantz_plyphon/src/lib.rs
@@ -24,8 +24,8 @@ pub use compile::{
 };
 pub use config::{Config, Status};
 pub use dsp::{
-    DspBuilder, FADE_LAG, GainRef, NodeDsp, NodeRate, ParamBinding, ScopeOutBinding, Signal,
-    ToNodeDsp, node_dsp_of,
+    DspBuilder, FADE_LAG, GainRef, NodeDsp, NodeRate, ParamBinding, PortShape, PortShapes,
+    ScopeOutBinding, Signal, ToNodeDsp, node_dsp_of, signal_rate,
 };
 pub use flatten::{
     AsRefNode, Flat, FlattenError, RefKind, flatten, flatten_from_registry,

--- a/crates/gantz_plyphon/src/lib.rs
+++ b/crates/gantz_plyphon/src/lib.rs
@@ -41,7 +41,7 @@ pub use ref_ext::{DSP_REF_EXT_KEY, DspRefExt, dsp_commits};
 pub use sugar::PlyphonSugar;
 // `self::` disambiguates from the extern `egui` crate at the crate root.
 #[cfg(feature = "egui")]
-pub use self::egui::{DspRefExtUi, DspSettingsTab};
+pub use self::egui::{DSP_PANE_KEY, DspPane, DspPaneHead, DspRefExtUi, DspSettingsTab};
 
 pub mod backend;
 pub mod builtin;

--- a/crates/gantz_plyphon/src/lib.rs
+++ b/crates/gantz_plyphon/src/lib.rs
@@ -22,7 +22,8 @@ pub use compile::{
     BusBinding, DeriveError, Derived, RegionDerived, content_def_name, derive_synthdef,
     derive_synthdefs, structural_sig,
 };
-pub use config::{Config, Status};
+pub use config::{Config, DeriveStatus, Status};
+pub use describe::describe_parts;
 pub use dsp::{
     DspBuilder, FADE_LAG, GainRef, NodeDsp, NodeRate, ParamBinding, PortShape, PortShapes,
     ScopeOutBinding, Signal, ToNodeDsp, node_dsp_of, signal_rate,
@@ -46,6 +47,7 @@ pub mod backend;
 pub mod builtin;
 pub mod compile;
 pub mod config;
+pub mod describe;
 pub mod dsp;
 #[cfg(feature = "egui")]
 pub mod egui;

--- a/crates/gantz_plyphon/tests/derive_synthdef.rs
+++ b/crates/gantz_plyphon/tests/derive_synthdef.rs
@@ -451,6 +451,29 @@ fn graph_without_sink_is_rejected() {
 }
 
 #[test]
+fn derive_error_displays_readably() {
+    // Derive failures surface in the UI, so each variant formats as a
+    // readable message rather than a `Debug` dump.
+    let ca = gantz_ca::ContentAddr([9; 32]);
+    assert_eq!(
+        DeriveError::NoSink.to_string(),
+        "no dsp sink (no `~out` output and no `~scopeout` monitor)",
+    );
+    assert_eq!(
+        DeriveError::BusCycle.to_string(),
+        "`~bus`/instance boundaries form a cycle between parts",
+    );
+    assert_eq!(
+        DeriveError::Unresolved(ca).to_string(),
+        format!("unresolved instanced reference: {ca}"),
+    );
+    assert_eq!(
+        DeriveError::RefCycle(ca).to_string(),
+        format!("instanced references form a cycle through {ca}"),
+    );
+}
+
+#[test]
 fn scopeout_joins_output_in_one_def() {
     // `~sinosc -> ~out` and `~sinosc -> ~scopeout`: the tap is a second sink that shares the
     // sine's chain, so one synthdef carries SinOsc, Out and a ScopeOut, with a single

--- a/crates/gantz_plyphon/tests/derive_synthdef.rs
+++ b/crates/gantz_plyphon/tests/derive_synthdef.rs
@@ -5,8 +5,8 @@
 use gantz_core::edge::Edge;
 use gantz_core::node::graph::Graph;
 use gantz_plyphon::{
-    Backend, DeriveError, DspBuilder, Embedded, Lag, NodeDsp, NodeRate, Out, Pack, ScopeOut,
-    Signal, SinOsc, Sum, ToNodeDsp, Unpack, derive_synthdef, structural_sig,
+    Backend, DeriveError, DspBuilder, Embedded, Lag, NodeDsp, NodeRate, Out, Pack, PortShape,
+    ScopeOut, Signal, SinOsc, Sum, ToNodeDsp, Unpack, derive_synthdef, structural_sig,
 };
 use plyphon::synthdef::{InputRef, SynthDef, UnitSpec};
 use plyphon::{AddAction, Options, ROOT_GROUP_ID, Rate, World, engine};
@@ -448,6 +448,41 @@ fn graph_without_sink_is_rejected() {
         derive_synthdef(&g, 1, "nope"),
         Err(DeriveError::NoSink)
     ));
+}
+
+#[test]
+fn port_shapes_record_width_and_rate() {
+    // Every dsp output port derivation materializes a signal for gets a
+    // `(path, port) -> (width, rate)` entry. `~out` has no dsp outputs, so a
+    // bare `~sinosc -> ~out` records exactly the oscillator's port.
+    let derived = derive_synthdef(&sine_to_out(), 1, "t").expect("derive");
+    let shape = |w, r| PortShape { width: w, rate: r };
+    assert_eq!(
+        derived.shapes.iter().collect::<Vec<_>>(),
+        vec![(&(vec![0], 0), &shape(1, Rate::Audio))],
+    );
+
+    // Two oscs packed into one group: the pack's port is 2 wide.
+    let mut g = Graph::<N>::default();
+    let a = g.add_node(N::SinOsc(SinOsc::default()));
+    let b = g.add_node(N::SinOsc(SinOsc::default()));
+    let pk = g.add_node(N::Pack(Pack::default()));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(a, pk, Edge::new(0.into(), 0.into()));
+    g.add_edge(b, pk, Edge::new(0.into(), 1.into()));
+    g.add_edge(pk, o, Edge::new(0.into(), 0.into()));
+    let derived = derive_synthdef(&g, 1, "t").expect("derive");
+    assert_eq!(derived.shapes[&(vec![2], 0)], shape(2, Rate::Audio));
+
+    // A control-rate osc's port stays kr even though `~out` lifts it via K2A.
+    let mut g = Graph::<N>::default();
+    let mut sine = SinOsc::default();
+    sine.set_rate(NodeRate::Control);
+    let s = g.add_node(N::SinOsc(sine));
+    let o = g.add_node(N::Out(Out::default()));
+    g.add_edge(s, o, Edge::new(0.into(), 0.into()));
+    let derived = derive_synthdef(&g, 1, "t").expect("derive");
+    assert_eq!(derived.shapes[&(vec![0], 0)], shape(1, Rate::Control));
 }
 
 #[test]

--- a/crates/gantz_plyphon/tests/flatten.rs
+++ b/crates/gantz_plyphon/tests/flatten.rs
@@ -339,6 +339,20 @@ fn ref_cycle_and_unresolved_are_errors() {
 }
 
 #[test]
+fn flatten_error_displays_readably() {
+    // Flatten failures surface in the UI, so each variant formats as a
+    // readable message rather than a `Debug` dump.
+    assert_eq!(
+        FlattenError::RefCycle(ca(9)).to_string(),
+        format!("graph reference resolves through itself: {}", ca(9)),
+    );
+    assert_eq!(
+        FlattenError::Unresolved(ca(9)).to_string(),
+        format!("unresolved graph reference: {}", ca(9)),
+    );
+}
+
+#[test]
 fn boundary_wiring_cycle_dissolves() {
     // Two pass-through refs wired into a loop (sharing one committed child -
     // no *ref* cycle). Resolution terminates and the consumer dissolves

--- a/crates/gantz_plyphon/tests/instance.rs
+++ b/crates/gantz_plyphon/tests/instance.rs
@@ -588,6 +588,18 @@ fn recursive_instantiate_prefixes_paths() {
 }
 
 #[test]
+fn describe_parts_renders_readably() {
+    // Substring checks only - the exact layout is free to iterate.
+    let (template, cache) = derive(&sine_out_child(), &HashMap::new()).expect("derive");
+    let resolved = instantiate(&template, &cache);
+    let text = gantz_plyphon::describe_parts(&resolved);
+    assert!(text.contains(&resolved[0].def.name), "def name:\n{text}");
+    assert!(text.contains("SinOsc ar"), "unit lines:\n{text}");
+    assert!(text.contains("freq"), "param names:\n{text}");
+    assert!(text.contains("[0].0: 1ch ar"), "port shapes:\n{text}");
+}
+
+#[test]
 fn resolved_part_shapes_are_instance_prefixed() {
     // head -> I1(child: sine -> out): the child's osc port shape resolves at
     // the absolute path [I1, sine].

--- a/crates/gantz_plyphon/tests/instance.rs
+++ b/crates/gantz_plyphon/tests/instance.rs
@@ -588,6 +588,23 @@ fn recursive_instantiate_prefixes_paths() {
 }
 
 #[test]
+fn resolved_part_shapes_are_instance_prefixed() {
+    // head -> I1(child: sine -> out): the child's osc port shape resolves at
+    // the absolute path [I1, sine].
+    let map = HashMap::from([(ca(1), sine_out_child())]);
+    let mut g = Graph::<N>::default();
+    let i1 = g.add_node(N::Ref(ca(1), 0, 0));
+
+    let (template, cache) = derive(&g, &map).expect("derive");
+    let resolved = instantiate(&template, &cache);
+    assert_eq!(resolved.len(), 1);
+    let shapes = &resolved[0].shapes;
+    assert_eq!(shapes.len(), 1, "only the osc has a dsp output port");
+    let shape = shapes[&(vec![i1.index(), 0], 0)];
+    assert_eq!((shape.width, shape.rate), (1, plyphon::Rate::Audio));
+}
+
+#[test]
 fn instance_to_instance_shares_one_bus() {
     // I1's consumed outlet feeds I2's inlet: both sides resolve to ONE
     // absolute bus (the bus carrying I1's child outlet signal) - no relay.


### PR DESCRIPTION
## Summary

Introduces an extensible top-level pane system and the first implementation: a "DSP" pane that surfaces the focused graph's derive status and a readable rendering of the derived program.

## Changes

### `gantz_plyphon`
- **`DeriveStatus`** - enum with `Pending`, `Silent`, `Ok { parts }`, and error variants (`FlattenError`, `DeriveError`)
- **Per-port shape recording** - `PortShape` (width + rate) and `PortShapes` recorded during derivation, so each DSP output port's channel count and rate is known at the instance level
- **Program description** - `describe_parts()` renders a head's resolved DSP program as readable text: part identity, params (with bound node paths, fade/trig/lag metadata), units, monitors, bus bindings, and port shapes
- **`Display` impls** for `DeriveError` and `FlattenError` (readable error messages)
- New `dsp.rs` helpers: `signal_rate()` and `record_port_shapes()`

### `gantz_egui`
- **`ExtPane` trait** - application-supplied top-level pane interface (key, title, description, `ui`), analogous to `SettingsTab`
- **`Pane::Ext(String)`** - new variant in the outer pane tree, rendering a placeholder when no provider supplies the key
- Extension panes appear as tray tiles, persist in the tile tree, and are togglable via Settings -> Panes and the graph-area context menu
- **`ExtPaneCtx`** - context passed to pane `ui()`: focused head and selection

### `bevy_gantz_egui`
- **`ExtPanes` resource** - cleared each frame in `First`, refilled by domain providers in `PreUpdate`, consumed by both the main render path and the pane-windowed render path
- DSP pane (`DspPane`) registered as a domain extension pane, providing a per-frame snapshot of each head's derive status and rendering the derived program text on success

### Fixes
- Extension panes now listed in the graph-area "Panes" submenu (previously only visible in Settings)

## Example output

The DSP pane shows something like:

```
ok - 2 part(s)

part 0: SynthDef[~"my-synth"]
  key 0xabc...  sig 0xdef...
  params:
    p0 freq = 440.0 kr lag 0.05
    p0 <- u0.0
  units:
    u0 Oscil ar (p0, u1.0) -> 2
    u1 SinOsc ar (p0) -> 1
  writes ~bus [3] 2ch (u0, p0)
  ports:
    [0, 0].0: 2ch ar

part 1: SynthDef[~"other"]
  ...
```
