### PR TITLE
feat(gantz_egui): `gantz_ui` tree interpreter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,6 +3866,7 @@ dependencies = [
  "gantz_format",
  "gantz_nodetag",
  "gantz_std",
+ "gantz_ui",
  "hex",
  "humantime",
  "log",

--- a/crates/gantz_egui/Cargo.toml
+++ b/crates/gantz_egui/Cargo.toml
@@ -24,6 +24,7 @@ gantz_core.workspace = true
 gantz_format.workspace = true
 gantz_nodetag.workspace = true
 gantz_std.workspace = true
+gantz_ui.workspace = true
 hex.workspace = true
 humantime.workspace = true
 log.workspace = true

--- a/crates/gantz_egui/src/impls/bang.rs
+++ b/crates/gantz_egui/src/impls/bang.rs
@@ -1,4 +1,6 @@
-use crate::{NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind};
+use crate::{
+    NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind, node, ui_tree::UiTree,
+};
 
 impl NodeUi for gantz_std::Bang {
     fn name(&self, _: &dyn Registry) -> &str {
@@ -9,19 +11,23 @@ impl NodeUi for gantz_std::Bang {
         Some("Trigger downstream evaluation")
     }
 
-    fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
+    fn ui(&mut self, mut ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
         // A bang only triggers downstream evaluation; it never edits the
-        // node's content address, so we queue an eval but never mark `changed`.
-        let mut clicked = false;
+        // node's content address, so the button pushes but never `changed`.
+        let (&id, prefix) = ctx.path().split_last().expect("a node path is never empty");
+        let tree = fragment(id);
+        let root_id = uictx.egui_id().with("gui");
+        let mut payloads = Vec::new();
         let framed = uictx.framed(|ui, _sockets| {
-            let res = ui.add(egui::Button::new(" ! "));
-            clicked = res.clicked();
-            res
+            let r = UiTree::new(root_id)
+                .instance_prefix(prefix)
+                .n_outputs(&|_: &[node::Id]| Some(1))
+                .show(&tree, &mut ctx, ui);
+            payloads = r.payloads;
+            r.inner.unwrap_or_else(|| ui.response())
         });
         let mut resp = NodeUiResponse::new(framed);
-        if clicked {
-            resp.push_eval(ctx.path(), 1);
-        }
+        resp.payloads.extend(payloads);
         resp
     }
 
@@ -35,5 +41,30 @@ impl NodeUi for gantz_std::Bang {
                 Some(SocketDoc::ty("trigger").with_description("ignored; emits a bang when pushed"))
             }
         }
+    }
+}
+
+/// The bang's button fragment, bound to its own id. The padded label is the
+/// bang's visual, not an interpreter default.
+fn fragment(id: node::Id) -> gantz_ui::Element {
+    gantz_ui::Element::Button(gantz_ui::Button {
+        bind: Some(gantz_ui::BindPath(vec![id])),
+        label: Some(" ! ".to_string()),
+        key: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fragment_bakes_bind_and_label() {
+        let expected = gantz_ui::Element::Button(gantz_ui::Button {
+            bind: Some(gantz_ui::BindPath(vec![5])),
+            label: Some(" ! ".to_string()),
+            key: None,
+        });
+        assert_eq!(fragment(5), expected);
     }
 }

--- a/crates/gantz_egui/src/impls/number.rs
+++ b/crates/gantz_egui/src/impls/number.rs
@@ -1,6 +1,6 @@
 use crate::{
     ContextMenuResponse, InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse, NodeViewResponse,
-    Registry, SocketDoc, SocketKind,
+    Registry, SocketDoc, SocketKind, node, ui_tree::UiTree,
 };
 use gantz_std::number::Number;
 use steel::SteelVal;
@@ -16,33 +16,38 @@ impl NodeUi for Number {
 
     fn ui(&mut self, mut ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
         // The numeric value lives in VM runtime state, not the node weight, so
-        // editing the dialer does NOT change the graph's content address - we
-        // only queue an evaluation (when enabled), never mark `changed`.
+        // editing the dialer does NOT change the graph's content address - the
+        // interpreter only queues an evaluation (when enabled), never `changed`.
         let frame = egui_graph::node::default_frame(uictx.style(), uictx.interaction());
-        let frame_fill = frame.fill;
-        let mut do_eval = false;
+        let (&id, prefix) = ctx.path().split_last().expect("a node path is never empty");
+        let tree = fragment(self, id);
+        let root_id = uictx.egui_id().with("gui");
+        let mut payloads = Vec::new();
         let framed = uictx.framed_with(frame, |ui, _sockets| {
-            let (res, eval) = dialer_ui(self, &mut ctx, frame_fill, ui);
-            do_eval = eval;
-            res
+            let r = UiTree::new(root_id)
+                .instance_prefix(prefix)
+                .n_outputs(&|_: &[node::Id]| Some(1))
+                .show(&tree, &mut ctx, ui);
+            payloads = r.payloads;
+            r.inner.unwrap_or_else(|| ui.response())
         });
         let mut resp = NodeUiResponse::new(framed);
-        if do_eval {
-            resp.push_eval(ctx.path(), 1);
-        }
+        resp.payloads.extend(payloads);
         resp
     }
 
     fn view_ui(&mut self, mut ctx: NodeCtx, ui: &mut egui::Ui) -> NodeViewResponse {
-        // The same dialer as the in-graph node; the pane provides the background
-        // and margin. Editing updates VM state and (when enabled) queues an eval.
-        let bg = ui.visuals().panel_fill;
-        let (res, do_eval) = dialer_ui(self, &mut ctx, bg, ui);
+        // The same fragment as the in-graph node; the pane provides the
+        // background and margin.
+        let (&id, prefix) = ctx.path().split_last().expect("a node path is never empty");
+        let tree = fragment(self, id);
+        let r = UiTree::new(ui.id().with("gui"))
+            .instance_prefix(prefix)
+            .n_outputs(&|_: &[node::Id]| Some(1))
+            .show(&tree, &mut ctx, ui);
         let mut resp = NodeViewResponse::default();
-        resp.inner = Some(res);
-        if do_eval {
-            resp.push_eval(ctx.path(), 1);
-        }
+        resp.inner = r.inner;
+        resp.payloads = r.payloads;
         resp
     }
 
@@ -159,55 +164,17 @@ impl NodeUi for Number {
     }
 }
 
-/// Render the value dialer (updating VM state on edit), shared by the in-graph
-/// node body and the detached view. `bg` is the surrounding fill used to
-/// "flatten" the dialer when push-eval is off - a cue that editing won't fire
-/// downstream. Returns the dialer's response and whether a push-eval should fire
-/// (an edit happened and push-eval is enabled).
-fn dialer_ui(
-    num: &Number,
-    ctx: &mut NodeCtx,
-    bg: egui::Color32,
-    ui: &mut egui::Ui,
-) -> (egui::Response, bool) {
-    let push = num.push_eval_on_edit();
-    if !push {
-        let widgets = &mut ui.visuals_mut().widgets;
-        widgets.inactive.weak_bg_fill = bg;
-        widgets.inactive.bg_fill = bg;
-    }
-    let (min, max, precision) = (num.min(), num.max(), num.precision());
-    let mut val = ctx.extract_value().unwrap().unwrap();
-    let res = match val {
-        SteelVal::NumV(ref mut f) => {
-            let mut dv = egui::DragValue::new(f);
-            if min.is_some() || max.is_some() {
-                dv = dv.range(min.unwrap_or(f64::NEG_INFINITY)..=max.unwrap_or(f64::INFINITY));
-            }
-            if let Some(p) = precision {
-                dv = dv.max_decimals(p as usize);
-            }
-            ui.add(dv)
-        }
-        SteelVal::IntV(ref mut i) => {
-            let mut dv = egui::DragValue::new(i);
-            if min.is_some() || max.is_some() {
-                let lo = min.map_or(isize::MIN, |m| m as isize);
-                let hi = max.map_or(isize::MAX, |m| m as isize);
-                dv = dv.range(lo..=hi);
-            }
-            ui.add(dv)
-        }
-        _ => ui.add(egui::Label::new("ERR")),
-    };
-    let mut do_eval = false;
-    if res.changed() {
-        ctx.update_value(val).unwrap();
-        if push {
-            do_eval = true;
-        }
-    }
-    (res, do_eval)
+/// The number's dialer fragment, bound to its own state. Attrs come from the
+/// weight, and the bind id is the node's id in its defining graph.
+fn fragment(num: &Number, id: node::Id) -> gantz_ui::Element {
+    gantz_ui::Element::Dialer(gantz_ui::Dialer {
+        bind: Some(gantz_ui::BindPath(vec![id])),
+        min: num.min(),
+        max: num.max(),
+        precision: num.precision(),
+        push: num.push_eval_on_edit(),
+        ..Default::default()
+    })
 }
 
 /// Keep `max >= min` and re-clamp the stored value into the new bounds so the
@@ -248,5 +215,37 @@ fn clamp_value(num: &Number, val: &SteelVal) -> Option<SteelVal> {
             })
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fragment_bakes_weight_attrs_and_bind() {
+        let mut num = Number::default();
+        num.set_min(Some(0.0));
+        num.set_max(Some(10.0));
+        num.set_precision(Some(2));
+        num.set_push_eval_on_edit(false);
+        let expected = gantz_ui::Element::Dialer(gantz_ui::Dialer {
+            bind: Some(gantz_ui::BindPath(vec![3])),
+            min: Some(0.0),
+            max: Some(10.0),
+            precision: Some(2),
+            push: false,
+            ..Default::default()
+        });
+        assert_eq!(fragment(&num, 3), expected);
+    }
+
+    #[test]
+    fn default_weight_yields_default_dialer_attrs() {
+        let expected = gantz_ui::Element::Dialer(gantz_ui::Dialer {
+            bind: Some(gantz_ui::BindPath(vec![0])),
+            ..Default::default()
+        });
+        assert_eq!(fragment(&Number::default(), 0), expected);
     }
 }

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -847,6 +847,26 @@ impl<'a> NodeCtx<'a> {
         node::state::update(self.vm, self.path, val)
     }
 
+    /// Extract the state of the node at `path`, which need not be this
+    /// node's own path.
+    ///
+    /// Exists for the UI tree interpreter, whose widgets bind to node state
+    /// at resolved paths.
+    pub fn extract_value_at(&self, path: &[node::Id]) -> Result<Option<SteelVal>, SteelErr> {
+        node::state::extract_value(self.vm, path)
+    }
+
+    /// Register `val` as the new state of the node at `path`, which need not
+    /// be this node's own path.
+    ///
+    /// Exists for the UI tree interpreter, whose widgets bind to node state
+    /// at resolved paths. Like [`update_value`][Self::update_value], this
+    /// writes VM runtime state only and must never mark a response
+    /// `changed`.
+    pub fn update_value_at(&mut self, path: &[node::Id], val: SteelVal) -> Result<(), SteelErr> {
+        node::state::update_value(self.vm, path, val)
+    }
+
     /// The IDs of the inlets within the current graph.
     ///
     /// Primarily exposed so that `Inlet` nodes can present their index.

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -819,8 +819,12 @@ impl<'a> NodeCtx<'a> {
     }
 
     /// The node's full path into the state tree.
-    pub fn path(&self) -> &[node::Id] {
-        &self.path
+    ///
+    /// Returns the slice with the ctx's own lifetime (rather than borrowing
+    /// `self`), so a node can split its path into id + instance prefix and
+    /// still pass the ctx on (e.g. to the [`ui_tree`] interpreter).
+    pub fn path(&self) -> &'a [node::Id] {
+        self.path
     }
 
     /// Read-only access to the VM.

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -21,6 +21,7 @@ pub mod reg;
 pub mod response;
 pub mod sugar;
 pub mod sync;
+pub mod ui_tree;
 pub mod view;
 pub mod widget;
 

--- a/crates/gantz_egui/src/node/inspect.rs
+++ b/crates/gantz_egui/src/node/inspect.rs
@@ -1,6 +1,6 @@
 //! An Inspect node for viewing SteelVals flowing through the graph.
 
-use crate::{NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind};
+use crate::{NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind, ui_tree::UiTree};
 use gantz_ca::CaHash;
 use gantz_core::node::{self, ExprCtx, ExprResult, MetaCtx, RegCtx};
 use gantz_nodetag::NodeTag;
@@ -43,16 +43,17 @@ impl NodeUi for Inspect {
         "inspect"
     }
 
-    fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
+    fn ui(&mut self, mut ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
         let mut frame = egui_graph::node::default_frame(uictx.style(), uictx.interaction());
         frame.fill = uictx.style().visuals.extreme_bg_color;
+        let (&id, prefix) = ctx.path().split_last().expect("a node path is never empty");
+        let tree = fragment(id);
+        let root_id = uictx.egui_id().with("gui");
         let framed = uictx.framed_with(frame, |ui, _sockets| {
-            let text = match ctx.extract_value() {
-                Ok(Some(val)) => format!("{:?}", val),
-                Ok(None) => "∅".to_string(),
-                Err(_) => "ERR".to_string(),
-            };
-            ui.add(egui::Label::new(&text).selectable(false))
+            let r = UiTree::new(root_id)
+                .instance_prefix(prefix)
+                .show(&tree, &mut ctx, ui);
+            r.inner.unwrap_or_else(|| ui.response())
         });
         NodeUiResponse::new(framed)
     }
@@ -66,5 +67,29 @@ impl NodeUi for Inspect {
                 SocketDoc::ty("any").with_description("the input value, unchanged")
             }
         })
+    }
+}
+
+/// The inspect's value fragment: a read-only repr of its own state.
+fn fragment(id: node::Id) -> gantz_ui::Element {
+    gantz_ui::Element::Value(gantz_ui::Value {
+        bind: Some(gantz_ui::BindPath(vec![id])),
+        wrap: false,
+        key: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fragment_bakes_bind() {
+        let expected = gantz_ui::Element::Value(gantz_ui::Value {
+            bind: Some(gantz_ui::BindPath(vec![2])),
+            wrap: false,
+            key: None,
+        });
+        assert_eq!(fragment(2), expected);
     }
 }

--- a/crates/gantz_egui/src/node/plot.rs
+++ b/crates/gantz_egui/src/node/plot.rs
@@ -22,7 +22,8 @@
 //! breaking the chain it flows through.
 
 use super::size_sync::{self, fitted_size};
-use crate::ui_tree::plot::{PlotParams, is_container, plot_body, resolve_color, split_channels};
+use crate::ui_tree::UiTree;
+use crate::ui_tree::plot::{is_container, resolve_color, split_channels};
 use crate::widget::node_inspector;
 use crate::widget::node_inspector::radio_option;
 use crate::{
@@ -306,20 +307,30 @@ impl gantz_core::Node for Plot {
 }
 
 impl Plot {
-    /// The shared plot leaf's rendering parameters, resolved from the weight.
-    fn params(&self) -> PlotParams {
-        PlotParams {
-            style: match self.style {
+    /// The plot's fragment, bound to its own state, with attrs baked from
+    /// the weight. `size` is the resolved body size (the resize container's
+    /// inner size); `None` fills the available space (the detached view).
+    fn fragment(&self, id: node::Id, size: Option<egui::Vec2>) -> gantz_ui::Element {
+        gantz_ui::Element::Plot(gantz_ui::Plot {
+            bind: Some(gantz_ui::BindPath(vec![id])),
+            mode: Some(match self.mode {
+                PlotMode::Scope => gantz_ui::PlotMode::Scope,
+                PlotMode::Signal => gantz_ui::PlotMode::Signal,
+            }),
+            style: Some(match self.style {
                 PlotStyle::Bars => gantz_ui::PlotStyle::Bars,
                 PlotStyle::Line => gantz_ui::PlotStyle::Line,
-            },
-            color: self.color,
+            }),
+            color: self.color.map(gantz_ui::Rgba),
             grid: self.show_grid,
             axes: self.show_axes,
             interactive: self.interactive,
             y_min: self.y_min.map(F32::get),
             y_max: self.y_max.map(F32::get),
-        }
+            w: size.map(|s| s.x),
+            h: size.map(|s| s.y),
+            key: None,
+        })
     }
 }
 
@@ -332,7 +343,7 @@ impl NodeUi for Plot {
         Some("Plot incoming values as a scrolling scope or a signal/array")
     }
 
-    fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
+    fn ui(&mut self, mut ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
         // Set when a settled resize commits a new (CA-affecting) body size.
         let mut changed = false;
 
@@ -351,12 +362,11 @@ impl NodeUi for Plot {
 
         let node_egui_id = uictx.egui_id();
         let resize_id = node_egui_id.with("resize");
-        let plot_id = node_egui_id.with("plot");
+        let root_id = node_egui_id.with("gui");
         let min_size = egui::Vec2::splat(style.interaction.interact_radius * 2.0);
         let default_size = egui::vec2(self.width as f32, self.height as f32);
 
-        // Read the series once, up-front (only borrows `ctx`).
-        let ys = series(&ctx);
+        let (&id, prefix) = ctx.path().split_last().expect("a node path is never empty");
 
         let size_sync_id = node_egui_id.with("size_sync");
         let framed = uictx.framed_with(frame, |ui, _sockets| {
@@ -399,7 +409,11 @@ impl NodeUi for Plot {
                     changed = true;
                 }
 
-                plot_body(&self.params(), &ys, plot_id, avail, ui)
+                let tree = self.fragment(id, Some(avail));
+                let r = UiTree::new(root_id)
+                    .instance_prefix(prefix)
+                    .show(&tree, &mut ctx, ui);
+                r.inner.unwrap_or_else(|| ui.response())
             });
 
             size_sync::store(
@@ -423,18 +437,20 @@ impl NodeUi for Plot {
         true
     }
 
-    fn view_ui(&mut self, ctx: NodeCtx, ui: &mut egui::Ui) -> NodeViewResponse {
-        // The detached view fills the pane. Unlike the in-graph body it has no
-        // resize handle and never writes back the node's CA-affecting
-        // `width`/`height` (so `changed` stays false). The plot id is derived
-        // from `ui` (scoped per pane by the caller), keeping it distinct from
-        // the in-graph plot's id.
-        let plot_id = ui.id().with("plot-view");
-        let ys = series(&ctx);
-        let size = ui.available_size();
-        let resp = plot_body(&self.params(), &ys, plot_id, size, ui);
+    fn view_ui(&mut self, mut ctx: NodeCtx, ui: &mut egui::Ui) -> NodeViewResponse {
+        // The detached view fills the pane (the fragment omits w/h). Unlike
+        // the in-graph body it has no resize handle and never writes back
+        // the node's CA-affecting `width`/`height` (so `changed` stays
+        // false). The root id is derived from `ui` (scoped per pane by the
+        // caller), keeping it distinct from the in-graph plot's id.
+        let (&id, prefix) = ctx.path().split_last().expect("a node path is never empty");
+        let tree = self.fragment(id, None);
+        let r = UiTree::new(ui.id().with("gui"))
+            .instance_prefix(prefix)
+            .show(&tree, &mut ctx, ui);
         let mut out = NodeViewResponse::default();
-        out.inner = Some(resp);
+        out.inner = r.inner;
+        out.payloads = r.payloads;
         out
     }
 
@@ -890,6 +906,44 @@ mod tests {
         // Stored as a lone number; `series` reads it as a single sample.
         let state = node::state::extract_value(&vm, &[p]).unwrap().unwrap();
         assert!(matches!(state, SteelVal::IntV(7)));
+    }
+
+    // The fragment bakes every render-relevant weight field, the bind id,
+    // and the resolved body size (absent for the fill-the-pane view).
+    #[test]
+    fn fragment_bakes_weight_attrs_and_bind() {
+        let plot = Plot {
+            mode: PlotMode::Signal,
+            style: PlotStyle::Line,
+            color: Some([1, 2, 3, 4]),
+            show_grid: true,
+            show_axes: true,
+            interactive: true,
+            y_min: Some(F32(-1.0)),
+            y_max: Some(F32(1.0)),
+            ..Default::default()
+        };
+        let expected = gantz_ui::Element::Plot(gantz_ui::Plot {
+            bind: Some(gantz_ui::BindPath(vec![4])),
+            mode: Some(gantz_ui::PlotMode::Signal),
+            style: Some(gantz_ui::PlotStyle::Line),
+            color: Some(gantz_ui::Rgba([1, 2, 3, 4])),
+            grid: true,
+            axes: true,
+            interactive: true,
+            y_min: Some(-1.0),
+            y_max: Some(1.0),
+            w: Some(120.0),
+            h: Some(80.0),
+            key: None,
+        });
+        assert_eq!(plot.fragment(4, Some(egui::vec2(120.0, 80.0))), expected);
+
+        // The view fragment omits w/h to fill the pane.
+        let gantz_ui::Element::Plot(p) = plot.fragment(4, None) else {
+            panic!("plot fragment is a plot element");
+        };
+        assert_eq!((p.w, p.h), (None, None));
     }
 
     // Registering the graph again on the same engine (as a recompile does) must

--- a/crates/gantz_egui/src/node/plot.rs
+++ b/crates/gantz_egui/src/node/plot.rs
@@ -22,6 +22,7 @@
 //! breaking the chain it flows through.
 
 use super::size_sync::{self, fitted_size};
+use crate::ui_tree::plot::{PlotParams, is_container, plot_body, resolve_color, split_channels};
 use crate::widget::node_inspector;
 use crate::widget::node_inspector::radio_option;
 use crate::{
@@ -252,61 +253,6 @@ fn series(ctx: &NodeCtx) -> Vec<Vec<f64>> {
     }
 }
 
-/// Split a stored plot value into per-channel series. A list or vector *of lists/vectors*
-/// is one series per inner container (`~scopeout`'s per-channel rings produce this); a
-/// flat numeric list or vector - or a lone number - is a single channel. Lists and
-/// vectors are treated identically ([`SteelVal::ListV`] and [`SteelVal::VectorV`]).
-fn split_channels(val: &SteelVal) -> Vec<Vec<f64>> {
-    // The top-level elements of a list or vector; `None` if `val` is not a container.
-    let elems: Option<Vec<&SteelVal>> = match val {
-        SteelVal::ListV(list) => Some(list.iter().collect()),
-        SteelVal::VectorV(vec) => Some(vec.iter().collect()),
-        _ => None,
-    };
-    match elems {
-        // A container whose elements are themselves containers: one series each.
-        Some(elems) if elems.iter().any(|v| is_container(v)) => {
-            elems.iter().map(|v| channel_numerics(v)).collect()
-        }
-        // A flat numeric container: a single channel.
-        Some(elems) => vec![elems.iter().filter_map(|v| steel_num(v)).collect()],
-        // A lone number: one single-sample channel.
-        None => vec![steel_num(val).into_iter().collect()],
-    }
-}
-
-/// Whether `v` is a list or vector (a channel container).
-fn is_container(v: &SteelVal) -> bool {
-    matches!(v, SteelVal::ListV(_) | SteelVal::VectorV(_))
-}
-
-/// One channel's numeric samples: a list's or vector's numeric elements, or a lone number.
-fn channel_numerics(val: &SteelVal) -> Vec<f64> {
-    match val {
-        SteelVal::ListV(list) => list.iter().filter_map(steel_num).collect(),
-        SteelVal::VectorV(vec) => vec.iter().filter_map(steel_num).collect(),
-        other => steel_num(other).into_iter().collect(),
-    }
-}
-
-/// Convert a numeric [`SteelVal`] to `f64`.
-fn steel_num(val: &SteelVal) -> Option<f64> {
-    match val {
-        SteelVal::NumV(f) => Some(*f),
-        SteelVal::IntV(i) => Some(*i as f64),
-        _ => None,
-    }
-}
-
-/// Resolve the configured colour, falling back to the theme's strong text
-/// colour when unset.
-fn resolve_color(color: Option<[u8; 4]>, ui: &egui::Ui) -> egui::Color32 {
-    match color {
-        Some([r, g, b, a]) => egui::Color32::from_rgba_unmultiplied(r, g, b, a),
-        None => ui.visuals().strong_text_color(),
-    }
-}
-
 impl gantz_core::Node for Plot {
     fn n_inputs(&self, _ctx: MetaCtx) -> usize {
         1
@@ -360,113 +306,20 @@ impl gantz_core::Node for Plot {
 }
 
 impl Plot {
-    /// Render the plot filling `size`: a single channel fills it; multiple channels
-    /// (a list-of-lists, e.g. from `~scopeout` + `deinterleave`) are stacked as one
-    /// sub-plot each. Returns the combined response. Shared by the in-graph node body
-    /// ([`NodeUi::ui`]) and the detached view ([`NodeUi::view_ui`]).
-    fn plot_body(
-        &self,
-        channels: &[Vec<f64>],
-        plot_id: egui::Id,
-        size: egui::Vec2,
-        ui: &mut egui::Ui,
-    ) -> egui::Response {
-        // No data yet: draw a single empty plot so the node still has a body.
-        if channels.len() <= 1 {
-            let ys = channels.first().map(Vec::as_slice).unwrap_or(&[]);
-            return self.plot_channel(ys, plot_id, size, ui);
+    /// The shared plot leaf's rendering parameters, resolved from the weight.
+    fn params(&self) -> PlotParams {
+        PlotParams {
+            style: match self.style {
+                PlotStyle::Bars => gantz_ui::PlotStyle::Bars,
+                PlotStyle::Line => gantz_ui::PlotStyle::Line,
+            },
+            color: self.color,
+            grid: self.show_grid,
+            axes: self.show_axes,
+            interactive: self.interactive,
+            y_min: self.y_min.map(F32::get),
+            y_max: self.y_max.map(F32::get),
         }
-        // Stack one sub-plot per channel, splitting the height evenly.
-        let sub_h = size.y / channels.len() as f32;
-        ui.vertical(|ui| {
-            let mut resp: Option<egui::Response> = None;
-            for (i, ch) in channels.iter().enumerate() {
-                let r = self.plot_channel(ch, plot_id.with(i), egui::vec2(size.x, sub_h), ui);
-                resp = Some(match resp.take() {
-                    Some(prev) => prev.union(r),
-                    None => r,
-                });
-            }
-            resp.expect("at least two channels")
-        })
-        .inner
-    }
-
-    /// Render one channel's series (axes, grid, line/bars and bounds) filling `size`.
-    fn plot_channel(
-        &self,
-        ys: &[f64],
-        plot_id: egui::Id,
-        size: egui::Vec2,
-        ui: &mut egui::Ui,
-    ) -> egui::Response {
-        let color = resolve_color(self.color, ui);
-        let plot_style = self.style;
-        let interactive = self.interactive;
-        let bounds = value_bounds(ys, plot_style, self.y_min, self.y_max);
-
-        let mut plot = egui_plot::Plot::new(plot_id)
-            .width(size.x)
-            .height(size.y)
-            .show_background(false)
-            .show_axes(egui::Vec2b::new(self.show_axes, self.show_axes))
-            .show_grid(egui::Vec2b::new(self.show_grid, self.show_grid))
-            // Pan/zoom are always off. `Sense::hover` lets the node frame beneath
-            // capture drags and right-clicks, so the node moves and its context
-            // menu opens as usual.
-            .allow_drag(false)
-            .allow_zoom(false)
-            .allow_scroll(false)
-            .allow_boxed_zoom(false)
-            .sense(egui::Sense::hover());
-        if !interactive {
-            // Purely visual: hide the crosshair (the value readout is also
-            // suppressed via `allow_hover(false)` below).
-            plot = plot.cursor_color(egui::Color32::TRANSPARENT);
-        }
-
-        let plot_resp = plot
-            .show(ui, |plot_ui| {
-                match plot_style {
-                    PlotStyle::Bars => {
-                        let bars = ys
-                            .iter()
-                            .enumerate()
-                            .map(|(i, &y)| {
-                                egui_plot::Bar::new(i as f64, y)
-                                    .width(1.0)
-                                    .fill(color)
-                                    .stroke(egui::Stroke::NONE)
-                            })
-                            .collect();
-                        plot_ui
-                            .bar_chart(egui_plot::BarChart::new("", bars).allow_hover(interactive));
-                    }
-                    PlotStyle::Line => {
-                        let points = egui_plot::PlotPoints::from_ys_f64(ys);
-                        plot_ui.line(
-                            egui_plot::Line::new("", points)
-                                .color(color)
-                                .allow_hover(interactive),
-                        );
-                    }
-                }
-                // Drive the view deterministically from the data + config (the
-                // plot never pans), so live updates and min/max apply.
-                let ([xlo, ylo], [xhi, yhi]) = bounds;
-                plot_ui.set_plot_bounds_x(xlo..=xhi);
-                plot_ui.set_plot_bounds_y(ylo..=yhi);
-            })
-            .response;
-
-        // egui_plot sets a crosshair *mouse cursor* on hover; when not
-        // interactive, restore the default arrow so the plot reads as a static
-        // node. (The resize corner sets its own cursor after this, so it is
-        // unaffected.)
-        if !interactive && plot_resp.hovered() {
-            ui.ctx().set_cursor_icon(egui::CursorIcon::Default);
-        }
-        plot_resp
     }
 }
 
@@ -546,7 +399,7 @@ impl NodeUi for Plot {
                     changed = true;
                 }
 
-                self.plot_body(&ys, plot_id, avail, ui)
+                plot_body(&self.params(), &ys, plot_id, avail, ui)
             });
 
             size_sync::store(
@@ -579,7 +432,7 @@ impl NodeUi for Plot {
         let plot_id = ui.id().with("plot-view");
         let ys = series(&ctx);
         let size = ui.available_size();
-        let resp = self.plot_body(&ys, plot_id, size, ui);
+        let resp = plot_body(&self.params(), &ys, plot_id, size, ui);
         let mut out = NodeViewResponse::default();
         out.inner = Some(resp);
         out
@@ -803,55 +656,10 @@ impl NodeUi for Plot {
     }
 }
 
-/// Compute `([x_min, y_min], [x_max, y_max])` for the view from the data and
-/// optional fixed value bounds. Bars include the baseline `0` and span integer
-/// x; lines span sample indices. The plot itself adds no margin.
-fn value_bounds(
-    ys: &[f64],
-    style: PlotStyle,
-    y_min: Option<F32>,
-    y_max: Option<F32>,
-) -> ([f64; 2], [f64; 2]) {
-    let n = ys.len() as f64;
-    let (xlo, xhi) = match style {
-        PlotStyle::Bars => (-0.5, (n - 0.5).max(0.5)),
-        PlotStyle::Line => (0.0, (n - 1.0).max(1.0)),
-    };
-
-    let (dmin, dmax) = ys
-        .iter()
-        .copied()
-        .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), v| {
-            (lo.min(v), hi.max(v))
-        });
-    let (mut ylo, mut yhi) = if dmin <= dmax {
-        match style {
-            // Bars draw from the baseline, so keep `0` in view.
-            PlotStyle::Bars => (dmin.min(0.0), dmax.max(0.0)),
-            PlotStyle::Line => (dmin, dmax),
-        }
-    } else {
-        (0.0, 1.0)
-    };
-    if (yhi - ylo).abs() < 1e-9 {
-        ylo -= 1.0;
-        yhi += 1.0;
-    }
-
-    // Fixed overrides are exact.
-    if let Some(v) = y_min {
-        ylo = v.get() as f64;
-    }
-    if let Some(v) = y_max {
-        yhi = v.get() as f64;
-    }
-
-    ([xlo, ylo], [xhi, yhi])
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ui_tree::plot::steel_num;
     use gantz_core::node::{Node, WithPushEval};
     use gantz_core::{
         Edge, ROOT_STATE,
@@ -1026,52 +834,6 @@ mod tests {
         // [1,2,3], then keep the last 4 of [1,2,3] ++ [1,2,3] = [3,1,2,3].
         fire(&mut vm, &g, s, 2);
         assert_eq!(samples_of(&vm, p), vec![3.0, 1.0, 2.0, 3.0]);
-    }
-
-    // `split_channels` treats a list-or-vector-of-containers as one series per inner
-    // container (for the stacked multi-channel plot), and a flat list/vector or lone
-    // number as a single channel. Lists and vectors are interchangeable, including mixed.
-    #[test]
-    fn split_channels_by_shape() {
-        let num = |n: f64| SteelVal::NumV(n);
-        let list = |xs: Vec<SteelVal>| SteelVal::ListV(xs.into_iter().collect());
-        let vector = |xs: Vec<SteelVal>| SteelVal::VectorV(xs.into_iter().collect());
-
-        // A flat numeric list or vector is one channel.
-        assert_eq!(
-            split_channels(&list(vec![num(1.0), num(2.0), num(3.0)])),
-            vec![vec![1.0, 2.0, 3.0]],
-        );
-        assert_eq!(
-            split_channels(&vector(vec![num(1.0), num(2.0), num(3.0)])),
-            vec![vec![1.0, 2.0, 3.0]],
-        );
-        // A lone number is one single-sample channel.
-        assert_eq!(split_channels(&num(7.0)), vec![vec![7.0]]);
-        // A list of lists, a vector of vectors, and a mixed list of vectors all give
-        // one channel per inner container.
-        let expected = vec![vec![1.0, 3.0], vec![2.0, 4.0]];
-        assert_eq!(
-            split_channels(&list(vec![
-                list(vec![num(1.0), num(3.0)]),
-                list(vec![num(2.0), num(4.0)]),
-            ])),
-            expected,
-        );
-        assert_eq!(
-            split_channels(&vector(vec![
-                vector(vec![num(1.0), num(3.0)]),
-                vector(vec![num(2.0), num(4.0)]),
-            ])),
-            expected,
-        );
-        assert_eq!(
-            split_channels(&list(vec![
-                vector(vec![num(1.0), num(3.0)]),
-                vector(vec![num(2.0), num(4.0)]),
-            ])),
-            expected,
-        );
     }
 
     // `plot_push` accepts a vector input, accumulating its numeric elements into the

--- a/crates/gantz_egui/src/ui_tree.rs
+++ b/crates/gantz_egui/src/ui_tree.rs
@@ -1,0 +1,360 @@
+//! A data-driven egui renderer for [`gantz_ui`] element trees.
+//!
+//! [`UiTree`] walks a decoded [`Element`] tree each frame, resolving widget
+//! bindings against VM state and reporting interactions as response
+//! payloads. It is the single rendering path for widget node GUIs: builtins
+//! construct their own fragments and render through it, and graph-defined
+//! GUIs evaluate to trees rendered the same way.
+//!
+//! ## Bindings
+//!
+//! A widget's `bind` path is relative to the graph its tree was defined in.
+//! The walker resolves it as `instance prefix ++ scope prefixes ++ bind
+//! path` and reads via [`NodeCtx::extract_value_at`], writes via
+//! [`NodeCtx::update_value_at`]. Those touch VM runtime state only, so
+//! interpreting a tree never mutates CA-affecting state and
+//! [`UiTreeResponse`] carries no `changed` flag.
+//!
+//! ## Identity
+//!
+//! Every element's [`egui::Id`] derives from the render root's id, its
+//! structural position beneath its parent (overridden by a `key` attr), and
+//! any enclosing `scope` ids. Label text never contributes, so relabelling
+//! never resets widget state.
+//!
+//! ## Errors
+//!
+//! [`gantz_ui::decode()`] is total: every node of the tree is renderable and
+//! [`Element::Error`] is the only inline-error case, drawn as an error chip
+//! in place while siblings render normally. Decode warnings never reach the
+//! walker. Callers that decode (rather than construct) trees surface them
+//! themselves.
+
+use crate::{NodeCtx, node, response::DynResponse};
+use gantz_ui::{Align, BindPath, Element, Key, Rgba};
+
+/// The outcome of interpreting a UI tree for one frame.
+///
+/// Interpreting a tree never edits CA-affecting state (controls write VM
+/// runtime state and queue evaluations only), so there is no `changed` flag.
+#[derive(Debug, Default)]
+pub struct UiTreeResponse {
+    /// The union of every rendered widget's response, if anything rendered.
+    pub inner: Option<egui::Response>,
+    /// Payloads emitted for the application to handle after the GUI pass
+    /// ([`EvalEntry`][crate::EvalEntry] push evaluations in v1).
+    pub payloads: Vec<DynResponse>,
+}
+
+/// Renders a [`gantz_ui::Element`] tree, resolving bindings against VM state
+/// through the given [`NodeCtx`].
+///
+/// This is the only seam through which the tree touches the VM: state access
+/// goes via [`NodeCtx`], and everything else is reported on the returned
+/// [`UiTreeResponse`].
+pub struct UiTree<'a> {
+    root_id: egui::Id,
+    instance_prefix: &'a [node::Id],
+}
+
+/// Walker state threaded through one tree traversal.
+struct Walk<'a> {
+    instance_prefix: &'a [node::Id],
+    /// Accumulated `(scope id ...)` prefixes enclosing the current element.
+    scopes: Vec<node::Id>,
+    resp: UiTreeResponse,
+}
+
+impl<'a> UiTree<'a> {
+    /// Interpret a tree whose widget identities derive from `root_id`.
+    pub fn new(root_id: egui::Id) -> Self {
+        Self {
+            root_id,
+            instance_prefix: &[],
+        }
+    }
+
+    /// The path prefix prepended to every binding, i.e. the path at which
+    /// the tree's defining graph is instanced. Empty by default.
+    pub fn instance_prefix(mut self, prefix: &'a [node::Id]) -> Self {
+        self.instance_prefix = prefix;
+        self
+    }
+
+    /// Render the tree, resolving bindings via `ctx`.
+    pub fn show(self, tree: &Element, ctx: &mut NodeCtx, ui: &mut egui::Ui) -> UiTreeResponse {
+        let mut walk = Walk {
+            instance_prefix: self.instance_prefix,
+            scopes: Vec::new(),
+            resp: UiTreeResponse::default(),
+        };
+        walk.element(tree, self.root_id, ctx, ui);
+        walk.resp
+    }
+}
+
+impl Walk<'_> {
+    /// Render one element with the given derived id.
+    fn element(&mut self, e: &Element, id: egui::Id, ctx: &mut NodeCtx, ui: &mut egui::Ui) {
+        match e {
+            Element::Col(col) => {
+                let cross = cross_align(col.align.unwrap_or(Align::Start));
+                ui.with_layout(egui::Layout::top_down(cross), |ui| {
+                    if let Some(gap) = col.gap {
+                        ui.spacing_mut().item_spacing.y = gap;
+                    }
+                    self.children(&col.children, id, ctx, ui);
+                });
+            }
+            Element::Row(row) => {
+                // Mirror `Ui::horizontal`: seed the row with the interact
+                // height so cross-alignment centres within one row, not
+                // within all remaining vertical space.
+                let cross = cross_align(row.align.unwrap_or(Align::Center));
+                let initial = egui::vec2(
+                    ui.available_size_before_wrap().x,
+                    ui.spacing().interact_size.y,
+                );
+                ui.allocate_ui_with_layout(initial, egui::Layout::left_to_right(cross), |ui| {
+                    if let Some(gap) = row.gap {
+                        ui.spacing_mut().item_spacing.x = gap;
+                    }
+                    self.children(&row.children, id, ctx, ui);
+                });
+            }
+            Element::Grid(grid) => {
+                let cols = (grid.cols.max(1)) as usize;
+                let mut g = egui::Grid::new(id).num_columns(cols);
+                if let Some(gap) = grid.gap {
+                    g = g.spacing([gap, gap]);
+                }
+                g.show(ui, |ui| {
+                    for (ix, child) in grid.children.iter().enumerate() {
+                        self.element(child, child_id(id, ix, child.key()), ctx, ui);
+                        if (ix + 1) % cols == 0 {
+                            ui.end_row();
+                        }
+                    }
+                });
+            }
+            Element::Frame(frame) => {
+                egui::Frame::group(ui.style()).show(ui, |ui| {
+                    ui.vertical(|ui| {
+                        if let Some(title) = &frame.title {
+                            ui.strong(title);
+                        }
+                        self.children(&frame.children, id, ctx, ui);
+                    });
+                });
+            }
+            Element::Sep(_) => {
+                let r = ui.separator();
+                self.merge(r);
+            }
+            Element::Space(space) => {
+                let amount = space.amount.unwrap_or_else(|| {
+                    let spacing = ui.spacing().item_spacing;
+                    if ui.layout().main_dir().is_horizontal() {
+                        spacing.x
+                    } else {
+                        spacing.y
+                    }
+                });
+                ui.add_space(amount);
+            }
+            Element::Scope(scope) => {
+                // No visuals: children render inline under the extended
+                // binding prefix, with the scope id salting their identity.
+                self.scopes.push(scope.id);
+                let parent = id.with(("scope", scope.id));
+                self.children(&scope.children, parent, ctx, ui);
+                self.scopes.pop();
+            }
+            Element::Dialer(_) | Element::Toggle(_) | Element::Button(_) | Element::Matrix(_) => {
+                let r = placeholder_chip(ui, e.tag());
+                self.merge(r);
+            }
+            Element::Label(label) => {
+                let mut text = egui::RichText::new(&label.text);
+                if let Some(size) = label.size {
+                    text = text.size(size);
+                }
+                if let Some(Rgba([r, g, b, a])) = label.color {
+                    text = text.color(egui::Color32::from_rgba_unmultiplied(r, g, b, a));
+                }
+                // Non-selectable so surrounding node bodies stay draggable.
+                let r = ui.add(egui::Label::new(text).selectable(false));
+                self.merge(r);
+            }
+            Element::Value(value) => {
+                let text = match &value.bind {
+                    None => "∅".to_string(),
+                    Some(bind) => match ctx.extract_value_at(&self.resolve(bind)) {
+                        Ok(Some(val)) => format!("{val:?}"),
+                        Ok(None) => "∅".to_string(),
+                        Err(_) => "ERR".to_string(),
+                    },
+                };
+                let mut label = egui::Label::new(text).selectable(false);
+                label = if value.wrap {
+                    label.wrap()
+                } else {
+                    label.extend()
+                };
+                let r = ui.add(label);
+                self.merge(r);
+            }
+            Element::Plot(_) => {
+                let r = placeholder_chip(ui, e.tag());
+                self.merge(r);
+            }
+            Element::RefGui(ref_gui) => {
+                let r = weak_chip(ui, &format!("ref-gui {}", ref_gui.id))
+                    .on_hover_text("embedded reference GUIs resolve in a future version");
+                self.merge(r);
+            }
+            Element::Error(err) => {
+                let color = ui.visuals().error_fg_color;
+                let r = egui::Frame::group(ui.style())
+                    .stroke(egui::Stroke::new(1.0, color))
+                    .show(ui, |ui| {
+                        ui.add(
+                            egui::Label::new(egui::RichText::new(err.reason.to_string()).weak())
+                                .selectable(false),
+                        )
+                    })
+                    .inner
+                    .on_hover_text(format!("tree path: {:?}", err.path.0));
+                self.merge(r);
+            }
+        }
+    }
+
+    /// Render container children, deriving each child's id from `parent`.
+    fn children(
+        &mut self,
+        children: &[Element],
+        parent: egui::Id,
+        ctx: &mut NodeCtx,
+        ui: &mut egui::Ui,
+    ) {
+        for (ix, child) in children.iter().enumerate() {
+            self.element(child, child_id(parent, ix, child.key()), ctx, ui);
+        }
+    }
+
+    /// Resolve a binding to its full state-tree path.
+    fn resolve(&self, bind: &BindPath) -> Vec<node::Id> {
+        resolve_path(self.instance_prefix, &self.scopes, bind)
+    }
+
+    /// Union `r` into the response.
+    fn merge(&mut self, r: egui::Response) {
+        self.resp.inner = Some(match self.resp.inner.take() {
+            Some(prev) => prev.union(r),
+            None => r,
+        });
+    }
+}
+
+/// A child's identity: its structural position beneath `parent`, overridden
+/// by a `key` attr. Key spaces are disjoint from position spaces, so keyed
+/// and unkeyed siblings can never collide.
+fn child_id(parent: egui::Id, position: usize, key: Option<&Key>) -> egui::Id {
+    match key {
+        Some(Key::Str(s)) => parent.with(("k", s.as_str())),
+        Some(Key::Int(i)) => parent.with(("k", i)),
+        None => parent.with(position),
+    }
+}
+
+/// The full state-tree path of a binding: the tree's instance prefix, then
+/// the accumulated scope prefixes, then the bind path itself.
+fn resolve_path(prefix: &[node::Id], scopes: &[node::Id], bind: &BindPath) -> Vec<node::Id> {
+    prefix
+        .iter()
+        .chain(scopes.iter())
+        .chain(bind.0.iter())
+        .copied()
+        .collect()
+}
+
+/// Map a cross-axis alignment to egui's.
+fn cross_align(align: Align) -> egui::Align {
+    match align {
+        Align::Start => egui::Align::Min,
+        Align::Center => egui::Align::Center,
+        Align::End => egui::Align::Max,
+    }
+}
+
+/// An inline chip for elements that cannot render yet.
+fn placeholder_chip(ui: &mut egui::Ui, text: &str) -> egui::Response {
+    weak_chip(ui, text)
+}
+
+/// A small framed chip with weak text.
+fn weak_chip(ui: &mut egui::Ui, text: &str) -> egui::Response {
+    egui::Frame::group(ui.style())
+        .show(ui, |ui| {
+            ui.add(egui::Label::new(egui::RichText::new(text).weak()).selectable(false))
+        })
+        .inner
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_path_concatenates_prefix_scopes_and_bind() {
+        let bind = BindPath(vec![7]);
+        assert_eq!(resolve_path(&[], &[], &bind), vec![7]);
+        assert_eq!(resolve_path(&[1], &[], &bind), vec![1, 7]);
+        assert_eq!(resolve_path(&[], &[4], &bind), vec![4, 7]);
+        assert_eq!(resolve_path(&[1, 2], &[3, 4], &bind), vec![1, 2, 3, 4, 7]);
+        let deep = BindPath(vec![5, 6]);
+        assert_eq!(resolve_path(&[1], &[2], &deep), vec![1, 2, 5, 6]);
+    }
+
+    #[test]
+    fn keyed_children_keep_their_id_under_reorder() {
+        let parent = egui::Id::new("parent");
+        let key = Key::Str("a".to_string());
+        assert_eq!(
+            child_id(parent, 0, Some(&key)),
+            child_id(parent, 5, Some(&key)),
+        );
+        assert_eq!(
+            child_id(parent, 0, Some(&Key::Int(3))),
+            child_id(parent, 9, Some(&Key::Int(3))),
+        );
+    }
+
+    #[test]
+    fn unkeyed_children_are_identified_by_position() {
+        let parent = egui::Id::new("parent");
+        assert_ne!(child_id(parent, 0, None), child_id(parent, 1, None));
+        assert_eq!(child_id(parent, 2, None), child_id(parent, 2, None));
+    }
+
+    #[test]
+    fn distinct_keys_are_distinct_ids() {
+        let parent = egui::Id::new("parent");
+        let a = Key::Str("a".to_string());
+        let b = Key::Str("b".to_string());
+        assert_ne!(child_id(parent, 0, Some(&a)), child_id(parent, 0, Some(&b)));
+        assert_ne!(
+            child_id(parent, 0, Some(&Key::Int(1))),
+            child_id(parent, 0, Some(&Key::Int(2))),
+        );
+    }
+
+    #[test]
+    fn ids_derive_from_the_parent() {
+        let (p1, p2) = (egui::Id::new("p1"), egui::Id::new("p2"));
+        assert_ne!(child_id(p1, 0, None), child_id(p2, 0, None));
+        let key = Key::Str("a".to_string());
+        assert_ne!(child_id(p1, 0, Some(&key)), child_id(p2, 0, Some(&key)));
+    }
+}

--- a/crates/gantz_egui/src/ui_tree.rs
+++ b/crates/gantz_egui/src/ui_tree.rs
@@ -43,6 +43,8 @@ use crate::{NodeCtx, node, response::DynResponse};
 use gantz_ui::{Align, BindPath, Button, Dialer, Element, Key, Matrix, Rgba, Toggle};
 use steel::{SteelVal, Vector, gc::Gc};
 
+pub(crate) mod plot;
+
 /// The outcome of interpreting a UI tree for one frame.
 ///
 /// Interpreting a tree never edits CA-affecting state (controls write VM
@@ -230,10 +232,7 @@ impl Walk<'_> {
                 let r = ui.add(label);
                 self.merge(r);
             }
-            Element::Plot(_) => {
-                let r = placeholder_chip(ui, e.tag());
-                self.merge(r);
-            }
+            Element::Plot(plot) => self.plot(plot, id, ctx, ui),
             Element::RefGui(ref_gui) => {
                 let r = weak_chip(ui, &format!("ref-gui {}", ref_gui.id))
                     .on_hover_text("embedded reference GUIs resolve in a future version");
@@ -467,6 +466,39 @@ impl Walk<'_> {
         }
     }
 
+    /// Render bound state through the shared plot leaf. The `mode` attr
+    /// selects how the *producing* node accumulates its state and is
+    /// irrelevant to drawing, so the walker ignores it.
+    fn plot(&mut self, p: &gantz_ui::Plot, id: egui::Id, ctx: &mut NodeCtx, ui: &mut egui::Ui) {
+        let Some(bind) = &p.bind else {
+            let r = unbound_chip(ui, "plot");
+            self.merge(r);
+            return;
+        };
+        let path = self.resolve(bind);
+        let channels = match ctx.extract_value_at(&path) {
+            Ok(Some(val)) => plot::split_channels(&val),
+            _ => Vec::new(),
+        };
+        let params = plot::PlotParams {
+            style: p.style.unwrap_or(gantz_ui::PlotStyle::Bars),
+            color: p.color.map(|Rgba(c)| c),
+            grid: p.grid,
+            axes: p.axes,
+            interactive: p.interactive,
+            y_min: p.y_min,
+            y_max: p.y_max,
+        };
+        // Absent dimensions fill the available space (the detached view and
+        // debug pane cases). Fragments with a fixed size set both.
+        let size = egui::vec2(
+            p.w.unwrap_or_else(|| ui.available_width()),
+            p.h.unwrap_or_else(|| ui.available_height()),
+        );
+        let r = plot::plot_body(&params, &channels, id, size, ui);
+        self.merge(r);
+    }
+
     /// Write an edited value to its bound state, then queue a push
     /// evaluation when `push` is on.
     fn emit_set(&mut self, ctx: &mut NodeCtx, path: &[node::Id], val: SteelVal, push: bool) {
@@ -590,11 +622,6 @@ fn seq_rebuild(seq: Seq, items: Vec<SteelVal>) -> SteelVal {
             SteelVal::VectorV(Gc::new(v).into())
         }
     }
-}
-
-/// An inline chip for elements that cannot render yet.
-fn placeholder_chip(ui: &mut egui::Ui, text: &str) -> egui::Response {
-    weak_chip(ui, text)
 }
 
 /// An inline chip for a control missing its `bind` attr.

--- a/crates/gantz_egui/src/ui_tree.rs
+++ b/crates/gantz_egui/src/ui_tree.rs
@@ -22,6 +22,15 @@
 //! any enclosing `scope` ids. Label text never contributes, so relabelling
 //! never resets widget state.
 //!
+//! ## Events
+//!
+//! Controls write their bound state on real user edits only (an egui
+//! `changed` signal guarded by a value comparison), then queue a push
+//! evaluation at the bound node when their `push` attr is on (`button`
+//! always pushes). Restoring or externally rewriting state never emits.
+//! Push evaluations name the compiled entry fn from the bound node's output
+//! count, so callers provide a resolver via [`UiTree::n_outputs`].
+//!
 //! ## Errors
 //!
 //! [`gantz_ui::decode()`] is total: every node of the tree is renderable and
@@ -31,7 +40,8 @@
 //! themselves.
 
 use crate::{NodeCtx, node, response::DynResponse};
-use gantz_ui::{Align, BindPath, Element, Key, Rgba};
+use gantz_ui::{Align, BindPath, Button, Dialer, Element, Key, Matrix, Rgba, Toggle};
+use steel::{SteelVal, Vector, gc::Gc};
 
 /// The outcome of interpreting a UI tree for one frame.
 ///
@@ -55,6 +65,7 @@ pub struct UiTreeResponse {
 pub struct UiTree<'a> {
     root_id: egui::Id,
     instance_prefix: &'a [node::Id],
+    n_outputs: Option<&'a dyn Fn(&[node::Id]) -> Option<usize>>,
 }
 
 /// Walker state threaded through one tree traversal.
@@ -62,6 +73,7 @@ struct Walk<'a> {
     instance_prefix: &'a [node::Id],
     /// Accumulated `(scope id ...)` prefixes enclosing the current element.
     scopes: Vec<node::Id>,
+    n_outputs: Option<&'a dyn Fn(&[node::Id]) -> Option<usize>>,
     resp: UiTreeResponse,
 }
 
@@ -71,6 +83,7 @@ impl<'a> UiTree<'a> {
         Self {
             root_id,
             instance_prefix: &[],
+            n_outputs: None,
         }
     }
 
@@ -81,11 +94,24 @@ impl<'a> UiTree<'a> {
         self
     }
 
+    /// The output count of the node at the given resolved path, required to
+    /// queue push evaluations (the entry fn's identity covers the count).
+    ///
+    /// A node rendering its own fragment knows its own count. A caller whose
+    /// tree binds arbitrary nodes resolves counts from the graph. Without a
+    /// resolver (or when it returns `None`) pushes are skipped with a
+    /// warning.
+    pub fn n_outputs(mut self, f: &'a dyn Fn(&[node::Id]) -> Option<usize>) -> Self {
+        self.n_outputs = Some(f);
+        self
+    }
+
     /// Render the tree, resolving bindings via `ctx`.
     pub fn show(self, tree: &Element, ctx: &mut NodeCtx, ui: &mut egui::Ui) -> UiTreeResponse {
         let mut walk = Walk {
             instance_prefix: self.instance_prefix,
             scopes: Vec::new(),
+            n_outputs: self.n_outputs,
             resp: UiTreeResponse::default(),
         };
         walk.element(tree, self.root_id, ctx, ui);
@@ -170,10 +196,10 @@ impl Walk<'_> {
                 self.children(&scope.children, parent, ctx, ui);
                 self.scopes.pop();
             }
-            Element::Dialer(_) | Element::Toggle(_) | Element::Button(_) | Element::Matrix(_) => {
-                let r = placeholder_chip(ui, e.tag());
-                self.merge(r);
-            }
+            Element::Dialer(dialer) => self.dialer(dialer, id, ctx, ui),
+            Element::Toggle(toggle) => self.toggle(toggle, id, ctx, ui),
+            Element::Button(button) => self.button(button, id, ui),
+            Element::Matrix(matrix) => self.matrix(matrix, id, ctx, ui),
             Element::Label(label) => {
                 let mut text = egui::RichText::new(&label.text);
                 if let Some(size) = label.size {
@@ -243,6 +269,231 @@ impl Walk<'_> {
         }
     }
 
+    /// Render a numeric drag value bound to number state.
+    fn dialer(&mut self, d: &Dialer, id: egui::Id, ctx: &mut NodeCtx, ui: &mut egui::Ui) {
+        let Some(bind) = &d.bind else {
+            let r = unbound_chip(ui, "dialer");
+            self.merge(r);
+            return;
+        };
+        let path = self.resolve(bind);
+        let Ok(Some(mut val)) = ctx.extract_value_at(&path) else {
+            let r = err_label(ui, "no state at the bound path");
+            self.merge(r);
+            return;
+        };
+        let original = val.clone();
+        let r = ui
+            .push_id(id, |ui| {
+                if !d.push {
+                    // Flatten the dialer's fill: a cue that editing won't
+                    // fire downstream.
+                    let widgets = &mut ui.visuals_mut().widgets;
+                    widgets.inactive.weak_bg_fill = egui::Color32::TRANSPARENT;
+                    widgets.inactive.bg_fill = egui::Color32::TRANSPARENT;
+                }
+                let drag = |ui: &mut egui::Ui, val: &mut SteelVal| match val {
+                    SteelVal::NumV(f) => {
+                        let mut dv = egui::DragValue::new(f);
+                        if d.min.is_some() || d.max.is_some() {
+                            let (lo, hi) = (
+                                d.min.unwrap_or(f64::NEG_INFINITY),
+                                d.max.unwrap_or(f64::INFINITY),
+                            );
+                            dv = dv.range(lo..=hi);
+                        }
+                        if let Some(p) = d.precision {
+                            dv = dv.max_decimals(p as usize);
+                        }
+                        if let Some(s) = d.step {
+                            dv = dv.speed(s);
+                        }
+                        ui.add(dv)
+                    }
+                    SteelVal::IntV(i) => {
+                        let mut dv = egui::DragValue::new(i);
+                        if d.min.is_some() || d.max.is_some() {
+                            let lo = d.min.map_or(isize::MIN, |m| m as isize);
+                            let hi = d.max.map_or(isize::MAX, |m| m as isize);
+                            dv = dv.range(lo..=hi);
+                        }
+                        if let Some(s) = d.step {
+                            dv = dv.speed(s);
+                        }
+                        ui.add(dv)
+                    }
+                    _ => err_label(ui, "bound state is not a number"),
+                };
+                match &d.label {
+                    Some(label) => {
+                        ui.horizontal(|ui| {
+                            ui.weak(label);
+                            drag(ui, &mut val)
+                        })
+                        .inner
+                    }
+                    None => drag(ui, &mut val),
+                }
+            })
+            .inner;
+        if r.changed() && val != original {
+            self.emit_set(ctx, &path, val, d.push);
+        }
+        self.merge(r);
+    }
+
+    /// Render a checkbox bound to bool state.
+    fn toggle(&mut self, t: &Toggle, id: egui::Id, ctx: &mut NodeCtx, ui: &mut egui::Ui) {
+        let Some(bind) = &t.bind else {
+            let r = unbound_chip(ui, "toggle");
+            self.merge(r);
+            return;
+        };
+        let path = self.resolve(bind);
+        let Ok(Some(val)) = ctx.extract_value_at(&path) else {
+            let r = err_label(ui, "no state at the bound path");
+            self.merge(r);
+            return;
+        };
+        let SteelVal::BoolV(mut b) = val else {
+            let r = err_label(ui, "bound state is not a bool");
+            self.merge(r);
+            return;
+        };
+        let text = t.label.as_deref().unwrap_or("");
+        let r = ui.push_id(id, |ui| ui.checkbox(&mut b, text)).inner;
+        if r.changed() {
+            self.emit_set(ctx, &path, SteelVal::BoolV(b), t.push);
+        }
+        self.merge(r);
+    }
+
+    /// Render a button that queues a push evaluation at the bound node.
+    /// Buttons never write state: bang semantics stay in the node's expr.
+    fn button(&mut self, b: &Button, id: egui::Id, ui: &mut egui::Ui) {
+        let text = b.label.as_deref().unwrap_or("!");
+        let r = ui.push_id(id, |ui| ui.button(text)).inner;
+        if r.clicked() {
+            match &b.bind {
+                Some(bind) => {
+                    let path = self.resolve(bind);
+                    self.emit_push(&path);
+                }
+                None => log::warn!("button with no bind pressed, nothing to push"),
+            }
+        }
+        self.merge(r);
+    }
+
+    /// Render a grid of cells bound to rows-of-cells state (bool or number
+    /// cells). Rows and columns come from the state shape, and any cell edit
+    /// rebuilds and writes the whole value.
+    fn matrix(&mut self, m: &Matrix, id: egui::Id, ctx: &mut NodeCtx, ui: &mut egui::Ui) {
+        let Some(bind) = &m.bind else {
+            let r = unbound_chip(ui, "matrix");
+            self.merge(r);
+            return;
+        };
+        let path = self.resolve(bind);
+        let Ok(Some(val)) = ctx.extract_value_at(&path) else {
+            let r = err_label(ui, "no state at the bound path");
+            self.merge(r);
+            return;
+        };
+        let Some(rows) = matrix_rows(&val) else {
+            let r = err_label(ui, "bound state is not rows of cells");
+            self.merge(r);
+            return;
+        };
+        if rows.is_empty() {
+            let r = weak_chip(ui, "∅");
+            self.merge(r);
+            return;
+        }
+        let cell_size = m.cell_size.unwrap_or(DEFAULT_CELL_SIZE);
+        let mut edit: Option<(usize, usize, SteelVal)> = None;
+        let r = ui
+            .push_id(id, |ui| {
+                ui.vertical(|ui| {
+                    let mut area: Option<egui::Response> = None;
+                    for (row_ix, row) in rows.iter().enumerate() {
+                        ui.horizontal(|ui| {
+                            for (col_ix, cell) in row.iter().enumerate() {
+                                let size = [cell_size, cell_size];
+                                let r = match cell {
+                                    SteelVal::BoolV(b) => {
+                                        let button = egui::Button::new("").selected(*b);
+                                        let r = ui.add_sized(size, button);
+                                        if r.clicked() {
+                                            let flipped = SteelVal::BoolV(!b);
+                                            edit = Some((row_ix, col_ix, flipped));
+                                        }
+                                        r
+                                    }
+                                    SteelVal::NumV(_) | SteelVal::IntV(_) => {
+                                        let mut n = cell.clone();
+                                        let dv = match &mut n {
+                                            SteelVal::NumV(f) => egui::DragValue::new(f),
+                                            SteelVal::IntV(i) => egui::DragValue::new(i),
+                                            _ => unreachable!("numeric match above"),
+                                        };
+                                        let r = ui.add_sized(size, dv);
+                                        if r.changed() && n != *cell {
+                                            edit = Some((row_ix, col_ix, n));
+                                        }
+                                        r
+                                    }
+                                    _ => err_label(ui, "cell is not a bool or number"),
+                                };
+                                area = Some(match area.take() {
+                                    Some(prev) => prev.union(r),
+                                    None => r,
+                                });
+                            }
+                        });
+                    }
+                    area
+                })
+                .inner
+            })
+            .inner;
+        if let Some((row, col, cell)) = edit {
+            if let Some(new_val) = matrix_set_cell(&val, row, col, cell) {
+                self.emit_set(ctx, &path, new_val, m.push);
+            }
+        }
+        if let Some(r) = r {
+            self.merge(r);
+        }
+    }
+
+    /// Write an edited value to its bound state, then queue a push
+    /// evaluation when `push` is on.
+    fn emit_set(&mut self, ctx: &mut NodeCtx, path: &[node::Id], val: SteelVal, push: bool) {
+        if let Err(e) = ctx.update_value_at(path, val) {
+            log::warn!("failed to write bound state at {path:?}: {e}");
+            return;
+        }
+        if push {
+            self.emit_push(path);
+        }
+    }
+
+    /// Queue a push evaluation for the node at `path`.
+    fn emit_push(&mut self, path: &[node::Id]) {
+        let n_outputs = self.n_outputs.and_then(|f| f(path));
+        let Some(n) = n_outputs.and_then(|n| u8::try_from(n).ok()) else {
+            log::warn!(
+                "cannot resolve the output count of the node at {path:?}, skipping push eval"
+            );
+            return;
+        };
+        let ep = gantz_core::compile::entrypoint::push(path.to_vec(), n);
+        self.resp
+            .payloads
+            .push(DynResponse::new(crate::EvalEntry(ep)));
+    }
+
     /// Resolve a binding to its full state-tree path.
     fn resolve(&self, bind: &BindPath) -> Vec<node::Id> {
         resolve_path(self.instance_prefix, &self.scopes, bind)
@@ -288,9 +539,74 @@ fn cross_align(align: Align) -> egui::Align {
     }
 }
 
+/// The default side length of a matrix cell.
+const DEFAULT_CELL_SIZE: f32 = 18.0;
+
+/// A matrix value's cells as rows, or `None` when the bound state is not
+/// rows-of-cells shaped. Lists and vectors are accepted interchangeably.
+fn matrix_rows(val: &SteelVal) -> Option<Vec<Vec<SteelVal>>> {
+    let (_, rows) = seq_elems(val)?;
+    rows.iter()
+        .map(|row| seq_elems(row).map(|(_, cells)| cells))
+        .collect()
+}
+
+/// Rebuild a whole matrix value with one cell replaced, preserving the
+/// list-vs-vector shape at both levels. `None` when `val` is not a matrix or
+/// the cell is out of bounds.
+fn matrix_set_cell(val: &SteelVal, row: usize, col: usize, cell: SteelVal) -> Option<SteelVal> {
+    let (outer, mut rows) = seq_elems(val)?;
+    let (inner, mut cells) = seq_elems(rows.get(row)?)?;
+    if col >= cells.len() {
+        return None;
+    }
+    cells[col] = cell;
+    rows[row] = seq_rebuild(inner, cells);
+    Some(seq_rebuild(outer, rows))
+}
+
+/// Whether a value is a steel list or vector (interchangeable throughout).
+#[derive(Clone, Copy)]
+enum Seq {
+    List,
+    Vector,
+}
+
+/// A sequence value's kind and elements.
+fn seq_elems(val: &SteelVal) -> Option<(Seq, Vec<SteelVal>)> {
+    match val {
+        SteelVal::ListV(l) => Some((Seq::List, l.iter().cloned().collect())),
+        SteelVal::VectorV(v) => Some((Seq::Vector, v.iter().cloned().collect())),
+        _ => None,
+    }
+}
+
+/// Rebuild a sequence of the given kind.
+fn seq_rebuild(seq: Seq, items: Vec<SteelVal>) -> SteelVal {
+    match seq {
+        Seq::List => SteelVal::ListV(items.into_iter().collect()),
+        Seq::Vector => {
+            let v: Vector<SteelVal> = items.into_iter().collect();
+            SteelVal::VectorV(Gc::new(v).into())
+        }
+    }
+}
+
 /// An inline chip for elements that cannot render yet.
 fn placeholder_chip(ui: &mut egui::Ui, text: &str) -> egui::Response {
     weak_chip(ui, text)
+}
+
+/// An inline chip for a control missing its `bind` attr.
+fn unbound_chip(ui: &mut egui::Ui, tag: &str) -> egui::Response {
+    weak_chip(ui, tag).on_hover_text("no `bind` attribute")
+}
+
+/// An inline "ERR" label for a control whose bound state has the wrong
+/// shape, with the reason on hover.
+fn err_label(ui: &mut egui::Ui, why: &str) -> egui::Response {
+    ui.add(egui::Label::new("ERR").selectable(false))
+        .on_hover_text(why)
 }
 
 /// A small framed chip with weak text.
@@ -356,5 +672,78 @@ mod tests {
         assert_ne!(child_id(p1, 0, None), child_id(p2, 0, None));
         let key = Key::Str("a".to_string());
         assert_ne!(child_id(p1, 0, Some(&key)), child_id(p2, 0, Some(&key)));
+    }
+
+    fn list(items: Vec<SteelVal>) -> SteelVal {
+        SteelVal::ListV(items.into_iter().collect())
+    }
+
+    fn vector(items: Vec<SteelVal>) -> SteelVal {
+        let v: Vector<SteelVal> = items.into_iter().collect();
+        SteelVal::VectorV(Gc::new(v).into())
+    }
+
+    #[test]
+    fn matrix_rows_requires_rows_of_cells() {
+        let m = list(vec![list(vec![
+            SteelVal::BoolV(true),
+            SteelVal::BoolV(false),
+        ])]);
+        let rows = matrix_rows(&m).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].len(), 2);
+
+        // A flat sequence of numbers is not a matrix.
+        let flat = list(vec![SteelVal::IntV(1), SteelVal::IntV(2)]);
+        assert_eq!(matrix_rows(&flat), None);
+        // Nor is a lone number.
+        assert_eq!(matrix_rows(&SteelVal::IntV(1)), None);
+    }
+
+    #[test]
+    fn matrix_set_cell_replaces_one_cell() {
+        let m = list(vec![
+            list(vec![SteelVal::BoolV(false), SteelVal::BoolV(false)]),
+            list(vec![SteelVal::BoolV(false), SteelVal::BoolV(false)]),
+        ]);
+        let new = matrix_set_cell(&m, 1, 0, SteelVal::BoolV(true)).unwrap();
+        let rows = matrix_rows(&new).unwrap();
+        assert_eq!(
+            rows[0],
+            vec![SteelVal::BoolV(false), SteelVal::BoolV(false)]
+        );
+        assert_eq!(rows[1], vec![SteelVal::BoolV(true), SteelVal::BoolV(false)]);
+    }
+
+    #[test]
+    fn matrix_set_cell_preserves_list_vs_vector_shape() {
+        // A vector of lists keeps its shape at both levels.
+        let m = vector(vec![
+            list(vec![SteelVal::IntV(0), SteelVal::IntV(1)]),
+            list(vec![SteelVal::IntV(2), SteelVal::IntV(3)]),
+        ]);
+        let new = matrix_set_cell(&m, 0, 1, SteelVal::IntV(9)).unwrap();
+        let SteelVal::VectorV(rows) = &new else {
+            panic!("outer vector became {new:?}");
+        };
+        let row0 = rows.iter().next().unwrap();
+        assert!(
+            matches!(row0, SteelVal::ListV(_)),
+            "inner list became {row0:?}"
+        );
+        let rows = matrix_rows(&new).unwrap();
+        assert_eq!(rows[0], vec![SteelVal::IntV(0), SteelVal::IntV(9)]);
+        assert_eq!(rows[1], vec![SteelVal::IntV(2), SteelVal::IntV(3)]);
+    }
+
+    #[test]
+    fn matrix_set_cell_out_of_bounds_is_none() {
+        let m = list(vec![list(vec![SteelVal::BoolV(false)])]);
+        assert_eq!(matrix_set_cell(&m, 1, 0, SteelVal::BoolV(true)), None);
+        assert_eq!(matrix_set_cell(&m, 0, 1, SteelVal::BoolV(true)), None);
+        assert_eq!(
+            matrix_set_cell(&SteelVal::IntV(1), 0, 0, SteelVal::BoolV(true)),
+            None,
+        );
     }
 }

--- a/crates/gantz_egui/src/ui_tree/plot.rs
+++ b/crates/gantz_egui/src/ui_tree/plot.rs
@@ -1,0 +1,313 @@
+//! The shared plot leaf renderer.
+//!
+//! Draws per-channel numeric series with `egui_plot`, parameterized by
+//! [`PlotParams`] so the same code renders both the `Plot` node (params from
+//! its weight) and the interpreter's `plot` element (params from its attrs).
+
+use steel::SteelVal;
+
+/// The resolved rendering parameters of one plot.
+pub(crate) struct PlotParams {
+    /// How the series is drawn.
+    pub style: gantz_ui::PlotStyle,
+    /// Plot colour, theme default when absent.
+    pub color: Option<[u8; 4]>,
+    /// Whether a grid draws behind the samples.
+    pub grid: bool,
+    /// Whether axes draw.
+    pub axes: bool,
+    /// Whether hovering the samples shows a value readout.
+    pub interactive: bool,
+    /// A fixed lower value axis bound.
+    pub y_min: Option<f32>,
+    /// A fixed upper value axis bound.
+    pub y_max: Option<f32>,
+}
+
+/// Render the plot filling `size`: a single channel fills it; multiple channels
+/// (a list-of-lists, e.g. from `~scopeout` + `deinterleave`) are stacked as one
+/// sub-plot each. Returns the combined response.
+pub(crate) fn plot_body(
+    params: &PlotParams,
+    channels: &[Vec<f64>],
+    plot_id: egui::Id,
+    size: egui::Vec2,
+    ui: &mut egui::Ui,
+) -> egui::Response {
+    // No data yet: draw a single empty plot so the node still has a body.
+    if channels.len() <= 1 {
+        let ys = channels.first().map(Vec::as_slice).unwrap_or(&[]);
+        return plot_channel(params, ys, plot_id, size, ui);
+    }
+    // Stack one sub-plot per channel, splitting the height evenly.
+    let sub_h = size.y / channels.len() as f32;
+    ui.vertical(|ui| {
+        let mut resp: Option<egui::Response> = None;
+        for (i, ch) in channels.iter().enumerate() {
+            let r = plot_channel(params, ch, plot_id.with(i), egui::vec2(size.x, sub_h), ui);
+            resp = Some(match resp.take() {
+                Some(prev) => prev.union(r),
+                None => r,
+            });
+        }
+        resp.expect("at least two channels")
+    })
+    .inner
+}
+
+/// Render one channel's series (axes, grid, line/bars and bounds) filling `size`.
+fn plot_channel(
+    params: &PlotParams,
+    ys: &[f64],
+    plot_id: egui::Id,
+    size: egui::Vec2,
+    ui: &mut egui::Ui,
+) -> egui::Response {
+    let color = resolve_color(params.color, ui);
+    let plot_style = params.style;
+    let interactive = params.interactive;
+    let bounds = value_bounds(ys, plot_style, params.y_min, params.y_max);
+
+    let mut plot = egui_plot::Plot::new(plot_id)
+        .width(size.x)
+        .height(size.y)
+        .show_background(false)
+        .show_axes(egui::Vec2b::new(params.axes, params.axes))
+        .show_grid(egui::Vec2b::new(params.grid, params.grid))
+        // Pan/zoom are always off. `Sense::hover` lets the node frame beneath
+        // capture drags and right-clicks, so the node moves and its context
+        // menu opens as usual.
+        .allow_drag(false)
+        .allow_zoom(false)
+        .allow_scroll(false)
+        .allow_boxed_zoom(false)
+        .sense(egui::Sense::hover());
+    if !interactive {
+        // Purely visual: hide the crosshair (the value readout is also
+        // suppressed via `allow_hover(false)` below).
+        plot = plot.cursor_color(egui::Color32::TRANSPARENT);
+    }
+
+    let plot_resp = plot
+        .show(ui, |plot_ui| {
+            match plot_style {
+                gantz_ui::PlotStyle::Bars => {
+                    let bars = ys
+                        .iter()
+                        .enumerate()
+                        .map(|(i, &y)| {
+                            egui_plot::Bar::new(i as f64, y)
+                                .width(1.0)
+                                .fill(color)
+                                .stroke(egui::Stroke::NONE)
+                        })
+                        .collect();
+                    plot_ui.bar_chart(egui_plot::BarChart::new("", bars).allow_hover(interactive));
+                }
+                gantz_ui::PlotStyle::Line => {
+                    let points = egui_plot::PlotPoints::from_ys_f64(ys);
+                    plot_ui.line(
+                        egui_plot::Line::new("", points)
+                            .color(color)
+                            .allow_hover(interactive),
+                    );
+                }
+            }
+            // Drive the view deterministically from the data + config (the
+            // plot never pans), so live updates and min/max apply.
+            let ([xlo, ylo], [xhi, yhi]) = bounds;
+            plot_ui.set_plot_bounds_x(xlo..=xhi);
+            plot_ui.set_plot_bounds_y(ylo..=yhi);
+        })
+        .response;
+
+    // egui_plot sets a crosshair *mouse cursor* on hover; when not
+    // interactive, restore the default arrow so the plot reads as a static
+    // node. (The resize corner sets its own cursor after this, so it is
+    // unaffected.)
+    if !interactive && plot_resp.hovered() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::Default);
+    }
+    plot_resp
+}
+
+/// Compute `([x_min, y_min], [x_max, y_max])` for the view from the data and
+/// optional fixed value bounds. Bars include the baseline `0` and span integer
+/// x; lines span sample indices. The plot itself adds no margin.
+fn value_bounds(
+    ys: &[f64],
+    style: gantz_ui::PlotStyle,
+    y_min: Option<f32>,
+    y_max: Option<f32>,
+) -> ([f64; 2], [f64; 2]) {
+    let n = ys.len() as f64;
+    let (xlo, xhi) = match style {
+        gantz_ui::PlotStyle::Bars => (-0.5, (n - 0.5).max(0.5)),
+        gantz_ui::PlotStyle::Line => (0.0, (n - 1.0).max(1.0)),
+    };
+
+    let (dmin, dmax) = ys
+        .iter()
+        .copied()
+        .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), v| {
+            (lo.min(v), hi.max(v))
+        });
+    let (mut ylo, mut yhi) = if dmin <= dmax {
+        match style {
+            // Bars draw from the baseline, so keep `0` in view.
+            gantz_ui::PlotStyle::Bars => (dmin.min(0.0), dmax.max(0.0)),
+            gantz_ui::PlotStyle::Line => (dmin, dmax),
+        }
+    } else {
+        (0.0, 1.0)
+    };
+    if (yhi - ylo).abs() < 1e-9 {
+        ylo -= 1.0;
+        yhi += 1.0;
+    }
+
+    // Fixed overrides are exact.
+    if let Some(v) = y_min {
+        ylo = v as f64;
+    }
+    if let Some(v) = y_max {
+        yhi = v as f64;
+    }
+
+    ([xlo, ylo], [xhi, yhi])
+}
+
+/// Resolve the configured colour, falling back to the theme's strong text
+/// colour when unset.
+pub(crate) fn resolve_color(color: Option<[u8; 4]>, ui: &egui::Ui) -> egui::Color32 {
+    match color {
+        Some([r, g, b, a]) => egui::Color32::from_rgba_unmultiplied(r, g, b, a),
+        None => ui.visuals().strong_text_color(),
+    }
+}
+
+/// Split a stored plot value into per-channel series. A list or vector *of lists/vectors*
+/// is one series per inner container (`~scopeout`'s per-channel rings produce this); a
+/// flat numeric list or vector - or a lone number - is a single channel. Lists and
+/// vectors are treated identically ([`SteelVal::ListV`] and [`SteelVal::VectorV`]).
+pub(crate) fn split_channels(val: &SteelVal) -> Vec<Vec<f64>> {
+    // The top-level elements of a list or vector; `None` if `val` is not a container.
+    let elems: Option<Vec<&SteelVal>> = match val {
+        SteelVal::ListV(list) => Some(list.iter().collect()),
+        SteelVal::VectorV(vec) => Some(vec.iter().collect()),
+        _ => None,
+    };
+    match elems {
+        // A container whose elements are themselves containers: one series each.
+        Some(elems) if elems.iter().any(|v| is_container(v)) => {
+            elems.iter().map(|v| channel_numerics(v)).collect()
+        }
+        // A flat numeric container: a single channel.
+        Some(elems) => vec![elems.iter().filter_map(|v| steel_num(v)).collect()],
+        // A lone number: one single-sample channel.
+        None => vec![steel_num(val).into_iter().collect()],
+    }
+}
+
+/// Whether `v` is a list or vector (a channel container).
+pub(crate) fn is_container(v: &SteelVal) -> bool {
+    matches!(v, SteelVal::ListV(_) | SteelVal::VectorV(_))
+}
+
+/// One channel's numeric samples: a list's or vector's numeric elements, or a lone number.
+fn channel_numerics(val: &SteelVal) -> Vec<f64> {
+    match val {
+        SteelVal::ListV(list) => list.iter().filter_map(steel_num).collect(),
+        SteelVal::VectorV(vec) => vec.iter().filter_map(steel_num).collect(),
+        other => steel_num(other).into_iter().collect(),
+    }
+}
+
+/// Convert a numeric [`SteelVal`] to `f64`.
+pub(crate) fn steel_num(val: &SteelVal) -> Option<f64> {
+    match val {
+        SteelVal::NumV(f) => Some(*f),
+        SteelVal::IntV(i) => Some(*i as f64),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `split_channels` treats a list-or-vector-of-containers as one series per inner
+    // container (for the stacked multi-channel plot), and a flat list/vector or lone
+    // number as a single channel. Lists and vectors are interchangeable, including mixed.
+    #[test]
+    fn split_channels_by_shape() {
+        let num = |n: f64| SteelVal::NumV(n);
+        let list = |xs: Vec<SteelVal>| SteelVal::ListV(xs.into_iter().collect());
+        let vector = |xs: Vec<SteelVal>| SteelVal::VectorV(xs.into_iter().collect());
+
+        // A flat numeric list or vector is one channel.
+        assert_eq!(
+            split_channels(&list(vec![num(1.0), num(2.0), num(3.0)])),
+            vec![vec![1.0, 2.0, 3.0]],
+        );
+        assert_eq!(
+            split_channels(&vector(vec![num(1.0), num(2.0), num(3.0)])),
+            vec![vec![1.0, 2.0, 3.0]],
+        );
+        // A lone number is one single-sample channel.
+        assert_eq!(split_channels(&num(7.0)), vec![vec![7.0]]);
+        // A list of lists, a vector of vectors, and a mixed list of vectors all give
+        // one channel per inner container.
+        let expected = vec![vec![1.0, 3.0], vec![2.0, 4.0]];
+        assert_eq!(
+            split_channels(&list(vec![
+                list(vec![num(1.0), num(3.0)]),
+                list(vec![num(2.0), num(4.0)]),
+            ])),
+            expected,
+        );
+        assert_eq!(
+            split_channels(&vector(vec![
+                vector(vec![num(1.0), num(3.0)]),
+                vector(vec![num(2.0), num(4.0)]),
+            ])),
+            expected,
+        );
+        assert_eq!(
+            split_channels(&list(vec![
+                vector(vec![num(1.0), num(3.0)]),
+                vector(vec![num(2.0), num(4.0)]),
+            ])),
+            expected,
+        );
+    }
+
+    // Bars keep the baseline in view and pad a flat series; fixed bounds are exact.
+    #[test]
+    fn value_bounds_by_style() {
+        use gantz_ui::PlotStyle::{Bars, Line};
+
+        // Bars: x spans integer bar positions, y includes the baseline 0.
+        let ([xlo, ylo], [xhi, yhi]) = value_bounds(&[1.0, 2.0, 3.0], Bars, None, None);
+        assert_eq!((xlo, xhi), (-0.5, 2.5));
+        assert_eq!((ylo, yhi), (0.0, 3.0));
+
+        // Lines: x spans sample indices, y spans the data.
+        let ([xlo, ylo], [xhi, yhi]) = value_bounds(&[1.0, 2.0, 3.0], Line, None, None);
+        assert_eq!((xlo, xhi), (0.0, 2.0));
+        assert_eq!((ylo, yhi), (1.0, 3.0));
+
+        // A flat series is padded so it stays visible.
+        let ([_, ylo], [_, yhi]) = value_bounds(&[2.0, 2.0], Line, None, None);
+        assert_eq!((ylo, yhi), (1.0, 3.0));
+
+        // Fixed overrides are exact.
+        let ([_, ylo], [_, yhi]) = value_bounds(&[1.0, 2.0], Line, Some(-1.0), Some(1.0));
+        assert_eq!((ylo, yhi), (-1.0, 1.0));
+
+        // No data: a unit-ish default window.
+        let ([xlo, ylo], [xhi, yhi]) = value_bounds(&[], Bars, None, None);
+        assert_eq!((xlo, xhi), (-0.5, 0.5));
+        assert_eq!((ylo, yhi), (0.0, 1.0));
+    }
+}

--- a/crates/gantz_egui/src/widget.rs
+++ b/crates/gantz_egui/src/widget.rs
@@ -35,6 +35,7 @@ pub mod global_config;
 pub mod graph_config;
 pub mod graph_scene;
 pub mod graph_select;
+pub mod gui_debug;
 pub mod head_name_edit;
 pub mod head_row;
 pub mod history_view;

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -399,6 +399,9 @@ pub enum Pane {
     /// Contains the inner graph tree with all open graph tabs.
     GraphScene,
     Graphs,
+    /// An editable GUI tree literal rendered live through the
+    /// [`ui_tree`][crate::ui_tree] interpreter against the focused head's VM.
+    GuiDebug,
     GuiPerf,
     History,
     Logs,
@@ -674,6 +677,7 @@ pub struct ViewToggles {
     pub perf_gui: bool,
     pub perf_vm: bool,
     pub steel: bool,
+    pub gui_debug: bool,
     pub graph_config: bool,
     /// Per-[`Pane::Ext`] visibility, keyed by the provider key. A missing
     /// entry means hidden (matching the tray panes' default). Keys of
@@ -697,6 +701,7 @@ impl Default for ViewToggles {
             perf_gui: false,
             perf_vm: false,
             steel: false,
+            gui_debug: false,
             graph_config: true,
             ext: BTreeMap::new(),
         }
@@ -942,6 +947,10 @@ impl<'a> Gantz<'a> {
         // Ensure every supplied extension pane has a tile.
         let ext_keys: Vec<&str> = self.ext_panes.iter().map(|p| p.key()).collect();
         sync_ext_panes(&mut tree, &ext_keys);
+
+        // Ensure the GUI Debug pane has a tile (trees persisted before it
+        // existed).
+        sync_singleton_pane(&mut tree, Pane::GuiDebug);
 
         // Check the `view_toggles` match the pane visibility.
         set_tile_visibility(&mut tree, &state.view_toggles);
@@ -1852,6 +1861,70 @@ where
                 ui,
             );
         }
+        Pane::GuiDebug => {
+            // The editor (plus its eval error and decode warnings) on the
+            // left, the interpreted tree on the right, rendered against the
+            // focused head's live VM: bindings resolve into its node state
+            // and pushes fire its entrypoints.
+            let cache = egui::Panel::left(egui::Id::new("gui-debug-editor-panel"))
+                .resizable(true)
+                .show_inside(ui, |ui| {
+                    egui::ScrollArea::vertical()
+                        .show(ui, |ui| {
+                            let id = egui::Id::new("gantz-gui-debug-editor");
+                            let out = super::gui_debug::tree_editor(id, ui);
+                            if let Some(err) = &out.cache.eval_err {
+                                ui.colored_label(ui.visuals().error_fg_color, err);
+                            }
+                            if let Some(decoded) = &out.cache.decoded {
+                                if !decoded.warnings.is_empty() {
+                                    let title = format!("warnings ({})", decoded.warnings.len());
+                                    egui::CollapsingHeader::new(title).show(ui, |ui| {
+                                        for w in &decoded.warnings {
+                                            ui.horizontal_wrapped(|ui| {
+                                                ui.weak(format!("{:?}", w.path.0));
+                                                ui.label(w.kind.to_string());
+                                            });
+                                        }
+                                    });
+                                }
+                            }
+                            out.cache
+                        })
+                        .inner
+                })
+                .inner;
+            egui::CentralPanel::default().show_inside(ui, |ui| {
+                let Some(decoded) = &cache.decoded else {
+                    ui.weak("nothing to render");
+                    return;
+                };
+                let Some(head) = access.heads().get(*focused_head).cloned() else {
+                    ui.weak("no focused graph");
+                    return;
+                };
+                let env = gantz.env;
+                egui::ScrollArea::both().show(ui, |ui| {
+                    let payloads = access.with_head_mut(&head, |data| {
+                        let (inlets, outlets) = crate::inlet_outlet_ids(env, data.graph);
+                        let n_outs = super::gui_debug::node_output_counts(env, data.graph);
+                        let resolver = move |p: &[node::Id]| match p {
+                            &[ix] => n_outs.get(&ix).copied(),
+                            _ => None,
+                        };
+                        let mut node_ctx = NodeCtx::new(env, &[], &inlets, &outlets, &[], data.vm);
+                        let root_id = egui::Id::new(("gantz-gui-debug", &head));
+                        let r = crate::ui_tree::UiTree::new(root_id)
+                            .n_outputs(&resolver)
+                            .show(&decoded.root, &mut node_ctx, ui);
+                        r.payloads
+                    });
+                    if let Some(payloads) = payloads {
+                        gantz_response.responses.extend(Some(&head), payloads);
+                    }
+                });
+            });
+        }
         Pane::VmPerf => {
             if let Some(ref mut capture) = gantz.perf_vm {
                 perf_view("VM Perf", capture, ui);
@@ -2230,6 +2303,7 @@ where
         Pane::NodeInspector => with_head("Node Inspector"),
         Pane::NodeView(p) => node_view_title(p),
         Pane::Steel => with_head("Steel"),
+        Pane::GuiDebug => with_head("GUI Debug"),
         Pane::VmPerf => "VM Perf".to_string(),
     }
 }
@@ -2288,7 +2362,9 @@ impl Default for GantzState {
 fn create_tree() -> egui_tiles::Tree<Pane> {
     let mut tiles = egui_tiles::Tiles::default();
 
-    // The leaf panes.
+    // The leaf panes. The GUI Debug pane is not created here: it joins the
+    // tray via `sync_singleton_pane` (the same path that serves persisted
+    // trees predating it).
     let graph_config = tiles.insert_pane(Pane::GraphConfig);
     let graph_scene = tiles.insert_pane(Pane::GraphScene);
     let graphs = tiles.insert_pane(Pane::Graphs);
@@ -2365,12 +2441,18 @@ fn add_node_view_pane(
         tree.make_active(|tile_id, _| tile_id == id);
         return;
     }
-    let pane_id = tree.tiles.insert_pane(Pane::NodeView(NodeViewPane {
+    let pane = Pane::NodeView(NodeViewPane {
         head,
         path,
         ty_name,
-    }));
-    // Default to the tray; fall back to the root if the layout isn't canonical.
+    });
+    insert_tray_pane(tree, pane);
+}
+
+/// Insert a new tile for `pane`, defaulting to the tray and falling back to
+/// the root if the layout isn't canonical.
+fn insert_tray_pane(tree: &mut egui_tiles::Tree<Pane>, pane: Pane) {
+    let pane_id = tree.tiles.insert_pane(pane);
     let container = layout_anchors(tree).map(|a| a.tray).or_else(|| tree.root());
     match container {
         Some(c) => tree.move_tile_to_container(pane_id, c, usize::MAX, true),
@@ -2388,15 +2470,21 @@ fn sync_ext_panes(tree: &mut egui_tiles::Tree<Pane>, keys: &[&str]) {
             .tiles
             .iter()
             .any(|(_, tile)| matches!(tile, egui_tiles::Tile::Pane(Pane::Ext(k)) if k == key));
-        if exists {
-            continue;
+        if !exists {
+            insert_tray_pane(tree, Pane::Ext(key.to_string()));
         }
-        let pane_id = tree.tiles.insert_pane(Pane::Ext(key.to_string()));
-        let container = layout_anchors(tree).map(|a| a.tray).or_else(|| tree.root());
-        match container {
-            Some(c) => tree.move_tile_to_container(pane_id, c, usize::MAX, true),
-            None => tree.root = Some(pane_id),
-        }
+    }
+}
+
+/// Ensure a tile exists for the given singleton pane, adding it to the tray
+/// when missing (a tree persisted before the pane existed).
+fn sync_singleton_pane(tree: &mut egui_tiles::Tree<Pane>, pane: Pane) {
+    let exists = tree
+        .tiles
+        .iter()
+        .any(|(_, tile)| matches!(tile, egui_tiles::Tile::Pane(p) if *p == pane));
+    if !exists {
+        insert_tray_pane(tree, pane);
     }
 }
 
@@ -2586,7 +2674,7 @@ fn impose_fixed_sizes(tree: &mut egui_tiles::Tree<Pane>, state: &GantzState, are
             (avail - width).max(1.0),
         );
     }
-    if state.view_toggles.logs || state.view_toggles.steel {
+    if state.view_toggles.logs || state.view_toggles.steel || state.view_toggles.gui_debug {
         let avail = area.height() - TILE_GAP;
         let height = state
             .tray_height
@@ -2701,6 +2789,7 @@ fn set_pane_visible(view: &mut ViewToggles, pane: &Pane, visible: bool) {
         Pane::GuiPerf => view.perf_gui = visible,
         Pane::Logs => view.logs = visible,
         Pane::Steel => view.steel = visible,
+        Pane::GuiDebug => view.gui_debug = visible,
         // No visibility toggle: always-visible scene / closable node views.
         Pane::GraphScene | Pane::NodeView(_) => {}
     }
@@ -2720,6 +2809,7 @@ fn pane_is_visible(view: &ViewToggles, pane: &Pane) -> bool {
         Pane::GuiPerf => view.perf_gui,
         Pane::Logs => view.logs,
         Pane::Steel => view.steel,
+        Pane::GuiDebug => view.gui_debug,
         Pane::GraphScene | Pane::NodeView(_) => true,
     }
 }
@@ -2741,6 +2831,7 @@ pub fn pane_key(pane: &Pane) -> String {
         Pane::GraphConfig => "graph-config".to_string(),
         Pane::GraphScene => "graph-scene".to_string(),
         Pane::Graphs => "graphs".to_string(),
+        Pane::GuiDebug => "gui-debug".to_string(),
         Pane::GuiPerf => "gui-perf".to_string(),
         Pane::History => "history".to_string(),
         Pane::Logs => "logs".to_string(),
@@ -2901,6 +2992,7 @@ fn set_tile_visibility(tree: &mut egui_tiles::Tree<Pane>, view: &ViewToggles) {
                 Pane::VmPerf => tree.set_visible(id, open && view.perf_vm),
                 Pane::Logs => tree.set_visible(id, view.logs),
                 Pane::Steel => tree.set_visible(id, view.steel),
+                Pane::GuiDebug => tree.set_visible(id, view.gui_debug),
                 // Always visible: a node view is removed by closing, not hiding.
                 Pane::NodeView(_) => tree.set_visible(id, true),
             }

--- a/crates/gantz_egui/src/widget/gui_debug.rs
+++ b/crates/gantz_egui/src/widget/gui_debug.rs
@@ -1,0 +1,145 @@
+//! The GUI Debug pane's editor: a Steel tree literal that evaluates and
+//! decodes into a [`gantz_ui::Element`] tree as it is typed.
+//!
+//! The pane renders the decoded tree through the [`ui_tree`][crate::ui_tree]
+//! interpreter against the focused head's live VM, making it both a
+//! playground for the GUI vocabulary and a live harness: bindings resolve
+//! into the focused graph's node state, and pushes fire its entrypoints.
+
+use crate::{Registry, node};
+use petgraph::visit::{IntoNodeReferences, NodeRef};
+use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::sync::Arc;
+
+/// The tree seeded into a fresh editor: self-contained layout/display
+/// elements plus a couple of bindings into the focused graph (nodes 0 and 1)
+/// to demonstrate the live harness. Evaluated by `Engine::new_base` (no
+/// prelude), hence the quote.
+const SEED: &str = r#"'(col
+  (frame (@ (title "gui debug"))
+    (label "edit this tree - it renders live")
+    (sep)
+    (row (dialer (@ (bind (0)) (label "node 0")))
+         (button (@ (bind (1)))))
+    (value (@ (bind (0))))))
+"#;
+
+/// The evaluated + decoded state of the editor text, cached by text hash so
+/// the Steel engine only runs when the text changes.
+pub struct Cache {
+    text_hash: u64,
+    /// The engine's error when the text failed to evaluate to a value.
+    pub eval_err: Option<String>,
+    /// The decoded tree + warnings when evaluation yielded a value.
+    pub decoded: Option<gantz_ui::Decoded>,
+}
+
+/// The editor's response and its current evaluation state.
+pub struct TreeEditOutput {
+    /// The cached evaluation of the editor's current text.
+    pub cache: Arc<Cache>,
+    /// The text editor's response.
+    pub response: egui::Response,
+}
+
+/// A multiline Steel editor whose text is evaluated (in a scratch base
+/// engine) and decoded into an element tree whenever it changes. The WIP
+/// text and the evaluation cache persist in egui temp memory under `id`.
+pub fn tree_editor(id: egui::Id, ui: &mut egui::Ui) -> TreeEditOutput {
+    let code_id = id.with("code");
+    let cache_id = id.with("cache");
+
+    let mut code: String = ui
+        .memory_mut(|m| m.data.get_temp(code_id))
+        .unwrap_or_else(|| SEED.to_string());
+
+    let language = "scm";
+    let theme = egui_extras::syntax_highlighting::CodeTheme::from_memory(ui.ctx(), ui.style());
+    let mut layouter = |ui: &egui::Ui, buf: &dyn egui::TextBuffer, wrap_width: f32| {
+        let mut layout_job = egui_extras::syntax_highlighting::highlight(
+            ui.ctx(),
+            ui.style(),
+            &theme,
+            buf.as_str(),
+            language,
+        );
+        layout_job.wrap.max_width = wrap_width;
+        ui.fonts_mut(|fonts| fonts.layout_job(layout_job))
+    };
+
+    let font_id = egui::FontSelection::from(egui::TextStyle::Monospace).resolve(ui.style());
+    let response = ui
+        .add(
+            egui::TextEdit::multiline(&mut code)
+                .id(id)
+                .code_editor()
+                .font(font_id)
+                .desired_width(ui.available_width())
+                .layouter(&mut layouter),
+        )
+        .on_hover_text(
+            "A quoted tree literal, evaluated by a scratch Steel engine on \
+             the UI thread whenever the text changes (no prelude - primitive \
+             forms only)",
+        );
+
+    // Re-evaluate only when the text changes.
+    let text_hash = {
+        let mut h = DefaultHasher::new();
+        code.hash(&mut h);
+        h.finish()
+    };
+    let cache: Option<Arc<Cache>> = ui.memory_mut(|m| m.data.get_temp(cache_id));
+    let cache = match cache {
+        Some(cache) if cache.text_hash == text_hash => cache,
+        _ => Arc::new(evaluate(text_hash, &code)),
+    };
+
+    ui.memory_mut(|m| {
+        m.data.insert_temp(code_id, code);
+        m.data.insert_temp(cache_id, cache.clone());
+    });
+
+    TreeEditOutput { cache, response }
+}
+
+/// Evaluate the editor text in a scratch base engine and decode the last
+/// yielded value into an element tree.
+fn evaluate(text_hash: u64, code: &str) -> Cache {
+    let mut engine = steel::steel_vm::engine::Engine::new_base();
+    let (eval_err, decoded) = match engine.run(code.to_string()) {
+        Err(e) => (Some(e.to_string()), None),
+        Ok(vals) => match vals.last() {
+            None => (Some("the text evaluates to no value".to_string()), None),
+            Some(val) => (
+                None,
+                Some(gantz_ui::codec::steel::decode(
+                    val,
+                    &gantz_ui::Limits::default(),
+                )),
+            ),
+        },
+    };
+    Cache {
+        text_hash,
+        eval_err,
+        decoded,
+    }
+}
+
+/// The output count of every node in `g`, backing the interpreter's
+/// push-eval resolver (a push entry fn's identity covers the count).
+pub fn node_output_counts<N>(
+    registry: &dyn Registry,
+    g: &gantz_core::node::graph::Graph<N>,
+) -> HashMap<node::Id, usize>
+where
+    N: gantz_core::Node,
+{
+    let get_node = |ca: &gantz_ca::ContentAddr| registry.node(ca);
+    let ctx = gantz_core::node::MetaCtx::new(&get_node);
+    g.node_references()
+        .map(|n| (n.id().index(), n.weight().n_outputs(ctx)))
+        .collect()
+}

--- a/crates/gantz_egui/src/widget/panes_config.rs
+++ b/crates/gantz_egui/src/widget/panes_config.rs
@@ -65,6 +65,9 @@ pub fn panes_config(view: &mut ViewToggles, ext: &[super::ExtPaneEntry], ui: &mu
         .on_hover_text("Log output from the running graphs.");
     ui.checkbox(&mut view.steel, "Steel")
         .on_hover_text("The compiled Steel code for the focused graph.");
+    ui.checkbox(&mut view.gui_debug, "GUI Debug").on_hover_text(
+        "An editable GUI tree literal rendered live against the focused graph's VM.",
+    );
     for entry in ext {
         let on = view.ext.entry(entry.key.clone()).or_insert(false);
         ui.checkbox(on, entry.title.as_str())

--- a/crates/gantz_ui/src/decode.rs
+++ b/crates/gantz_ui/src/decode.rs
@@ -488,6 +488,7 @@ fn elem(ctx: &mut Ctx, path: &mut Vec<usize>, depth: usize, expr: SExpr) -> Elem
             let color = a.color("color");
             let grid = a.bool_or("grid", false);
             let axes = a.bool_or("axes", false);
+            let interactive = a.bool_or("interactive", false);
             let y_min = a.f32("y-min");
             let y_max = a.f32("y-max");
             let w = a.f32("w");
@@ -502,6 +503,7 @@ fn elem(ctx: &mut Ctx, path: &mut Vec<usize>, depth: usize, expr: SExpr) -> Elem
                 color,
                 grid,
                 axes,
+                interactive,
                 y_min,
                 y_max,
                 w,
@@ -904,6 +906,7 @@ mod tests {
                 attr("color", str_("#00ff0080")),
                 attr("grid", SExpr::Bool(true)),
                 attr("axes", SExpr::Bool(true)),
+                attr("interactive", SExpr::Bool(true)),
                 attr("y-min", float(-1.0)),
                 attr("y-max", float(1.0)),
                 attr("w", int(120)),
@@ -917,6 +920,7 @@ mod tests {
             color: Some(Rgba([0, 255, 0, 128])),
             grid: true,
             axes: true,
+            interactive: true,
             y_min: Some(-1.0),
             y_max: Some(1.0),
             w: Some(120.0),

--- a/crates/gantz_ui/src/elem.rs
+++ b/crates/gantz_ui/src/elem.rs
@@ -303,6 +303,8 @@ pub struct Plot {
     pub grid: bool,
     /// Whether axes draw.
     pub axes: bool,
+    /// Whether hovering the samples shows a value readout.
+    pub interactive: bool,
     /// A fixed lower value axis bound. Attribute `y-min`.
     pub y_min: Option<f32>,
     /// A fixed upper value axis bound. Attribute `y-max`.

--- a/crates/gantz_ui/src/encode.rs
+++ b/crates/gantz_ui/src/encode.rs
@@ -128,6 +128,7 @@ pub fn encode(elem: &Element) -> SExpr {
             push_color(&mut attrs, "color", e.color);
             push_bool(&mut attrs, "grid", e.grid, false);
             push_bool(&mut attrs, "axes", e.axes, false);
+            push_bool(&mut attrs, "interactive", e.interactive, false);
             push_f32(&mut attrs, "y-min", e.y_min);
             push_f32(&mut attrs, "y-max", e.y_max);
             push_f32(&mut attrs, "w", e.w);
@@ -412,6 +413,7 @@ mod tests {
             color: Some(Rgba([0, 255, 0, 255])),
             grid: true,
             axes: true,
+            interactive: true,
             y_min: Some(-1.0),
             y_max: Some(1.0),
             w: Some(120.0),

--- a/crates/gantz_ui/src/lib.rs
+++ b/crates/gantz_ui/src/lib.rs
@@ -87,7 +87,7 @@
 //! |---|---|---|
 //! | `(label "text")` | none | positional text (required), `size` (number), `color` (`"#rrggbb"` or `"#rrggbbaa"`) |
 //! | `(value)` | any, rendered as its representation | `bind`, `wrap` (bool, default `#f`) |
-//! | `(plot)` | scope buffer or signal, a list of lists renders as stacked channels | `bind`, `mode` (`scope`/`signal`), `style` (`bars`/`line`), `color`, `grid`, `axes` (bools, default `#f`), `y-min`, `y-max`, `w`, `h` (numbers) |
+//! | `(plot)` | scope buffer or signal, a list of lists renders as stacked channels | `bind`, `mode` (`scope`/`signal`), `style` (`bars`/`line`), `color`, `grid`, `axes`, `interactive` (bools, default `#f`), `y-min`, `y-max`, `w`, `h` (numbers) |
 //!
 //! ## Embedding
 //!

--- a/crates/gantz_ui/tests/cross_codec.rs
+++ b/crates/gantz_ui/tests/cross_codec.rs
@@ -84,6 +84,7 @@ fn full_tree() -> Element {
                 color: Some(Rgba([0, 255, 0, 255])),
                 grid: true,
                 axes: true,
+                interactive: true,
                 y_min: Some(-1.0),
                 y_max: Some(1.0),
                 w: Some(120.0),


### PR DESCRIPTION
Part 2 of #318 

Introduce a data-driven egui renderer for `gantz_ui` element trees. This is the single rendering path for widget node GUIs: builtins render through the interpreter, and graph-defined GUIs evaluate to trees that are rendered the same way.

### New

- **`UiTree` interpreter** - walks a decoded `gantz_ui::Element` tree each frame, resolving widget bindings against VM state via `NodeCtx` and reporting interactions as `UiTreeResponse` payloads.
- **Path-addressed state access** on `NodeCtx` - `extract_value_at` / `update_value_at` resolve `bind` paths relative to the graph (`instance prefix ++ scope prefixes ++ bind path`), touching VM runtime state only (no CA-affecting mutations).
- **Widget event interpretation** - controls write bound state on real user edits (guarded by a `changed` signal + value comparison), then queue a push evaluation at the bound node when their `push` attr is on (buttons always push). Push evaluations are named by the compiled entry fn from the bound node's output count.
- **Widget identity** - every element's `egui::Id` derives from the render root id, its structural position, and enclosing scope ids. Label text never contributes, so relabelling never resets widget state.
- **GUI Debug pane** - a live Steel tree literal editor that evaluates and decodes into a `gantz_ui::Element` tree as you type. It renders through the interpreter against the focused head's live VM, making it a playground for the GUI vocabulary and a live harness.
- **`interactive` attr** on the `plot` element.
- **Shared plot leaf renderer** (`ui_tree::plot`) - parameterized by `PlotParams`, rendering both the `Plot` node and the interpreter's `plot` element from the same code.

### Refactors

- Extracted fragment renderers so each builtin widget type renders through the tree interpreter: `Plot` -> plot fragment, `Number` -> dialer fragment, `Bang` -> button fragment, `Inspect` -> value fragment.