### PR TITLE
feat: Add support for custom edge styling based on the connected node sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3185,9 +3185,9 @@ dependencies = [
 
 [[package]]
 name = "egui_graph"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e78cde82fcc5339f1665c14f40913fe7e33f01efba31e8ede5d726e3d60a1f"
+checksum = "838e8c5c82e8a73a87ad7bbe6f57f47ad2dfba9390e9c0b782b9550c784dad0a"
 dependencies = [
  "egui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ eframe = { version = "0.34", default-features = false, features = [
 ] }
 egui = { version = "0.34", default-features = false, features = ["serde", "persistence"] }
 egui_extras = { version = "0.34", default-features = false, features = ["syntect"] }
-egui_graph = "0.16"
+egui_graph = "0.16.2"
 egui_plot = "0.35"
 egui_tiles = "0.15"
 env_logger = { version = "0.11", default-features = false }

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -151,6 +151,7 @@ where
             .init_resource::<SettingsTabs>()
             .init_resource::<ExtPanes>()
             .init_resource::<RefExtUis>()
+            .init_resource::<EdgeStyles>()
             // GUI state observers
             .add_observer(on_head_opened::<N>)
             .add_observer(on_head_changed::<N>)
@@ -207,16 +208,18 @@ where
 }
 
 /// Empty the domain-provided GUI collections ([`SettingsTabs`], [`ExtPanes`],
-/// [`RefExtUis`]) so domain providers refill them with fresh snapshots each
-/// frame (see the resource docs for the schedule contract).
+/// [`RefExtUis`], [`EdgeStyles`]) so domain providers refill them with fresh
+/// snapshots each frame (see the resource docs for the schedule contract).
 fn clear_ui_providers(
     mut tabs: ResMut<SettingsTabs>,
     mut ext_panes: ResMut<ExtPanes>,
     mut ref_ext_uis: ResMut<RefExtUis>,
+    mut edge_styles: ResMut<EdgeStyles>,
 ) {
     tabs.0.clear();
     ext_panes.0.clear();
     ref_ext_uis.0.clear();
+    edge_styles.0.clear();
 }
 
 // ----------------------------------------------------------------------------
@@ -326,6 +329,17 @@ pub struct ExtPanes(pub Vec<Box<dyn gantz_egui::widget::ExtPane + Send + Sync>>)
 /// shared.
 #[derive(Default, Resource)]
 pub struct RefExtUis(pub Vec<Box<dyn gantz_egui::node::RefExtUi + Send + Sync>>);
+
+/// Graph-scene edge stylers contributed by domains (see
+/// [`EdgeStyle`][gantz_egui::widget::EdgeStyle]).
+///
+/// Same provider contract as [`SettingsTabs`]: cleared each frame in `First`,
+/// refilled by domain provider systems in `PreUpdate`, consumed by both GUI
+/// render paths. Stylers take `&self`, so consumers borrow the resource
+/// shared. A provider typically pushes a styler holding precomputed per-head
+/// classifications, since the erased GUI registry hides concrete node types.
+#[derive(Default, Resource)]
+pub struct EdgeStyles(pub Vec<Box<dyn gantz_egui::widget::EdgeStyle + Send + Sync>>);
 
 // ----------------------------------------------------------------------------
 // Events
@@ -1797,6 +1811,7 @@ pub fn update<N>(
         mut settings_tabs,
         mut ext_panes,
         ref_ext_uis,
+        edge_styles,
         mut requested,
         host_native,
         export_paths,
@@ -1810,6 +1825,7 @@ pub fn update<N>(
         ResMut<SettingsTabs>,
         ResMut<ExtPanes>,
         Res<RefExtUis>,
+        Res<EdgeStyles>,
         ResMut<WindowedPanesRequested>,
         Option<Res<HostNativePaneWindows>>,
         Option<Res<base::ExportPaths>>,
@@ -1900,6 +1916,11 @@ where
                 .iter()
                 .map(|e| &**e as &dyn gantz_egui::node::RefExtUi)
                 .collect();
+            let stylers: Vec<&dyn gantz_egui::widget::EdgeStyle> = edge_styles
+                .0
+                .iter()
+                .map(|s| &**s as &dyn gantz_egui::widget::EdgeStyle)
+                .collect();
             let mut widget = gantz_egui::widget::Gantz::new(&node_reg, &base_names.0)
                 .base_immutable(base_immutable.0)
                 .demos(&demos.0)
@@ -1910,7 +1931,8 @@ where
                 .pane_window_mode(pane_window_mode)
                 .settings_tabs(&mut tabs)
                 .ext_panes(&mut panes)
-                .ref_ext_uis(&exts);
+                .ref_ext_uis(&exts)
+                .edge_styles(&stylers);
             // Base-source authoring context, present only where the
             // per-source write-back runs (`update-base` inserts ExportPaths),
             // so the main app never shows a non-durable source dropdown.

--- a/crates/bevy_gantz_egui/src/pane_window.rs
+++ b/crates/bevy_gantz_egui/src/pane_window.rs
@@ -18,10 +18,10 @@
 //! `egui::Window`s instead.
 
 use crate::{
-    BaseImmutable, BaseNames, BuiltinNodes, CompileConfig, Demos, ExtPanes, GuiState, HeadAccess,
-    HostNativePaneWindows, ImportTask, OpenHeadViews, PerfGui, PerfVm, RefExtUis, Registry,
-    ResponseDispatchers, SettingsTabs, TraceCapture, WindowedPanesRequested, handle_gantz_response,
-    head, registry_ref,
+    BaseImmutable, BaseNames, BuiltinNodes, CompileConfig, Demos, EdgeStyles, ExtPanes, GuiState,
+    HeadAccess, HostNativePaneWindows, ImportTask, OpenHeadViews, PerfGui, PerfVm, RefExtUis,
+    Registry, ResponseDispatchers, SettingsTabs, TraceCapture, WindowedPanesRequested,
+    handle_gantz_response, head, registry_ref,
 };
 use bevy_app::prelude::*;
 use bevy_camera::{Camera2d, RenderTarget};
@@ -194,6 +194,7 @@ fn render_windowed_panes<N: PaneNode>(
         mut settings_tabs,
         mut ext_panes,
         ref_ext_uis,
+        edge_styles,
         mut demos,
         dispatchers,
         export_paths,
@@ -207,6 +208,7 @@ fn render_windowed_panes<N: PaneNode>(
         ResMut<SettingsTabs>,
         ResMut<ExtPanes>,
         Res<RefExtUis>,
+        Res<EdgeStyles>,
         ResMut<Demos>,
         Res<ResponseDispatchers>,
         Option<Res<crate::base::ExportPaths>>,
@@ -268,6 +270,11 @@ fn render_windowed_panes<N: PaneNode>(
                 .iter()
                 .map(|e| &**e as &dyn gantz_egui::node::RefExtUi)
                 .collect();
+            let stylers: Vec<&dyn gantz_egui::widget::EdgeStyle> = edge_styles
+                .0
+                .iter()
+                .map(|s| &**s as &dyn gantz_egui::widget::EdgeStyle)
+                .collect();
             let mut widget = gantz_egui::widget::Gantz::new(&node_reg, &base_names.0)
                 .base_immutable(base_immutable.0)
                 .demos(&demos.0)
@@ -277,7 +284,8 @@ fn render_windowed_panes<N: PaneNode>(
                 .perf_captures(&mut perf_vm.0, &mut perf_gui.0)
                 .settings_tabs(&mut tabs)
                 .ext_panes(&mut panes)
-                .ref_ext_uis(&exts);
+                .ref_ext_uis(&exts)
+                .edge_styles(&stylers);
             // Base-source authoring context (mirrors `update`).
             if let Some(paths) = &export_paths {
                 widget = widget.base_sources(gantz_egui::widget::BaseSourcesCtx {

--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -141,9 +141,10 @@ fn osc(secs: f64) -> u64 {
 ///   `insert_resource`, which would clobber earlier contributions.
 /// - GUI surfaces are provided by per-frame systems in `PreUpdate`
 ///   (here `sync_dsp_settings` and `provide_dsp_ref_ext`) pushing into the
-///   `First`-cleared collections ([`SettingsTabs`], [`RefExtUis`]), whose
-///   `init_resource` calls are idempotent on purpose so the plugin works
-///   with or without `GantzEguiPlugin`.
+///   `First`-cleared collections ([`SettingsTabs`], [`RefExtUis`],
+///   [`EdgeStyles`][bevy_gantz_egui::EdgeStyles]), whose `init_resource`
+///   calls are idempotent on purpose so the plugin works with or without
+///   `GantzEguiPlugin`.
 /// - The domain's own extension points (here
 ///   [`with_units`](Self::with_units)) hang off the plugin itself.
 pub struct PlyphonPlugin<N> {

--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -53,10 +53,10 @@ type UnitRegistrar = Box<dyn Fn(&mut plyphon::UnitRegistry) + Send + Sync>;
 
 use bevy_gantz::head::{HeadRef, HeadVms, OpenHead, WorkingGraph};
 use bevy_gantz::{EntrypointSet, EvalEpoch, Registry, VmSet};
-use bevy_gantz_egui::{ExtPanes, RefExtUis, RegisterResponseExt, SettingsTabs};
+use bevy_gantz_egui::{EdgeStyles, ExtPanes, RefExtUis, RegisterResponseExt, SettingsTabs};
 use gantz_plyphon::{
-    Config, DeriveStatus, DspPane, DspPaneHead, DspRefExtUi, DspSettingsTab, Status,
-    describe_parts, dsp_commits,
+    Config, DeriveStatus, DspEdgeStyle, DspPane, DspPaneHead, DspRefExtUi, DspSettingsTab,
+    RootPortInfo, Status, describe_parts, dsp_commits, root_port_info,
 };
 
 /// Editable DSP settings: the domain's [`Config`] as a bevy resource.
@@ -147,9 +147,8 @@ fn osc(secs: f64) -> u64 {
 /// - GUI surfaces are provided by per-frame systems in `PreUpdate`
 ///   (here `sync_dsp_settings` and `provide_dsp_ref_ext`) pushing into the
 ///   `First`-cleared collections ([`SettingsTabs`], [`RefExtUis`],
-///   [`EdgeStyles`][bevy_gantz_egui::EdgeStyles]), whose `init_resource`
-///   calls are idempotent on purpose so the plugin works with or without
-///   `GantzEguiPlugin`.
+///   [`EdgeStyles`]), whose `init_resource` calls are idempotent on purpose
+///   so the plugin works with or without `GantzEguiPlugin`.
 /// - The domain's own extension points (here
 ///   [`with_units`](Self::with_units)) hang off the plugin itself.
 pub struct PlyphonPlugin<N> {
@@ -207,6 +206,7 @@ where
         app.init_resource::<SettingsTabs>()
             .init_resource::<ExtPanes>()
             .init_resource::<RefExtUis>()
+            .init_resource::<EdgeStyles>()
             .add_message::<DspSettingsChanged>()
             .register_response_with::<Config>(dispatch_dsp_settings)
             .add_systems(
@@ -215,6 +215,7 @@ where
                     sync_dsp_settings,
                     provide_dsp_pane,
                     provide_dsp_ref_ext::<N>,
+                    provide_dsp_edge_style::<N>,
                 ),
             );
         // The DSP domain's base graphs (see `bevy_gantz_egui::base`).
@@ -621,6 +622,41 @@ fn provide_dsp_ref_ext<N>(
     }
     let dsp_graphs = dsp_graphs.clone().expect("just initialised");
     ref_ext_uis.0.push(Box::new(DspRefExtUi { dsp_graphs }));
+}
+
+/// Provide this frame's DSP edge styler: each open head's root-level port
+/// classification, driving signal-edge rendering in the graph scene (see
+/// [`EdgeStyles`] for the First/PreUpdate schedule contract).
+///
+/// Classification requires the concrete node type (see
+/// [`root_port_info`]), so it is computed here and handed to the UI -
+/// recomputed per head only when the registry, the head's working graph or
+/// its [`DspHead`] change.
+fn provide_dsp_edge_style<N>(
+    registry: Res<Registry<N>>,
+    heads: Query<(&HeadRef, Ref<WorkingGraph<N>>, Option<Ref<DspHead>>), With<OpenHead>>,
+    mut cache: Local<HashMap<ca::Head, std::sync::Arc<RootPortInfo>>>,
+    mut edge_styles: ResMut<EdgeStyles>,
+) where
+    N: 'static + ToNodeDsp + gantz_core::Node + AsRefNode + Send + Sync,
+{
+    let mut styled: HashMap<ca::Head, std::sync::Arc<RootPortInfo>> = HashMap::new();
+    for (head_ref, wg, dsp) in heads.iter() {
+        let head = head_ref.0.clone();
+        let stale = registry.is_changed()
+            || wg.is_changed()
+            || dsp.as_ref().is_some_and(|d| d.is_changed())
+            || !cache.contains_key(&head);
+        if stale {
+            let shapes = dsp.as_ref().map(|d| d.shapes.clone()).unwrap_or_default();
+            let info = root_port_info(&wg.0, &registry.0, &shapes);
+            cache.insert(head.clone(), std::sync::Arc::new(info));
+        }
+        styled.insert(head.clone(), cache[&head].clone());
+    }
+    // Forget heads that are no longer open.
+    cache.retain(|head, _| styled.contains_key(head));
+    edge_styles.0.push(Box::new(DspEdgeStyle { heads: styled }));
 }
 
 /// Keep each open head's synth in sync, `.after(VmSet)` and `.after(EntrypointSet)`.

--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -87,6 +87,11 @@ pub struct DspHead {
     /// The derived program rendered as text ([`describe_parts`]), or the
     /// failure message.
     pub view: std::sync::Arc<str>,
+    /// The per-port shapes recorded at derive time, merged across the head's
+    /// parts. Instanced parts arrive absolutized by their instance path (see
+    /// [`gantz_plyphon::instance`]), so keys are node paths absolute to the
+    /// head's root graph. Empty unless `status` is [`DeriveStatus::Ok`].
+    pub shapes: std::sync::Arc<gantz_plyphon::PortShapes>,
 }
 
 /// OSC/NTP fixed-point units per second (OSC time is 32.32 fixed point: 2^32).
@@ -717,6 +722,7 @@ fn drive_synths<N>(
                     DspHead {
                         status: DeriveStatus::FlattenError(e.to_string()),
                         view: format!("{e} - keeping the previous synths").into(),
+                        shapes: Default::default(),
                     }
                 }
             };
@@ -919,6 +925,7 @@ where
             return DspHead {
                 status: DeriveStatus::Silent,
                 view: "no dsp sink (`~out` / `~scopeout`) - silent".into(),
+                shapes: Default::default(),
             };
         }
         // A part cycle (`~bus` regions or instances with no runnable
@@ -931,13 +938,20 @@ where
             return DspHead {
                 status: DeriveStatus::DeriveError(e.to_string()),
                 view: format!("{e} - keeping the previous synths").into(),
+                shapes: Default::default(),
             };
         }
     };
 
-    // The GUI's readable rendering, taken before the planning loop below
-    // consumes `derived`.
+    // The GUI's readable rendering and the merged per-port shapes, taken
+    // before the planning loop below consumes `derived`.
     let view: std::sync::Arc<str> = describe_parts(&derived).into();
+    let shapes: std::sync::Arc<gantz_plyphon::PortShapes> = std::sync::Arc::new(
+        derived
+            .iter()
+            .flat_map(|r| r.shapes.iter().map(|(k, v)| (k.clone(), *v)))
+            .collect(),
+    );
     let n_parts = derived.len();
 
     // Release bus runs whose keys are gone from the derivation.
@@ -1066,6 +1080,7 @@ where
     DspHead {
         status: DeriveStatus::Ok { parts: n_parts },
         view,
+        shapes,
     }
 }
 

--- a/crates/gantz_egui/src/widget.rs
+++ b/crates/gantz_egui/src/widget.rs
@@ -2,6 +2,7 @@
 use time::{OffsetDateTime, UtcOffset, format_description};
 
 pub use checkbox_enabled::CheckboxEnabled;
+pub use edge_style::{EdgeStyle, EdgeStyleCtx, EdgeStyling};
 pub use ext_pane::{ExtPane, ExtPaneCtx, ExtPaneEntry};
 pub use gantz::{
     AlignConfig, BaseSourcesCtx, Gantz, GantzState, GridConfig, LayoutConfig, NodeViewPane, Pane,
@@ -29,6 +30,7 @@ pub use style_config::style_config;
 pub use tab::{Tab, TabResponse};
 
 pub mod checkbox_enabled;
+pub mod edge_style;
 pub mod ext_pane;
 pub mod gantz;
 pub mod global_config;

--- a/crates/gantz_egui/src/widget/edge_style.rs
+++ b/crates/gantz_egui/src/widget/edge_style.rs
@@ -1,0 +1,148 @@
+//! The domain seam for styling graph-scene edges (see [`EdgeStyle`]).
+
+use gantz_core::node;
+
+/// A domain-supplied edge styler - the edge analogue of
+/// [`RefExtUi`][crate::node::RefExtUi].
+///
+/// Domains style the edges of the graph scene by supplying implementations to
+/// the [`Gantz`][super::Gantz] widget via
+/// [`Gantz::edge_styles`][super::Gantz::edge_styles]. Implementations
+/// self-gate: return `None` for edges (or heads) the domain has no interest
+/// in, leaving the default egui-visuals styling. When several stylers are
+/// supplied, the first `Some` wins (supply order).
+///
+/// Styling affects painting only - edge interaction (hover, selection,
+/// deletion, context menu) is identical for styled and unstyled edges.
+pub trait EdgeStyle {
+    /// The styling for the given edge, or `None` for the default.
+    fn edge_styling(&self, ctx: &EdgeStyleCtx) -> Option<EdgeStyling>;
+}
+
+/// What the widget knows about an edge when asking for its styling.
+///
+/// `#[non_exhaustive]` so future context (e.g. node state, evaluation
+/// timing) reaches stylers without breaking implementors: constructed via
+/// [`EdgeStyleCtx::new`] (by the widget, and by downstream styler tests),
+/// with any future fields defaulting there.
+#[non_exhaustive]
+pub struct EdgeStyleCtx<'a> {
+    /// The head whose root graph is being viewed. Nested graphs are separate
+    /// heads, so the root-level node ids below fully identify the endpoints.
+    pub head: &'a gantz_ca::Head,
+    /// The edge's source: root-level node id and output port.
+    pub src: (node::Id, usize),
+    /// The edge's destination: root-level node id and input port.
+    pub dst: (node::Id, usize),
+}
+
+impl<'a> EdgeStyleCtx<'a> {
+    /// The context for the edge from `src` to `dst` in `head`'s root graph.
+    pub fn new(head: &'a gantz_ca::Head, src: (node::Id, usize), dst: (node::Id, usize)) -> Self {
+        Self { head, src, dst }
+    }
+}
+
+/// A declarative edge style, interpreted by the graph scene's painter.
+///
+/// `#[non_exhaustive]` so styling capabilities can grow without breaking
+/// constructors: start from [`EdgeStyling::default`] and set fields.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct EdgeStyling {
+    /// Colour for the default (unselected, unhovered) state. Hovered and
+    /// selected edges keep the theme strokes so those affordances stay
+    /// consistent across all edges.
+    pub color: Option<egui::Color32>,
+    /// A multiplier on the theme stroke width, applied in every state so the
+    /// edge keeps its weight when hovered or selected. `1.0` leaves the width
+    /// unchanged. The strand spacing and notch scale with it.
+    pub width_scale: f32,
+    /// Dash and gap lengths in graph units. Solid when `None`. A dash length
+    /// close to the stroke width reads as dotted.
+    pub dash: Option<(f32, f32)>,
+    /// The number of parallel strands to paint, e.g. a channel count. Counts
+    /// above a painter cap still draw the cap-width band, overlaid with
+    /// diagonal wrap stripes that read as a thick bound bundle rather than
+    /// adding ever-thinner strands (see [`graph_scene`][super::graph_scene]).
+    pub strands: usize,
+    /// A notched-cord texture: even dashes (equal dash and gap of this
+    /// length, graph units) painted over the line in the theme's extreme
+    /// background colour, or `None` for none. The notches stay within the
+    /// line's own width - a theme-neutral cue independent of the line colour.
+    pub notch: Option<f32>,
+    /// Hover tooltip text, e.g. `"2ch ar"`.
+    pub hover_text: Option<String>,
+}
+
+impl Default for EdgeStyling {
+    fn default() -> Self {
+        Self {
+            color: None,
+            width_scale: 1.0,
+            dash: None,
+            strands: 1,
+            notch: None,
+            hover_text: None,
+        }
+    }
+}
+
+/// The styling for the given edge: the first `Some` among `styles`, in
+/// supply order, or `None` when no styler claims the edge.
+pub fn edge_styling(styles: &[&dyn EdgeStyle], ctx: &EdgeStyleCtx) -> Option<EdgeStyling> {
+    styles.iter().find_map(|s| s.edge_styling(ctx))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Claims edges out of the given source node with the given colour.
+    struct StubStyle {
+        src_node: node::Id,
+        color: egui::Color32,
+    }
+
+    impl EdgeStyle for StubStyle {
+        fn edge_styling(&self, ctx: &EdgeStyleCtx) -> Option<EdgeStyling> {
+            (ctx.src.0 == self.src_node).then(|| EdgeStyling {
+                color: Some(self.color),
+                ..Default::default()
+            })
+        }
+    }
+
+    /// Stylers self-gate, the first `Some` wins, and unclaimed edges yield
+    /// `None` (the default styling).
+    #[test]
+    fn first_claiming_styler_wins() {
+        let red = egui::Color32::RED;
+        let blue = egui::Color32::BLUE;
+        let a = StubStyle {
+            src_node: 0,
+            color: red,
+        };
+        let b = StubStyle {
+            src_node: 0,
+            color: blue,
+        };
+        let c = StubStyle {
+            src_node: 1,
+            color: blue,
+        };
+        let styles: [&dyn EdgeStyle; 3] = [&a, &b, &c];
+        let head = gantz_ca::Head::Branch("test".to_string());
+        let ctx = |src_node| EdgeStyleCtx {
+            head: &head,
+            src: (src_node, 0),
+            dst: (2, 0),
+        };
+        // Both `a` and `b` claim node 0's edges: supply order breaks the tie.
+        assert_eq!(edge_styling(&styles, &ctx(0)).unwrap().color, Some(red));
+        // Only `c` claims node 1's edges.
+        assert_eq!(edge_styling(&styles, &ctx(1)).unwrap().color, Some(blue));
+        // No styler claims node 2's edges.
+        assert!(edge_styling(&styles, &ctx(2)).is_none());
+    }
+}

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -65,6 +65,7 @@ pub struct Gantz<'a> {
     settings_tabs: &'a mut [&'a mut dyn widget::SettingsTab],
     ext_panes: &'a mut [&'a mut dyn widget::ExtPane],
     ref_ext_uis: &'a [&'a dyn crate::node::RefExtUi],
+    edge_styles: &'a [&'a dyn widget::EdgeStyle],
     base_sources: Option<BaseSourcesCtx<'a>>,
     pane_window_mode: PaneWindowMode,
 }
@@ -796,6 +797,7 @@ impl<'a> Gantz<'a> {
             settings_tabs: &mut [],
             ext_panes: &mut [],
             ref_ext_uis: &[],
+            edge_styles: &[],
             base_sources: None,
             pane_window_mode: PaneWindowMode::default(),
         }
@@ -852,6 +854,14 @@ impl<'a> Gantz<'a> {
     /// are appended after the ref's own inspector rows.
     pub fn ref_ext_uis(mut self, uis: &'a [&'a dyn crate::node::RefExtUi]) -> Self {
         self.ref_ext_uis = uis;
+        self
+    }
+
+    /// Provide domain edge stylers for the graph scenes (see
+    /// [`EdgeStyle`][widget::EdgeStyle]). Each edge is styled by the first
+    /// styler returning `Some`; unclaimed edges keep the default styling.
+    pub fn edge_styles(mut self, styles: &'a [&'a dyn widget::EdgeStyle]) -> Self {
+        self.edge_styles = styles;
         self
     }
 
@@ -1510,6 +1520,7 @@ where
                 base_names,
                 base_immutable: gantz.base_immutable,
                 ext_panes: &ext_panes,
+                edge_styles: gantz.edge_styles,
             };
             graph_tree.ui(&mut graph_behaviour, ui);
 
@@ -1994,6 +2005,8 @@ where
     /// Extension-pane toggle entries for the scene's "Panes" context submenu
     /// (see [`ext_pane_entries`]).
     ext_panes: &'a [widget::ExtPaneEntry],
+    /// Domain edge stylers for the graph scenes (see [`widget::EdgeStyle`]).
+    edge_styles: &'a [&'a dyn widget::EdgeStyle],
 }
 
 impl<'a, Access> egui_tiles::Behavior<GraphPane> for GraphTreeBehaviour<'a, Access>
@@ -2211,6 +2224,7 @@ where
                 head_state,
                 view_toggles,
                 self.ext_panes,
+                self.edge_styles,
                 data.view,
                 layout_params,
                 scene_config,
@@ -3176,6 +3190,7 @@ fn graph_scene<N>(
     head_state: &mut OpenHeadState,
     view_toggles: &mut ViewToggles,
     ext_panes: &[widget::ExtPaneEntry],
+    edge_styles: &[&dyn widget::EdgeStyle],
     head_view: &mut crate::SceneView,
     layout_params: egui_graph::LayoutParams,
     scene_config: SceneConfig,
@@ -3224,6 +3239,7 @@ where
         .immutable(immutable)
         .view_toggles(view_toggles)
         .ext_panes(ext_panes)
+        .edge_styles(head, edge_styles)
         .show(head_view, &mut head_state.scene, vm, ui);
 
     graph_scene::paint_diagnostics(diagnostics, &[], &response, ui);

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -71,6 +71,9 @@ pub struct GraphScene<'a, N> {
     /// The supplied extension panes, for the "Panes" submenu's checkboxes
     /// (see [`panes_config`][super::panes_config()]).
     ext_panes: &'a [crate::widget::ExtPaneEntry],
+    /// The supplied domain edge stylers along with the viewed head they key
+    /// their styling by (see [`EdgeStyle`][crate::widget::EdgeStyle]).
+    edge_styles: Option<(&'a gantz_ca::Head, &'a [&'a dyn crate::widget::EdgeStyle])>,
 }
 
 /// State associated with the [`GraphScene`] widget that can be useful to access
@@ -130,6 +133,7 @@ where
             immutable: false,
             view_toggles: None,
             ext_panes: &[],
+            edge_styles: None,
         }
     }
 
@@ -181,6 +185,21 @@ where
     /// lists them alongside the built-in panes, matching Settings -> Panes.
     pub fn ext_panes(mut self, ext_panes: &'a [crate::widget::ExtPaneEntry]) -> Self {
         self.ext_panes = ext_panes;
+        self
+    }
+
+    /// Provide the domain edge stylers, along with the viewed head whose
+    /// root graph this scene shows (the stylers key their styling by it).
+    ///
+    /// Each edge is styled by the first styler returning `Some` - see
+    /// [`EdgeStyle`][crate::widget::EdgeStyle]. Edges no styler claims keep
+    /// the default egui-visuals styling.
+    pub fn edge_styles(
+        mut self,
+        head: &'a gantz_ca::Head,
+        styles: &'a [&'a dyn crate::widget::EdgeStyle],
+    ) -> Self {
+        self.edge_styles = Some((head, styles));
         self
     }
 
@@ -276,7 +295,15 @@ where
                     );
                 })
                 .edges(ui, |ectx, ui| {
-                    edges(self.graph, ectx, state, &mut responses, &mut changed, ui)
+                    edges(
+                        self.graph,
+                        ectx,
+                        state,
+                        &mut responses,
+                        &mut changed,
+                        self.edge_styles,
+                        ui,
+                    )
                 });
             });
 
@@ -864,6 +891,7 @@ fn edges<N>(
     state: &mut GraphSceneState,
     responses: &mut Vec<DynResponse>,
     changed: &mut bool,
+    edge_styles: Option<(&gantz_ca::Head, &[&dyn crate::widget::EdgeStyle])>,
     ui: &mut egui::Ui,
 ) {
     // Track whether any edge has a context menu open this frame.
@@ -880,8 +908,24 @@ fn edges<N>(
         let a = egui_graph::NodeId::from_u64(na.index() as u64);
         let b = egui_graph::NodeId::from_u64(nb.index() as u64);
         let mut selected = state.interaction.selection.edges.contains(&e);
-        let response =
-            egui_graph::edge::Edge::new((a, output), (b, input), &mut selected).show(ectx, ui);
+
+        // Ask the domain stylers for this edge's styling (first `Some` wins).
+        let styling = edge_styles.and_then(|(head, styles)| {
+            let ctx =
+                crate::widget::EdgeStyleCtx::new(head, (na.index(), output), (nb.index(), input));
+            crate::widget::edge_style::edge_styling(styles, &ctx)
+        });
+
+        let edge = egui_graph::edge::Edge::new((a, output), (b, input), &mut selected);
+        let response = match &styling {
+            None => edge.show(ectx, ui),
+            Some(styling) => edge.show_with(ectx, ui, |ui, pctx| {
+                paint_styled_edge(styling, &pctx, ui);
+            }),
+        };
+        if let Some(text) = styling.and_then(|s| s.hover_text) {
+            (*response).clone().on_hover_text(text);
+        }
 
         if response.deleted() {
             to_delete.push(e);
@@ -960,6 +1004,136 @@ fn edges<N>(
     if let Some(edge) = ectx.in_progress(ui) {
         edge.show(ui, egui_graph::bezier::Cubic::DEFAULT_CURVATURE);
     }
+}
+
+/// The most parallel strands a styled edge paints: a wider channel count
+/// still draws this many strands (the full band width), overlaid with
+/// diagonal wrap stripes reading as a thick bound bundle rather than adding
+/// ever-thinner strands. The exact count is left to the hover tooltip.
+const STRAND_CAP: usize = 4;
+
+/// Extra width the notch overlay adds over the base stroke so its opaque core
+/// swallows the base line's anti-aliased edge (see [`EdgeStyling::notch`]).
+/// Without it, a continuous base line and the dashed overlay rasterize onto
+/// slightly different pixels at some sub-pixel positions, leaving a faint
+/// fringe of the base colour beside each notch.
+const NOTCH_COVER: f32 = 1.0;
+
+/// The wrap stripes marking a bundle wider than [`STRAND_CAP`]: their spacing
+/// along the edge, how far each stripe overshoots the band (total, split
+/// across both sides, so it reads as wrapping around) and their lean off
+/// perpendicular (radians, a forward diagonal), all in graph units.
+const WRAP_SPACING: f32 = 7.0;
+const WRAP_OVERHANG: f32 = 4.0;
+const WRAP_LEAN: f32 = 0.7;
+
+/// Paint one edge according to its domain-supplied styling.
+///
+/// The custom colour applies to the default state only - hovered and
+/// selected edges keep the theme strokes resolved by the widget so those
+/// affordances read the same on every edge. The width multiplier, strand
+/// layout and notches apply in every state so an edge keeps its look when
+/// interacted.
+fn paint_styled_edge(
+    styling: &crate::widget::EdgeStyling,
+    pctx: &egui_graph::edge::EdgePaintCtx,
+    ui: &egui::Ui,
+) {
+    let mut stroke = pctx.stroke;
+    if !(pctx.selected || pctx.hovered) {
+        if let Some(color) = styling.color {
+            stroke.color = color;
+        }
+    }
+    stroke.width *= styling.width_scale;
+    let spacing = stroke.width + 1.5;
+    // A wider channel count still draws the full `STRAND_CAP` band; the wrap
+    // stripes below mark it as a larger bundle.
+    let strands = styling.strands.max(1).min(STRAND_CAP);
+    let strand_lines = egui_graph::paint::parallel_polylines(pctx.points, strands, spacing);
+    for points in &strand_lines {
+        paint_strand(ui, points, stroke, styling.dash);
+    }
+    // Notched-cord texture: even dashes overpainted in the theme's extreme
+    // background colour, so each strand reads as regularly notched. The
+    // overlay is a hair wider than the base ([`NOTCH_COVER`]) so it fully
+    // covers the base line's anti-aliased edge.
+    if let Some(notch) = styling.notch {
+        let notch_stroke = egui::Stroke {
+            width: stroke.width + NOTCH_COVER,
+            color: ui.style().visuals.extreme_bg_color,
+        };
+        for points in &strand_lines {
+            ui.painter()
+                .extend(egui::Shape::dashed_line(points, notch_stroke, notch, notch));
+        }
+    }
+    // A bundle wider than the band draws diagonal wrap stripes across it, so
+    // it reads as many channels bound together rather than exactly four.
+    if styling.strands > STRAND_CAP {
+        let band = spacing * (STRAND_CAP as f32 - 1.0);
+        for [a, b] in wrap_stripes(pctx.points, WRAP_SPACING, band + WRAP_OVERHANG, WRAP_LEAN) {
+            ui.painter().add(egui::Shape::line(vec![a, b], stroke));
+        }
+    }
+}
+
+/// Paint a single strand along `points`, solid or dashed per `dash`.
+fn paint_strand(
+    ui: &egui::Ui,
+    points: &[egui::Pos2],
+    stroke: egui::Stroke,
+    dash: Option<(f32, f32)>,
+) {
+    match dash {
+        None => {
+            ui.painter().add(egui::Shape::line(points.to_vec(), stroke));
+        }
+        Some((dash, gap)) => {
+            ui.painter()
+                .extend(egui::Shape::dashed_line(points, stroke, dash, gap));
+        }
+    }
+}
+
+/// Diagonal stripe segments crossing `points` every `spacing` graph units,
+/// each `length` long, centred on the path and leaning `lean` radians off
+/// perpendicular (toward the direction of travel). Used to "wrap" a
+/// multi-strand band into one bundle. The first stripe sits half a `spacing`
+/// in, so stripes never crowd the sockets.
+fn wrap_stripes(
+    points: &[egui::Pos2],
+    spacing: f32,
+    length: f32,
+    lean: f32,
+) -> Vec<[egui::Pos2; 2]> {
+    let mut stripes = Vec::new();
+    if points.len() < 2 || spacing <= 0.0 {
+        return stripes;
+    }
+    let half = length * 0.5;
+    let (sin, cos) = lean.sin_cos();
+    let mut acc = 0.0;
+    let mut next = spacing * 0.5;
+    for w in points.windows(2) {
+        let (a, b) = (w[0], w[1]);
+        let seg = b - a;
+        let seg_len = seg.length();
+        if seg_len <= f32::EPSILON {
+            continue;
+        }
+        let dir = seg / seg_len;
+        // The path normal (90 deg CCW), leaned toward the travel direction.
+        let perp = egui::vec2(-dir.y, dir.x);
+        let stripe = perp * cos + dir * sin;
+        while next <= acc + seg_len {
+            let center = a + seg * ((next - acc) / seg_len);
+            stripes.push([center - stripe * half, center + stripe * half]);
+            next += spacing;
+        }
+        acc += seg_len;
+    }
+    stripes
 }
 
 /// The id of the node to flag at the viewed level for a diagnostic path: the
@@ -1047,7 +1221,29 @@ pub fn paint_diagnostics(
 
 #[cfg(test)]
 mod tests {
-    use super::diagnostic_node_at_level;
+    use super::{diagnostic_node_at_level, wrap_stripes};
+
+    #[test]
+    fn wrap_stripes_space_and_span() {
+        // A rightward band, length 30. First stripe at spacing/2 = 5, then
+        // every 10, so at 5, 15, 25 - three stripes, each `length` across.
+        let pts = [egui::pos2(0.0, 0.0), egui::pos2(30.0, 0.0)];
+        let stripes = wrap_stripes(&pts, 10.0, 8.0, 0.0);
+        assert_eq!(stripes.len(), 3);
+        for (i, [a, b]) in stripes.iter().enumerate() {
+            let x = 5.0 + i as f32 * 10.0;
+            // A square stripe (lean 0) is perpendicular here: vertical,
+            // centred on the path, `length` tall.
+            assert!((a.x - x).abs() < 1e-4 && (b.x - x).abs() < 1e-4);
+            assert!(((b.y - a.y).abs() - 8.0).abs() < 1e-4);
+        }
+        // A forward lean tilts the stripe toward the travel direction.
+        let leaned = wrap_stripes(&pts, 10.0, 8.0, 0.7);
+        assert!(leaned[0][1].x > leaned[0][0].x);
+        // Degenerate inputs yield nothing.
+        assert!(wrap_stripes(&pts, 0.0, 8.0, 0.0).is_empty());
+        assert!(wrap_stripes(&pts[..1], 10.0, 8.0, 0.0).is_empty());
+    }
 
     #[test]
     fn diagnostic_level_resolution() {

--- a/crates/gantz_plyphon/src/describe.rs
+++ b/crates/gantz_plyphon/src/describe.rs
@@ -147,7 +147,7 @@ fn bus_key_str(key: &BusKey) -> String {
 }
 
 /// The display token of a [`Rate`]: `ar`/`kr`/`ir`/`dr`.
-fn rate_token(rate: Rate) -> &'static str {
+pub(crate) fn rate_token(rate: Rate) -> &'static str {
     match rate {
         Rate::Audio => "ar",
         Rate::Control => "kr",

--- a/crates/gantz_plyphon/src/egui/edge_style.rs
+++ b/crates/gantz_plyphon/src/egui/edge_style.rs
@@ -1,0 +1,147 @@
+//! The DSP domain's graph-scene edge styling: signal edges rendered
+//! distinctly from control edges (see [`DspEdgeStyle`]).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use gantz_egui::widget::{EdgeStyle, EdgeStyleCtx, EdgeStyling};
+use plyphon::Rate;
+
+use crate::describe::rate_token;
+use crate::dsp::PortShape;
+use crate::port_info::RootPortInfo;
+
+/// The DSP domain's [`EdgeStyle`]: an edge from a signal output into a
+/// signal input styles by the source port's derive-time shape - one strand
+/// per channel, rate-coded colour and dash, and a width/rate hover tooltip.
+/// Everything else (control edges, non-DSP heads) keeps the default styling.
+///
+/// The per-head port classification requires the concrete node type, so a
+/// provider computes it where that type is known (see
+/// [`root_port_info`][crate::root_port_info]) and hands it over here.
+#[derive(Debug, Default)]
+pub struct DspEdgeStyle {
+    /// Each open head's root port classification.
+    pub heads: HashMap<gantz_ca::Head, Arc<RootPortInfo>>,
+}
+
+/// The notch spacing (graph units) of a signal edge's notched-cord texture -
+/// the theme-neutral "this is a signal cord" cue: even dashes overpainted in
+/// the extreme background colour. Rate stays encoded as the base dash.
+const SIGNAL_NOTCH: f32 = 6.0;
+
+/// A signal edge's stroke is slightly heavier than a control edge's, to
+/// reinforce the notched cord as a signal.
+const SIGNAL_WIDTH_SCALE: f32 = 1.8;
+
+impl EdgeStyle for DspEdgeStyle {
+    fn edge_styling(&self, ctx: &EdgeStyleCtx) -> Option<EdgeStyling> {
+        let info = self.heads.get(ctx.head)?;
+        if !info.signal_inputs.contains(&ctx.dst) {
+            return None;
+        }
+        let shape = info.signal_outputs.get(&ctx.src)?;
+        Some(dsp_edge_styling(*shape))
+    }
+}
+
+/// The styling of a signal edge whose source port recorded `shape` at derive
+/// time (`None`: the port is signal-classified but derivation materialized
+/// nothing for it - it feeds no sink, or the head's shapes are unavailable,
+/// e.g. an inlet/outlet boundary edge in a nested view).
+///
+/// Signal edges are distinguished from control edges by a notched-cord
+/// texture, not colour. Rate is the base dash pattern (audio solid, control
+/// dashed, scalar/demand dotted) and channel width is the parallel strand
+/// count.
+fn dsp_edge_styling(shape: Option<PortShape>) -> EdgeStyling {
+    let mut styling = EdgeStyling::default();
+    styling.width_scale = SIGNAL_WIDTH_SCALE;
+    let Some(shape) = shape else {
+        // Signal-classified but nothing materialized (a boundary edge, or a
+        // port feeding no sink): the same notched cadence, but with the
+        // off-segments left as gaps rather than filled - an "open" cord that
+        // reads as an as-yet-unmaterialised signal.
+        styling.dash = Some((SIGNAL_NOTCH, SIGNAL_NOTCH));
+        styling.hover_text = Some("signal".to_string());
+        return styling;
+    };
+    styling.notch = Some(SIGNAL_NOTCH);
+    styling.strands = shape.width;
+    styling.hover_text = Some(format!("{}ch {}", shape.width, rate_token(shape.rate)));
+    match shape.rate {
+        // Audio: solid base (notched).
+        Rate::Audio => {}
+        // Control: dashed base.
+        Rate::Control => styling.dash = Some((6.0, 4.0)),
+        // Scalar and demand: dotted base (a short dash reads as dots).
+        Rate::Scalar | Rate::Demand => styling.dash = Some((1.5, 3.0)),
+    }
+    styling
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Signal edges style only when the source is a signal output AND the
+    /// destination is a signal input of the viewed head. They distinguish
+    /// themselves by a notched-cord texture, not colour, and pass the true
+    /// channel count (the painter, not the styler, renders wide bundles).
+    #[test]
+    fn styles_signal_edges_only() {
+        let mut info = RootPortInfo::default();
+        info.signal_outputs.insert(
+            (0, 0),
+            Some(PortShape {
+                width: 2,
+                rate: Rate::Audio,
+            }),
+        );
+        // A wide bus output, to check the strand count is not clamped here.
+        info.signal_outputs.insert(
+            (3, 0),
+            Some(PortShape {
+                width: 8,
+                rate: Rate::Audio,
+            }),
+        );
+        // A boundary/unmaterialised signal output (no recorded shape).
+        info.signal_outputs.insert((4, 0), None);
+        info.signal_inputs.insert((1, 0));
+        let head = gantz_ca::Head::Branch("test".to_string());
+        let style = DspEdgeStyle {
+            heads: [(head.clone(), Arc::new(info))].into_iter().collect(),
+        };
+        let ctx = |src: (usize, usize), dst: (usize, usize)| EdgeStyleCtx::new(&head, src, dst);
+
+        // The signal edge styles: heavier notched cord, no colour,
+        // per-channel strands and the width/rate tooltip.
+        let styling = style.edge_styling(&ctx((0, 0), (1, 0))).unwrap();
+        assert!(styling.notch.is_some());
+        assert!(styling.width_scale > 1.0);
+        assert!(styling.color.is_none());
+        assert_eq!(styling.strands, 2);
+        assert_eq!(styling.hover_text.as_deref(), Some("2ch ar"));
+        // The wide bus passes its true channel count (abridging is the
+        // painter's job) and reports it in the tooltip.
+        let wide = style.edge_styling(&ctx((3, 0), (1, 0))).unwrap();
+        assert_eq!(wide.strands, 8);
+        assert_eq!(wide.hover_text.as_deref(), Some("8ch ar"));
+        // An unmaterialised signal edge (boundary/no-shape) is an "open"
+        // cord: gapped dashes, no notch fill, "signal" tooltip.
+        let open = style.edge_styling(&ctx((4, 0), (1, 0))).unwrap();
+        assert!(open.notch.is_none());
+        assert!(open.dash.is_some());
+        assert_eq!(open.hover_text.as_deref(), Some("signal"));
+        // A control destination (`~out`'s gain input 1) keeps the default.
+        assert!(style.edge_styling(&ctx((0, 0), (1, 1))).is_none());
+        // A control source into a signal input (a hybrid input's control
+        // feed) keeps the default.
+        assert!(style.edge_styling(&ctx((2, 0), (1, 0))).is_none());
+        // An unknown head keeps the default.
+        let other = gantz_ca::Head::Branch("other".to_string());
+        let ctx = EdgeStyleCtx::new(&other, (0, 0), (1, 0));
+        assert!(style.edge_styling(&ctx).is_none());
+    }
+}

--- a/crates/gantz_plyphon/src/egui/mod.rs
+++ b/crates/gantz_plyphon/src/egui/mod.rs
@@ -8,10 +8,12 @@
 //! of the crate is headless by construction, so new UI code cannot
 //! accidentally leak egui into a `--no-default-features` build.
 
+pub use edge_style::DspEdgeStyle;
 pub use pane::{DSP_PANE_KEY, DspPane, DspPaneHead};
 pub use ref_ext::DspRefExtUi;
 pub use settings::DspSettingsTab;
 
+pub mod edge_style;
 pub mod node;
 pub mod pane;
 pub mod param;

--- a/crates/gantz_plyphon/src/lib.rs
+++ b/crates/gantz_plyphon/src/lib.rs
@@ -37,6 +37,7 @@ pub use instance::{
     TemplateRegion, VariantKey, derive_template, instantiate,
 };
 pub use node::{Bus, Lag, Out, Pack, ScopeOut, SinOsc, Sum, Unpack};
+pub use port_info::{RootPortInfo, root_port_info};
 pub use ref_ext::{DSP_REF_EXT_KEY, DspRefExt, dsp_commits};
 pub use sugar::PlyphonSugar;
 // `self::` disambiguates from the extern `egui` crate at the crate root.
@@ -56,6 +57,7 @@ pub mod instance;
 pub mod monitor;
 pub mod node;
 pub mod param;
+pub mod port_info;
 pub mod ref_ext;
 pub mod sugar;
 

--- a/crates/gantz_plyphon/src/lib.rs
+++ b/crates/gantz_plyphon/src/lib.rs
@@ -42,7 +42,9 @@ pub use ref_ext::{DSP_REF_EXT_KEY, DspRefExt, dsp_commits};
 pub use sugar::PlyphonSugar;
 // `self::` disambiguates from the extern `egui` crate at the crate root.
 #[cfg(feature = "egui")]
-pub use self::egui::{DSP_PANE_KEY, DspPane, DspPaneHead, DspRefExtUi, DspSettingsTab};
+pub use self::egui::{
+    DSP_PANE_KEY, DspEdgeStyle, DspPane, DspPaneHead, DspRefExtUi, DspSettingsTab,
+};
 
 pub mod backend;
 pub mod builtin;

--- a/crates/gantz_plyphon/src/port_info.rs
+++ b/crates/gantz_plyphon/src/port_info.rs
@@ -1,0 +1,290 @@
+//! Root-level DSP port classification for a viewed graph (see
+//! [`root_port_info`]), the data behind DSP edge styling.
+//!
+//! The GUI shows one graph per head, so an edge endpoint is fully identified
+//! by a `(root node index, port)` pair. This module classifies those pairs
+//! as *signal* ports (they carry DSP signals at derive time) or control
+//! ports, and attaches the [`PortShape`] derivation recorded for each signal
+//! output where one is recoverable. Typed probes like [`ToNodeDsp`] are
+//! unreachable through the GUI's erased registry, so callers (e.g. a bevy
+//! provider system) compute this where the concrete node type is known and
+//! hand the result to the UI - the same shape as
+//! [`dsp_commits`][crate::ref_ext::dsp_commits].
+//!
+//! Classification is structural, mirroring how flattening lowers the graph
+//! (see [`flatten`][crate::flatten()]): a concrete DSP node's ports come
+//! straight off [`NodeDsp`][crate::NodeDsp], a reference's ports resolve
+//! recursively through the referenced graph's inlets/outlets, and root-level
+//! boundary nodes forward their neighbours' classification. One deliberate
+//! approximation: a chain that resolves through a referenced graph's *inlet*
+//! (parent-side wiring, e.g. a pure `inlet -> outlet` wire child) is not
+//! followed, so such a reference's ports classify as control.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use petgraph::Direction;
+use petgraph::visit::EdgeRef;
+
+use gantz_ca::ContentAddr;
+use gantz_core::node::graph::{Graph, NodeIx};
+use gantz_core::node::{AsRefNode, MetaCtx};
+use plyphon::Rate;
+
+use crate::dsp::{PortShape, PortShapes, ToNodeDsp};
+
+/// Root-level DSP port classification for one head's viewed graph, keyed by
+/// `(root node index, port)`. A pair absent from both maps is a control
+/// port.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct RootPortInfo {
+    /// The signal *input* ports (the ports the synthdef compiler would wire).
+    pub signal_inputs: BTreeSet<(usize, usize)>,
+    /// The signal *output* ports, with the shape derivation recorded for
+    /// them. `None` when no shape is recoverable: the port fed no sink at
+    /// derive time, or the derivation's shapes are unavailable (e.g. a
+    /// nested view whose own head derived silent).
+    pub signal_outputs: BTreeMap<(usize, usize), Option<PortShape>>,
+}
+
+/// Memoized reference probes, shared across one [`root_port_info`] pass so
+/// repeated references stay linear overall. Stacks guard reference cycles:
+/// a chain re-entering a graph it is already resolving through contributes
+/// nothing (mirroring [`dsp_commits`][crate::ref_ext::dsp_commits]).
+#[derive(Default)]
+struct Memos {
+    inlets: HashMap<ContentAddr, Vec<bool>>,
+    inlet_stack: Vec<ContentAddr>,
+    outlets: HashMap<(ContentAddr, usize), Vec<(Vec<usize>, usize)>>,
+    outlet_stack: Vec<(ContentAddr, usize)>,
+}
+
+/// Classify `graph`'s root-level ports, resolving references through
+/// `registry` and attaching the [`PortShape`]s recorded in `shapes` (the
+/// union of the head's derived parts' shapes, keyed by node paths absolute
+/// to `graph` - see [`PortShapes`]).
+pub fn root_port_info<N>(
+    graph: &Graph<N>,
+    registry: &gantz_ca::Registry<Graph<N>>,
+    shapes: &PortShapes,
+) -> RootPortInfo
+where
+    N: gantz_core::Node + AsRefNode + ToNodeDsp,
+{
+    let get_node = |ca: &ContentAddr| {
+        registry
+            .commit_graph_ref(&(*ca).into())
+            .map(|g| g as &dyn gantz_core::Node)
+    };
+    let ctx = MetaCtx::new(&get_node);
+    let mut memos = Memos::default();
+    let mut info = RootPortInfo::default();
+
+    // Concrete DSP nodes and references.
+    for ix in graph.node_indices() {
+        let i = ix.index();
+        if let Some(dsp) = graph[ix].to_node_dsp() {
+            for p in 0..dsp.n_dsp_inputs() {
+                info.signal_inputs.insert((i, p));
+            }
+            for p in 0..dsp.n_dsp_outputs() {
+                let shape = shapes.get(&(vec![i], p)).copied();
+                info.signal_outputs.insert((i, p), shape);
+            }
+        } else if let Some(r) = graph[ix].as_ref_node() {
+            let ca = r.content_addr();
+            for (p, signal) in signal_inlets(registry, ctx, ca, &mut memos)
+                .iter()
+                .enumerate()
+            {
+                if *signal {
+                    info.signal_inputs.insert((i, p));
+                }
+            }
+            for p in 0..n_outlets(registry, ctx, ca) {
+                let sources = outlet_sources(registry, ctx, ca, p, &mut memos);
+                if !sources.is_empty() {
+                    info.signal_outputs
+                        .insert((i, p), sum_shape(shapes, i, &sources));
+                }
+            }
+        }
+    }
+
+    // Root-level boundary nodes forward their neighbours' classification, so
+    // nested views style their interface edges too. Inlets before outlets:
+    // an outlet fed by a signal-classified inlet then classifies signal.
+    for ix in graph.node_indices() {
+        if graph[ix].inlet(ctx) {
+            let signal = graph.edges_directed(ix, Direction::Outgoing).any(|e| {
+                let dst = (e.target().index(), e.weight().input.0 as usize);
+                info.signal_inputs.contains(&dst)
+            });
+            if signal {
+                info.signal_outputs.insert((ix.index(), 0), None);
+            }
+        }
+    }
+    for ix in graph.node_indices() {
+        if graph[ix].outlet(ctx) {
+            let signal = graph.edges_directed(ix, Direction::Incoming).any(|e| {
+                let src = (e.source().index(), e.weight().output.0 as usize);
+                info.signal_outputs.contains_key(&src)
+            });
+            if signal {
+                info.signal_inputs.insert((ix.index(), 0));
+            }
+        }
+    }
+
+    info
+}
+
+/// Which of the graph-at-`ca`'s inlets (ascending node index, the "input i
+/// to inlet i" contract) transitively feed a DSP input, i.e. which of a
+/// reference's inputs carry signals. Empty when `ca` is unresolved or
+/// re-entered (a reference cycle).
+fn signal_inlets<N>(
+    registry: &gantz_ca::Registry<Graph<N>>,
+    ctx: MetaCtx,
+    ca: ContentAddr,
+    memos: &mut Memos,
+) -> Vec<bool>
+where
+    N: gantz_core::Node + AsRefNode + ToNodeDsp,
+{
+    if let Some(known) = memos.inlets.get(&ca) {
+        return known.clone();
+    }
+    if memos.inlet_stack.contains(&ca) {
+        return Vec::new();
+    }
+    let Some(graph) = registry.commit_graph_ref(&ca.into()) else {
+        memos.inlets.insert(ca, Vec::new());
+        return Vec::new();
+    };
+    memos.inlet_stack.push(ca);
+    let inlets: Vec<_> = graph
+        .node_indices()
+        .filter(|&n| graph[n].inlet(ctx))
+        .collect();
+    let mut result = Vec::with_capacity(inlets.len());
+    for inlet in inlets {
+        let consumers: Vec<(usize, usize)> = graph
+            .edges_directed(inlet, Direction::Outgoing)
+            .map(|e| (e.target().index(), e.weight().input.0 as usize))
+            .collect();
+        let signal = consumers.into_iter().any(|(t, tp)| {
+            let t = NodeIx::new(t);
+            if let Some(dsp) = graph[t].to_node_dsp() {
+                tp < dsp.n_dsp_inputs()
+            } else if let Some(r) = graph[t].as_ref_node() {
+                signal_inlets(registry, ctx, r.content_addr(), memos)
+                    .get(tp)
+                    .copied()
+                    .unwrap_or(false)
+            } else {
+                false
+            }
+        });
+        result.push(signal);
+    }
+    memos.inlet_stack.pop();
+    memos.inlets.insert(ca, result.clone());
+    result
+}
+
+/// The number of outlets of the graph at `ca` (a reference's output count).
+fn n_outlets<N>(registry: &gantz_ca::Registry<Graph<N>>, ctx: MetaCtx, ca: ContentAddr) -> usize
+where
+    N: gantz_core::Node,
+{
+    registry
+        .commit_graph_ref(&ca.into())
+        .map(|g| g.node_indices().filter(|&n| g[n].outlet(ctx)).count())
+        .unwrap_or(0)
+}
+
+/// The concrete DSP `(path relative to the graph at ca, output port)`
+/// sources that transitively feed the graph-at-`ca`'s `outlet`-th outlet,
+/// i.e. the DSP sources behind a reference's output. Chains that dead-end
+/// (a non-DSP source, an inlet - parent-side wiring - or a cycle) contribute
+/// nothing; an empty result means the output carries no signal.
+fn outlet_sources<N>(
+    registry: &gantz_ca::Registry<Graph<N>>,
+    ctx: MetaCtx,
+    ca: ContentAddr,
+    outlet: usize,
+    memos: &mut Memos,
+) -> Vec<(Vec<usize>, usize)>
+where
+    N: gantz_core::Node + AsRefNode + ToNodeDsp,
+{
+    let key = (ca, outlet);
+    if let Some(known) = memos.outlets.get(&key) {
+        return known.clone();
+    }
+    if memos.outlet_stack.contains(&key) {
+        return Vec::new();
+    }
+    let Some(graph) = registry.commit_graph_ref(&ca.into()) else {
+        memos.outlets.insert(key, Vec::new());
+        return Vec::new();
+    };
+    memos.outlet_stack.push(key);
+    let mut sources = Vec::new();
+    let outlet_node = graph
+        .node_indices()
+        .filter(|&n| graph[n].outlet(ctx))
+        .nth(outlet);
+    if let Some(o) = outlet_node {
+        let feeds: Vec<(usize, usize)> = graph
+            .edges_directed(o, Direction::Incoming)
+            .filter(|e| e.weight().input.0 == 0)
+            .map(|e| (e.source().index(), e.weight().output.0 as usize))
+            .collect();
+        for (s, sp) in feeds {
+            let six = NodeIx::new(s);
+            if let Some(dsp) = graph[six].to_node_dsp() {
+                if sp < dsp.n_dsp_outputs() {
+                    sources.push((vec![s], sp));
+                }
+            } else if let Some(r) = graph[six].as_ref_node() {
+                for (rel, port) in outlet_sources(registry, ctx, r.content_addr(), sp, memos) {
+                    let mut path = vec![s];
+                    path.extend(rel);
+                    sources.push((path, port));
+                }
+            }
+        }
+    }
+    memos.outlet_stack.pop();
+    memos.outlets.insert(key, sources.clone());
+    sources
+}
+
+/// The shape of a reference output fed by the given concrete DSP `sources`
+/// (paths relative to the reference, which sits at root index `root_ix`).
+/// Derivation sums a multi-fed input, so the width is the widest summand and
+/// the rate is audio if any summand is audio (mirroring
+/// [`sum_signals`][crate::dsp::sum_signals] + [`signal_rate`][crate::signal_rate]).
+/// `None` when no source has a recorded shape.
+fn sum_shape(
+    shapes: &PortShapes,
+    root_ix: usize,
+    sources: &[(Vec<usize>, usize)],
+) -> Option<PortShape> {
+    let mut found = sources.iter().filter_map(|(rel, port)| {
+        let mut path = Vec::with_capacity(rel.len() + 1);
+        path.push(root_ix);
+        path.extend(rel);
+        shapes.get(&(path, *port)).copied()
+    });
+    let first = found.next()?;
+    Some(found.fold(first, |acc, s| PortShape {
+        width: acc.width.max(s.width),
+        rate: match (acc.rate, s.rate) {
+            (Rate::Audio, _) | (_, Rate::Audio) => Rate::Audio,
+            (rate, _) => rate,
+        },
+    }))
+}

--- a/crates/gantz_plyphon/tests/port_info.rs
+++ b/crates/gantz_plyphon/tests/port_info.rs
@@ -1,0 +1,300 @@
+//! Tests for `root_port_info` - the root-level DSP port classification
+//! behind DSP edge styling (#300).
+
+use gantz_ca::{CaHash, ContentAddr};
+use gantz_core::Edge;
+use gantz_core::node::graph::Graph;
+use gantz_core::node::{AsRefNode, ExprCtx, ExprResult, MetaCtx, Ref, parse_expr};
+use gantz_plyphon::{Lag, NodeDsp, Out, PortShape, PortShapes, SinOsc, ToNodeDsp, root_port_info};
+use plyphon::Rate;
+
+/// A minimal node standing in for the app's node set.
+#[derive(Clone)]
+enum N {
+    SinOsc(SinOsc),
+    Lag(Lag),
+    Out(Out),
+    Ref(Ref),
+    Inlet,
+    Outlet,
+    /// A non-DSP control node (e.g. a slider) with one output.
+    Other,
+}
+
+impl ToNodeDsp for N {
+    fn to_node_dsp(&self) -> Option<&dyn NodeDsp> {
+        match self {
+            N::SinOsc(s) => Some(s),
+            N::Lag(l) => Some(l),
+            N::Out(o) => Some(o),
+            N::Ref(_) | N::Inlet | N::Outlet | N::Other => None,
+        }
+    }
+}
+
+impl AsRefNode for N {
+    fn as_ref_node(&self) -> Option<&Ref> {
+        match self {
+            N::Ref(r) => Some(r),
+            _ => None,
+        }
+    }
+}
+
+impl gantz_core::Node for N {
+    fn expr(&self, _ctx: ExprCtx<'_, '_>) -> ExprResult {
+        parse_expr("'()")
+    }
+
+    fn n_inputs(&self, ctx: MetaCtx) -> usize {
+        match self {
+            N::SinOsc(_) | N::Lag(_) | N::Outlet => 1,
+            N::Out(o) => gantz_core::Node::n_inputs(o, ctx),
+            N::Ref(_) | N::Inlet | N::Other => 0,
+        }
+    }
+
+    fn n_outputs(&self, _ctx: MetaCtx) -> usize {
+        match self {
+            N::SinOsc(_) | N::Lag(_) | N::Inlet | N::Other => 1,
+            N::Out(_) | N::Ref(_) | N::Outlet => 0,
+        }
+    }
+
+    fn inlet(&self, _ctx: MetaCtx) -> bool {
+        matches!(self, N::Inlet)
+    }
+
+    fn outlet(&self, _ctx: MetaCtx) -> bool {
+        matches!(self, N::Outlet)
+    }
+}
+
+impl CaHash for N {
+    fn hash(&self, hasher: &mut gantz_ca::Hasher) {
+        match self {
+            N::SinOsc(s) => CaHash::hash(s, hasher),
+            N::Lag(l) => CaHash::hash(l, hasher),
+            N::Out(o) => CaHash::hash(o, hasher),
+            N::Ref(r) => CaHash::hash(r, hasher),
+            N::Inlet => {
+                hasher.update(b"test.inlet");
+            }
+            N::Outlet => {
+                hasher.update(b"test.outlet");
+            }
+            N::Other => {
+                hasher.update(b"test.other");
+            }
+        }
+    }
+}
+
+/// Commit `graph`, returning its commit address as a `ContentAddr` (the form
+/// `Ref::content_addr` reports).
+fn commit(registry: &mut gantz_ca::Registry<Graph<N>>, graph: Graph<N>) -> ContentAddr {
+    let now = std::time::Duration::from_secs(1);
+    let addr = gantz_ca::graph_addr(&graph);
+    registry.commit_graph(now, None, addr, || graph).into()
+}
+
+fn shape(width: usize, rate: Rate) -> PortShape {
+    PortShape { width, rate }
+}
+
+fn shapes<const M: usize>(entries: [(&[usize], usize, PortShape); M]) -> PortShapes {
+    entries
+        .into_iter()
+        .map(|(path, port, shape)| ((path.to_vec(), port), shape))
+        .collect()
+}
+
+/// Concrete DSP nodes classify their leading dsp ports; control inputs
+/// beyond `n_dsp_inputs` and non-DSP nodes stay unclassified.
+#[test]
+fn flat_graph_classifies_dsp_ports() {
+    let registry = gantz_ca::Registry::<Graph<N>>::default();
+    let mut g: Graph<N> = Graph::default();
+    let sin = g.add_node(N::SinOsc(SinOsc::default()));
+    let out = g.add_node(N::Out(Out::default()));
+    let slider = g.add_node(N::Other);
+    let slider2 = g.add_node(N::Other);
+    g.add_edge(sin, out, Edge::new(0.into(), 0.into()));
+    // Control connections: `~out`'s gain (input 1) and `~sinosc`'s hybrid freq.
+    g.add_edge(slider, out, Edge::new(0.into(), 1.into()));
+    g.add_edge(slider2, sin, Edge::new(0.into(), 0.into()));
+
+    let shapes = shapes([(&[0], 0, shape(1, Rate::Audio))]);
+    let info = root_port_info(&g, &registry, &shapes);
+
+    // `~sinosc`'s hybrid input and `~out`'s signal input are signal inputs.
+    let sins: Vec<_> = info.signal_inputs.iter().copied().collect();
+    assert_eq!(sins, vec![(sin.index(), 0), (out.index(), 0)]);
+    // Only `~sinosc`'s output is a signal output (`~out` has no dsp outputs),
+    // carrying its recorded shape. The sliders are unclassified.
+    let souts: Vec<_> = info.signal_outputs.iter().collect();
+    assert_eq!(
+        souts,
+        vec![(&(sin.index(), 0), &Some(shape(1, Rate::Audio)))],
+    );
+}
+
+/// A reference's ports classify through the referenced graph's boundaries,
+/// and its output shapes resolve through absolutized `PortShapes` keys.
+#[test]
+fn ref_ports_classify_through_child() {
+    let mut registry = gantz_ca::Registry::<Graph<N>>::default();
+
+    // Child: inlet -> ~lag -> outlet.
+    let mut child: Graph<N> = Graph::default();
+    let i = child.add_node(N::Inlet);
+    let l = child.add_node(N::Lag(Lag::default()));
+    let o = child.add_node(N::Outlet);
+    child.add_edge(i, l, Edge::new(0.into(), 0.into()));
+    child.add_edge(l, o, Edge::new(0.into(), 0.into()));
+    let ca = commit(&mut registry, child);
+
+    // Root: ~sinosc -> ref -> ~out.
+    let mut g: Graph<N> = Graph::default();
+    let sin = g.add_node(N::SinOsc(SinOsc::default()));
+    let r = g.add_node(N::Ref(Ref::new(ca)));
+    let out = g.add_node(N::Out(Out::default()));
+    g.add_edge(sin, r, Edge::new(0.into(), 0.into()));
+    g.add_edge(r, out, Edge::new(0.into(), 0.into()));
+
+    // The lag inside the ref keys its shape by its absolute path `[1, 1]`.
+    let shapes = shapes([
+        (&[0], 0, shape(1, Rate::Audio)),
+        (&[1, 1], 0, shape(2, Rate::Audio)),
+    ]);
+    let info = root_port_info(&g, &registry, &shapes);
+
+    assert!(info.signal_inputs.contains(&(r.index(), 0)));
+    assert!(info.signal_inputs.contains(&(out.index(), 0)));
+    assert_eq!(
+        info.signal_outputs.get(&(r.index(), 0)),
+        Some(&Some(shape(2, Rate::Audio))),
+    );
+}
+
+/// A signal-classified reference output with no recorded shape (e.g. the
+/// head derived silent) still classifies, with an unknown shape.
+#[test]
+fn ref_output_without_recorded_shape_is_signal_with_none() {
+    let mut registry = gantz_ca::Registry::<Graph<N>>::default();
+    let mut child: Graph<N> = Graph::default();
+    let s = child.add_node(N::SinOsc(SinOsc::default()));
+    let o = child.add_node(N::Outlet);
+    child.add_edge(s, o, Edge::new(0.into(), 0.into()));
+    let ca = commit(&mut registry, child);
+
+    let mut g: Graph<N> = Graph::default();
+    let r = g.add_node(N::Ref(Ref::new(ca)));
+
+    let info = root_port_info(&g, &registry, &PortShapes::default());
+    assert_eq!(info.signal_outputs.get(&(r.index(), 0)), Some(&None));
+}
+
+/// Reference output shapes resolve through nested references, composing the
+/// relative paths into the absolutized key.
+#[test]
+fn nested_ref_paths_compose() {
+    let mut registry = gantz_ca::Registry::<Graph<N>>::default();
+
+    // Inner: ~sinosc -> outlet.
+    let mut inner: Graph<N> = Graph::default();
+    let s = inner.add_node(N::SinOsc(SinOsc::default()));
+    let o = inner.add_node(N::Outlet);
+    inner.add_edge(s, o, Edge::new(0.into(), 0.into()));
+    let inner_ca = commit(&mut registry, inner);
+
+    // Outer: ref(inner) -> outlet.
+    let mut outer: Graph<N> = Graph::default();
+    let ri = outer.add_node(N::Ref(Ref::new(inner_ca)));
+    let oo = outer.add_node(N::Outlet);
+    outer.add_edge(ri, oo, Edge::new(0.into(), 0.into()));
+    let outer_ca = commit(&mut registry, outer);
+
+    // Root: ref(outer) at index 0. The sine's absolute path is [0, 0, 0].
+    let mut g: Graph<N> = Graph::default();
+    let r = g.add_node(N::Ref(Ref::new(outer_ca)));
+
+    let shapes = shapes([(&[0, 0, 0], 0, shape(2, Rate::Audio))]);
+    let info = root_port_info(&g, &registry, &shapes);
+    assert_eq!(
+        info.signal_outputs.get(&(r.index(), 0)),
+        Some(&Some(shape(2, Rate::Audio))),
+    );
+}
+
+/// Root-level boundary nodes forward classification: an inlet feeding a
+/// signal input classifies as a signal source, and an outlet fed by a
+/// signal output classifies as a signal consumer (nested views style their
+/// interface edges).
+#[test]
+fn root_boundaries_forward_classification() {
+    let registry = gantz_ca::Registry::<Graph<N>>::default();
+    let mut g: Graph<N> = Graph::default();
+    let i = g.add_node(N::Inlet);
+    let l = g.add_node(N::Lag(Lag::default()));
+    let o = g.add_node(N::Outlet);
+    g.add_edge(i, l, Edge::new(0.into(), 0.into()));
+    g.add_edge(l, o, Edge::new(0.into(), 0.into()));
+
+    let info = root_port_info(&g, &registry, &PortShapes::default());
+    assert_eq!(info.signal_outputs.get(&(i.index(), 0)), Some(&None));
+    assert!(info.signal_inputs.contains(&(l.index(), 0)));
+    assert!(info.signal_inputs.contains(&(o.index(), 0)));
+
+    // A pure inlet -> outlet wire carries no DSP: neither side classifies.
+    let mut wire: Graph<N> = Graph::default();
+    let wi = wire.add_node(N::Inlet);
+    let wo = wire.add_node(N::Outlet);
+    wire.add_edge(wi, wo, Edge::new(0.into(), 0.into()));
+    let info = root_port_info(&wire, &registry, &PortShapes::default());
+    assert!(info.signal_inputs.is_empty());
+    assert!(info.signal_outputs.is_empty());
+}
+
+/// A reference to a missing commit classifies as control without panicking.
+#[test]
+fn dangling_ref_is_control() {
+    let registry = gantz_ca::Registry::<Graph<N>>::default();
+    let mut g: Graph<N> = Graph::default();
+    let r = g.add_node(N::Ref(Ref::new(ContentAddr::from([9u8; 32]))));
+    let sin = g.add_node(N::SinOsc(SinOsc::default()));
+    g.add_edge(sin, r, Edge::new(0.into(), 0.into()));
+
+    let info = root_port_info(&g, &registry, &PortShapes::default());
+    assert!(!info.signal_inputs.contains(&(r.index(), 0)));
+    assert!(!info.signal_outputs.contains_key(&(r.index(), 0)));
+}
+
+/// A multi-fed reference outlet sums its sources' shapes: the width is the
+/// widest summand and audio rate dominates (mirroring derivation).
+#[test]
+fn multi_fed_ref_outlet_sums_shapes() {
+    let mut registry = gantz_ca::Registry::<Graph<N>>::default();
+
+    // Child: two sources feeding the one outlet.
+    let mut child: Graph<N> = Graph::default();
+    let a = child.add_node(N::SinOsc(SinOsc::default()));
+    let b = child.add_node(N::Lag(Lag::default()));
+    let o = child.add_node(N::Outlet);
+    child.add_edge(a, o, Edge::new(0.into(), 0.into()));
+    child.add_edge(b, o, Edge::new(0.into(), 0.into()));
+    let ca = commit(&mut registry, child);
+
+    let mut g: Graph<N> = Graph::default();
+    let r = g.add_node(N::Ref(Ref::new(ca)));
+
+    let shapes = shapes([
+        (&[0, 0], 0, shape(2, Rate::Control)),
+        (&[0, 1], 0, shape(1, Rate::Audio)),
+    ]);
+    let info = root_port_info(&g, &registry, &shapes);
+    assert_eq!(
+        info.signal_outputs.get(&(r.index(), 0)),
+        Some(&Some(shape(2, Rate::Audio))),
+    );
+}


### PR DESCRIPTION
## Summary

Adds a domain-level edge styling system to the graph scene, allowing different visual representations for edges based on their semantic type. The DSP (Plyphon) domain is the first consumer, rendering signal edges as thicker, notched cords with channel-count strands and rate-coded dash patterns.

## Changes

### `gantz_egui` - Edge styling infrastructure

- **New `EdgeStyle` trait** - domains supply implementations that return `EdgeStyling` for edges they recognise, or `None` for the default egui visuals. The first `Some` wins (supply order).
- **`EdgeStyling` struct** - declarative style with fields for colour, width scale, dashes, parallel strands, notch texture and hover tooltip.
- **`Gantz` widget** gains `edge_styles()` builder and passes stylers through to `GraphScene`, which delegates styled edges to `paint_styled_edge`.
- **`paint_styled_edge`** - paints parallel strand polylines, optional notched cord overlays (even dashes in the theme's bg colour), and diagonal wrap stripes for bundles exceeding the strand cap (4), so very wide channels read as a thick bound bundle rather than impossibly thin strands.

### `gantz_plyphon` - DSP domain styling

- **New `DspEdgeStyle`** - the `EdgeStyle` implementor for DSP. Styles edges where both source and destination are signal-classified ports, using the source port's derive-time `PortShape` (channel count, rate).
- **New `port_info` module** - classifies root-level ports as signal or control by structural analysis (DSP node ports, reference inlet/outlet resolution, boundary forwarding). Memoises reference probes to stay linear across repeated lookups and guard cycles.
- **Signal edges** read as notched cords - rate encoded as the base dash (audio = solid, control = dashed, scalar/demand = dotted), channel count as parallel strands, and a hover tooltip like `"2ch ar"`. Unmaterialised signal edges (boundary ports) render as "open" cords (gapped dashes, no notch fill).