### PR TITLE
Rewrite the `gantz_ca::Registry` to better enable domain extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,6 +993,7 @@ dependencies = [
 name = "bevy_gantz"
 version = "0.4.0"
 dependencies = [
+ "base64",
  "bevy_app",
  "bevy_ecs",
  "bevy_input",

--- a/crates/bevy_gantz/Cargo.toml
+++ b/crates/bevy_gantz/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 repository.workspace = true
 
 [dependencies]
+base64.workspace = true
 bevy_app.workspace = true
 bevy_ecs.workspace = true
 bevy_input.workspace = true

--- a/crates/bevy_gantz/src/head.rs
+++ b/crates/bevy_gantz/src/head.rs
@@ -200,6 +200,14 @@ pub struct FocusedHead(pub Option<Entity>);
 pub struct HeadTabOrder(pub Vec<Entity>);
 
 // ----------------------------------------------------------------------------
+// Consts
+// ----------------------------------------------------------------------------
+
+/// The id of the shared graph-description section, mirrored by the GUI
+/// layer's typed declaration (`gantz_egui::section::Descriptions`).
+pub const DESCRIPTIONS_ID: &str = "gantz.description";
+
+// ----------------------------------------------------------------------------
 // Deref impls
 // ----------------------------------------------------------------------------
 
@@ -281,6 +289,36 @@ pub fn find_entity(
         .iter()
         .find(|(_, head_ref)| &***head_ref == head)
         .map(|(entity, _)| entity)
+}
+
+/// The stored description for the named graph, if any.
+///
+/// Reads the shared `gantz.description` section (see
+/// [`DESCRIPTIONS_ID`]) directly so this crate stays independent of the
+/// GUI layer that declares the typed accessor.
+pub fn description<G>(reg: &ca::Registry<G>, name: &ca::Name) -> Option<String> {
+    let key = ca::Key::Name(name.clone());
+    reg.section_entry(DESCRIPTIONS_ID, &key)
+        .and_then(ca::section::value_from_datum)
+}
+
+/// Store a description for the named graph in the shared `gantz.description`
+/// section. An empty string removes the entry.
+pub fn set_description<G>(reg: &mut ca::Registry<G>, name: ca::Name, description: String) {
+    let key = ca::Key::Name(name);
+    if description.is_empty() {
+        reg.remove_section_entry(DESCRIPTIONS_ID, &key);
+    } else {
+        ca::section_insert_datum(
+            reg,
+            DESCRIPTIONS_ID,
+            ca::MergePolicy::KeepExisting,
+            ca::Liveness::WithName,
+            key,
+            &description,
+        )
+        .expect("a `String` always encodes as a datum");
+    }
 }
 
 /// Check if the given head is the currently focused head.
@@ -378,13 +416,11 @@ pub fn on_replace<N>(
     // for every node present on both sides) and reset the memo so `vm::sync`
     // recompiles.
     // Note: HeadGuiState and GraphViews are updated by GantzEguiPlugin observer.
-    let old_ca = old_head
-        .as_ref()
-        .and_then(|h| registry.head_commit_ca(h).copied());
+    let old_ca = old_head.as_ref().and_then(|h| registry.head_commit_ca(h));
     let old_graph = old_head
         .as_ref()
         .and_then(|h| registry.head_commit(h).map(|c| c.graph));
-    let new_ca = registry.head_commit_ca(new_head).copied();
+    let new_ca = registry.head_commit_ca(new_head);
     let new_graph = registry.head_commit(new_head).map(|c| c.graph);
     let same_graph = matches!((old_graph, new_graph), (Some(a), Some(b)) if a == b);
     if same_graph {
@@ -465,9 +501,10 @@ pub fn on_branch_head<N>(
     N: 'static + Send + Sync,
 {
     let BranchHeadEvent { original, new_name } = trigger.event();
+    let new_name: ca::Name = new_name.parse().expect("infallible");
 
     // Get commit CA from original head.
-    let Some(commit_ca) = registry.head_commit_ca(original).copied() else {
+    let Some(commit_ca) = registry.head_commit_ca(original) else {
         log::error!("Failed to get commit address for head: {:?}", original);
         return;
     };
@@ -481,12 +518,12 @@ pub fn on_branch_head<N>(
         });
 
     // Insert new branch name pointing to the fresh commit.
-    registry.insert_name(new_name.clone(), new_commit_ca);
+    registry.set_head(new_name.clone(), new_commit_ca);
 
     // Inherit the original graph's description, if any.
     if let ca::Head::Branch(orig_name) = original {
-        if let Some(desc) = registry.description(orig_name).map(str::to_string) {
-            registry.set_description(new_name.clone(), desc);
+        if let Some(desc) = description(&registry, orig_name) {
+            set_description(&mut registry, new_name.clone(), desc);
         }
     }
 
@@ -524,9 +561,9 @@ pub fn on_move_branch<N>(
     // Capture the current commit before moving the branch pointer so we can
     // detect a same-graph move (a layout-only undo/redo) and migrate node
     // state below.
-    let old_ca = registry.head_commit_ca(&head).copied();
+    let old_ca = registry.head_commit_ca(&head);
     let old_graph = registry.head_commit(&head).map(|c| c.graph);
-    registry.insert_name(event.name.clone(), event.target);
+    registry.set_head(event.name.clone(), event.target);
     let Some(graph) = registry.head_graph(&head).cloned() else {
         log::error!("MoveBranch: graph missing for target commit");
         return;

--- a/crates/bevy_gantz/src/reg.rs
+++ b/crates/bevy_gantz/src/reg.rs
@@ -53,14 +53,15 @@ pub fn timestamp() -> Duration {
 
 /// Look up a node by content address.
 ///
-/// Checks commit graphs in the registry first, then falls back to builtins.
+/// Checks graphs in the registry first (a graph in the registry IS a node),
+/// then falls back to builtins.
 pub fn lookup_node<'a, N: 'static + Node + Send + Sync>(
     registry: &'a ca::Registry<Graph<N>>,
     builtins: &'a dyn Builtins<Node = N>,
     ca: &ca::ContentAddr,
 ) -> Option<&'a dyn Node> {
-    let commit_ca = ca::CommitAddr::from(*ca);
-    if let Some(graph) = registry.commit_graph_ref(&commit_ca) {
+    let graph_ca = ca::GraphAddr::from(*ca);
+    if let Some(graph) = registry.graph(&graph_ca) {
         return Some(graph as &dyn Node);
     }
     builtins.instance(ca).map(|n| n as &dyn Node)
@@ -70,7 +71,7 @@ pub fn lookup_node<'a, N: 'static + Node + Send + Sync>(
 // Systems
 // ---------------------------------------------------------------------------
 
-/// Prune unreachable graphs and commits from the registry.
+/// Prune unreachable content and metadata from the registry.
 pub fn prune_unused<N>(
     mut registry: ResMut<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
@@ -78,8 +79,10 @@ pub fn prune_unused<N>(
 ) where
     N: 'static + Node + Send + Sync,
 {
-    let get_node = |ca: &ca::ContentAddr| lookup_node(&registry, &**builtins, ca);
-    let head_iter = heads.iter().map(|h| &**h);
-    let required = gantz_core::reg::required_commits(&get_node, &registry, head_iter);
-    registry.prune_unreachable(&required);
+    let live = {
+        let get_node = |ca: &ca::ContentAddr| lookup_node(&registry, &**builtins, ca);
+        let head_iter = heads.iter().map(|h| &**h);
+        gantz_core::reg::live(&get_node, &registry, head_iter)
+    };
+    ca::prune(&mut registry.0, &live);
 }

--- a/crates/bevy_gantz/src/storage.rs
+++ b/crates/bevy_gantz/src/storage.rs
@@ -4,9 +4,31 @@
 //! generic [`load`] and [`save`] helpers for RON serialization, and functions
 //! for persisting the gantz registry, open heads and focused head.
 //!
-//! GUI-related storage (views, gui state) is provided by `bevy_gantz_egui::storage`.
+//! # Registry schema
+//!
+//! Content is append-only and written once per address. Mutable metadata
+//! sections are small and written whole per section, so an edit rewrites
+//! exactly one section blob:
+//!
+//! - `o/c/<hex>`: one commit, RON (append-only).
+//! - `o/g/<hex>`: one graph, RON (append-only).
+//! - `b/<section>/<hex>`: one blob, base64 of the raw bytes (append-only).
+//! - `commit-addrs`: sorted `Vec<CommitAddr>` index, rewritten on membership
+//!   change.
+//! - `graph-addrs`: sorted `Vec<GraphAddr>` index.
+//! - `blob-manifest`: RON `Vec<(SectionId, BlobLiveness, Vec<ContentAddr>)>`,
+//!   rewritten on membership change (store liveness rides here, since blob
+//!   values are raw bytes).
+//! - `ns/<section>`: one whole [`gantz_ca::Section`] (policy + liveness +
+//!   entries), rewritten when it differs from the last persisted form.
+//! - `ns-index`: sorted `Vec<SectionId>`, rewritten on membership change.
+//! - `open-heads`, `focused-head`: session state.
+//!
+//! GUI-related storage (gui state, egui memory) is provided by
+//! `bevy_gantz_egui::storage`.
 
 use crate::reg::Registry;
+use base64::Engine as _;
 use bevy_ecs::prelude::Resource;
 use bevy_log as log;
 use gantz_ca as ca;
@@ -29,6 +51,10 @@ pub trait Save {
     fn set_string(&mut self, key: &str, value: &str) -> Result<(), Self::Err>;
 }
 
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
 /// A [`Save`] that buffers writes instead of committing them.
 ///
 /// Lets a caller build a batch on the main thread - serializing in place via the
@@ -39,12 +65,64 @@ pub struct BatchWriter {
     pub writes: Vec<(String, String)>,
 }
 
+/// Tracks what is already written to storage, so [`save_registry_incremental`]
+/// only writes what changed.
+///
+/// Content addresses (graphs, commits and per-section blobs) are tracked as
+/// sets: content is immutable, so a known address never needs rewriting.
+/// Sections are mutable, so each is tracked as its last-persisted clone and
+/// rewritten whole when it differs.
+///
+/// Seed it from the disk-loaded registry via [`PersistedRegistry::from_registry`]:
+/// everything `load_registry` returns is, by definition, already on disk.
+#[derive(Resource, Default)]
+pub struct PersistedRegistry {
+    graphs: HashSet<ca::GraphAddr>,
+    commits: HashSet<ca::CommitAddr>,
+    blobs: BTreeMap<ca::SectionId, HashSet<ca::ContentAddr>>,
+    sections: BTreeMap<ca::SectionId, ca::Section>,
+}
+
+// ---------------------------------------------------------------------------
+// Inherent impls
+// ---------------------------------------------------------------------------
+
 impl BatchWriter {
     /// Take the collected writes, leaving the buffer empty.
     pub fn take(&mut self) -> Vec<(String, String)> {
         std::mem::take(&mut self.writes)
     }
 }
+
+impl PersistedRegistry {
+    /// Snapshot a registry whose contents are all known to be on disk.
+    pub fn from_registry<N>(registry: &Registry<N>) -> Self {
+        Self {
+            graphs: registry.graphs().keys().copied().collect(),
+            commits: registry.commits().keys().copied().collect(),
+            blobs: registry
+                .blobs()
+                .iter()
+                .map(|(id, store)| (id.clone(), store.entries.keys().copied().collect()))
+                .collect(),
+            sections: registry.sections().clone(),
+        }
+    }
+
+    /// The number of graph blobs known to be on disk.
+    pub fn graphs_len(&self) -> usize {
+        self.graphs.len()
+    }
+
+    /// The number of commit blobs known to be on disk.
+    pub fn commits_len(&self) -> usize {
+        self.commits.len()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Trait impls
+// ---------------------------------------------------------------------------
 
 impl Save for BatchWriter {
     type Err = std::convert::Infallible;
@@ -100,14 +178,14 @@ pub fn load<T: DeserializeOwned>(storage: &impl Load, key: &str) -> Option<T> {
 // ---------------------------------------------------------------------------
 
 mod key {
-    /// All known graph addresses.
+    /// All known graph addresses (sorted).
     pub const GRAPH_ADDRS: &str = "graph-addrs";
-    /// All known commit addresses.
+    /// All known commit addresses (sorted).
     pub const COMMIT_ADDRS: &str = "commit-addrs";
-    /// The key at which the mapping from names to graph CAs is stored.
-    pub const NAMES: &str = "graph-names";
-    /// The key at which the mapping from names to descriptions is stored.
-    pub const DESCRIPTIONS: &str = "graph-descriptions";
+    /// Every blob store's section id, liveness and addresses.
+    pub const BLOB_MANIFEST: &str = "blob-manifest";
+    /// All known section ids (sorted).
+    pub const SECTION_INDEX: &str = "ns-index";
     /// The key at which the list of open heads is stored.
     pub const OPEN_HEADS: &str = "open-heads";
     /// The key at which the focused head is stored.
@@ -115,12 +193,22 @@ mod key {
 
     /// The key for a particular graph in storage.
     pub fn graph(ca: gantz_ca::GraphAddr) -> String {
-        format!("{}", ca)
+        format!("o/g/{ca}")
     }
 
     /// The key for a particular commit in storage.
     pub fn commit(ca: gantz_ca::CommitAddr) -> String {
-        format!("{}", ca)
+        format!("o/c/{ca}")
+    }
+
+    /// The key for a particular blob in storage.
+    pub fn blob(section: &str, addr: &gantz_ca::ContentAddr) -> String {
+        format!("b/{section}/{addr}")
+    }
+
+    /// The key for a whole metadata section in storage.
+    pub fn section(id: &str) -> String {
+        format!("ns/{id}")
     }
 }
 
@@ -128,46 +216,11 @@ mod key {
 // Registry
 // ---------------------------------------------------------------------------
 
-/// Tracks which graph/commit content addresses (and the small name-keyed maps)
-/// are already written to storage, so [`save_registry_incremental`] only writes
-/// what changed.
-///
-/// Seed it from the disk-loaded registry via [`PersistedRegistry::from_registry`]:
-/// everything `load_registry` returns is, by definition, already on disk.
-#[derive(Resource, Default)]
-pub struct PersistedRegistry {
-    graphs: HashSet<ca::GraphAddr>,
-    commits: HashSet<ca::CommitAddr>,
-    names: BTreeMap<String, ca::CommitAddr>,
-    descriptions: BTreeMap<String, String>,
-}
-
-impl PersistedRegistry {
-    /// Snapshot the keys of a registry whose blobs are all known to be on disk.
-    pub fn from_registry<N>(registry: &Registry<N>) -> Self {
-        Self {
-            graphs: registry.graphs().keys().copied().collect(),
-            commits: registry.commits().keys().copied().collect(),
-            names: registry.names().clone(),
-            descriptions: registry.descriptions().clone(),
-        }
-    }
-
-    /// The number of graph blobs known to be on disk.
-    pub fn graphs_len(&self) -> usize {
-        self.graphs.len()
-    }
-
-    /// The number of commit blobs known to be on disk.
-    pub fn commits_len(&self) -> usize {
-        self.commits.len()
-    }
-}
-
 /// Incrementally persist the registry, writing only what `persisted` doesn't yet
-/// have. Graphs and commits are content-addressed and immutable (the key *is*
-/// the content hash), so an already-written blob never needs rewriting and this
-/// is O(new blobs) rather than O(graphs + commits).
+/// have. Content is content-addressed and immutable (the key *is* the content
+/// hash), so an already-written entry never needs rewriting and this is O(new
+/// content + changed sections) rather than O(registry). An unchanged registry
+/// writes nothing.
 ///
 /// A fresh [`PersistedRegistry::default`] makes this a full save.
 pub fn save_registry_incremental<N: Serialize>(
@@ -217,14 +270,56 @@ pub fn save_registry_incremental<N: Serialize>(
         save(storage, key::COMMIT_ADDRS, &addrs);
     }
 
-    // Tiny name-keyed maps: write only when they differ from last-persisted.
-    if registry.names() != &persisted.names {
-        persisted.names = registry.names().clone();
-        save(storage, key::NAMES, registry.names());
+    // Blob stores: raw bytes per address, membership (and store liveness) in
+    // the manifest.
+    let mut manifest_changed = false;
+    for (id, store) in registry.blobs() {
+        let tracked = persisted.blobs.entry(id.clone()).or_default();
+        for (addr, bytes) in &store.entries {
+            if tracked.insert(*addr) {
+                save_blob(storage, &key::blob(id, addr), bytes);
+                manifest_changed = true;
+            }
+        }
+        if tracked.len() != store.entries.len() {
+            tracked.retain(|addr| store.entries.contains_key(addr));
+            manifest_changed = true;
+        }
     }
-    if registry.descriptions() != &persisted.descriptions {
-        persisted.descriptions = registry.descriptions().clone();
-        save(storage, key::DESCRIPTIONS, registry.descriptions());
+    let tracked_stores = persisted.blobs.len();
+    persisted
+        .blobs
+        .retain(|id, _| registry.blobs().contains_key(id));
+    manifest_changed |= persisted.blobs.len() != tracked_stores;
+    if manifest_changed {
+        let manifest: Vec<(&ca::SectionId, ca::BlobLiveness, Vec<&ca::ContentAddr>)> = registry
+            .blobs()
+            .iter()
+            .map(|(id, store)| (id, store.liveness, store.entries.keys().collect()))
+            .collect();
+        save(storage, key::BLOB_MANIFEST, &manifest);
+    }
+
+    // Sections: mutable, so each is compared against its last-persisted form
+    // and rewritten whole when it differs.
+    let mut index_changed = false;
+    for (id, section) in registry.sections() {
+        if persisted.sections.get(id) != Some(section) {
+            save(storage, &key::section(id), section);
+            index_changed |= persisted
+                .sections
+                .insert(id.clone(), section.clone())
+                .is_none();
+        }
+    }
+    let tracked_sections = persisted.sections.len();
+    persisted
+        .sections
+        .retain(|id, _| registry.sections().contains_key(id));
+    index_changed |= persisted.sections.len() != tracked_sections;
+    if index_changed {
+        let ids: Vec<&ca::SectionId> = registry.sections().keys().collect();
+        save(storage, key::SECTION_INDEX, &ids);
     }
 }
 
@@ -242,14 +337,63 @@ pub fn load_registry<N: DeserializeOwned>(storage: &impl Load) -> Registry<N> {
         .filter_map(|ca| Some((ca, load(storage, &key::commit(ca))?)))
         .collect();
 
-    let names = load(storage, key::NAMES).unwrap_or_default();
-    let mut registry = ca::Registry::new(graphs, commits, names);
-    let descriptions: std::collections::BTreeMap<String, String> =
-        load(storage, key::DESCRIPTIONS).unwrap_or_default();
-    for (name, description) in descriptions {
-        registry.set_description(name, description);
+    let mut registry = ca::Registry::from_parts(graphs, commits, BTreeMap::new());
+
+    // Sections load whole: the first write per section stamps its stored
+    // policy and liveness.
+    let section_ids: Vec<ca::SectionId> = load(storage, key::SECTION_INDEX).unwrap_or_default();
+    for id in section_ids {
+        let Some(section) = load::<ca::Section>(storage, &key::section(&id)) else {
+            continue;
+        };
+        for (key, value) in section.entries {
+            registry.set_section_value(id.as_str(), section.policy, section.liveness, key, value);
+        }
     }
+
+    // Blobs: `add_blob` re-derives each address from the bytes, so the load is
+    // self-verifying (corrupt bytes land under a different address and are
+    // unreachable).
+    let manifest: Vec<(ca::SectionId, ca::BlobLiveness, Vec<ca::ContentAddr>)> =
+        load(storage, key::BLOB_MANIFEST).unwrap_or_default();
+    for (id, liveness, addrs) in manifest {
+        for addr in addrs {
+            let Some(bytes) = load_blob(storage, &key::blob(&id, &addr)) else {
+                continue;
+            };
+            registry.add_blob(id.as_str(), liveness, bytes);
+        }
+    }
+
     Registry(registry)
+}
+
+/// Persist raw blob bytes under `key`, base64-encoded to fit the string store.
+fn save_blob(storage: &mut impl Save, key: &str, bytes: &[u8]) {
+    let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+    match storage.set_string(key, &encoded) {
+        Ok(()) => log::debug!("Persisted {key}"),
+        Err(e) => log::error!("Failed to persist {key}: {e}"),
+    }
+}
+
+/// Load raw blob bytes from `key` (see [`save_blob`]).
+fn load_blob(storage: &impl Load, key: &str) -> Option<Vec<u8>> {
+    let encoded = match storage.get_string(key) {
+        Ok(Some(s)) => s,
+        Ok(None) => return None,
+        Err(e) => {
+            log::error!("Failed to read {key}: {e}");
+            return None;
+        }
+    };
+    match base64::engine::general_purpose::STANDARD.decode(encoded.as_bytes()) {
+        Ok(bytes) => Some(bytes),
+        Err(e) => {
+            log::error!("Failed to decode {key}: {e}");
+            None
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -287,7 +431,10 @@ pub fn load_focused_head(storage: &impl Load) -> Option<ca::Head> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gantz_ca::{Commit, CommitAddr, ContentAddr, GraphAddr};
+    use gantz_ca::{
+        BlobLiveness, Commit, CommitAddr, ContentAddr, GraphAddr, Key, Liveness, MergePolicy, Name,
+        Value,
+    };
     use gantz_core::node::graph::Graph;
     use std::collections::{HashMap, HashSet};
     use std::time::Duration;
@@ -329,14 +476,23 @@ mod tests {
         CommitAddr::from(ContentAddr::from([n; 32]))
     }
 
+    fn name(s: &str) -> Name {
+        s.parse().unwrap()
+    }
+
     fn wrote(writes: &[String], key: &str) -> bool {
         writes.iter().any(|w| w == key)
     }
 
+    /// The `ns/<section>` key for the core heads section.
+    fn heads_key() -> String {
+        key::section(ca::HEADS_ID)
+    }
+
     /// Build a registry from `(graph, commit)` synthetic-addr pairs (one commit
-    /// per graph) plus `(name, commit)` pairs. Graph blob values are empty - the
-    /// dedup is keyed on the map keys, not the values.
-    fn registry(graphs: &[(u8, u8)], names: &[(&str, u8)]) -> Registry<()> {
+    /// per graph) plus `(name, commit)` head pairs. Graph blob values are empty -
+    /// the dedup is keyed on the map keys, not the values.
+    fn registry(graphs: &[(u8, u8)], heads: &[(&str, u8)]) -> Registry<()> {
         let g = graphs
             .iter()
             .map(|&(ga, _)| (graph_addr(ga), Graph::<()>::default()))
@@ -348,15 +504,29 @@ mod tests {
                 (commit_addr(ca), commit)
             })
             .collect();
-        let nm = names
+        let h = heads
             .iter()
-            .map(|&(n, ca)| (n.to_string(), commit_addr(ca)))
+            .map(|&(n, ca)| (name(n), commit_addr(ca)))
             .collect();
-        Registry(ca::Registry::new(g, c, nm))
+        Registry(ca::Registry::from_parts(g, c, h))
+    }
+
+    /// Store a synthetic per-commit "view" entry in a KeepExisting/WithCommit
+    /// section, mirroring how the GUI persists scene views.
+    fn set_view(reg: &mut Registry<()>, commit: u8, value: u8) {
+        ca::section_insert_datum(
+            &mut reg.0,
+            "egui.view",
+            MergePolicy::KeepExisting,
+            Liveness::WithCommit,
+            Key::Commit(commit_addr(commit)),
+            &value,
+        )
+        .unwrap();
     }
 
     #[test]
-    fn first_save_writes_all_blobs_indices_and_names() {
+    fn first_save_writes_all_content_indices_and_sections() {
         let reg = registry(&[(1, 11), (2, 12)], &[("alpha", 11)]);
         let mut persisted = PersistedRegistry::default();
         let mut store = MockStore::default();
@@ -368,14 +538,17 @@ mod tests {
         assert!(wrote(&writes, &key::commit(commit_addr(11))));
         assert!(wrote(&writes, &key::commit(commit_addr(12))));
         assert!(wrote(&writes, key::COMMIT_ADDRS));
-        assert!(wrote(&writes, key::NAMES));
-        // Descriptions is empty, so it is not written.
-        assert!(!wrote(&writes, key::DESCRIPTIONS));
+        assert!(wrote(&writes, &heads_key()));
+        assert!(wrote(&writes, key::SECTION_INDEX));
+        // No blobs, so no manifest.
+        assert!(!wrote(&writes, key::BLOB_MANIFEST));
     }
 
     #[test]
     fn resave_unchanged_writes_nothing() {
-        let reg = registry(&[(1, 11), (2, 12)], &[("alpha", 11)]);
+        let mut reg = registry(&[(1, 11), (2, 12)], &[("alpha", 11)]);
+        set_view(&mut reg, 11, 1);
+        reg.add_blob("dsp.buffer", BlobLiveness::Pinned, &b"pcm"[..]);
         let mut persisted = PersistedRegistry::default();
         let mut store = MockStore::default();
         save_registry_incremental(&mut store, &reg, &mut persisted);
@@ -401,22 +574,57 @@ mod tests {
         assert!(wrote(&writes, &key::commit(commit_addr(12))));
         assert!(wrote(&writes, key::GRAPH_ADDRS));
         assert!(wrote(&writes, key::COMMIT_ADDRS));
-        // Already-persisted blobs and unchanged names are not rewritten.
+        // Already-persisted blobs and unchanged sections are not rewritten.
         assert!(!wrote(&writes, &key::graph(graph_addr(1))));
         assert!(!wrote(&writes, &key::commit(commit_addr(11))));
-        assert!(!wrote(&writes, key::NAMES));
+        assert!(!wrote(&writes, &heads_key()));
+        assert!(!wrote(&writes, key::SECTION_INDEX));
     }
 
     #[test]
-    fn changing_description_writes_only_descriptions() {
+    fn changing_one_section_entry_writes_only_that_section() {
+        let mut reg = registry(&[(1, 11), (2, 12)], &[("alpha", 11)]);
+        set_view(&mut reg, 11, 1);
+        set_view(&mut reg, 12, 2);
+        let mut persisted = PersistedRegistry::default();
+        let mut store = MockStore::default();
+        save_registry_incremental(&mut store, &reg, &mut persisted);
+        store.take_writes();
+        // One view entry moves; heads and content are untouched.
+        set_view(&mut reg, 12, 3);
+        save_registry_incremental(&mut store, &reg, &mut persisted);
+        let writes = store.take_writes();
+        assert_eq!(writes, vec![key::section("egui.view")]);
+    }
+
+    #[test]
+    fn new_section_writes_the_section_and_the_index() {
         let mut reg = registry(&[(1, 11)], &[("alpha", 11)]);
         let mut persisted = PersistedRegistry::default();
         let mut store = MockStore::default();
         save_registry_incremental(&mut store, &reg, &mut persisted);
         store.take_writes();
-        reg.set_description("alpha".to_string(), "doc".to_string());
+        set_view(&mut reg, 11, 1);
         save_registry_incremental(&mut store, &reg, &mut persisted);
-        assert_eq!(store.take_writes(), vec![key::DESCRIPTIONS.to_string()]);
+        let writes = store.take_writes();
+        assert!(wrote(&writes, &key::section("egui.view")));
+        assert!(wrote(&writes, key::SECTION_INDEX));
+        assert_eq!(writes.len(), 2);
+    }
+
+    #[test]
+    fn new_blob_writes_the_blob_and_the_manifest() {
+        let mut reg = registry(&[(1, 11)], &[("alpha", 11)]);
+        let mut persisted = PersistedRegistry::default();
+        let mut store = MockStore::default();
+        save_registry_incremental(&mut store, &reg, &mut persisted);
+        store.take_writes();
+        let addr = reg.add_blob("dsp.buffer", BlobLiveness::Pinned, &b"pcm"[..]);
+        save_registry_incremental(&mut store, &reg, &mut persisted);
+        let writes = store.take_writes();
+        assert!(wrote(&writes, &key::blob("dsp.buffer", &addr)));
+        assert!(wrote(&writes, key::BLOB_MANIFEST));
+        assert_eq!(writes.len(), 2);
     }
 
     #[test]
@@ -427,8 +635,12 @@ mod tests {
         save_registry_incremental(&mut store, &reg, &mut persisted);
         store.take_writes();
         // Keep only commit 11 (and graph 1, which it references).
-        let required: HashSet<CommitAddr> = [commit_addr(11)].into_iter().collect();
-        reg.prune_unreachable(&required);
+        let live = ca::LiveSet {
+            commits: HashSet::from([commit_addr(11)]),
+            graphs: HashSet::from([graph_addr(1)]),
+            blobs: BTreeMap::new(),
+        };
+        ca::prune(&mut reg.0, &live);
         save_registry_incremental(&mut store, &reg, &mut persisted);
         let writes = store.take_writes();
         // Nothing new to write, but both indices shrank and are rewritten.
@@ -443,14 +655,18 @@ mod tests {
 
     #[test]
     fn load_round_trips_incremental_save() {
-        let reg = registry(&[(1, 11), (2, 12)], &[("alpha", 11)]);
+        let mut reg = registry(&[(1, 11), (2, 12)], &[("alpha", 11)]);
+        set_view(&mut reg, 11, 7);
+        reg.add_blob("dsp.buffer", BlobLiveness::Pinned, &b"pcm"[..]);
         let mut persisted = PersistedRegistry::default();
         let mut store = MockStore::default();
         save_registry_incremental(&mut store, &reg, &mut persisted);
         let loaded: Registry<()> = load_registry(&store);
         assert_eq!(loaded.graphs().len(), reg.graphs().len());
-        assert_eq!(loaded.commits().len(), reg.commits().len());
-        assert_eq!(loaded.names(), reg.names());
+        assert_eq!(loaded.commits(), reg.commits());
+        assert_eq!(loaded.sections(), reg.sections());
+        assert_eq!(loaded.blobs(), reg.blobs());
+        assert_eq!(loaded.head(&name("alpha")), Some(commit_addr(11)));
     }
 
     #[test]
@@ -467,18 +683,50 @@ mod tests {
         assert!(keys.contains(&key::commit(commit_addr(11)).as_str()));
         assert!(keys.contains(&key::GRAPH_ADDRS));
         assert!(keys.contains(&key::COMMIT_ADDRS));
-        assert!(keys.contains(&key::NAMES));
+        assert!(keys.contains(&heads_key().as_str()));
         // Values are the RON the direct `save` path would have written.
-        let (_, names_ron) = batch
+        let (_, heads_ron) = batch
             .writes
             .iter()
-            .find(|(k, _)| k == key::NAMES)
-            .expect("names written");
-        assert_eq!(names_ron, &ron::to_string(reg.names()).unwrap());
+            .find(|(k, _)| *k == heads_key())
+            .expect("heads section written");
+        let heads_section = reg.section(ca::HEADS_ID).expect("heads section");
+        assert_eq!(heads_ron, &ron::to_string(heads_section).unwrap());
 
         // `take` hands off the buffer and leaves it empty.
         let taken = batch.take();
         assert!(!taken.is_empty());
         assert!(batch.writes.is_empty());
+    }
+
+    /// A section entry's raw `Value` forms (datum, blob pointer, commit) all
+    /// survive the whole-section round trip.
+    #[test]
+    fn section_value_forms_round_trip() {
+        let mut reg = registry(&[(1, 11)], &[("alpha", 11)]);
+        let blob_addr = reg.add_blob("dsp.buffer", BlobLiveness::SectionReferenced, &b"pcm"[..]);
+        reg.0.set_section_value(
+            "dsp.meta",
+            MergePolicy::KeepExisting,
+            Liveness::Pinned,
+            Key::Addr(blob_addr),
+            Value::Blob("dsp.buffer".to_string(), blob_addr),
+        );
+        reg.0.set_section_value(
+            "test.pin",
+            MergePolicy::KeepExisting,
+            Liveness::Pinned,
+            Key::Name(name("alpha")),
+            Value::Commit(commit_addr(11)),
+        );
+        let mut persisted = PersistedRegistry::default();
+        let mut store = MockStore::default();
+        save_registry_incremental(&mut store, &reg, &mut persisted);
+        let loaded: Registry<()> = load_registry(&store);
+        assert_eq!(loaded.sections(), reg.sections());
+        assert_eq!(
+            loaded.blob("dsp.buffer", &blob_addr).map(|b| &b[..]),
+            Some(&b"pcm"[..]),
+        );
     }
 }

--- a/crates/bevy_gantz_egui/src/base.rs
+++ b/crates/bevy_gantz_egui/src/base.rs
@@ -25,19 +25,11 @@
 use bevy_ecs::prelude::*;
 use bevy_gantz::reg::Registry;
 use bevy_log as log;
+use gantz_ca::Name;
 use gantz_core::node::graph::Graph;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::BaseNames;
-
-/// Fixed timestamp used to stamp the base's hand-authored (uncommitted) graphs.
-///
-/// Every base source is parsed at startup *and* again on demo reset; both must
-/// agree on the synthesized commit addresses, otherwise a reset demo's `ref`s
-/// point at commits that are absent from the already-loaded registry (its
-/// primitives were stamped at startup). A constant makes those addresses
-/// reproducible.
-pub const BASE_TIMESTAMP: gantz_ca::Timestamp = std::time::Duration::ZERO;
 
 /// One domain's baked-in base `.gantz` export.
 pub struct BaseSource {
@@ -65,98 +57,6 @@ pub struct BaseSources(pub Vec<BaseSource>);
 #[derive(Default, Resource)]
 pub struct BaseNameSources(pub HashMap<String, &'static str>);
 
-/// Startup system that deserializes each embedded base source and merges it
-/// into the registry, populating [`BaseNames`] and [`BaseNameSources`].
-///
-/// A source may reference names another source defines, so loading runs to a
-/// fixpoint: each round parses every still-pending source seeded with the
-/// names loaded so far, deferring sources whose references do not resolve
-/// yet. Push order therefore does not matter - sources load in dependency
-/// order. A source whose references never resolve (or that fails to parse
-/// outright) is logged and dropped.
-pub fn load<N>(
-    sources: Res<BaseSources>,
-    mut registry: ResMut<Registry<N>>,
-    mut base_names: ResMut<BaseNames>,
-    mut name_sources: ResMut<BaseNameSources>,
-    mut views: ResMut<crate::Views>,
-    mut demos: ResMut<crate::Demos>,
-) where
-    N: 'static
-        + serde::Serialize
-        + serde::de::DeserializeOwned
-        + gantz_ca::CaHash
-        + gantz_format::NodeSugar
-        + Send
-        + Sync,
-{
-    let mut pending: Vec<&BaseSource> = sources.0.iter().collect();
-    loop {
-        let mut deferred: Vec<&BaseSource> = Vec::new();
-        for source in pending.iter().copied() {
-            let export: gantz_egui::export::Export<Graph<N>> =
-                match gantz_egui::export::parse_export_seeded_at(
-                    source.bytes,
-                    BASE_TIMESTAMP,
-                    &base_names.0,
-                ) {
-                    Ok(e) => e,
-                    // An unresolved reference may resolve once another
-                    // source loads - retry next round.
-                    Err(gantz_egui::export::ParseExportError::Format(e))
-                        if matches!(e.kind, gantz_format::ErrorKind::MissingDependency(_)) =>
-                    {
-                        deferred.push(source);
-                        continue;
-                    }
-                    Err(e) => {
-                        log::error!("base source `{}`: {e}", source.name);
-                        continue;
-                    }
-                };
-            for name in export.registry.names().keys() {
-                if let Some(prev) = name_sources.0.get(name.as_str()) {
-                    log::warn!(
-                        "base source `{}` redefines `{name}` from source `{prev}` \
-                         (last source wins)",
-                        source.name,
-                    );
-                }
-                name_sources.0.insert(name.clone(), source.name);
-            }
-            base_names.0.extend(export.registry.names().clone());
-            // NOTE: the merge's `names_replaced` is deliberately not logged -
-            // base names replacing a user's persisted edits on launch is the
-            // by-design authoritative reset, not a collision. Source-vs-source
-            // collisions are the ones worth warning about, caught above.
-            registry.merge(export.registry);
-            views.0.extend(export.views);
-            demos.0.extend(export.demos);
-        }
-        // Done, or stuck: no deferred source can make progress once a full
-        // round loads nothing new.
-        if deferred.is_empty() {
-            break;
-        }
-        if deferred.len() == pending.len() {
-            for source in deferred {
-                if let Err(err) = gantz_egui::export::parse_export_seeded_at::<N>(
-                    source.bytes,
-                    BASE_TIMESTAMP,
-                    &base_names.0,
-                ) {
-                    log::error!(
-                        "base source `{}` has unresolvable references: {err}",
-                        source.name,
-                    );
-                }
-            }
-            break;
-        }
-        pending = deferred;
-    }
-}
-
 /// Paths to write each base source back to (a [`BaseSource::name`] to file
 /// path map), plus the source that receives names with no recorded
 /// attribution (graphs created during the session).
@@ -173,6 +73,117 @@ pub struct ExportPaths {
     pub default_source: &'static str,
 }
 
+/// Fixed timestamp used to stamp the base's hand-authored (uncommitted) graphs.
+///
+/// Every base source is parsed at startup *and* again on demo reset; both must
+/// agree on the synthesized commit addresses, otherwise a reset demo's `ref`s
+/// point at commits that are absent from the already-loaded registry (its
+/// primitives were stamped at startup). A constant makes those addresses
+/// reproducible.
+pub const BASE_TIMESTAMP: gantz_ca::Timestamp = std::time::Duration::ZERO;
+
+/// Startup system that deserializes each embedded base source and merges it
+/// into the registry, populating [`BaseNames`] and [`BaseNameSources`].
+///
+/// A source may reference names another source defines, so loading runs to a
+/// fixpoint: each round parses every still-pending source seeded with the
+/// names loaded so far, deferring sources whose references do not resolve
+/// yet. Push order therefore does not matter - sources load in dependency
+/// order. A source whose references never resolve (or that fails to parse
+/// outright) is logged and dropped.
+pub fn load<N>(
+    sources: Res<BaseSources>,
+    mut registry: ResMut<Registry<N>>,
+    mut base_names: ResMut<BaseNames>,
+    mut name_sources: ResMut<BaseNameSources>,
+) where
+    N: 'static
+        + serde::Serialize
+        + serde::de::DeserializeOwned
+        + gantz_ca::CaHash
+        + gantz_format::NodeSugar
+        + Send
+        + Sync,
+{
+    let mut pending: Vec<&BaseSource> = sources.0.iter().collect();
+    loop {
+        let mut deferred: Vec<&BaseSource> = Vec::new();
+        for source in pending.iter().copied() {
+            let seed = seed_graph_addrs(&base_names.0, &registry);
+            let parsed: gantz_ca::Registry<Graph<N>> =
+                match gantz_egui::export::parse_export_seeded_at(
+                    source.bytes,
+                    BASE_TIMESTAMP,
+                    &seed,
+                ) {
+                    Ok(e) => e,
+                    // An unresolved reference may resolve once another
+                    // source loads - retry next round.
+                    Err(gantz_egui::export::ParseExportError::Format(e))
+                        if matches!(e.kind, gantz_format::ErrorKind::MissingDependency(_)) =>
+                    {
+                        deferred.push(source);
+                        continue;
+                    }
+                    Err(e) => {
+                        log::error!("base source `{}`: {e}", source.name);
+                        continue;
+                    }
+                };
+            for (name, ca) in parsed.heads() {
+                let display = name.to_string();
+                if let Some(prev) = name_sources.0.get(&display) {
+                    log::warn!(
+                        "base source `{}` redefines `{name}` from source `{prev}` \
+                         (last source wins)",
+                        source.name,
+                    );
+                }
+                name_sources.0.insert(display, source.name);
+                base_names.0.insert(name.clone(), ca);
+            }
+            // The base's GUI metadata (demos, views) must win over the user's
+            // persisted entries: the demo/view sections merge KeepExisting, so
+            // reinsert the parsed entries explicitly after the merge.
+            let demos: Vec<_> = gantz_egui::section::demos(&parsed).collect();
+            let views: Vec<_> = gantz_egui::section::views(&parsed).collect();
+            // NOTE: the merge's `heads_replaced` is deliberately not logged -
+            // base names replacing a user's persisted edits on launch is the
+            // by-design authoritative reset, not a collision. Source-vs-source
+            // collisions are the ones worth warning about, caught above.
+            registry.merge(parsed);
+            for (name, demo) in demos {
+                gantz_egui::section::set_demo(&mut registry.0, name, demo);
+            }
+            for (ca, view) in views {
+                gantz_egui::section::set_view(&mut registry.0, ca, &view);
+            }
+        }
+        // Done, or stuck: no deferred source can make progress once a full
+        // round loads nothing new.
+        if deferred.is_empty() {
+            break;
+        }
+        if deferred.len() == pending.len() {
+            let seed = seed_graph_addrs(&base_names.0, &registry);
+            for source in deferred {
+                if let Err(err) = gantz_egui::export::parse_export_seeded_at::<N>(
+                    source.bytes,
+                    BASE_TIMESTAMP,
+                    &seed,
+                ) {
+                    log::error!(
+                        "base source `{}` has unresolvable references: {err}",
+                        source.name,
+                    );
+                }
+            }
+            break;
+        }
+        pending = deferred;
+    }
+}
+
 /// System that exports every named graph back to its owning source's file
 /// (see [`ExportPaths`] and [`BaseNameSources`]).
 ///
@@ -182,8 +193,6 @@ pub fn export_to_file<N>(
     paths: Res<ExportPaths>,
     name_sources: Res<BaseNameSources>,
     registry: Res<Registry<N>>,
-    views: Res<crate::Views>,
-    demos: Res<crate::Demos>,
 ) where
     N: 'static
         + serde::Serialize
@@ -194,7 +203,8 @@ pub fn export_to_file<N>(
         + Send
         + Sync,
 {
-    let partitioned = partition_names(registry.names().keys(), &name_sources, paths.default_source);
+    let names: Vec<Name> = registry.heads().map(|(name, _)| name.clone()).collect();
+    let partitioned = partition_names(&names, &name_sources, paths.default_source);
     for (source, names) in &partitioned {
         let Some(path) = paths.paths.get(source) else {
             log::warn!(
@@ -207,7 +217,8 @@ pub fn export_to_file<N>(
         // Exactly this source's names, with refs into other sources written
         // by name only (no transitive closure) - loading resolves them via
         // the seeded parse.
-        match gantz_egui::export::export_names_sexpr_named(&registry, &views, &demos.0, names) {
+        let names: Vec<String> = names.iter().map(|name| name.to_string()).collect();
+        match gantz_egui::export::export_names_sexpr_named(&registry, &names) {
             Ok(text) => {
                 if let Err(e) = std::fs::write(path, text) {
                     log::error!("export_to_file: failed to write {path}: {e}");
@@ -228,8 +239,6 @@ pub fn export_to_file<N>(
 pub fn export_all_named<N>(
     registry: &Registry<N>,
     builtins: &bevy_gantz::BuiltinNodes<N>,
-    views: &crate::Views,
-    demos: &crate::Demos,
 ) -> Option<String>
 where
     N: 'static
@@ -241,23 +250,31 @@ where
         + Send
         + Sync,
 {
-    let node_reg = crate::registry_ref(registry, builtins, demos);
+    let node_reg = crate::registry_ref(registry, builtins);
     let get_node = |ca: &gantz_ca::ContentAddr| node_reg.node(ca);
 
     let named_heads: Vec<gantz_ca::Head> = registry
-        .names()
-        .keys()
-        .map(|name| gantz_ca::Head::Branch(name.clone()))
+        .heads()
+        .map(|(name, _)| gantz_ca::Head::Branch(name.clone()))
         .collect();
 
-    gantz_egui::export::export_heads_sexpr_named(
-        &get_node,
-        registry,
-        views,
-        &demos.0,
-        named_heads.iter(),
-    )
-    .ok()
+    gantz_egui::export::export_heads_sexpr_named(&get_node, registry, named_heads.iter()).ok()
+}
+
+/// The name -> head graph address seed for a seeded base parse: each known
+/// base name resolved to its head commit's graph in the given registry (see
+/// [`gantz_egui::export::parse_export_seeded_at`]).
+pub fn seed_graph_addrs<G>(
+    names: &gantz_egui::reg::Names,
+    registry: &gantz_ca::Registry<G>,
+) -> BTreeMap<String, gantz_ca::GraphAddr> {
+    names
+        .iter()
+        .filter_map(|(name, ca)| {
+            let commit = registry.commits().get(ca)?;
+            Some((name.to_string(), commit.graph))
+        })
+        .collect()
 }
 
 /// Partition base names by their owning source for per-source write-back.
@@ -268,24 +285,24 @@ where
 /// names (e.g. graphs created during an `update-base` session) are attributed
 /// to `default_source`.
 pub fn partition_names<'a>(
-    names: impl IntoIterator<Item = &'a String>,
+    names: impl IntoIterator<Item = &'a Name>,
     name_sources: &BaseNameSources,
     default_source: &'static str,
-) -> std::collections::BTreeMap<&'static str, Vec<String>> {
+) -> std::collections::BTreeMap<&'static str, Vec<Name>> {
     fn source_of(
-        name: &str,
+        name: &Name,
         name_sources: &BaseNameSources,
         default_source: &'static str,
     ) -> &'static str {
-        if let Some(&source) = name_sources.0.get(name) {
+        if let Some(&source) = name_sources.0.get(&name.to_string()) {
             return source;
         }
-        match name.rsplit_once(gantz_egui::node::NESTED_SEP) {
-            Some((parent, _)) => source_of(parent, name_sources, default_source),
+        match name.parent() {
+            Some(parent) => source_of(&parent, name_sources, default_source),
             None => default_source,
         }
     }
-    let mut partitioned = std::collections::BTreeMap::<&'static str, Vec<String>>::new();
+    let mut partitioned = std::collections::BTreeMap::<&'static str, Vec<Name>>::new();
     for name in names {
         let source = source_of(name, name_sources, default_source);
         partitioned.entry(source).or_default().push(name.clone());
@@ -297,6 +314,10 @@ pub fn partition_names<'a>(
 mod tests {
     use super::*;
 
+    fn name(s: &str) -> Name {
+        s.parse().unwrap()
+    }
+
     /// Attributed names route to their source, unattributed names to the
     /// default source.
     #[test]
@@ -304,20 +325,13 @@ mod tests {
         let mut name_sources = BaseNameSources::default();
         name_sources.0.insert("add".to_string(), "gantz");
         name_sources.0.insert("demo-sine".to_string(), "plyphon");
-        let names = [
-            "add".to_string(),
-            "demo-sine".to_string(),
-            "new".to_string(),
-        ];
+        let names = [name("add"), name("demo-sine"), name("new")];
         let partitioned = partition_names(names.iter(), &name_sources, "gantz");
         assert_eq!(
             partitioned.get("gantz"),
-            Some(&vec!["add".to_string(), "new".to_string()]),
+            Some(&vec![name("add"), name("new")]),
         );
-        assert_eq!(
-            partitioned.get("plyphon"),
-            Some(&vec!["demo-sine".to_string()])
-        );
+        assert_eq!(partitioned.get("plyphon"), Some(&vec![name("demo-sine")]));
     }
 
     /// An unrecorded nested name follows its parent's attribution, however
@@ -327,21 +341,18 @@ mod tests {
         let mut name_sources = BaseNameSources::default();
         name_sources.0.insert("demo-sine".to_string(), "plyphon");
         let names = [
-            "demo-sine:child".to_string(),
-            "demo-sine:child:grandchild".to_string(),
-            "orphan:child".to_string(),
+            name("demo-sine:child"),
+            name("demo-sine:child:grandchild"),
+            name("orphan:child"),
         ];
         let partitioned = partition_names(names.iter(), &name_sources, "gantz");
         assert_eq!(
             partitioned.get("plyphon"),
             Some(&vec![
-                "demo-sine:child".to_string(),
-                "demo-sine:child:grandchild".to_string(),
+                name("demo-sine:child"),
+                name("demo-sine:child:grandchild"),
             ]),
         );
-        assert_eq!(
-            partitioned.get("gantz"),
-            Some(&vec!["orphan:child".to_string()]),
-        );
+        assert_eq!(partitioned.get("gantz"), Some(&vec![name("orphan:child")]));
     }
 }

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -145,8 +145,6 @@ where
             .init_resource::<TraceCapture>()
             .init_resource::<PerfVm>()
             .init_resource::<PerfGui>()
-            .init_resource::<Views>()
-            .init_resource::<Demos>()
             .init_resource::<WindowedPanesRequested>()
             .init_resource::<SettingsTabs>()
             .init_resource::<ExtPanes>()
@@ -257,22 +255,12 @@ pub struct PerfGui(pub gantz_egui::widget::PerfCapture);
 #[derive(Resource, Default)]
 pub struct GuiState(pub gantz_egui::widget::GantzState);
 
-/// Views (layout + camera) for all known commits.
-#[derive(Resource, Default)]
-pub struct Views(pub HashMap<ca::CommitAddr, gantz_egui::SceneView>);
-
-/// Demo graph associations: maps a graph *name* to its associated `demo-*`
-/// graph name. Keyed by name (not commit) so the association survives edits,
-/// which mint a new commit but keep the name.
-#[derive(Resource, Default)]
-pub struct Demos(pub HashMap<String, String>);
-
 /// Names of base nodes baked into the binary.
 ///
 /// When present, these names are displayed with a `[base]` prefix and
 /// cannot be deleted from the Graphs pane.
 #[derive(Resource, Default)]
-pub struct BaseNames(pub gantz_ca::registry::Names);
+pub struct BaseNames(pub gantz_egui::reg::Names);
 
 /// Whether base node graphs are immutable (view-only) in the GUI.
 ///
@@ -382,7 +370,7 @@ pub struct ImportFileEvent {
 
 /// Event emitted when a base graph should be reset to its original state.
 #[derive(Event)]
-pub struct ResetBaseGraphEvent(pub String);
+pub struct ResetBaseGraphEvent(pub ca::Name);
 
 // ----------------------------------------------------------------------------
 // Response dispatch
@@ -573,32 +561,6 @@ impl DerefMut for GuiState {
     }
 }
 
-impl Deref for Views {
-    type Target = HashMap<ca::CommitAddr, gantz_egui::SceneView>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for Views {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl Deref for Demos {
-    type Target = HashMap<String, String>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for Demos {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 impl Deref for GraphView {
     type Target = gantz_egui::SceneView;
     fn deref(&self) -> &Self::Target {
@@ -619,9 +581,8 @@ impl DerefMut for GraphView {
 pub fn registry_ref<'a, N: 'static + Send + Sync>(
     registry: &'a Registry<N>,
     builtins: &'a BuiltinNodes<N>,
-    demos: &'a Demos,
 ) -> RegistryRef<'a, N> {
-    RegistryRef::new(&**registry, &*builtins.0, &demos.0)
+    RegistryRef::new(&**registry, &*builtins.0)
 }
 
 // ----------------------------------------------------------------------------
@@ -638,11 +599,11 @@ fn on_eval_entry_complete(trigger: On<EvalEntryComplete>, mut perf_vm: ResMut<Pe
 
 /// Initialize GUI state entry and components for opened head.
 ///
-/// Loads views from the `Views` resource and spawns `GraphView` + `HeadGuiState` components.
+/// Loads the view from the registry's view section and spawns `GraphView` +
+/// `HeadGuiState` components.
 pub fn on_head_opened<N: 'static + Send + Sync>(
     trigger: On<head::OpenedEvent>,
     registry: Res<Registry<N>>,
-    views: Res<Views>,
     mut gui_state: ResMut<GuiState>,
     mut cmds: Commands,
 ) {
@@ -652,7 +613,7 @@ pub fn on_head_opened<N: 'static + Send + Sync>(
     // Load the view for this head's commit.
     let head_view = registry
         .head_commit_ca(&event.head)
-        .and_then(|ca| views.get(ca).cloned())
+        .and_then(|ca| gantz_egui::section::view(&registry, &ca))
         .unwrap_or_default();
 
     cmds.entity(event.entity)
@@ -665,8 +626,7 @@ pub fn on_head_opened<N: 'static + Send + Sync>(
 /// Loads views for the new head and updates `GraphView` + `HeadGuiState` components.
 pub fn on_head_changed<N: 'static + ca::CaHash + Send + Sync>(
     trigger: On<head::ChangedEvent>,
-    registry: Res<Registry<N>>,
-    mut views: ResMut<Views>,
+    mut registry: ResMut<Registry<N>>,
     mut gui_state: ResMut<GuiState>,
     mut ctxs: EguiContexts,
     graph_views: Query<&GraphView>,
@@ -685,7 +645,9 @@ pub fn on_head_changed<N: 'static + ca::CaHash + Send + Sync>(
     // falling back to an empty layout - which the scene would destructively
     // auto-layout - and seed the store so the commit has a view before any
     // same-frame session announce.
-    let stored = event.new_commit.and_then(|ca| views.get(&ca).cloned());
+    let stored = event
+        .new_commit
+        .and_then(|ca| gantz_egui::section::view(&registry, &ca));
     let mut head_view = match stored {
         Some(view) => view,
         None => {
@@ -705,7 +667,7 @@ pub fn on_head_changed<N: 'static + ca::CaHash + Send + Sync>(
             };
             if let Some(new) = event.new_commit {
                 if !carried.layout.is_empty() {
-                    views.insert(new, carried.clone());
+                    gantz_egui::section::set_view(&mut registry.0, new, &carried);
                 }
             }
             carried
@@ -769,12 +731,11 @@ pub fn on_head_committed_resync<N>(
     _trigger: On<head::CommittedEvent>,
     mut registry: ResMut<Registry<N>>,
     mut heads: Query<head::OpenHeadData<N>, With<head::OpenHead>>,
-    mut views: ResMut<Views>,
 ) where
     N: 'static + Clone + ca::CaHash + gantz_egui::sync::AsNamedRefMut + Send + Sync,
 {
     let moves = gantz_egui::sync::resync(&mut registry, bevy_gantz::reg::timestamp());
-    refresh_moved_heads(&moves, &registry, &mut heads, &mut views);
+    refresh_moved_heads(&moves, &mut registry, &mut heads);
 }
 
 /// On a fork (branch from a head), give the fork independent nested children:
@@ -784,7 +745,6 @@ pub fn on_branched_head_fork_nested<N>(
     trigger: On<head::BranchedHeadEvent>,
     mut registry: ResMut<Registry<N>>,
     mut heads: Query<head::OpenHeadData<N>, With<head::OpenHead>>,
-    mut views: ResMut<Views>,
 ) where
     N: 'static + Clone + ca::CaHash + gantz_egui::sync::AsNamedRefMut + Send + Sync,
 {
@@ -802,7 +762,7 @@ pub fn on_branched_head_fork_nested<N>(
         old,
         new,
     ));
-    refresh_moved_heads(&moves, &registry, &mut heads, &mut views);
+    refresh_moved_heads(&moves, &mut registry, &mut heads);
 }
 
 /// Carry moved graphs' views forward to their new commits, and refresh any open
@@ -811,9 +771,8 @@ pub fn on_branched_head_fork_nested<N>(
 /// since the registry already holds this graph).
 fn refresh_moved_heads<N>(
     moves: &[gantz_egui::sync::Moved],
-    registry: &Registry<N>,
+    registry: &mut Registry<N>,
     heads: &mut Query<head::OpenHeadData<N>, With<head::OpenHead>>,
-    views: &mut Views,
 ) where
     N: 'static + Clone + Send + Sync,
 {
@@ -821,8 +780,10 @@ fn refresh_moved_heads<N>(
         return;
     }
     for m in moves {
-        if let Some(gv) = views.0.get(&m.old_commit).cloned() {
-            views.0.entry(m.new_commit).or_insert(gv);
+        if gantz_egui::section::view(registry, &m.new_commit).is_none() {
+            if let Some(gv) = gantz_egui::section::view(registry, &m.old_commit) {
+                gantz_egui::section::set_view(&mut registry.0, m.new_commit, &gv);
+            }
         }
     }
     for mut data in heads.iter_mut() {
@@ -844,7 +805,6 @@ pub fn on_create_node<N>(
     trigger: On<ForHead<gantz_egui::CreateNode>>,
     mut registry: ResMut<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
-    demos: Res<Demos>,
     mut gui_state: ResMut<GuiState>,
     mut vms: NonSendMut<head::HeadVms>,
     mut cmds: Commands,
@@ -866,7 +826,7 @@ pub fn on_create_node<N>(
         return;
     };
     let editing = match &**data.head_ref {
-        ca::Head::Branch(name) => Some(name.clone()),
+        ca::Head::Branch(name) => Some(name.to_string()),
         ca::Head::Commit(_) => None,
     };
     let Ok(mut views) = views_query.get_mut(event.head) else {
@@ -882,7 +842,7 @@ pub fn on_create_node<N>(
         return;
     };
 
-    let node_reg = registry_ref(&registry, &builtins, &demos);
+    let node_reg = registry_ref(&registry, &builtins);
     let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
     gantz_egui::ops::create_node(
         node_reg.ca_registry(),
@@ -1008,7 +968,6 @@ pub fn on_inspect_edge<N>(
     trigger: On<ForHead<gantz_egui::InspectEdge>>,
     mut registry: ResMut<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
-    demos: Res<Demos>,
     mut vms: NonSendMut<head::HeadVms>,
     mut cmds: Commands,
     mut heads: Query<head::OpenHeadData<N>, With<head::OpenHead>>,
@@ -1030,7 +989,7 @@ pub fn on_inspect_edge<N>(
         return;
     };
 
-    let node_reg = registry_ref(&registry, &builtins, &demos);
+    let node_reg = registry_ref(&registry, &builtins);
     let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
     gantz_egui::ops::inspect_edge(
         &get_node,
@@ -1058,7 +1017,6 @@ pub fn on_inspect_edge<N>(
 pub fn on_copy_nodes<N>(
     trigger: On<ForHead<gantz_egui::CopyNodes>>,
     registry: Res<Registry<N>>,
-    views: Res<Views>,
     mut clipboard: ResMut<bevy_egui::EguiClipboard>,
     mut heads: Query<(&mut head::WorkingGraph<N>, &GraphView), With<head::OpenHead>>,
 ) where
@@ -1078,7 +1036,7 @@ pub fn on_copy_nodes<N>(
         return;
     };
 
-    let text = gantz_egui::ops::copy_nodes(&registry, &views, &wg, gv, &event.data.0);
+    let text = gantz_egui::ops::copy_nodes(&registry, &wg, gv, &event.data.0);
     if let Some(text) = text {
         clipboard.set_text(&text);
     }
@@ -1095,8 +1053,6 @@ pub fn on_paste<N>(
     mut registry: ResMut<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
     mut gui_state: ResMut<GuiState>,
-    mut views: ResMut<Views>,
-    mut demos: ResMut<Demos>,
     mut vms: NonSendMut<head::HeadVms>,
     mut clipboard: ResMut<bevy_egui::EguiClipboard>,
     mut cmds: Commands,
@@ -1129,7 +1085,7 @@ pub fn on_paste<N>(
         return;
     };
     let editing = match &**head_ref {
-        ca::Head::Branch(name) => Some(name.clone()),
+        ca::Head::Branch(name) => Some(name.to_string()),
         ca::Head::Commit(_) => None,
     };
     let Some(head_state) = gui_state.open_heads.get_mut(&**head_ref) else {
@@ -1140,8 +1096,6 @@ pub fn on_paste<N>(
     let pasted = gantz_egui::ops::paste(
         &mut registry,
         editing.as_deref(),
-        &mut views,
-        &mut demos,
         &mut wg,
         &mut gv,
         head_state,
@@ -1154,7 +1108,7 @@ pub fn on_paste<N>(
     // for existing nodes.
     if pasted {
         if let Some(vm) = vms.get_mut(&event.head) {
-            let node_reg = registry_ref(&registry, &builtins, &demos);
+            let node_reg = registry_ref(&registry, &builtins);
             let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
             gantz_core::graph::register(&get_node, &**wg, &[], vm);
         }
@@ -1168,7 +1122,6 @@ pub fn on_paste<N>(
 pub fn on_cut_nodes<N>(
     trigger: On<ForHead<gantz_egui::CutNodes>>,
     mut registry: ResMut<Registry<N>>,
-    views: Res<Views>,
     mut gui_state: ResMut<GuiState>,
     mut vms: NonSendMut<head::HeadVms>,
     mut clipboard: ResMut<bevy_egui::EguiClipboard>,
@@ -1208,7 +1161,6 @@ pub fn on_cut_nodes<N>(
 
     let text = gantz_egui::ops::cut_nodes(
         &registry,
-        &views,
         &mut wg,
         vm,
         &mut gv,
@@ -1230,8 +1182,6 @@ pub fn on_duplicate_nodes<N>(
     mut registry: ResMut<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
     mut gui_state: ResMut<GuiState>,
-    mut views: ResMut<Views>,
-    mut demos: ResMut<Demos>,
     mut vms: NonSendMut<head::HeadVms>,
     mut cmds: Commands,
     mut heads: Query<
@@ -1260,7 +1210,7 @@ pub fn on_duplicate_nodes<N>(
         return;
     };
     let editing = match &**head_ref {
-        ca::Head::Branch(name) => Some(name.clone()),
+        ca::Head::Branch(name) => Some(name.to_string()),
         ca::Head::Commit(_) => None,
     };
     let Some(head_state) = gui_state.open_heads.get_mut(&**head_ref) else {
@@ -1271,8 +1221,6 @@ pub fn on_duplicate_nodes<N>(
     let duplicated = gantz_egui::ops::duplicate_nodes(
         &mut registry,
         editing.as_deref(),
-        &mut views,
-        &mut demos,
         &mut wg,
         &mut gv,
         head_state,
@@ -1283,7 +1231,7 @@ pub fn on_duplicate_nodes<N>(
     // initialized. Idempotent for existing nodes.
     if duplicated {
         if let Some(vm) = vms.get_mut(&event.head) {
-            let node_reg = registry_ref(&registry, &builtins, &demos);
+            let node_reg = registry_ref(&registry, &builtins);
             let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
             gantz_core::graph::register(&get_node, &**wg, &[], vm);
         }
@@ -1305,8 +1253,6 @@ pub fn on_merge_head<N>(
     trigger: On<ForHead<gantz_egui::MergeHead>>,
     mut registry: ResMut<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
-    views: Res<Views>,
-    demos: Res<Demos>,
     mut gui_state: ResMut<GuiState>,
     mut vms: NonSendMut<head::HeadVms>,
     mut cmds: Commands,
@@ -1338,7 +1284,6 @@ pub fn on_merge_head<N>(
     let old_head = head_ref.0.clone();
     let outcome = gantz_egui::ops::merge_head(
         &mut registry,
-        &views,
         bevy_gantz::reg::timestamp(),
         &mut head_ref.0,
         &mut wg,
@@ -1362,7 +1307,7 @@ pub fn on_merge_head<N>(
             );
             // Re-register the root graph so merged-in nodes get their state
             // initialized. Idempotent for existing nodes.
-            let node_reg = registry_ref(&registry, &builtins, &demos);
+            let node_reg = registry_ref(&registry, &builtins);
             let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
             gantz_core::graph::register(&get_node, &**wg, &[], vm);
             // The op already committed (with both parents), so fire the
@@ -1435,8 +1380,6 @@ pub fn on_export_head<N>(
     trigger: On<ExportHeadEvent>,
     registry: Res<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
-    views: Res<Views>,
-    demos: Res<Demos>,
     heads: Query<&head::HeadRef, With<head::OpenHead>>,
 ) where
     N: 'static
@@ -1455,16 +1398,10 @@ pub fn on_export_head<N>(
     };
     let head: &ca::Head = &**head_ref;
 
-    let node_reg = registry_ref(&registry, &builtins, &demos);
+    let node_reg = registry_ref(&registry, &builtins);
     let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
 
-    let text = match gantz_egui::export::export_heads_sexpr(
-        &get_node,
-        &registry,
-        &views,
-        &demos,
-        [head],
-    ) {
+    let text = match gantz_egui::export::export_heads_sexpr(&get_node, &registry, [head]) {
         Ok(s) => s,
         Err(e) => {
             log::error!("ExportHead: failed to serialize: {e}");
@@ -1500,8 +1437,6 @@ pub fn on_export_all_named<N>(
     _trigger: On<ExportAllNamedEvent>,
     registry: Res<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
-    views: Res<Views>,
-    demos: Res<Demos>,
 ) where
     N: 'static
         + serde::Serialize
@@ -1512,13 +1447,12 @@ pub fn on_export_all_named<N>(
         + Send
         + Sync,
 {
-    let node_reg = registry_ref(&registry, &builtins, &demos);
+    let node_reg = registry_ref(&registry, &builtins);
     let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
 
     let named_heads: Vec<ca::Head> = registry
-        .names()
-        .keys()
-        .map(|name| ca::Head::Branch(name.clone()))
+        .heads()
+        .map(|(name, _)| ca::Head::Branch(name.clone()))
         .collect();
 
     if named_heads.is_empty() {
@@ -1526,19 +1460,14 @@ pub fn on_export_all_named<N>(
         return;
     }
 
-    let text = match gantz_egui::export::export_heads_sexpr(
-        &get_node,
-        &registry,
-        &views,
-        &demos,
-        named_heads.iter(),
-    ) {
-        Ok(s) => s,
-        Err(e) => {
-            log::error!("ExportAllNamed: failed to serialize: {e}");
-            return;
-        }
-    };
+    let text =
+        match gantz_egui::export::export_heads_sexpr(&get_node, &registry, named_heads.iter()) {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!("ExportAllNamed: failed to serialize: {e}");
+                return;
+            }
+        };
 
     let dialog = rfd::AsyncFileDialog::new()
         .set_title("Export All Named Graphs")
@@ -1565,8 +1494,6 @@ pub fn on_import_file<N>(
     trigger: On<ImportFileEvent>,
     mut registry: ResMut<Registry<N>>,
     builtins: Res<BuiltinNodes<N>>,
-    mut views: ResMut<Views>,
-    mut demos: ResMut<Demos>,
     mut cmds: Commands,
 ) where
     N: 'static
@@ -1590,18 +1517,18 @@ pub fn on_import_file<N>(
 
     // Compute the root name before merge if we might open a head.
     let root_name = if event.open_head {
-        let node_reg = registry_ref(&registry, &builtins, &demos);
+        let node_reg = registry_ref(&registry, &builtins);
         let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
         gantz_egui::export::unique_root_name(&get_node, &export)
     } else {
         None
     };
 
-    let result = gantz_egui::export::merge_with(&mut registry, &mut views, &mut demos, export);
+    let report = registry.merge(export);
     log::info!(
         "Imported: {} names added, {} replaced",
-        result.names_added.len(),
-        result.names_replaced.len(),
+        report.heads_added.len(),
+        report.heads_replaced.len(),
     );
 
     if let Some(name) = root_name {
@@ -1618,6 +1545,7 @@ pub fn on_reset_base_graph<N>(
     mut registry: ResMut<Registry<N>>,
 ) where
     N: 'static
+        + Node
         + Clone
         + serde::Serialize
         + serde::de::DeserializeOwned
@@ -1633,34 +1561,39 @@ pub fn on_reset_base_graph<N>(
     // source parses at BASE_TIMESTAMP, so addresses match the startup parse.
     let Some(source) = name_sources
         .0
-        .get(name.as_str())
+        .get(&name.to_string())
         .and_then(|source_name| sources.0.iter().find(|s| s.name == *source_name))
     else {
         log::warn!("ResetBaseGraph: no base source recorded for '{name}'");
         return;
     };
-    let export: gantz_egui::export::Export<Graph<N>> =
-        match gantz_egui::export::parse_export_seeded_at::<N>(
-            source.bytes,
-            crate::base::BASE_TIMESTAMP,
-            &base_names.0,
-        ) {
-            Ok(e) => e,
-            Err(e) => {
-                log::error!(
-                    "ResetBaseGraph: failed to parse base source `{}`: {e}",
-                    source.name
-                );
-                return;
-            }
-        };
-    // Extract just the commits reachable from the target name (all parents,
+    let seed = base::seed_graph_addrs(&base_names.0, &registry);
+    let export: gantz_ca::Registry<Graph<N>> = match gantz_egui::export::parse_export_seeded_at::<N>(
+        source.bytes,
+        crate::base::BASE_TIMESTAMP,
+        &seed,
+    ) {
+        Ok(e) => e,
+        Err(e) => {
+            log::error!(
+                "ResetBaseGraph: failed to parse base source `{}`: {e}",
+                source.name
+            );
+            return;
+        }
+    };
+    // Extract just the content reachable from the target name (all parents,
     // so merge ancestry survives a reset).
-    if let Some(&base_commit_ca) = export.registry.names().get(name) {
-        let required: std::collections::HashSet<_> =
-            ca::ancestors(export.registry.commits(), base_commit_ca).collect();
-        let mut subset = export.registry.export(&required);
-        subset.insert_name(name.clone(), base_commit_ca);
+    if let Some(base_commit_ca) = export.head(name) {
+        let get_node = |ca: &ca::ContentAddr| {
+            export
+                .graph(&ca::GraphAddr::from(*ca))
+                .map(|g| g as &dyn Node)
+        };
+        let live =
+            gantz_core::reg::live_for_heads(&get_node, &export, [ca::Head::Commit(base_commit_ca)]);
+        let mut subset = ca::export(&export, &live);
+        subset.set_head(name.clone(), base_commit_ca);
         registry.merge(subset);
         log::info!("Reset base graph '{name}' to original version");
     } else {
@@ -1684,21 +1617,25 @@ pub fn on_reset_base_graph<N>(
 /// (see [`settle_layout`]). The camera is excluded from undo, so it tracks the
 /// live view in place every frame.
 pub fn persist_camera_and_seed<N: 'static + Send + Sync>(
-    registry: Res<Registry<N>>,
-    mut views: ResMut<Views>,
+    mut registry: ResMut<Registry<N>>,
     heads: Query<(&head::HeadRef, &GraphView), With<head::OpenHead>>,
 ) {
     for (head_ref, head_view) in heads.iter() {
-        let Some(commit_addr) = registry.head_commit_ca(&**head_ref).copied() else {
+        let Some(commit_addr) = registry.head_commit_ca(&**head_ref) else {
             continue;
         };
-        match views.get_mut(&commit_addr) {
+        match gantz_egui::section::view(&registry, &commit_addr) {
             // Layout frozen as the undo baseline; only the camera tracks live.
-            Some(view) => view.camera = head_view.camera,
+            Some(mut view) => {
+                if view.camera != head_view.camera {
+                    view.camera = head_view.camera;
+                    gantz_egui::section::set_view(&mut registry.0, commit_addr, &view);
+                }
+            }
             // Seed the baseline once the scene has laid the graph out. Guarding
             // on a non-empty layout avoids capturing an empty pre-layout frame.
             None if !head_view.layout.is_empty() => {
-                views.insert(commit_addr, (**head_view).clone());
+                gantz_egui::section::set_view(&mut registry.0, commit_addr, head_view);
             }
             None => {}
         }
@@ -1718,7 +1655,6 @@ pub fn persist_camera_and_seed<N: 'static + Send + Sync>(
 /// [`DebouncedInputEvent`]: bevy_gantz::debounced_input::DebouncedInputEvent
 pub fn settle_layout<N>(
     mut registry: ResMut<Registry<N>>,
-    mut views: ResMut<Views>,
     mut gui_state: ResMut<GuiState>,
     mut ctxs: EguiContexts,
     mut heads: Query<(&mut head::HeadRef, &GraphView), With<head::OpenHead>>,
@@ -1729,7 +1665,6 @@ pub fn settle_layout<N>(
         let old_head = (**head_ref).clone();
         let Some(new_commit) = gantz_egui::ops::commit_layout(
             &mut registry,
-            &views,
             bevy_gantz::reg::timestamp(),
             &mut head_ref,
             head_view,
@@ -1737,8 +1672,8 @@ pub fn settle_layout<N>(
             continue;
         };
         // Freeze the new commit's layout baseline this frame, before any
-        // debounce-gated `save_views`/export reads the `Views` resource.
-        views.insert(new_commit, (**head_view).clone());
+        // debounce-gated save/export reads the registry's view section.
+        gantz_egui::section::set_view(&mut registry.0, new_commit, head_view);
         // Clear redo (a new commit invalidates it) and migrate GUI state.
         let new_head = (**head_ref).clone();
         gui_state.migrate_head(&old_head, &new_head, true);
@@ -1763,24 +1698,6 @@ fn poll_import_task(task: Option<ResMut<ImportTask>>, mut cmds: Commands) {
             });
         }
     }
-}
-
-/// Prune views for unreachable commits.
-///
-/// This should run after `reg::prune_unused` to clean up views for commits
-/// that are no longer reachable from any open head.
-pub fn prune_views<N: 'static + Node + Send + Sync>(
-    registry: Res<Registry<N>>,
-    builtins: Res<BuiltinNodes<N>>,
-    demos: Res<Demos>,
-    mut views: ResMut<Views>,
-    heads: Query<&head::HeadRef, With<head::OpenHead>>,
-) {
-    let node_reg = registry_ref(&registry, &builtins, &demos);
-    let get_node = |ca: &ca::ContentAddr| node_reg.node(ca);
-    let head_iter = heads.iter().map(|h| &**h);
-    let required = gantz_core::reg::required_commits(&get_node, &registry, head_iter);
-    views.retain(|ca, _| required.contains(ca));
 }
 
 /// Update the Gantz GUI and process widget responses.
@@ -1832,7 +1749,6 @@ pub fn update<N>(
         Res<base::BaseSources>,
         ResMut<base::BaseNameSources>,
     ),
-    mut demos: ResMut<Demos>,
     dispatchers: Res<ResponseDispatchers>,
     mut cmds: Commands,
 ) -> Result
@@ -1869,7 +1785,7 @@ where
     let mut access = HeadAccess::new(&tab_order, &mut heads_query, &mut vms);
 
     // Construct node registry on-demand for the widget (with demo + doc lookup).
-    let node_reg = registry_ref(&registry, &builtins, &demos);
+    let node_reg = registry_ref(&registry, &builtins);
 
     let level = bevy_log::tracing_subscriber::filter::LevelFilter::current();
 
@@ -1923,7 +1839,6 @@ where
                 .collect();
             let mut widget = gantz_egui::widget::Gantz::new(&node_reg, &base_names.0)
                 .base_immutable(base_immutable.0)
-                .demos(&demos.0)
                 .compile_config(current_compile_config)
                 .validate_change_tracking(current_validate_change_tracking)
                 .trace_capture(trace_capture.0.clone(), level)
@@ -1961,7 +1876,6 @@ where
         &mut focused,
         &mut heads_query,
         &mut registry,
-        &mut demos,
         &base_names,
         &mut compile_config,
         &mut change_validation,
@@ -1993,7 +1907,6 @@ pub(crate) fn handle_gantz_response<N>(
     focused: &mut head::FocusedHead,
     heads_query: &mut Query<OpenHeadViews<N>, With<head::OpenHead>>,
     registry: &mut Registry<N>,
-    demos: &mut Demos,
     base_names: &BaseNames,
     compile_config: &mut CompileConfig,
     change_validation: &mut bevy_gantz::ValidateCommitted,
@@ -2024,12 +1937,12 @@ pub(crate) fn handle_gantz_response<N>(
         for mut data in heads_query.iter_mut() {
             if let ca::Head::Branch(head_name) = &**data.core.head_ref {
                 if *head_name == name {
-                    let commit_ca = *registry.head_commit_ca(&*data.core.head_ref).unwrap();
+                    let commit_ca = registry.head_commit_ca(&data.core.head_ref).unwrap();
                     **data.core.head_ref = ca::Head::Commit(commit_ca);
                 }
             }
         }
-        registry.remove_name(&name);
+        registry.remove_head(&name);
     }
 
     // Trigger events for head operations (handled by observers).
@@ -2082,17 +1995,17 @@ pub(crate) fn handle_gantz_response<N>(
     if let Some((ca::Head::Branch(graph_name), demo_val)) = &response.demo_changed {
         match demo_val {
             Some(demo) => {
-                demos.insert(graph_name.clone(), demo.clone());
+                gantz_egui::section::set_demo(&mut registry.0, graph_name.clone(), demo.clone());
             }
             None => {
-                demos.remove(graph_name);
+                gantz_egui::section::remove_demo(&mut registry.0, graph_name);
             }
         }
     }
 
     // Handle a graph description edit (keyed by the graph's name).
     if let Some((ca::Head::Branch(name), description)) = &response.description_changed {
-        registry.set_description(name.clone(), description.clone());
+        gantz_egui::section::set_description(&mut registry.0, name.clone(), description.clone());
     }
 
     // Re-attribute a graph to a different base source. Durable wherever the
@@ -2101,7 +2014,7 @@ pub(crate) fn handle_gantz_response<N>(
     if let Some((ca::Head::Branch(name), source)) = &response.base_source_changed {
         match base_sources.0.iter().find(|s| s.name == source.as_str()) {
             Some(s) => {
-                base_name_sources.0.insert(name.clone(), s.name);
+                base_name_sources.0.insert(name.to_string(), s.name);
             }
             None => log::warn!("base source `{source}` is not registered"),
         }
@@ -2117,7 +2030,7 @@ pub(crate) fn handle_gantz_response<N>(
     // Handle "reset all demos" - re-merge every `demo-*` base graph.
     if response.reset_all_demos {
         for name in base_names.0.keys() {
-            if name.starts_with("demo-") {
+            if name.to_string().starts_with("demo-") {
                 cmds.trigger(ResetBaseGraphEvent(name.clone()));
             }
         }

--- a/crates/bevy_gantz_egui/src/node/tick_bang.rs
+++ b/crates/bevy_gantz_egui/src/node/tick_bang.rs
@@ -236,8 +236,8 @@ impl gantz_core::Node for TickBang {
 }
 
 impl gantz_egui::NodeUi for TickBang {
-    fn name(&self, _: &dyn gantz_egui::Registry) -> &str {
-        "tick!"
+    fn name(&self, _: &dyn gantz_egui::Registry) -> std::borrow::Cow<'_, str> {
+        std::borrow::Cow::Borrowed("tick!")
     }
 
     fn description(&self) -> Option<&'static str> {
@@ -437,7 +437,6 @@ pub fn drive_tick_bangs<N>(
     epoch: Res<bevy_gantz::EvalEpoch>,
     registry: Res<crate::Registry<N>>,
     builtins: Res<bevy_gantz::BuiltinNodes<N>>,
-    demos: Res<crate::Demos>,
     mut vms: NonSendMut<bevy_gantz::head::HeadVms>,
     heads: Query<(Entity, &bevy_gantz::head::WorkingGraph<N>), With<bevy_gantz::head::OpenHead>>,
     mut cmds: Commands,
@@ -449,7 +448,7 @@ pub fn drive_tick_bangs<N>(
     let now = epoch.now_secs();
 
     for (entity, wg) in heads.iter() {
-        let node_reg = crate::registry_ref(&registry, &builtins, &demos);
+        let node_reg = crate::registry_ref(&registry, &builtins);
         let get_node = |ca: &gantz_ca::ContentAddr| node_reg.node(ca);
 
         // Collect all TickBang paths + durations.

--- a/crates/bevy_gantz_egui/src/node/update_bang.rs
+++ b/crates/bevy_gantz_egui/src/node/update_bang.rs
@@ -52,8 +52,8 @@ impl gantz_core::Node for UpdateBang {
 }
 
 impl gantz_egui::NodeUi for UpdateBang {
-    fn name(&self, _: &dyn gantz_egui::Registry) -> &str {
-        "update!"
+    fn name(&self, _: &dyn gantz_egui::Registry) -> std::borrow::Cow<'_, str> {
+        std::borrow::Cow::Borrowed("update!")
     }
 
     fn description(&self) -> Option<&'static str> {
@@ -165,7 +165,6 @@ pub fn drive_update_bangs<N>(
     time: Res<Time>,
     registry: Res<crate::Registry<N>>,
     builtins: Res<bevy_gantz::BuiltinNodes<N>>,
-    demos: Res<crate::Demos>,
     mut vms: NonSendMut<bevy_gantz::head::HeadVms>,
     heads: Query<(Entity, &bevy_gantz::head::WorkingGraph<N>), With<bevy_gantz::head::OpenHead>>,
     mut cmds: Commands,
@@ -175,7 +174,7 @@ pub fn drive_update_bangs<N>(
     let dt = time.delta_secs_f64();
 
     for (entity, wg) in heads.iter() {
-        let node_reg = crate::registry_ref(&registry, &builtins, &demos);
+        let node_reg = crate::registry_ref(&registry, &builtins);
         let get_node = |ca: &gantz_ca::ContentAddr| node_reg.node(ca);
 
         // Collect all UpdateBang paths.

--- a/crates/bevy_gantz_egui/src/pane_window.rs
+++ b/crates/bevy_gantz_egui/src/pane_window.rs
@@ -18,7 +18,7 @@
 //! `egui::Window`s instead.
 
 use crate::{
-    BaseImmutable, BaseNames, BuiltinNodes, CompileConfig, Demos, EdgeStyles, ExtPanes, GuiState,
+    BaseImmutable, BaseNames, BuiltinNodes, CompileConfig, EdgeStyles, ExtPanes, GuiState,
     HeadAccess, HostNativePaneWindows, ImportTask, OpenHeadViews, PerfGui, PerfVm, RefExtUis,
     Registry, ResponseDispatchers, SettingsTabs, TraceCapture, WindowedPanesRequested,
     handle_gantz_response, head, registry_ref,
@@ -195,7 +195,6 @@ fn render_windowed_panes<N: PaneNode>(
         mut ext_panes,
         ref_ext_uis,
         edge_styles,
-        mut demos,
         dispatchers,
         export_paths,
         base_sources,
@@ -209,7 +208,6 @@ fn render_windowed_panes<N: PaneNode>(
         ResMut<ExtPanes>,
         Res<RefExtUis>,
         Res<EdgeStyles>,
-        ResMut<Demos>,
         Res<ResponseDispatchers>,
         Option<Res<crate::base::ExportPaths>>,
         Res<crate::base::BaseSources>,
@@ -253,7 +251,7 @@ fn render_windowed_panes<N: PaneNode>(
         // rebuilt per window: each iteration's borrow of the boxes ends with
         // it (mirrors `update`, where it is built inside the panel closure).
         let mut response = {
-            let node_reg = registry_ref(&registry, &builtins, &demos);
+            let node_reg = registry_ref(&registry, &builtins);
             let mut access = HeadAccess::new(&tab_order, &mut heads_query, &mut vms);
             let mut tabs: Vec<&mut dyn gantz_egui::widget::SettingsTab> = settings_tabs
                 .0
@@ -277,7 +275,6 @@ fn render_windowed_panes<N: PaneNode>(
                 .collect();
             let mut widget = gantz_egui::widget::Gantz::new(&node_reg, &base_names.0)
                 .base_immutable(base_immutable.0)
-                .demos(&demos.0)
                 .compile_config(compile_config.0)
                 .validate_change_tracking(change_validation.0)
                 .trace_capture(trace_capture.0.clone(), level)
@@ -326,7 +323,6 @@ fn render_windowed_panes<N: PaneNode>(
             &mut focused,
             &mut heads_query,
             &mut registry,
-            &mut demos,
             &base_names,
             &mut compile_config,
             &mut change_validation,

--- a/crates/bevy_gantz_egui/src/storage.rs
+++ b/crates/bevy_gantz_egui/src/storage.rs
@@ -1,12 +1,12 @@
 //! Storage utilities for GUI-related state.
 //!
-//! This module provides storage functions for views and GUI state.
-//! Core storage functions (registry, graphs, commits, names) are provided
-//! by `bevy_gantz::storage`.
+//! This module provides storage functions for the gantz GUI state and egui
+//! memory. Registry storage (content, sections, blobs, open heads) is
+//! provided by `bevy_gantz::storage` - views, demos and descriptions ride
+//! the registry's metadata sections.
 
-use crate::{GraphView, GuiState, Views};
+use crate::{GraphView, GuiState};
 use base64::Engine as _;
-use bevy_ecs::prelude::Resource;
 use bevy_egui::egui;
 use bevy_gantz::clone_graph;
 use bevy_gantz::reg::Registry;
@@ -15,102 +15,14 @@ use bevy_log as log;
 use gantz_ca as ca;
 use gantz_core::node::graph::Graph;
 use serde::de::DeserializeOwned;
-use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 mod key {
-    /// The key at which all graph views were stored as a single blob (legacy;
-    /// still read for backwards compatibility, see [`super::load_views`]).
-    pub const VIEWS: &str = "views";
-    /// Index of commit addresses that have a per-commit persisted view.
-    pub const VIEW_ADDRS: &str = "view-addrs";
     /// The key at which the gantz GUI state is stored.
     pub const GUI_STATE: &str = "gui-state";
     /// The key at which egui memory (widget states) is saved/loaded. Versioned
     /// for the RON -> bincode switch; the old `egui-memory-ron` blob is ignored.
     pub const EGUI_MEMORY: &str = "egui-memory-bin";
-
-    /// The key for a particular commit's view.
-    pub fn view(ca: gantz_ca::CommitAddr) -> String {
-        format!("view-{ca}")
-    }
-}
-
-/// Tracks the views already written to storage (and their last-persisted form),
-/// so [`save_views_incremental`] only serializes/writes those that changed.
-///
-/// Seed it from the disk-loaded views via [`PersistedViews::from_views`].
-#[derive(Resource, Default)]
-pub struct PersistedViews(HashMap<ca::CommitAddr, gantz_egui::SceneView>);
-
-impl PersistedViews {
-    /// Snapshot the views known to be on disk.
-    pub fn from_views(views: &Views) -> Self {
-        Self(views.iter().map(|(&ca, v)| (ca, v.clone())).collect())
-    }
-}
-
-/// Save all graph views to storage under a single key (legacy whole-map form).
-pub fn save_views(storage: &mut impl bevy_gantz::storage::Save, views: &Views) {
-    let sorted: std::collections::BTreeMap<_, _> = views.iter().collect();
-    save(storage, key::VIEWS, &sorted);
-}
-
-/// Incrementally persist views, one key per commit.
-///
-/// Writes only the views whose commit is in `valid_commits` and that differ from
-/// the last-persisted form, and rewrites the small index only when the set of
-/// persisted commits changes. No change since the last persist writes nothing -
-/// a camera pan on one head writes just that one view, not the whole map.
-pub fn save_views_incremental(
-    storage: &mut impl Save,
-    views: &Views,
-    valid_commits: &HashSet<ca::CommitAddr>,
-    persisted: &mut PersistedViews,
-) {
-    let mut index_changed = false;
-    for (&ca, view) in views.iter() {
-        // Only persist views for commits that still exist.
-        if !valid_commits.contains(&ca) {
-            continue;
-        }
-        if persisted.0.get(&ca) != Some(view) {
-            save(storage, &key::view(ca), view);
-            // A newly-seen commit grows the index.
-            index_changed |= persisted.0.insert(ca, view.clone()).is_none();
-        }
-    }
-    // Drop tracked views whose commit no longer exists.
-    let before = persisted.0.len();
-    persisted.0.retain(|ca, _| valid_commits.contains(ca));
-    index_changed |= persisted.0.len() != before;
-
-    if index_changed {
-        let mut addrs: Vec<_> = persisted.0.keys().copied().collect();
-        addrs.sort();
-        save(storage, key::VIEW_ADDRS, &addrs);
-    }
-}
-
-/// Load all graph views from storage.
-///
-/// Reads the per-commit view keys via the `view-addrs` index, falling back to
-/// the legacy single-key blob for stores written before views were split per
-/// commit.
-pub fn load_views(storage: &impl Load) -> Views {
-    if let Some(addrs) = load::<Vec<ca::CommitAddr>>(storage, key::VIEW_ADDRS) {
-        return Views(
-            addrs
-                .into_iter()
-                .filter_map(|ca| Some((ca, load(storage, &key::view(ca))?)))
-                .collect(),
-        );
-    }
-    // Legacy: a single whole-map blob.
-    Views(
-        load::<HashMap<ca::CommitAddr, gantz_egui::SceneView>>(storage, key::VIEWS)
-            .unwrap_or_default(),
-    )
 }
 
 /// Save the GUI state to storage.
@@ -125,12 +37,13 @@ pub fn load_gui_state(storage: &impl Load) -> GuiState {
 
 /// Load the open heads data from storage.
 ///
-/// Returns a vector of (head, graph, views) tuples suitable for spawning entities.
-/// If no valid heads remain, creates a default empty graph head using the provided timestamp.
+/// Returns a vector of (head, graph, view) tuples suitable for spawning
+/// entities, with each head's view read from the registry's view section.
+/// If no valid heads remain, creates a default empty graph head using the
+/// provided timestamp.
 pub fn load_open<N>(
     storage: &impl Load,
     registry: &mut Registry<N>,
-    views: &Views,
     ts: Duration,
 ) -> Vec<(ca::Head, Graph<N>, GraphView)>
 where
@@ -143,10 +56,10 @@ where
         // Filter out heads that no longer exist in the registry.
         .filter_map(|head| {
             let graph = clone_graph(registry.head_graph(&head)?);
-            // Load the views for this head's commit, or create empty.
+            // Load the view for this head's commit, or create empty.
             let head_view = registry
                 .head_commit_ca(&head)
-                .and_then(|ca| views.get(ca).cloned())
+                .and_then(|ca| gantz_egui::section::view(registry, &ca))
                 .map(GraphView)
                 .unwrap_or_default();
             Some((head, graph, head_view))
@@ -213,153 +126,12 @@ pub fn load_egui_memory(storage: &impl Load, ctx: &egui::Context) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use gantz_ca::{CommitAddr, ContentAddr};
-
-    /// A mock key-value store recording the keys written to it.
-    #[derive(Default)]
-    struct MockStore {
-        map: HashMap<String, String>,
-        writes: Vec<String>,
-    }
-
-    impl MockStore {
-        fn take_writes(&mut self) -> Vec<String> {
-            std::mem::take(&mut self.writes)
-        }
-    }
-
-    impl Save for MockStore {
-        type Err = std::convert::Infallible;
-        fn set_string(&mut self, key: &str, value: &str) -> Result<(), Self::Err> {
-            self.map.insert(key.to_string(), value.to_string());
-            self.writes.push(key.to_string());
-            Ok(())
-        }
-    }
-
-    impl Load for MockStore {
-        type Err = std::convert::Infallible;
-        fn get_string(&self, key: &str) -> Result<Option<String>, Self::Err> {
-            Ok(self.map.get(key).cloned())
-        }
-    }
-
-    fn commit_addr(n: u8) -> CommitAddr {
-        CommitAddr::from(ContentAddr::from([n; 32]))
-    }
-
-    /// A view distinguishable by `n` (so changing it is detectable).
-    fn view(n: f32) -> gantz_egui::SceneView {
-        gantz_egui::SceneView {
-            camera: gantz_egui::Camera {
-                center: egui::pos2(n, n),
-                zoom: 1.0,
-            },
-            layout: Default::default(),
-        }
-    }
-
-    fn views(entries: &[(u8, f32)]) -> Views {
-        Views(
-            entries
-                .iter()
-                .map(|&(c, n)| (commit_addr(c), view(n)))
-                .collect(),
-        )
-    }
-
-    fn valid(commits: &[u8]) -> HashSet<CommitAddr> {
-        commits.iter().map(|&c| commit_addr(c)).collect()
-    }
-
-    fn wrote(writes: &[String], key: &str) -> bool {
-        writes.iter().any(|w| w == key)
-    }
-
-    #[test]
-    fn first_save_writes_each_view_and_the_index() {
-        let v = views(&[(1, 10.0), (2, 20.0)]);
-        let mut persisted = PersistedViews::default();
-        let mut store = MockStore::default();
-        save_views_incremental(&mut store, &v, &valid(&[1, 2]), &mut persisted);
-        let writes = store.take_writes();
-        assert!(wrote(&writes, &key::view(commit_addr(1))));
-        assert!(wrote(&writes, &key::view(commit_addr(2))));
-        assert!(wrote(&writes, key::VIEW_ADDRS));
-    }
-
-    #[test]
-    fn unchanged_views_write_nothing() {
-        let v = views(&[(1, 10.0), (2, 20.0)]);
-        let mut persisted = PersistedViews::default();
-        let mut store = MockStore::default();
-        save_views_incremental(&mut store, &v, &valid(&[1, 2]), &mut persisted);
-        store.take_writes();
-        save_views_incremental(&mut store, &v, &valid(&[1, 2]), &mut persisted);
-        assert!(store.take_writes().is_empty());
-    }
-
-    #[test]
-    fn changing_one_view_writes_only_that_view_not_the_index() {
-        let mut persisted = PersistedViews::default();
-        let mut store = MockStore::default();
-        save_views_incremental(
-            &mut store,
-            &views(&[(1, 10.0), (2, 20.0)]),
-            &valid(&[1, 2]),
-            &mut persisted,
-        );
-        store.take_writes();
-        // Commit 2's view moves; commit 1's is untouched.
-        let changed = views(&[(1, 10.0), (2, 25.0)]);
-        save_views_incremental(&mut store, &changed, &valid(&[1, 2]), &mut persisted);
-        let writes = store.take_writes();
-        assert_eq!(writes, vec![key::view(commit_addr(2))]);
-    }
-
-    #[test]
-    fn views_for_unknown_commits_are_skipped() {
-        let v = views(&[(1, 10.0), (9, 90.0)]);
-        let mut persisted = PersistedViews::default();
-        let mut store = MockStore::default();
-        // Only commit 1 exists.
-        save_views_incremental(&mut store, &v, &valid(&[1]), &mut persisted);
-        let writes = store.take_writes();
-        assert!(wrote(&writes, &key::view(commit_addr(1))));
-        assert!(!wrote(&writes, &key::view(commit_addr(9))));
-    }
-
-    #[test]
-    fn pruning_a_commit_rewrites_the_index_and_trims_the_tracker() {
-        let v = views(&[(1, 10.0), (2, 20.0)]);
-        let mut persisted = PersistedViews::default();
-        let mut store = MockStore::default();
-        save_views_incremental(&mut store, &v, &valid(&[1, 2]), &mut persisted);
-        store.take_writes();
-        // Commit 2 is gone; its view should drop from the tracker + index.
-        save_views_incremental(&mut store, &v, &valid(&[1]), &mut persisted);
-        let writes = store.take_writes();
-        assert_eq!(writes, vec![key::VIEW_ADDRS.to_string()]);
-        assert_eq!(persisted.0.len(), 1);
-    }
-
-    #[test]
-    fn load_round_trips_incremental_save() {
-        let v = views(&[(1, 10.0), (2, 20.0)]);
-        let mut persisted = PersistedViews::default();
-        let mut store = MockStore::default();
-        save_views_incremental(&mut store, &v, &valid(&[1, 2]), &mut persisted);
-        let loaded = load_views(&store);
-        assert_eq!(loaded.len(), 2);
-        assert_eq!(loaded.get(&commit_addr(2)), Some(&view(20.0)));
-    }
-
     /// `egui::Memory` must survive a bincode round-trip - the format used by
     /// `save_egui_memory`/`load_egui_memory`. Guards against a serde pattern
     /// bincode can't handle creeping into egui's `Memory` on an egui bump.
     #[test]
     fn egui_memory_round_trips_through_bincode() {
+        use bevy_egui::egui;
         let mem = egui::Memory::default();
         let bytes = bincode::serialize(&mem).expect("serialize egui::Memory");
         let _decoded: egui::Memory =

--- a/crates/bevy_gantz_plyphon/src/lib.rs
+++ b/crates/bevy_gantz_plyphon/src/lib.rs
@@ -56,7 +56,7 @@ use bevy_gantz::{EntrypointSet, EvalEpoch, Registry, VmSet};
 use bevy_gantz_egui::{EdgeStyles, ExtPanes, RefExtUis, RegisterResponseExt, SettingsTabs};
 use gantz_plyphon::{
     Config, DeriveStatus, DspEdgeStyle, DspPane, DspPaneHead, DspRefExtUi, DspSettingsTab,
-    RootPortInfo, Status, describe_parts, dsp_commits, root_port_info,
+    RootPortInfo, Status, describe_parts, root_port_info,
 };
 
 /// Editable DSP settings: the domain's [`Config`] as a bevy resource.
@@ -618,7 +618,7 @@ fn provide_dsp_ref_ext<N>(
     N: 'static + ToNodeDsp + gantz_core::Node + AsRefNode + Send + Sync,
 {
     if registry.is_changed() || dsp_graphs.is_none() {
-        *dsp_graphs = Some(std::sync::Arc::new(dsp_commits(&registry)));
+        *dsp_graphs = Some(std::sync::Arc::new(gantz_plyphon::dsp_graphs(&registry)));
     }
     let dsp_graphs = dsp_graphs.clone().expect("just initialised");
     ref_ext_uis.0.push(Box::new(DspRefExtUi { dsp_graphs }));

--- a/crates/gantz/src/main.rs
+++ b/crates/gantz/src/main.rs
@@ -9,7 +9,7 @@ use bevy_gantz::{
     debounced_input::{DebouncedInputEvent, DebouncedInputPlugin},
     reg, timestamp,
 };
-use bevy_gantz_egui::{GantzEguiPlugin, HeadGuiState, TraceCapture, Views};
+use bevy_gantz_egui::{GantzEguiPlugin, HeadGuiState, TraceCapture};
 use bevy_pkv::PkvStore;
 use storage::Pkv;
 
@@ -102,40 +102,33 @@ fn setup_resources(storage: Res<Pkv>, mut cmds: Commands) {
     // graphs (so they're written on first persist) and before `prune_unused`
     // (so prunes are detected on the first incremental save).
     let persisted = bevy_gantz::storage::PersistedRegistry::from_registry(&registry);
-    let views = bevy_gantz_egui::storage::load_views(&*storage);
-    // Seed the view tracker likewise: the loaded views are all on disk.
-    let persisted_views = bevy_gantz_egui::storage::PersistedViews::from_views(&views);
     let gui_state = bevy_gantz_egui::storage::load_gui_state(&*storage);
     cmds.insert_resource(registry);
     cmds.insert_resource(persisted);
-    cmds.insert_resource(views);
-    cmds.insert_resource(persisted_views);
     cmds.insert_resource(gui_state);
 }
 
 fn setup_open(
     storage: Res<Pkv>,
     mut registry: ResMut<Registry<Box<dyn node::Node>>>,
-    views: Res<Views>,
     mut cmds: Commands,
     mut tab_order: ResMut<HeadTabOrder>,
     mut focused: ResMut<FocusedHead>,
 ) {
-    let loaded =
-        bevy_gantz_egui::storage::load_open(&*storage, &mut *registry, &*views, timestamp());
+    let loaded = bevy_gantz_egui::storage::load_open(&*storage, &mut *registry, timestamp());
     let focused_head = bevy_gantz::storage::load_focused_head(&*storage);
 
     // Spawn entities for each open head. `OpenHead`'s required components
     // cover the compile outcome; `vm::sync` initializes the VMs on the first
     // `Update`.
-    for (head, graph, head_views) in loaded {
+    for (head, graph, head_view) in loaded {
         let is_focused = focused_head.as_ref() == Some(&head);
         let entity = cmds
             .spawn((
                 OpenHead,
                 HeadRef(head),
                 WorkingGraph(graph),
-                head_views,
+                head_view,
                 HeadGuiState::default(),
             ))
             .id();
@@ -165,7 +158,7 @@ mod tests {
 
     #[test]
     fn base_gantz_deserializes() {
-        let _export: gantz_egui::export::Export<
+        let _registry: gantz_ca::Registry<
             gantz_core::node::graph::Graph<Box<dyn super::node::Node>>,
         > = gantz_egui::export::parse_export(BASE_GANTZ).expect("valid .gantz");
     }

--- a/crates/gantz/src/main_update_base.rs
+++ b/crates/gantz/src/main_update_base.rs
@@ -1,7 +1,7 @@
 //! Developer tool for authoring base nodes.
 //!
 //! Starts with the registry populated from `base/base.gantz`. GUI state
-//! (open heads, views, egui memory) is persisted under a separate
+//! (open heads, egui memory) is persisted under a separate
 //! `PkvStore` so it never collides with the main gantz binary's storage.
 //! On every debounced input event, named graphs are exported back to
 //! `base/base.gantz` and GUI state is saved.
@@ -16,7 +16,7 @@ use bevy_gantz::{
     debounced_input::{DebouncedInputEvent, DebouncedInputPlugin},
     timestamp,
 };
-use bevy_gantz_egui::{GantzEguiPlugin, GuiState, HeadGuiState, TraceCapture, Views};
+use bevy_gantz_egui::{GantzEguiPlugin, GuiState, HeadGuiState, TraceCapture};
 use bevy_pkv::PkvStore;
 use storage::Pkv;
 
@@ -109,34 +109,30 @@ fn setup_camera(mut cmds: Commands) {
 }
 
 fn setup_gui_state(storage: Res<Pkv>, mut cmds: Commands) {
-    let views = bevy_gantz_egui::storage::load_views(&*storage);
     let gui_state = bevy_gantz_egui::storage::load_gui_state(&*storage);
-    cmds.insert_resource(views);
     cmds.insert_resource(gui_state);
 }
 
 fn setup_open(
     storage: Res<Pkv>,
     mut registry: ResMut<bevy_gantz::Registry<Box<dyn node::Node>>>,
-    views: Res<Views>,
     mut cmds: Commands,
     mut tab_order: ResMut<HeadTabOrder>,
     mut focused: ResMut<FocusedHead>,
 ) {
-    let loaded =
-        bevy_gantz_egui::storage::load_open(&*storage, &mut *registry, &*views, timestamp());
+    let loaded = bevy_gantz_egui::storage::load_open(&*storage, &mut *registry, timestamp());
     let focused_head = bevy_gantz::storage::load_focused_head(&*storage);
 
     // `OpenHead`'s required components cover the compile outcome; `vm::sync`
     // initializes the VMs on the first `Update`.
-    for (head, graph, head_views) in loaded {
+    for (head, graph, head_view) in loaded {
         let is_focused = focused_head.as_ref() == Some(&head);
         let entity = cmds
             .spawn((
                 OpenHead,
                 HeadRef(head),
                 WorkingGraph(graph),
-                head_views,
+                head_view,
                 HeadGuiState::default(),
             ))
             .id();
@@ -159,7 +155,6 @@ fn load_egui_memory(mut ctxs: EguiContexts, mut storage: ResMut<Pkv>, mut loaded
 }
 
 fn persist_state(
-    views: Res<Views>,
     gui_state: Res<GuiState>,
     mut storage: ResMut<Pkv>,
     mut ctxs: EguiContexts,
@@ -184,8 +179,6 @@ fn persist_state(
             bevy_gantz::storage::save_focused_head(&mut *storage, &**data.head_ref);
         }
     }
-    // Save views.
-    bevy_gantz_egui::storage::save_views(&mut *storage, &*views);
     // Save GUI state.
     bevy_gantz_egui::storage::save_gui_state(&mut *storage, &gui_state);
     // Save egui memory (widget states, tile layouts).

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -148,6 +148,10 @@ pub fn builtins() -> gantz_core::BuiltinSet<Box<dyn Node>> {
 mod tests {
     use super::Node;
 
+    fn name(s: &str) -> gantz_ca::Name {
+        s.parse().expect("infallible")
+    }
+
     /// Fire the push entrypoint of the node at `node_ix` (a flat-graph index).
     fn fire_push(
         vm: &mut gantz_core::steel::steel_vm::engine::Engine,
@@ -362,7 +366,7 @@ mod tests {
         let expr: Box<dyn Node> = Box::new(gantz_core::node::Expr::new("(+ $a $b)").unwrap());
         let fn_named_ref: Box<dyn Node> =
             Box::new(gantz_core::node::Fn(gantz_egui::node::NamedRef::new(
-                "mul".to_string(),
+                name("mul"),
                 gantz_core::node::Ref::new(gantz_ca::ContentAddr::from([0u8; 32])),
             )));
 
@@ -519,12 +523,12 @@ mod tests {
 (graph head
   (s ~sinosc) (out ~out) (i inlet) (o outlet)
   (-> s (out 0)))";
-        let export: gantz_egui::export::Export<G> =
+        let registry: gantz_ca::Registry<G> =
             gantz_egui::format::from_str(text, Duration::from_secs(0)).expect("from_str");
-        let head = gantz_ca::Head::Branch("head".into());
-        let graph = export.registry.head_graph(&head).expect("head graph");
+        let head = gantz_ca::Head::Branch(name("head"));
+        let graph = registry.head_graph(&head).expect("head graph");
 
-        let flat = gantz_plyphon::flatten_from_registry(graph, &export.registry).expect("flatten");
+        let flat = gantz_plyphon::flatten_from_registry(graph, &registry).expect("flatten");
         // Root inlet/outlet survive as markers (the head graph's interface);
         // they are non-DSP, so derivation ignores them.
         assert_eq!(
@@ -586,15 +590,12 @@ mod tests {
 (graph env
   (s ~sinosc) (sub (ref env:1)) (out ~out)
   (-> s (sub 0)) (-> sub (out 0)))";
-        let export: gantz_egui::export::Export<G> =
+        let registry: gantz_ca::Registry<G> =
             gantz_egui::format::from_str(text, Duration::from_secs(0)).expect("from_str");
-        let parent_head = gantz_ca::Head::Branch("env".into());
-        let child_head = gantz_ca::Head::Branch("env:1".into());
-        let parent = export.registry.head_graph(&parent_head).expect("env graph");
-        let child = export
-            .registry
-            .head_graph(&child_head)
-            .expect("env:1 graph");
+        let parent_head = gantz_ca::Head::Branch(name("env"));
+        let child_head = gantz_ca::Head::Branch(name("env:1"));
+        let parent = registry.head_graph(&parent_head).expect("env graph");
+        let child = registry.head_graph(&child_head).expect("env:1 graph");
 
         // The indices the flattened path must carry: the ref within the parent,
         // the lag within the child (its only dsp node).
@@ -609,7 +610,7 @@ mod tests {
             .expect("lag node")
             .index();
 
-        let flat = gantz_plyphon::flatten_from_registry(parent, &export.registry).expect("flatten");
+        let flat = gantz_plyphon::flatten_from_registry(parent, &registry).expect("flatten");
         // The DSP-bearing child lowers as an instance marker by default.
         let markers = flat
             .node_indices()
@@ -617,7 +618,7 @@ mod tests {
             .count();
         assert_eq!(markers, 1, "the ref stays an instance marker");
         let children =
-            gantz_plyphon::flatten_instance_children(&flat, &export.registry).expect("children");
+            gantz_plyphon::flatten_instance_children(&flat, &registry).expect("children");
         let resolve = |ca: &gantz_ca::ContentAddr| children.get(ca);
         let mut cache = gantz_plyphon::DefCache::new();
         let template =
@@ -632,7 +633,7 @@ mod tests {
         // The binding's path reaches the nested lag's live param state in a VM
         // compiled from the same (un-flattened) graph.
         let builtins = super::builtins();
-        let reg_ref = gantz_egui::RegistryRef::new(&export.registry, &builtins, &export.demos);
+        let reg_ref = gantz_egui::RegistryRef::new(&registry, &builtins);
         let get_node = |ca: &gantz_ca::ContentAddr| reg_ref.node(ca);
         let config = gantz_core::compile::Config::default();
         let (mut vm, _compiled) =
@@ -659,14 +660,14 @@ mod tests {
 
 (graph env
   (a (ref voice)) (b (ref voice)))";
-        let export: gantz_egui::export::Export<G> =
+        let registry: gantz_ca::Registry<G> =
             gantz_egui::format::from_str(text, Duration::from_secs(0)).expect("from_str");
-        let head = gantz_ca::Head::Branch("env".into());
-        let parent = export.registry.head_graph(&head).expect("env graph");
+        let head = gantz_ca::Head::Branch(name("env"));
+        let parent = registry.head_graph(&head).expect("env graph");
 
-        let flat = gantz_plyphon::flatten_from_registry(parent, &export.registry).expect("flatten");
+        let flat = gantz_plyphon::flatten_from_registry(parent, &registry).expect("flatten");
         let children =
-            gantz_plyphon::flatten_instance_children(&flat, &export.registry).expect("children");
+            gantz_plyphon::flatten_instance_children(&flat, &registry).expect("children");
         let resolve = |ca: &gantz_ca::ContentAddr| children.get(ca);
         let mut cache = gantz_plyphon::DefCache::new();
         let template =
@@ -950,13 +951,10 @@ mod tests {
         use std::time::Duration;
         type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
 
-        let base: gantz_egui::export::Export<G> =
+        let base: gantz_ca::Registry<G> =
             gantz_egui::export::parse_export(gantz_base::BYTES).expect("parse base");
-        let base_head = gantz_ca::Head::Branch("mul".to_string());
-        let base_graph = base
-            .registry
-            .head_graph(&base_head)
-            .expect("base mul graph");
+        let base_head = gantz_ca::Head::Branch(name("mul"));
+        let base_graph = base.head_graph(&base_head).expect("base mul graph");
         let base_addr = gantz_ca::ContentAddr::from(gantz_ca::graph_addr(base_graph)).to_string();
 
         let text = "\
@@ -964,10 +962,10 @@ mod tests {
   (m (expr (* $l $r)))
   (l (inlet \"number\" \"left operand\")) (r (inlet \"number\" \"right operand\")) (out (outlet \"number\" \"product\"))
   (-> l (m 0)) (-> r (m 1)) (-> m out))";
-        let mine: gantz_egui::export::Export<G> =
+        let mine: gantz_ca::Registry<G> =
             gantz_egui::format::from_str(text, Duration::from_secs(0)).expect("lower");
-        let head = gantz_ca::Head::Branch("mul".to_string());
-        let graph = mine.registry.head_graph(&head).expect("mul graph");
+        let head = gantz_ca::Head::Branch(name("mul"));
+        let graph = mine.head_graph(&head).expect("mul graph");
         let my_addr = gantz_ca::ContentAddr::from(gantz_ca::graph_addr(graph)).to_string();
 
         assert_eq!(my_addr, base_addr, "lowered mul graph addr must match base");
@@ -994,24 +992,24 @@ mod tests {
   (mref (ref mul))
   (-> a (mref 0)) (-> b (mref 1)) (-> mref out))";
 
-        let export1: gantz_egui::export::Export<G> =
+        let export1: gantz_ca::Registry<G> =
             gantz_egui::format::from_str(text1, now).expect("from_str 1");
         let text2 = gantz_egui::format::to_string(&export1).expect("to_string");
-        let export2: gantz_egui::export::Export<G> =
+        let export2: gantz_ca::Registry<G> =
             gantz_egui::format::from_str(&text2, Duration::from_secs(7)).expect("from_str 2");
 
-        let names1: BTreeSet<_> = export1.registry.names().keys().cloned().collect();
-        let names2: BTreeSet<_> = export2.registry.names().keys().cloned().collect();
+        let names1: BTreeSet<_> = export1.heads().map(|(n, _)| n.clone()).collect();
+        let names2: BTreeSet<_> = export2.heads().map(|(n, _)| n.clone()).collect();
         assert_eq!(names1, names2, "names must match\n--- text2 ---\n{text2}");
 
-        for (name, &head1) in export1.registry.names() {
-            let head2 = *export2.registry.names().get(name).expect("name present");
+        for (name, head1) in export1.heads() {
+            let head2 = export2.head(name).expect("name present");
             assert_eq!(
                 head1, head2,
                 "commit addr for `{name}`\n--- text2 ---\n{text2}"
             );
-            let g1 = export1.registry.commit_graph_ref(&head1).expect("g1");
-            let g2 = export2.registry.commit_graph_ref(&head2).expect("g2");
+            let g1 = export1.commit_graph_ref(&head1).expect("g1");
+            let g2 = export2.commit_graph_ref(&head2).expect("g2");
             assert_eq!(
                 gantz_ca::graph_addr(g1),
                 gantz_ca::graph_addr(g2),
@@ -1029,24 +1027,24 @@ mod tests {
         use std::time::Duration;
         type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
 
-        let base: gantz_egui::export::Export<G> =
+        let base: gantz_ca::Registry<G> =
             gantz_egui::export::parse_export(gantz_base::BYTES).expect("parse base");
         let text = gantz_egui::format::to_string(&base).expect("to_string");
-        let back: gantz_egui::export::Export<G> =
+        let back: gantz_ca::Registry<G> =
             gantz_egui::format::from_str(&text, Duration::from_secs(0)).expect("from_str");
 
-        let base_names: BTreeSet<_> = base.registry.names().keys().cloned().collect();
-        let back_names: BTreeSet<_> = back.registry.names().keys().cloned().collect();
+        let base_names: BTreeSet<_> = base.heads().map(|(n, _)| n.clone()).collect();
+        let back_names: BTreeSet<_> = back.heads().map(|(n, _)| n.clone()).collect();
         assert_eq!(
             base_names, back_names,
             "names preserved\n--- text ---\n{text}"
         );
 
         // base.gantz is consistent: addresses survive the round-trip exactly.
-        for (name, &head) in base.registry.names() {
+        for (name, head) in base.heads() {
             assert_eq!(
-                Some(&head),
-                back.registry.names().get(name),
+                Some(head),
+                back.head(name),
                 "commit addr for `{name}` preserved",
             );
         }
@@ -1071,20 +1069,20 @@ mod tests {
   (in inlet) (out outlet)
   (sub (ref env:1))
   (-> in (sub 0)) (-> sub out))";
-        let e1: gantz_egui::export::Export<G> =
+        let e1: gantz_ca::Registry<G> =
             gantz_egui::format::from_str(text1, now).expect("from_str 1");
         let text2 = gantz_egui::format::to_string(&e1).expect("to_string");
-        let e2: gantz_egui::export::Export<G> =
+        let e2: gantz_ca::Registry<G> =
             gantz_egui::format::from_str(&text2, now).expect("from_str 2");
 
-        for name in ["env", "env:1"] {
-            let head = gantz_ca::Head::Branch(name.to_string());
-            let g1 = e1.registry.head_graph(&head).expect("g1");
-            let g2 = e2.registry.head_graph(&head).expect("g2");
+        for n in ["env", "env:1"] {
+            let head = gantz_ca::Head::Branch(name(n));
+            let g1 = e1.head_graph(&head).expect("g1");
+            let g2 = e2.head_graph(&head).expect("g2");
             assert_eq!(
                 gantz_ca::graph_addr(g1),
                 gantz_ca::graph_addr(g2),
-                "graph addr for `{name}` must survive round-trip\n--- text2 ---\n{text2}",
+                "graph addr for `{n}` must survive round-trip\n--- text2 ---\n{text2}",
             );
         }
     }
@@ -1104,9 +1102,9 @@ mod tests {
   (c (comment \"hello world\" 16 2))
   (l (log warn))
   (-> n (s 0)) (-> (s 1) (b 0)))";
-        let export: gantz_egui::export::Export<G> =
+        let registry: gantz_ca::Registry<G> =
             gantz_egui::format::from_str(text1, Duration::from_secs(0)).expect("from_str");
-        let out = gantz_egui::format::to_string(&export).expect("to_string");
+        let out = gantz_egui::format::to_string(&registry).expect("to_string");
         steel::parser::parser::Parser::parse(&out)
             .unwrap_or_else(|e| panic!("output is not valid Steel: {e}\n--- output ---\n{out}"));
     }
@@ -1126,13 +1124,13 @@ mod tests {
   (t (tick-bang #:rate 2))
   (l (log warn))
   (-> t (l 0)))";
-        let export: gantz_egui::export::Export<G> =
+        let registry: gantz_ca::Registry<G> =
             gantz_egui::format::from_str(text, Duration::from_secs(0)).expect("from_str");
-        let head = gantz_ca::Head::Branch("g".into());
-        let graph = export.registry.head_graph(&head).expect("g graph");
+        let head = gantz_ca::Head::Branch(name("g"));
+        let graph = registry.head_graph(&head).expect("g graph");
 
         let builtins = super::builtins();
-        let reg_ref = gantz_egui::RegistryRef::new(&export.registry, &builtins, &export.demos);
+        let reg_ref = gantz_egui::RegistryRef::new(&registry, &builtins);
         let get_node = |ca: &gantz_ca::ContentAddr| reg_ref.node(ca);
 
         let entrypoints = bevy_gantz_egui::node::tick_bang::entrypoints(&get_node, graph);
@@ -1169,9 +1167,9 @@ mod tests {
 (graph g (e (expr 1)))
 (commits (\"abcd1234\" (time 5 0) (parent \"deadbeef\") (graph g)))
 (names (gname \"abcd1234\"))";
-        let export: gantz_egui::export::Export<G> =
+        let registry: gantz_ca::Registry<G> =
             gantz_egui::format::from_str(text, Duration::from_secs(0)).expect("import");
-        let commit = export.registry.named_commit("gname").expect("commit");
+        let commit = registry.named_commit(&name("gname")).expect("commit");
         assert_eq!(commit.parent, None, "absent parent must be cleared to None");
     }
 
@@ -1194,10 +1192,10 @@ mod tests {
   (m -10 20) (l 3.5 -4.5)
   (camera 25 -15 1.5))";
 
-        let e1: gantz_egui::export::Export<G> =
+        let e1: gantz_ca::Registry<G> =
             gantz_egui::format::from_str(text1, now).expect("from_str 1");
-        let head = *e1.registry.names().get("mul").expect("mul name");
-        let view = e1.views.get(&head).expect("view");
+        let head = e1.head(&name("mul")).expect("mul name");
+        let view = gantz_egui::section::view(&e1, &head).expect("view");
         // `m` is node index 0, `l` is 1.
         assert_eq!(
             view.layout.get(&egui_graph::NodeId(0)).map(|p| (p.x, p.y)),
@@ -1211,10 +1209,10 @@ mod tests {
         assert_eq!(view.camera.zoom, 1.5);
 
         let text2 = gantz_egui::format::to_string(&e1).expect("to_string");
-        let e2: gantz_egui::export::Export<G> =
+        let e2: gantz_ca::Registry<G> =
             gantz_egui::format::from_str(&text2, now).expect("from_str 2");
-        let head2 = *e2.registry.names().get("mul").expect("mul name 2");
-        let view2 = e2.views.get(&head2).expect("view 2");
+        let head2 = e2.head(&name("mul")).expect("mul name 2");
+        let view2 = gantz_egui::section::view(&e2, &head2).expect("view 2");
         assert_eq!(view.layout.len(), view2.layout.len());
         assert_eq!(
             view2.layout.get(&egui_graph::NodeId(0)).map(|p| (p.x, p.y)),
@@ -1241,10 +1239,9 @@ mod tests {
   (m -10 20)
   (scene -50 -50 100 100))";
 
-        let e: gantz_egui::export::Export<G> =
-            gantz_egui::format::from_str(text, now).expect("from_str");
-        let head = *e.registry.names().get("mul").expect("mul name");
-        let view = e.views.get(&head).expect("view");
+        let e: gantz_ca::Registry<G> = gantz_egui::format::from_str(text, now).expect("from_str");
+        let head = e.head(&name("mul")).expect("mul name");
+        let view = gantz_egui::section::view(&e, &head).expect("view");
         // Centre of (-50,-50)..(100,100), default zoom.
         assert_eq!((view.camera.center.x, view.camera.center.y), (25.0, 25.0));
         assert_eq!(view.camera.zoom, 1.0);
@@ -1257,7 +1254,7 @@ mod tests {
     fn clipboard_round_trips_through_gantz_text() {
         use bevy_egui::egui;
         use gantz_egui::export;
-        use std::collections::{HashMap, HashSet};
+        use std::collections::HashSet;
         type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
 
         fn node(tag: &str) -> Box<dyn Node> {
@@ -1279,7 +1276,7 @@ mod tests {
         layout.insert(egui_graph::NodeId(1), egui::pos2(3.0, 4.0));
         let selected: HashSet<gantz_core::node::graph::NodeIx> = [a, b].into_iter().collect();
 
-        let copied = export::copy(&registry, &HashMap::new(), &graph, &selected, &layout);
+        let copied = export::copy(&registry, &graph, &selected, &layout);
         let text = export::copied_to_string(&copied).expect("copied to text");
         // The clipboard payload is itself reader-valid `.gantz` text.
         steel::parser::parser::Parser::parse(&text)
@@ -1305,7 +1302,7 @@ mod tests {
 
     /// Editing a nested child commits it to a new address; [`sync::resync`] must
     /// then propagate that up to its parent, recommitting the parent so its
-    /// `NamedRef` references the child's new commit.
+    /// `NamedRef` references the child's new graph.
     #[test]
     fn resync_propagates_child_edit_to_parent() {
         use gantz_core::node::{Identity, Ref};
@@ -1320,45 +1317,45 @@ mod tests {
         // Child "p:1": a single node.
         let mut child = G::default();
         child.add_node(Box::new(Identity) as Box<dyn Node>);
-        let child_old =
-            registry.commit_graph_to_name(ts, gantz_ca::graph_addr(&child), || child, "p:1");
+        let child_addr = gantz_ca::graph_addr(&child);
+        let child_old = registry.commit_graph_to_name(ts, child_addr, || child, &name("p:1"));
 
-        // Parent "p": a sync-enabled NamedRef to "p:1".
+        // Parent "p": a sync-enabled NamedRef to "p:1"'s head graph.
         let mut parent = G::default();
         parent.add_node(Box::new(NamedRef::with_sync(
-            "p:1".to_string(),
-            Ref::new(child_old.into()),
+            name("p:1"),
+            Ref::new(child_addr.into()),
         )) as Box<dyn Node>);
         let parent_old =
-            registry.commit_graph_to_name(ts, gantz_ca::graph_addr(&parent), || parent, "p");
+            registry.commit_graph_to_name(ts, gantz_ca::graph_addr(&parent), || parent, &name("p"));
 
         // Edit the child: commit a different graph under "p:1".
         let mut child2 = G::default();
         child2.add_node(Box::new(Identity) as Box<dyn Node>);
         child2.add_node(Box::new(Identity) as Box<dyn Node>);
-        let child_new =
-            registry.commit_graph_to_name(ts, gantz_ca::graph_addr(&child2), || child2, "p:1");
+        let child2_addr = gantz_ca::graph_addr(&child2);
+        let child_new = registry.commit_graph_to_name(ts, child2_addr, || child2, &name("p:1"));
         assert_ne!(child_old, child_new);
 
-        // Resync: the parent must follow the child's new commit.
+        // Resync: the parent must follow the child's new head graph.
         let moves = gantz_egui::sync::resync(&mut registry, ts);
         assert!(
-            moves.iter().any(|m| m.name == "p"),
+            moves.iter().any(|m| m.name == name("p")),
             "parent should have recommitted: {moves:?}"
         );
 
-        let parent_new = *registry.names().get("p").unwrap();
+        let parent_new = registry.head(&name("p")).unwrap();
         assert_ne!(parent_old, parent_new, "parent commit must change");
         let p_graph = registry.commit_graph_ref(&parent_new).unwrap();
         let points_at_new_child = p_graph.node_weights().any(|n| {
             ((&**n) as &dyn Any)
                 .downcast_ref::<NamedRef>()
-                .map(|nr| nr.content_addr() == child_new.into())
+                .map(|nr| nr.content_addr() == child2_addr.into())
                 .unwrap_or(false)
         });
         assert!(
             points_at_new_child,
-            "parent's NamedRef must reference the child's new commit"
+            "parent's NamedRef must reference the child's new graph"
         );
     }
 
@@ -1379,103 +1376,92 @@ mod tests {
         // Child "A:1" and parent "A" referencing it.
         let mut child = G::default();
         child.add_node(Box::new(Identity) as Box<dyn Node>);
-        let child_ca =
-            registry.commit_graph_to_name(ts, gantz_ca::graph_addr(&child), || child, "A:1");
+        let child_addr = gantz_ca::graph_addr(&child);
+        registry.commit_graph_to_name(ts, child_addr, || child, &name("A:1"));
         let mut parent = G::default();
         parent.add_node(Box::new(NamedRef::with_sync(
-            "A:1".to_string(),
-            Ref::new(child_ca.into()),
+            name("A:1"),
+            Ref::new(child_addr.into()),
         )) as Box<dyn Node>);
-        registry.commit_graph_to_name(ts, gantz_ca::graph_addr(&parent), || parent, "A");
+        registry.commit_graph_to_name(ts, gantz_ca::graph_addr(&parent), || parent, &name("A"));
 
         // Fork "A" -> "B": a fresh commit over A's graph (as `on_branch_head` does),
         // so "B" initially references A's child "A:1".
-        let a_commit = *registry.names().get("A").unwrap();
+        let a_commit = registry.head(&name("A")).unwrap();
         let a_graph = registry.commits()[&a_commit].graph;
         let b_commit = registry.commit_graph(ts, Some(a_commit), a_graph, || unreachable!());
-        registry.insert_name("B".to_string(), b_commit);
+        registry.set_head(name("B"), b_commit);
 
         // Cascade: give "B" its own nested child "B:1".
-        let moves = gantz_egui::sync::fork_nested(&mut registry, ts, "A", "B");
+        let moves = gantz_egui::sync::fork_nested(&mut registry, ts, &name("A"), &name("B"));
         assert!(
-            moves.iter().any(|m| m.name == "B:1"),
+            moves.iter().any(|m| m.name == name("B:1")),
             "B:1 should be created: {moves:?}"
         );
         assert!(
-            moves.iter().any(|m| m.name == "B"),
+            moves.iter().any(|m| m.name == name("B")),
             "B's root should be rewritten: {moves:?}"
         );
 
-        // B references its own child B:1; A:1 is untouched.
-        let b1: gantz_ca::ContentAddr = (*registry.names().get("B:1").unwrap()).into();
-        let b_new = *registry.names().get("B").unwrap();
+        // B references its own child B:1's graph; A:1 is untouched.
+        let b1: gantz_ca::ContentAddr = registry.named_commit(&name("B:1")).unwrap().graph.into();
+        let b_new = registry.head(&name("B")).unwrap();
         let b_graph = registry.commit_graph_ref(&b_new).unwrap();
         let refs_b1 = b_graph.node_weights().any(|n| {
             ((&**n) as &dyn Any)
                 .downcast_ref::<NamedRef>()
-                .map(|nr| nr.name() == "B:1" && nr.content_addr() == b1)
+                .map(|nr| nr.name() == &name("B:1") && nr.content_addr() == b1)
                 .unwrap_or(false)
         });
         assert!(refs_b1, "the fork's root must reference its own child B:1");
         assert!(
-            registry.names().contains_key("A:1"),
+            registry.head(&name("A:1")).is_some(),
             "the original child A:1 must remain"
         );
     }
 
-    /// Copying a node that references a nested graph and pasting it must keep the
-    /// reference. The format preserves only the head commit per graph, so an
-    /// *edited* nested graph's head address heals on paste (its parent is
-    /// dropped); the `NamedRef` must still resolve - by name - rather than
-    /// vanish.
+    /// Copying a node that references a nested graph and pasting it must keep
+    /// the reference. The reference pins the nested graph's content (graph
+    /// address), which the clipboard payload carries along with the naming
+    /// head, so the pasted `NamedRef` must still resolve rather than vanish.
     #[test]
     fn clipboard_round_trips_nested_ref() {
         use gantz_core::node::{Identity, Ref};
         use gantz_egui::export;
         use gantz_egui::node::NamedRef;
         use std::any::Any;
-        use std::collections::{HashMap, HashSet};
+        use std::collections::HashSet;
         use std::time::Duration;
         type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
 
         let mut registry = gantz_ca::Registry::<G>::default();
 
         // Nested graph "A:1", committed twice so its head commit has a parent
-        // (the format does not preserve it, so the head address heals on paste).
+        // (the format does not preserve the parent chain).
         let mut v1 = G::default();
         v1.add_node(Box::new(Identity) as Box<dyn Node>);
         registry.commit_graph_to_name(
             Duration::from_secs(1),
             gantz_ca::graph_addr(&v1),
             || v1,
-            "A:1",
+            &name("A:1"),
         );
         let mut v2 = G::default();
         v2.add_node(Box::new(Identity) as Box<dyn Node>);
         v2.add_node(Box::new(Identity) as Box<dyn Node>);
-        let head = registry.commit_graph_to_name(
-            Duration::from_secs(2),
-            gantz_ca::graph_addr(&v2),
-            || v2,
-            "A:1",
-        );
+        let v2_addr = gantz_ca::graph_addr(&v2);
+        registry.commit_graph_to_name(Duration::from_secs(2), v2_addr, || v2, &name("A:1"));
 
-        // A graph holding a synced NamedRef to "A:1".
+        // A graph holding a synced NamedRef to "A:1"'s head graph.
         let mut graph: G = G::default();
         let nref = graph.add_node(Box::new(NamedRef::with_sync(
-            "A:1".to_string(),
-            Ref::new(head.into()),
+            name("A:1"),
+            Ref::new(v2_addr.into()),
         )) as Box<dyn Node>);
         let selected: HashSet<_> = [nref].into_iter().collect();
 
         // Copy -> clipboard text -> paste.
-        let copied = export::copy(
-            &registry,
-            &HashMap::new(),
-            &graph,
-            &selected,
-            &egui_graph::Layout::default(),
-        );
+        let copied = export::copy(&registry, &graph, &selected, &egui_graph::Layout::default());
         let text = export::copied_to_string(&copied).expect("copied to text");
         let back: export::Copied<Box<dyn Node>> =
             export::copied_from_str(&text).expect("copied from text");
@@ -1484,7 +1470,7 @@ mod tests {
         let kept = back.graph.node_weights().any(|n| {
             ((&**n) as &dyn Any)
                 .downcast_ref::<NamedRef>()
-                .map(|nr| nr.name() == "A:1")
+                .map(|nr| nr.name() == &name("A:1"))
                 .unwrap_or(false)
         });
         assert!(kept, "the pasted node must still be a NamedRef to A:1");
@@ -1507,43 +1493,44 @@ mod tests {
         // Nested child "A:1".
         let mut child = G::default();
         child.add_node(Box::new(Identity) as Box<dyn Node>);
-        let a1 = registry.commit_graph_to_name(ts, gantz_ca::graph_addr(&child), || child, "A:1");
+        let child_addr = gantz_ca::graph_addr(&child);
+        let a1 = registry.commit_graph_to_name(ts, child_addr, || child, &name("A:1"));
 
         // Parent "A" with THREE instances of the nested graph.
         let mut parent = G::default();
         for _ in 0..3 {
-            parent.add_node(
-                Box::new(NamedRef::with_sync("A:1".to_string(), Ref::new(a1.into())))
-                    as Box<dyn Node>,
-            );
+            parent.add_node(Box::new(NamedRef::with_sync(
+                name("A:1"),
+                Ref::new(child_addr.into()),
+            )) as Box<dyn Node>);
         }
-        registry.commit_graph_to_name(ts, gantz_ca::graph_addr(&parent), || parent, "A");
+        registry.commit_graph_to_name(ts, gantz_ca::graph_addr(&parent), || parent, &name("A"));
 
         // Simulate "rename A:1 -> B": a root "B" copy of A:1's graph (as the
         // fork does), then promote.
         let a1_graph = registry.commits()[&a1].graph;
         let b = registry.commit_graph(ts, Some(a1), a1_graph, || unreachable!());
-        registry.insert_name("B".to_string(), b);
-        let moves = gantz_egui::sync::promote_nested(&mut registry, ts, "A:1", "B");
+        registry.set_head(name("B"), b);
+        let moves = gantz_egui::sync::promote_nested(&mut registry, ts, &name("A:1"), &name("B"));
 
         assert!(
-            moves.iter().any(|m| m.name == "A"),
+            moves.iter().any(|m| m.name == name("A")),
             "parent A must recommit"
         );
         assert!(
-            !registry.names().contains_key("A:1"),
+            registry.head(&name("A:1")).is_none(),
             "the orphaned nested name must be dropped"
         );
 
         // All three parent references now point at "B".
-        let a_commit = *registry.names().get("A").unwrap();
+        let a_commit = registry.head(&name("A")).unwrap();
         let a_graph = registry.commit_graph_ref(&a_commit).unwrap();
         let to_b = a_graph
             .node_weights()
             .filter(|n| {
                 ((&***n) as &dyn Any)
                     .downcast_ref::<NamedRef>()
-                    .map(|nr| nr.name() == "B")
+                    .map(|nr| nr.name() == &name("B"))
                     .unwrap_or(false)
             })
             .count();
@@ -1566,10 +1553,10 @@ mod tests {
     fn base_graphs_all_compile() {
         type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
 
-        let base: gantz_egui::export::Export<G> =
+        let base: gantz_ca::Registry<G> =
             gantz_egui::export::parse_export(gantz_base::BYTES).expect("parse base");
         let builtins = super::builtins();
-        let reg_ref = gantz_egui::RegistryRef::new(&base.registry, &builtins, &base.demos);
+        let reg_ref = gantz_egui::RegistryRef::new(&base, &builtins);
         let get_node = |ca: &gantz_ca::ContentAddr| reg_ref.node(ca);
         let configs = [
             gantz_core::compile::Config::default(),
@@ -1580,13 +1567,12 @@ mod tests {
         ];
 
         assert!(
-            !base.registry.names().is_empty(),
+            base.heads().next().is_some(),
             "base.gantz registered no named graphs",
         );
-        for name in base.registry.names().keys() {
+        for (name, _) in base.heads() {
             let head = gantz_ca::Head::Branch(name.clone());
             let graph = base
-                .registry
                 .head_graph(&head)
                 .unwrap_or_else(|| panic!("`{name}` has no head graph"));
             let entrypoints = gantz_core::compile::push_pull_entrypoints(&get_node, graph);
@@ -1610,7 +1596,7 @@ mod tests {
     #[test]
     fn base_refs_are_synced() {
         type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
-        let base: gantz_egui::export::Export<G> =
+        let base: gantz_ca::Registry<G> =
             gantz_egui::export::parse_export(gantz_base::BYTES).expect("parse base");
         let text = gantz_egui::format::to_string(&base).expect("to_string");
         let refs = text.matches("(ref ").count() + text.matches("(fn-ref ").count();
@@ -1633,8 +1619,8 @@ mod tests {
         use gantz_egui::node::NamedRef;
         let ca = gantz_ca::ContentAddr::from([0u8; 32]);
         let ref_ = gantz_core::node::Ref::new(ca);
-        let off = NamedRef::new("x".to_string(), ref_.clone());
-        let on = NamedRef::with_sync("x".to_string(), ref_);
+        let off = NamedRef::new(name("x"), ref_.clone());
+        let on = NamedRef::with_sync(name("x"), ref_);
         assert_ne!(
             gantz_ca::content_addr(&off),
             gantz_ca::content_addr(&on),
@@ -1644,15 +1630,17 @@ mod tests {
     }
 
     /// The ext-free `NamedRef` address must never change: it is the address
-    /// every existing graph's references already hash to.
+    /// every existing graph's references already hash to. (Re-pinned once by
+    /// the registry rewrite, which made `name` a segmented [`gantz_ca::Name`]
+    /// and so changed the hashed form.)
     #[test]
     fn named_ref_ext_free_content_addr_is_pinned() {
         use gantz_egui::node::NamedRef;
         let ca = gantz_ca::ContentAddr::from([0u8; 32]);
-        let named = NamedRef::new("mul".to_string(), gantz_core::node::Ref::new(ca));
+        let named = NamedRef::new(name("mul"), gantz_core::node::Ref::new(ca));
         assert_eq!(
             gantz_ca::content_addr(&named).to_string(),
-            "c9e7273ea1f962854be2686011ac4f5bfc81bf05fd8e09fd4a9a02ee201ad816",
+            "b818ed6d50a54c2aef7efd05bcc0f8974511f2e464e1563249b04bb334064663",
             "ext-free NamedRef CA changed - this breaks every existing graph address",
         );
     }
@@ -1673,17 +1661,17 @@ mod tests {
         let key = "test.ext";
 
         let ca = gantz_ca::ContentAddr::from([0u8; 32]);
-        let mut named = NamedRef::new("mul".to_string(), gantz_core::node::Ref::new(ca));
+        let mut named = NamedRef::new(name("mul"), gantz_core::node::Ref::new(ca));
         let plain_ca = gantz_ca::content_addr(&named);
         named.set_ext(key, &ext).unwrap();
         assert_ne!(gantz_ca::content_addr(&named), plain_ca);
 
         // Rename cascade repoints - ext rides.
-        named.rename("mul2".to_string(), gantz_ca::ContentAddr::from([1u8; 32]));
+        named.rename(name("mul2"), gantz_ca::ContentAddr::from([1u8; 32]));
         assert_eq!(named.ext_as::<TestExt>(key), Some(TestExt { inline: true }));
 
         // Resync repoints - ext rides.
-        let mut synced = NamedRef::with_sync("mul".to_string(), gantz_core::node::Ref::new(ca));
+        let mut synced = NamedRef::with_sync(name("mul"), gantz_core::node::Ref::new(ca));
         synced.set_ext(key, &ext).unwrap();
         let latest = gantz_ca::ContentAddr::from([2u8; 32]);
         assert!(synced.resync(|_| Some(latest)));
@@ -1698,14 +1686,11 @@ mod tests {
         let now = std::time::Duration::from_secs(1);
         let child: G = G::default();
         let child_addr = gantz_ca::graph_addr(&child);
-        let commit_ca = registry.commit_graph(now, None, child_addr, || child);
-        registry.insert_name("child".to_string(), commit_ca);
+        registry.commit_graph_to_name(now, child_addr, || child, &name("child"));
 
         let mut graph: G = G::default();
-        let mut named = NamedRef::with_sync(
-            "child".to_string(),
-            gantz_core::node::Ref::new(commit_ca.into()),
-        );
+        let mut named =
+            NamedRef::with_sync(name("child"), gantz_core::node::Ref::new(child_addr.into()));
         named.set_ext(key, &ext).unwrap();
         let ix = graph.add_node(Box::new(named) as Box<dyn Node>);
 
@@ -1714,23 +1699,21 @@ mod tests {
             now,
             &mut graph,
             "fork".to_string(),
-            commit_ca.into(),
+            child_addr.into(),
             &[ix.index()],
         );
         let forked = gantz_egui::sync::AsNamedRef::as_named_ref(&graph[ix]).expect("named ref");
-        assert_eq!(forked.name(), "fork");
+        assert_eq!(forked.name(), &name("fork"));
         assert_eq!(
             forked.ext_as::<TestExt>(key),
             Some(TestExt { inline: true }),
             "fork must carry ext over - the forked content is identical",
         );
         // Whole-node identity: name, sync reset (a fork pins) and ext all
-        // land as an ext-carrying `NamedRef::new` of the fork's commit.
-        let fork_commit = *registry.names().get("fork").expect("fork name");
-        let mut expected = NamedRef::new(
-            "fork".to_string(),
-            gantz_core::node::Ref::new(fork_commit.into()),
-        );
+        // land as an ext-carrying `NamedRef::new` of the fork's graph.
+        assert!(registry.head(&name("fork")).is_some(), "fork name");
+        let mut expected =
+            NamedRef::new(name("fork"), gantz_core::node::Ref::new(child_addr.into()));
         expected.set_ext(key, &ext).unwrap();
         assert_eq!(
             gantz_ca::content_addr(forked),
@@ -1759,15 +1742,15 @@ mod tests {
   (mref (ref mul #:ext ((\"test.ext\" ((inline #t))))))
   (-> a (mref 0)) (-> b (mref 1)) (-> mref out))";
 
-        let export1: gantz_egui::export::Export<G> =
+        let export1: gantz_ca::Registry<G> =
             gantz_egui::format::from_str(text1, now).expect("from_str 1");
         let text2 = gantz_egui::format::to_string(&export1).expect("to_string");
         assert!(text2.contains("#:ext"), "ext tail must survive\n{text2}");
-        let export2: gantz_egui::export::Export<G> =
+        let export2: gantz_ca::Registry<G> =
             gantz_egui::format::from_str(&text2, Duration::from_secs(7)).expect("from_str 2");
 
-        for (name, &head1) in export1.registry.names() {
-            let head2 = *export2.registry.names().get(name).expect("name present");
+        for (name, head1) in export1.heads() {
+            let head2 = export2.head(name).expect("name present");
             assert_eq!(
                 head1, head2,
                 "commit addr for `{name}` (ext is CA-relevant)\n--- text2 ---\n{text2}"
@@ -1779,8 +1762,8 @@ mod tests {
         struct TestExt {
             inline: bool,
         }
-        let head = export2.registry.names().get("use-mul").expect("use-mul");
-        let g = export2.registry.commit_graph_ref(head).expect("graph");
+        let head = export2.head(&name("use-mul")).expect("use-mul");
+        let g = export2.commit_graph_ref(&head).expect("graph");
         let named = g
             .node_indices()
             .find_map(|ix| gantz_egui::sync::AsNamedRef::as_named_ref(&g[ix]))
@@ -1803,7 +1786,7 @@ mod tests {
             inline: bool,
         }
         let ca = gantz_ca::ContentAddr::from([0u8; 32]);
-        let mut named = NamedRef::new("mul".to_string(), gantz_core::node::Ref::new(ca));
+        let mut named = NamedRef::new(name("mul"), gantz_core::node::Ref::new(ca));
         named
             .set_ext("test.ext", &TestExt { inline: true })
             .unwrap();
@@ -1831,7 +1814,7 @@ mod tests {
     fn base_socket_docs() {
         use gantz_egui::{Registry as _, SocketKind};
         type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
-        let base: gantz_egui::export::Export<G> =
+        let base: gantz_ca::Registry<G> =
             gantz_egui::export::parse_export(gantz_base::BYTES).expect("parse base");
 
         // Completeness: no primitive socket serializes as a bare `inlet`/`outlet`.
@@ -1844,8 +1827,10 @@ mod tests {
 
         // Resolution: a `ref add` exposes `add`'s socket docs.
         let builtins = super::builtins();
-        let reg_ref = gantz_egui::RegistryRef::new(&base.registry, &builtins, &base.demos);
-        let add = gantz_ca::ContentAddr::from(*base.registry.names().get("add").expect("add"));
+        let reg_ref = gantz_egui::RegistryRef::new(&base, &builtins);
+        let add: gantz_ca::ContentAddr = gantz_egui::reg::head_graph_addr(&base, &name("add"))
+            .expect("add")
+            .into();
         let doc = |kind, ix| reg_ref.socket_doc(&add, kind, ix);
 
         let l = doc(SocketKind::Input, 0).expect("add input 0 doc");
@@ -1874,10 +1859,10 @@ mod tests {
         use gantz_core::compile::{EvalKind, entry_fn_name, push_pull_entrypoints};
         type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
 
-        let base: gantz_egui::export::Export<G> =
+        let base: gantz_ca::Registry<G> =
             gantz_egui::export::parse_export(gantz_base::BYTES).expect("parse base");
         let builtins = super::builtins();
-        let reg_ref = gantz_egui::RegistryRef::new(&base.registry, &builtins, &base.demos);
+        let reg_ref = gantz_egui::RegistryRef::new(&base, &builtins);
         let get_node = |ca: &gantz_ca::ContentAddr| reg_ref.node(ca);
         let config = gantz_core::compile::Config::default();
 
@@ -1888,12 +1873,11 @@ mod tests {
             "demo-list",
             "demo-predicate",
         ];
-        for name in demos {
-            let head = gantz_ca::Head::Branch(name.to_string());
+        for demo in demos {
+            let head = gantz_ca::Head::Branch(name(demo));
             let graph = base
-                .registry
                 .head_graph(&head)
-                .unwrap_or_else(|| panic!("{name} graph"));
+                .unwrap_or_else(|| panic!("{demo} graph"));
 
             // The single `bang` node drives every pipeline in the demo.
             let go = graph
@@ -1904,11 +1888,11 @@ mod tests {
                         .is_some()
                 })
                 .map(|ix| ix.index())
-                .unwrap_or_else(|| panic!("{name} has a bang"));
+                .unwrap_or_else(|| panic!("{demo} has a bang"));
 
             let eps = push_pull_entrypoints(&get_node, graph);
             let (mut vm, _compiled) = gantz_core::vm::init(&get_node, graph, &eps, &config)
-                .unwrap_or_else(|e| panic!("init {name}: {}", gantz_core::vm::error_chain(&e)));
+                .unwrap_or_else(|e| panic!("init {demo}: {}", gantz_core::vm::error_chain(&e)));
 
             let go_ep = eps
                 .iter()
@@ -1916,9 +1900,9 @@ mod tests {
                     ep.0.iter()
                         .any(|s| s.kind == EvalKind::Push && s.path == [go])
                 })
-                .unwrap_or_else(|| panic!("{name} bang entrypoint"));
+                .unwrap_or_else(|| panic!("{demo} bang entrypoint"));
             vm.call_function_by_name_with_args(&entry_fn_name(&go_ep.id()), vec![])
-                .unwrap_or_else(|e| panic!("firing {name} bang errored: {e}"));
+                .unwrap_or_else(|e| panic!("firing {demo} bang errored: {e}"));
         }
     }
 
@@ -1932,12 +1916,16 @@ mod tests {
     #[test]
     fn reset_then_reopen_demo_recompiles() {
         use gantz_core::compile::{Config, push_pull_entrypoints};
-        use std::collections::HashSet;
+        use std::collections::BTreeMap;
+        type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
 
         let ts = bevy_gantz_egui::base::BASE_TIMESTAMP;
-        let parse = || {
+        let parse = || -> gantz_ca::Registry<G> {
             gantz_egui::export::parse_export_at::<Box<dyn Node>>(gantz_base::BYTES, ts)
                 .expect("parse base")
+        };
+        let heads = |reg: &gantz_ca::Registry<G>| -> BTreeMap<_, _> {
+            reg.heads().map(|(n, ca)| (n.clone(), ca)).collect()
         };
 
         // Parsing the base at the fixed timestamp is reproducible: every name
@@ -1946,27 +1934,35 @@ mod tests {
         let startup = parse();
         let reparse = parse();
         assert_eq!(
-            startup.registry.names(),
-            reparse.registry.names(),
+            heads(&startup),
+            heads(&reparse),
             "base commit addresses must be reproducible across parses",
         );
 
-        // Simulate `on_reset_base_graph`: re-export the demo's commit subset
-        // from a fresh parse and merge it into the startup registry.
-        let mut registry = startup.registry;
-        let name = "demo-arithmetic";
-        let &demo_commit = reparse.registry.names().get(name).expect("demo name");
-        let required: HashSet<_> =
-            gantz_ca::ancestors(reparse.registry.commits(), demo_commit).collect();
-        let mut subset = reparse.registry.export(&required);
-        subset.insert_name(name.to_string(), demo_commit);
+        // Simulate `on_reset_base_graph`: re-export the demo's reachable
+        // subset from a fresh parse and merge it into the startup registry.
+        let mut registry = startup;
+        let demo = name("demo-arithmetic");
+        let demo_commit = reparse.head(&demo).expect("demo name");
+        let get_node = |ca: &gantz_ca::ContentAddr| {
+            reparse
+                .graph(&gantz_ca::GraphAddr::from(*ca))
+                .map(|g| g as &dyn gantz_core::Node)
+        };
+        let live = gantz_core::reg::live_for_heads(
+            &get_node,
+            &reparse,
+            [gantz_ca::Head::Commit(demo_commit)],
+        );
+        let mut subset = gantz_ca::export(&reparse, &live);
+        subset.set_head(demo.clone(), demo_commit);
         registry.merge(subset);
 
         // Reopen: the reset demo must still compile, i.e. every `ref` resolves.
         let builtins = super::builtins();
-        let reg_ref = gantz_egui::RegistryRef::new(&registry, &builtins, &startup.demos);
+        let reg_ref = gantz_egui::RegistryRef::new(&registry, &builtins);
         let get_node = |ca: &gantz_ca::ContentAddr| reg_ref.node(ca);
-        let head = gantz_ca::Head::Branch(name.to_string());
+        let head = gantz_ca::Head::Branch(demo);
         let graph = registry.head_graph(&head).expect("demo graph");
         let eps = push_pull_entrypoints(&get_node, graph);
         gantz_core::vm::init(&get_node, graph, &eps, &Config::default()).unwrap_or_else(|e| {
@@ -1988,7 +1984,7 @@ mod tests {
         use std::time::Duration;
         type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
 
-        let base: gantz_egui::export::Export<G> =
+        let base: gantz_ca::Registry<G> =
             gantz_egui::export::parse_export(gantz_base::BYTES).expect("parse base");
         let text = gantz_egui::format::to_string_named(&base).expect("to_string_named");
 
@@ -2005,14 +2001,14 @@ mod tests {
         );
 
         // Stable: reload the simplified text and re-serialize - byte-identical.
-        let back: gantz_egui::export::Export<G> =
+        let back: gantz_ca::Registry<G> =
             gantz_egui::format::from_str(&text, Duration::from_secs(0)).expect("from_str");
         let text2 = gantz_egui::format::to_string_named(&back).expect("to_string_named 2");
         assert_eq!(text, text2, "inline-name export must be idempotent");
 
         // Names survive the round-trip.
-        let n1: BTreeSet<_> = base.registry.names().keys().cloned().collect();
-        let n2: BTreeSet<_> = back.registry.names().keys().cloned().collect();
+        let n1: BTreeSet<_> = base.heads().map(|(n, _)| n.clone()).collect();
+        let n2: BTreeSet<_> = back.heads().map(|(n, _)| n.clone()).collect();
         assert_eq!(n1, n2, "names preserved");
     }
 
@@ -2024,7 +2020,7 @@ mod tests {
         type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
 
         let text1 = std::str::from_utf8(gantz_plyphon::BASE_BYTES).expect("utf8");
-        let base: gantz_egui::export::Export<G> =
+        let base: gantz_ca::Registry<G> =
             gantz_egui::export::parse_export(gantz_plyphon::BASE_BYTES).expect("parse base");
         let text2 = gantz_egui::format::to_string_named(&base).expect("to_string_named");
         assert_eq!(
@@ -2042,30 +2038,26 @@ mod tests {
 
         let mut merged: gantz_ca::Registry<G> = gantz_ca::Registry::default();
         for bytes in [gantz_base::BYTES, gantz_plyphon::BASE_BYTES] {
-            let export: gantz_egui::export::Export<G> =
+            let export: gantz_ca::Registry<G> =
                 gantz_egui::export::parse_export_at(bytes, bevy_gantz_egui::base::BASE_TIMESTAMP)
                     .expect("parse source");
-            merged.merge(export.registry);
+            merged.merge(export);
         }
         let builtins = super::builtins();
-        let demos = std::collections::HashMap::new();
-        let reg_ref = gantz_egui::RegistryRef::new(&merged, &builtins, &demos);
+        let reg_ref = gantz_egui::RegistryRef::new(&merged, &builtins);
         let get_node = |ca: &gantz_ca::ContentAddr| reg_ref.node(ca);
-        let names: Vec<String> = merged.names().keys().cloned().collect();
-        assert!(
-            names.contains(&"demo-sine".to_string()),
-            "plyphon demo loaded",
-        );
-        for name in names {
-            let head = gantz_ca::Head::Branch(name.clone());
+        let names: Vec<gantz_ca::Name> = merged.heads().map(|(n, _)| n.clone()).collect();
+        assert!(names.contains(&name("demo-sine")), "plyphon demo loaded");
+        for n in names {
+            let head = gantz_ca::Head::Branch(n.clone());
             let graph = merged
                 .head_graph(&head)
-                .unwrap_or_else(|| panic!("`{name}` has no head graph"));
+                .unwrap_or_else(|| panic!("`{n}` has no head graph"));
             let entrypoints = gantz_core::compile::push_pull_entrypoints(&get_node, graph);
             let config = gantz_core::compile::Config::default();
             gantz_core::vm::init(&get_node, graph, &entrypoints, &config).unwrap_or_else(|e| {
                 panic!(
-                    "merged base graph `{name}` failed to compile:\n{}",
+                    "merged base graph `{n}` failed to compile:\n{}",
                     gantz_core::vm::error_chain(&e),
                 )
             });
@@ -2078,7 +2070,7 @@ mod tests {
     #[test]
     fn plyphon_base_parses_reproducibly() {
         type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
-        let parse = || -> gantz_egui::export::Export<G> {
+        let parse = || -> gantz_ca::Registry<G> {
             gantz_egui::export::parse_export_at(
                 gantz_plyphon::BASE_BYTES,
                 bevy_gantz_egui::base::BASE_TIMESTAMP,
@@ -2087,8 +2079,8 @@ mod tests {
         };
         let a = parse();
         let b = parse();
-        let ca_a = a.registry.names().get("demo-sine").expect("demo-sine");
-        let ca_b = b.registry.names().get("demo-sine").expect("demo-sine");
+        let ca_a = a.head(&name("demo-sine")).expect("demo-sine");
+        let ca_b = b.head(&name("demo-sine")).expect("demo-sine");
         assert_eq!(ca_a, ca_b, "reset must resolve the startup commit address");
     }
 
@@ -2098,13 +2090,18 @@ mod tests {
     /// foreign ref by name WITHOUT embedding the foreign graph.
     #[test]
     fn cross_source_base_refs_resolve_via_seed() {
-        use std::collections::HashMap;
+        use std::collections::BTreeMap;
         type G = gantz_core::node::graph::Graph<Box<dyn Node>>;
         let ts = bevy_gantz_egui::base::BASE_TIMESTAMP;
 
-        let core: gantz_egui::export::Export<G> =
+        let core: gantz_ca::Registry<G> =
             gantz_egui::export::parse_export_at(gantz_base::BYTES, ts).expect("parse core");
-        let seed = core.registry.names().clone();
+        // Externally-known name -> head graph associations, the form the
+        // seeded parse resolves foreign refs through.
+        let seed: BTreeMap<String, gantz_ca::GraphAddr> = core
+            .heads()
+            .filter_map(|(n, ca)| Some((n.to_string(), core.commits().get(&ca)?.graph)))
+            .collect();
 
         // A synthetic domain source wrapping the core `add` graph.
         let text = "\
@@ -2123,19 +2120,18 @@ mod tests {
             Ok(_) => panic!("must not resolve unseeded"),
         }
 
-        // Seeded with the core source's names: resolves to the core commit.
-        let domain: gantz_egui::export::Export<G> =
+        // Seeded with the core source's names: resolves to the core content.
+        let domain: gantz_ca::Registry<G> =
             gantz_egui::export::parse_export_seeded_at(text.as_bytes(), ts, &seed)
                 .expect("seeded parse");
-        let mut merged = core.registry;
-        merged.merge(domain.registry);
+        let mut merged = core;
+        merged.merge(domain);
 
         // The merged registry compiles the wrapper.
         let builtins = super::builtins();
-        let demos = HashMap::new();
-        let reg_ref = gantz_egui::RegistryRef::new(&merged, &builtins, &demos);
+        let reg_ref = gantz_egui::RegistryRef::new(&merged, &builtins);
         let get_node = |ca: &gantz_ca::ContentAddr| reg_ref.node(ca);
-        let head = gantz_ca::Head::Branch("wrap-add".to_string());
+        let head = gantz_ca::Head::Branch(name("wrap-add"));
         let graph = merged.head_graph(&head).expect("wrap-add graph");
         let entrypoints = gantz_core::compile::push_pull_entrypoints(&get_node, graph);
         let config = gantz_core::compile::Config::default();
@@ -2147,13 +2143,8 @@ mod tests {
         });
 
         // The domain source's own export keeps `add` by name only.
-        let out = gantz_egui::export::export_names_sexpr_named(
-            &merged,
-            &HashMap::new(),
-            &HashMap::new(),
-            ["wrap-add"],
-        )
-        .expect("per-source export");
+        let out = gantz_egui::export::export_names_sexpr_named(&merged, ["wrap-add"])
+            .expect("per-source export");
         assert!(out.contains("(graph wrap-add"), "own graph present:\n{out}");
         assert!(out.contains("(ref add"), "foreign ref by name:\n{out}");
         assert!(

--- a/crates/gantz/src/persist.rs
+++ b/crates/gantz/src/persist.rs
@@ -20,7 +20,7 @@ use bevy_gantz::{
     FocusedHead, HeadTabOrder, OpenHead, OpenHeadDataReadOnly, Registry,
     debounced_input::{DebouncedEvent, DebouncedInputEvent, DebouncedInputPlugin},
 };
-use bevy_gantz_egui::{GuiState, Views};
+use bevy_gantz_egui::GuiState;
 
 #[cfg(not(target_arch = "wasm32"))]
 use bevy::tasks::{IoTaskPool, Task, block_on};
@@ -145,18 +145,15 @@ fn setup_persister(pkv: Res<Pkv>, mut cmds: Commands) {
     cmds.insert_resource(spawn_persister(pkv.clone()));
 }
 
-/// Collect the registry/heads/views/gui/window into a `(key, value)` batch to
-/// persist.
+/// Collect the registry/heads/gui/window into a `(key, value)` batch to
+/// persist. Views, demos and descriptions ride the registry's sections.
 ///
 /// Registry writes dedup against `persisted` (pass a fresh
 /// [`PersistedRegistry`](bevy_gantz::storage::PersistedRegistry) to force a
 /// complete write); everything else is written each call.
-#[allow(clippy::too_many_arguments)]
 fn collect_batch_to_persist(
     registry: &Registry<BoxNode>,
     persisted: &mut bevy_gantz::storage::PersistedRegistry,
-    views: &Views,
-    persisted_views: &mut bevy_gantz_egui::storage::PersistedViews,
     gui_state: &GuiState,
     tab_order: &HeadTabOrder,
     focused: &FocusedHead,
@@ -164,7 +161,7 @@ fn collect_batch_to_persist(
     window: Option<&Window>,
 ) -> Vec<(String, String)> {
     let mut batch = bevy_gantz::storage::BatchWriter::default();
-    // Registry: only newly-seen graphs/commits and any changed name maps.
+    // Registry: only newly-seen content and any changed sections.
     bevy_gantz::storage::save_registry_incremental(&mut batch, registry, persisted);
     // Open heads in tab order.
     let heads: Vec<_> = tab_order
@@ -183,15 +180,6 @@ fn collect_batch_to_persist(
             bevy_gantz::storage::save_focused_head(&mut batch, &**data.head_ref);
         }
     }
-    // Views (kept current by `persist_camera_and_seed` and `settle_layout`):
-    // write only the per-commit views that changed, for commits that still exist.
-    let valid_commits: std::collections::HashSet<_> = registry.commits().keys().copied().collect();
-    bevy_gantz_egui::storage::save_views_incremental(
-        &mut batch,
-        views,
-        &valid_commits,
-        persisted_views,
-    );
     // GUI state.
     bevy_gantz_egui::storage::save_gui_state(&mut batch, gui_state);
     // Native window size (no-op on web).
@@ -204,8 +192,6 @@ fn collect_batch_to_persist(
 fn persist_resources(
     registry: Res<Registry<BoxNode>>,
     mut persisted: ResMut<bevy_gantz::storage::PersistedRegistry>,
-    views: Res<Views>,
-    mut persisted_views: ResMut<bevy_gantz_egui::storage::PersistedViews>,
     gui_state: Res<GuiState>,
     mut persister: ResMut<Persister>,
     tab_order: Res<HeadTabOrder>,
@@ -218,8 +204,6 @@ fn persist_resources(
     let batch = collect_batch_to_persist(
         &registry,
         &mut persisted,
-        &views,
-        &mut persisted_views,
         &gui_state,
         &tab_order,
         &focused,
@@ -262,16 +246,14 @@ fn persist_egui_memory(mut persister: ResMut<Persister>, mut ctxs: EguiContexts)
 
 /// On exit, write the full current state and drain the worker before quitting.
 ///
-/// Fresh trackers force a complete registry + views write as a backstop for any
+/// A fresh tracker forces a complete registry write as a backstop for any
 /// blob optimistically tracked as persisted but not yet drained by the worker;
 /// FIFO + `shutdown` guarantee it lands last. egui memory is left to the
 /// worker's normal drain (best-effort widget state).
 #[cfg(not(target_arch = "wasm32"))]
-#[allow(clippy::too_many_arguments)]
 fn flush_on_exit(
     mut exit: MessageReader<AppExit>,
     registry: Res<Registry<BoxNode>>,
-    views: Res<Views>,
     gui_state: Res<GuiState>,
     mut persister: ResMut<Persister>,
     tab_order: Res<HeadTabOrder>,
@@ -283,13 +265,10 @@ fn flush_on_exit(
         return;
     }
     let mut full = bevy_gantz::storage::PersistedRegistry::default();
-    let mut full_views = bevy_gantz_egui::storage::PersistedViews::default();
     let window = primary_window.single().ok();
     let batch = collect_batch_to_persist(
         &registry,
         &mut full,
-        &views,
-        &mut full_views,
         &gui_state,
         &tab_order,
         &focused,

--- a/crates/gantz_ca/src/commit.rs
+++ b/crates/gantz_ca/src/commit.rs
@@ -1,4 +1,4 @@
-use super::{CaHash, ContentAddr, GraphAddr, Hasher};
+use super::{CaHash, ContentAddr, GraphAddr, Hasher, Name};
 use serde::{Deserialize, Serialize};
 use std::{fmt, ops, time::Duration};
 
@@ -32,7 +32,7 @@ pub struct CommitAddr(ContentAddr);
 /// Represents a name used to track a working series of commits.
 ///
 /// Users can think of this as their graph or project name.
-pub type Branch = String;
+pub type Branch = Name;
 
 /// Acts as a pointer to the current working graph, whether directly to a commit
 /// or to a name mapping.
@@ -92,14 +92,19 @@ impl Commit {
 }
 
 /// Commits addressed by timestamp, parent(s) and graph CA.
+///
+/// The `gantz.commit` prefix domain-separates commit addresses from every
+/// other kind (graphs carry their own prefix, blob addresses are raw blake3
+/// of their bytes), so no two kinds can collide on one address.
 impl CaHash for Commit {
     fn hash(&self, hasher: &mut Hasher) {
+        hasher.update(b"gantz.commit");
         self.timestamp.as_secs().hash(hasher);
         self.timestamp.subsec_nanos().hash(hasher);
         self.parent.hash(hasher);
         self.graph.hash(hasher);
-        // Folded in only when non-empty so ordinary commits hash byte-for-byte
-        // as they did before merge support existed.
+        // Folded in only when non-empty so a commit's address is unchanged
+        // by the presence of the (defaulted) field on ordinary commits.
         if !self.merge_parents.is_empty() {
             hasher.update(b"merge-parents");
             self.merge_parents.hash(hasher);
@@ -155,25 +160,19 @@ mod tests {
         CommitAddr::from(ContentAddr::from([n; 32]))
     }
 
-    /// The commit hash as it was before `merge_parents` existed. Ordinary
-    /// commits must keep hashing byte-for-byte like this so that existing
-    /// registries' commit addresses are unchanged.
-    fn pre_merge_addr(commit: &Commit) -> CommitAddr {
-        let mut hasher = Hasher::new();
-        commit.timestamp.as_secs().hash(&mut hasher);
-        commit.timestamp.subsec_nanos().hash(&mut hasher);
-        commit.parent.hash(&mut hasher);
-        commit.graph.hash(&mut hasher);
-        let bytes: [u8; 32] = hasher.finalize().into();
-        CommitAddr::from(ContentAddr::from(bytes))
-    }
-
     #[test]
-    fn ordinary_commit_addr_unchanged_by_merge_parents_field() {
+    fn commit_addr_is_domain_separated() {
+        // The kind prefix keeps a commit's address distinct from a raw
+        // blake3 hash of the same field bytes (blob addressing) and from
+        // graph addresses.
         let root = Commit::new(Duration::from_secs(1), None, graph_addr(1));
-        assert_eq!(addr(&root), pre_merge_addr(&root));
-        let child = Commit::new(Duration::from_secs(2), Some(addr(&root)), graph_addr(2));
-        assert_eq!(addr(&child), pre_merge_addr(&child));
+        let mut unprefixed = Hasher::new();
+        root.timestamp.as_secs().hash(&mut unprefixed);
+        root.timestamp.subsec_nanos().hash(&mut unprefixed);
+        root.parent.hash(&mut unprefixed);
+        root.graph.hash(&mut unprefixed);
+        let bytes: [u8; 32] = unprefixed.finalize().into();
+        assert_ne!(addr(&root), CommitAddr::from(ContentAddr::from(bytes)));
     }
 
     #[test]

--- a/crates/gantz_ca/src/datum.rs
+++ b/crates/gantz_ca/src/datum.rs
@@ -208,7 +208,7 @@ impl std::hash::Hash for Datum {
     }
 }
 
-impl gantz_ca::CaHash for Datum {
+impl crate::CaHash for Datum {
     /// Content-address folding over the datum's structure.
     ///
     /// A variant marker byte plus length-prefixed variable-size contents keep
@@ -217,8 +217,8 @@ impl gantz_ca::CaHash for Datum {
     /// pattern, matching the bitwise `Eq`/`Hash` semantics. Identity-sensitive
     /// callers hash the [canonical](Datum::canonicalize) form so one logical
     /// value has exactly one address.
-    fn hash(&self, hasher: &mut gantz_ca::Hasher) {
-        fn len(hasher: &mut gantz_ca::Hasher, n: usize) {
+    fn hash(&self, hasher: &mut crate::Hasher) {
+        fn len(hasher: &mut crate::Hasher, n: usize) {
             hasher.update(&(n as u64).to_be_bytes());
         }
         match self {
@@ -258,7 +258,7 @@ impl gantz_ca::CaHash for Datum {
                 hasher.update(&[8]);
                 len(hasher, items.len());
                 for item in items {
-                    gantz_ca::CaHash::hash(item, hasher);
+                    crate::CaHash::hash(item, hasher);
                 }
             }
             Datum::Map(entries) => {
@@ -267,7 +267,7 @@ impl gantz_ca::CaHash for Datum {
                 for (k, v) in entries {
                     len(hasher, k.len());
                     hasher.update(k.as_bytes());
-                    gantz_ca::CaHash::hash(v, hasher);
+                    crate::CaHash::hash(v, hasher);
                 }
             }
         }
@@ -1614,8 +1614,8 @@ mod tests {
     /// prefixes prevent adjacency and cross-variant collisions.
     #[test]
     fn ca_hash_distinctness() {
-        fn ca(d: &Datum) -> gantz_ca::ContentAddr {
-            gantz_ca::content_addr(d)
+        fn ca(d: &Datum) -> crate::ContentAddr {
+            crate::content_addr(d)
         }
         // Same numeric value, different variant.
         assert_ne!(ca(&Datum::I64(1)), ca(&Datum::U64(1)));
@@ -1652,7 +1652,7 @@ mod tests {
             ),
         ]);
         assert_eq!(
-            gantz_ca::content_addr(&d).to_string(),
+            crate::content_addr(&d).to_string(),
             "62ff57c18727d269cad8e0cfd62856b57efbecec761aadc2caad0073445dd09d",
             "Datum CaHash scheme changed - this breaks existing ext-carrying addresses",
         );

--- a/crates/gantz_ca/src/diff.rs
+++ b/crates/gantz_ca/src/diff.rs
@@ -431,7 +431,7 @@ mod tests {
             .into_iter()
             .collect();
         let commits = [(ca0, c0), (ca1, c1), (ca2, c2)].into_iter().collect();
-        let reg = Registry::new(graphs, commits, Default::default());
+        let reg = Registry::from_parts(graphs, commits, Default::default());
         // Direct matching pairs only the content-identical node.
         assert_eq!(matching(&reg, ca0, ca2).unwrap(), Matching::from([(0, 0)]));
     }

--- a/crates/gantz_ca/src/graph.rs
+++ b/crates/gantz_ca/src/graph.rs
@@ -111,11 +111,14 @@ where
     G::NodeId: Hash + Ord,
     G::EdgeWeight: CaHash + Ord,
 {
+    // Domain-separate graph addresses from every other kind (see the
+    // matching prefix on `Commit`'s `CaHash`).
+    hasher.update(b"gantz.graph");
     // Assign each node a canonical rank: its position in ascending-index order
     // (the order `node_references` yields for a `StableGraph`). For a hole-free
-    // graph the rank equals the raw index, so existing addresses are unchanged;
-    // vacant slots left by node removals are compacted away, making the address
-    // independent of the physical slot layout and stable across a round-trip.
+    // graph the rank equals the raw index; vacant slots left by node removals
+    // are compacted away, making the address independent of the physical slot
+    // layout and stable across a round-trip.
     let rank: HashMap<G::NodeId, u64> = g
         .node_references()
         .enumerate()

--- a/crates/gantz_ca/src/graph.rs
+++ b/crates/gantz_ca/src/graph.rs
@@ -1,5 +1,6 @@
 //! The gantz content-address implementation for graphs.
 
+use crate::section::Bytes;
 pub use crate::{
     ContentAddr, content_addr,
     hash::{CaHash, Hasher},
@@ -8,9 +9,47 @@ use petgraph::visit::{Data, EdgeRef, IntoEdgeReferences, IntoNodeReferences, Nod
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt, hash::Hash, ops};
 
+/// The one capability graph stores need from a graph payload: its address.
+///
+/// Typed (petgraph-shaped) payloads compute this from content (see [`addr`]).
+/// Payloads a process cannot decode, such as [`RawGraph`], carry the address
+/// they were validated against instead.
+pub trait GraphHash {
+    /// The content address of the graph.
+    fn graph_addr(&self) -> GraphAddr;
+}
+
 /// The content address of a graph.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 pub struct GraphAddr(ContentAddr);
+
+/// A blob-at-rest graph payload for serve-side stores: application
+/// serialized bytes carried under the address they were VALIDATED against.
+///
+/// A raw graph's address cannot be recomputed from its bytes (the structural
+/// graph hash needs the decoded graph), so a store holding raw graphs holds
+/// them under CLAIMED addresses that a decoding peer validated. Such a store
+/// is a relay: it serves what decoding peers verified, and a receiving peer
+/// always re-verifies through the typed
+/// [`Staged::insert_graph`](crate::sync::Staged::insert_graph) path, which
+/// is where the security boundary lives.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RawGraph {
+    /// The address a decoding peer validated the bytes against.
+    pub addr: GraphAddr,
+    /// The application-serialized (self-describing) graph bytes.
+    pub bytes: Bytes,
+}
+
+impl RawGraph {
+    /// A raw graph from its validated address and serialized bytes.
+    pub fn new(addr: GraphAddr, bytes: impl Into<Bytes>) -> Self {
+        Self {
+            addr,
+            bytes: bytes.into(),
+        }
+    }
+}
 
 impl ops::Deref for GraphAddr {
     type Target = ContentAddr;
@@ -34,6 +73,12 @@ impl From<GraphAddr> for ContentAddr {
 impl CaHash for GraphAddr {
     fn hash(&self, hasher: &mut Hasher) {
         CaHash::hash(&self.0, hasher);
+    }
+}
+
+impl GraphHash for RawGraph {
+    fn graph_addr(&self) -> GraphAddr {
+        self.addr
     }
 }
 

--- a/crates/gantz_ca/src/lib.rs
+++ b/crates/gantz_ca/src/lib.rs
@@ -30,8 +30,8 @@ pub use name::{Name, SEP as NAME_SEP};
 pub use reach::{LiveSet, OutRefs, closure, closure_from, export, prune};
 #[doc(inline)]
 pub use registry::{
-    Heads, MergeReport, Registry, section_get, section_insert, section_insert_datum, section_iter,
-    section_remove,
+    HEADS_ID, Heads, MergeReport, Registry, section_get, section_insert, section_insert_datum,
+    section_iter, section_remove,
 };
 #[doc(inline)]
 pub use section::{

--- a/crates/gantz_ca/src/lib.rs
+++ b/crates/gantz_ca/src/lib.rs
@@ -5,6 +5,8 @@ pub use ca::{ContentAddr, ContentAddrShort, content_addr};
 #[doc(inline)]
 pub use commit::{Branch, Commit, CommitAddr, Head, Timestamp, addr as commit_addr};
 #[doc(inline)]
+pub use datum::{Datum, DatumError, from_datum, to_datum};
+#[doc(inline)]
 pub use diff::{Diff, DiffSummary, Matching};
 /// Re-export the derive macro.
 pub use gantz_ca_derive::CaHash;
@@ -23,17 +25,27 @@ pub use merge::{
     Resolutions, Side, merge_commits,
 };
 #[doc(inline)]
+pub use name::{Name, SEP as NAME_SEP};
+#[doc(inline)]
 pub use registry::Registry;
+#[doc(inline)]
+pub use section::{
+    BlobDecl, BlobLiveness, BlobStore, Bytes, Key, Liveness, MergePolicy, Section, SectionDecl,
+    SectionId, Value, blob_addr,
+};
 #[doc(inline)]
 pub use sync::{SyncStep, monotonic_timestamp, plan_sync_step};
 
 mod ca;
 mod commit;
+pub mod datum;
 pub mod diff;
 mod graph;
 mod hash;
 pub mod history;
 pub mod merge;
+pub mod name;
 pub mod registry;
+pub mod section;
 pub mod serde_sorted;
 pub mod sync;

--- a/crates/gantz_ca/src/lib.rs
+++ b/crates/gantz_ca/src/lib.rs
@@ -27,7 +27,7 @@ pub use merge::{
 #[doc(inline)]
 pub use name::{Name, SEP as NAME_SEP};
 #[doc(inline)]
-pub use reach::{LiveSet, OutRefs, closure, export, prune};
+pub use reach::{LiveSet, OutRefs, closure, closure_from, export, prune};
 #[doc(inline)]
 pub use registry::{
     Heads, MergeReport, Registry, section_get, section_insert, section_insert_datum, section_iter,

--- a/crates/gantz_ca/src/lib.rs
+++ b/crates/gantz_ca/src/lib.rs
@@ -12,8 +12,8 @@ pub use diff::{Diff, DiffSummary, Matching};
 pub use gantz_ca_derive::CaHash;
 #[doc(inline)]
 pub use graph::{
-    GraphAddr, addr as graph_addr, addr_with_nodes as graph_addr_with_nodes, hash_graph,
-    hash_graph_with_nodes, node_addrs,
+    GraphAddr, GraphHash, RawGraph, addr as graph_addr, addr_with_nodes as graph_addr_with_nodes,
+    hash_graph, hash_graph_with_nodes, node_addrs,
 };
 #[doc(inline)]
 pub use hash::{CaHash, Hasher};

--- a/crates/gantz_ca/src/lib.rs
+++ b/crates/gantz_ca/src/lib.rs
@@ -27,7 +27,12 @@ pub use merge::{
 #[doc(inline)]
 pub use name::{Name, SEP as NAME_SEP};
 #[doc(inline)]
-pub use registry::Registry;
+pub use reach::{LiveSet, OutRefs, closure, export, prune};
+#[doc(inline)]
+pub use registry::{
+    Heads, MergeReport, Registry, section_get, section_insert, section_insert_datum, section_iter,
+    section_remove,
+};
 #[doc(inline)]
 pub use section::{
     BlobDecl, BlobLiveness, BlobStore, Bytes, Key, Liveness, MergePolicy, Section, SectionDecl,
@@ -45,6 +50,8 @@ mod hash;
 pub mod history;
 pub mod merge;
 pub mod name;
+pub mod ops;
+pub mod reach;
 pub mod registry;
 pub mod section;
 pub mod serde_sorted;

--- a/crates/gantz_ca/src/merge.rs
+++ b/crates/gantz_ca/src/merge.rs
@@ -1158,8 +1158,8 @@ mod tests {
         let (mut reg, o, t, res) = merge_two(&base, &ours, &theirs);
         let out = diverged(res);
         assert!(out.conflicts.is_empty());
-        reg.insert_name("alpha".to_string(), o);
-        let mut head = Head::Branch("alpha".to_string());
+        reg.set_head("alpha".parse().unwrap(), o);
+        let mut head = Head::Branch("alpha".parse().unwrap());
         let merge_ca = reg.commit_merge_to_head(
             Duration::from_secs(4),
             graph_addr(&out.graph),

--- a/crates/gantz_ca/src/name.rs
+++ b/crates/gantz_ca/src/name.rs
@@ -1,0 +1,168 @@
+//! Hierarchical names for heads (branches) and name-keyed metadata.
+//!
+//! A [`Name`] is a non-empty sequence of segments, displayed joined by
+//! [`SEP`] (`:`). Nesting is structural rather than a substring convention:
+//! `synth:filter` is the child segment `filter` under the root `synth`.
+
+use crate::{CaHash, Hasher};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{fmt, str};
+
+/// A hierarchical name: one or more segments, displayed joined by [`SEP`].
+///
+/// Ordering is segment-wise, so all of a name's descendants sort directly
+/// after it (`["a"] < ["a", "b"] < ["ab"]`).
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Name(Vec<String>);
+
+/// The separator between segments in a [`Name`]'s display form.
+pub const SEP: char = ':';
+
+impl Name {
+    /// A root name with the given single segment.
+    pub fn root(segment: impl Into<String>) -> Self {
+        Self(vec![segment.into()])
+    }
+
+    /// The name's segments (always at least one).
+    pub fn segments(&self) -> &[String] {
+        &self.0
+    }
+
+    /// This name with `segment` appended as a child.
+    pub fn child(&self, segment: impl Into<String>) -> Self {
+        let mut segments = self.0.clone();
+        segments.push(segment.into());
+        Self(segments)
+    }
+
+    /// The parent name, or `None` for a root name.
+    pub fn parent(&self) -> Option<Name> {
+        (self.0.len() > 1).then(|| Self(self.0[..self.0.len() - 1].to_vec()))
+    }
+
+    /// Nesting depth: `0` for a root name.
+    pub fn depth(&self) -> usize {
+        self.0.len() - 1
+    }
+
+    /// Whether the name is nested (has a parent).
+    pub fn is_nested(&self) -> bool {
+        self.0.len() > 1
+    }
+
+    /// Whether `prefix` is this name or an ancestor of it.
+    pub fn starts_with(&self, prefix: &Name) -> bool {
+        self.0.len() >= prefix.0.len() && self.0[..prefix.0.len()] == prefix.0[..]
+    }
+}
+
+impl CaHash for Name {
+    fn hash(&self, hasher: &mut Hasher) {
+        self.0.hash(hasher);
+    }
+}
+
+impl fmt::Display for Name {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut segments = self.0.iter();
+        if let Some(first) = segments.next() {
+            write!(f, "{first}")?;
+        }
+        for segment in segments {
+            write!(f, "{SEP}{segment}")?;
+        }
+        Ok(())
+    }
+}
+
+impl From<Vec<String>> for Name {
+    /// Constructs the name from raw segments. An empty vec becomes the name
+    /// with a single empty segment, preserving the "at least one segment"
+    /// invariant totally.
+    fn from(segments: Vec<String>) -> Self {
+        if segments.is_empty() {
+            Self(vec![String::new()])
+        } else {
+            Self(segments)
+        }
+    }
+}
+
+impl str::FromStr for Name {
+    type Err = std::convert::Infallible;
+    /// Splits on [`SEP`]. Total: every string is a valid name (an empty
+    /// string is the root name with one empty segment).
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.split(SEP).map(str::to_string).collect()))
+    }
+}
+
+impl Serialize for Name {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for Name {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(s.parse().expect("infallible"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_display_round_trip() {
+        for s in ["synth", "synth:filter", "a:b:c", "", "a::b"] {
+            let name: Name = s.parse().unwrap();
+            assert_eq!(name.to_string(), s);
+        }
+    }
+
+    #[test]
+    fn hierarchy() {
+        let root = Name::root("synth");
+        let child = root.child("filter");
+        assert_eq!(child.to_string(), "synth:filter");
+        assert_eq!(child.parent(), Some(root.clone()));
+        assert_eq!(root.parent(), None);
+        assert_eq!(root.depth(), 0);
+        assert_eq!(child.depth(), 1);
+        assert!(!root.is_nested());
+        assert!(child.is_nested());
+        assert!(child.starts_with(&root));
+        assert!(child.starts_with(&child));
+        assert!(!root.starts_with(&child));
+    }
+
+    #[test]
+    fn descendants_sort_adjacent() {
+        let mut names: Vec<Name> = ["ab", "a", "a:b", "b"]
+            .iter()
+            .map(|s| s.parse().unwrap())
+            .collect();
+        names.sort();
+        let displayed: Vec<String> = names.iter().map(Name::to_string).collect();
+        assert_eq!(displayed, ["a", "a:b", "ab", "b"]);
+    }
+
+    #[test]
+    fn prefix_is_segment_wise_not_substring() {
+        let ab: Name = "ab".parse().unwrap();
+        let a = Name::root("a");
+        assert!(!ab.starts_with(&a));
+    }
+
+    #[test]
+    fn serde_as_string() {
+        let name: Name = "synth:filter".parse().unwrap();
+        let ron = ron::to_string(&name).unwrap();
+        assert_eq!(ron, "\"synth:filter\"");
+        let back: Name = ron::de::from_str(&ron).unwrap();
+        assert_eq!(back, name);
+    }
+}

--- a/crates/gantz_ca/src/ops.rs
+++ b/crates/gantz_ca/src/ops.rs
@@ -1,0 +1,120 @@
+//! Commit operations over a [`Registry`]: minting commits and advancing
+//! heads.
+
+use crate::{Commit, CommitAddr, GraphAddr, Head, Name, Registry, Timestamp, commit_addr};
+
+/// Commit the graph at the given address.
+///
+/// If the graph doesn't exist, calls `graph()` to retrieve the graph for the
+/// registry.
+pub fn commit_graph<G>(
+    reg: &mut Registry<G>,
+    timestamp: Timestamp,
+    parent_ca: Option<CommitAddr>,
+    graph_ca: GraphAddr,
+    graph: impl FnOnce() -> G,
+) -> CommitAddr {
+    insert_graph_lazily(reg, graph_ca, graph);
+    let commit = Commit::new(timestamp, parent_ca, graph_ca);
+    let commit_ca = commit_addr(&commit);
+    reg.insert_commit_at(commit_ca, commit);
+    commit_ca
+}
+
+/// Commit the given graph to the given name (branch).
+///
+/// If the graph doesn't exist, calls `graph()` to retrieve the graph for the
+/// registry.
+pub fn commit_graph_to_name<G>(
+    reg: &mut Registry<G>,
+    timestamp: Timestamp,
+    graph_ca: GraphAddr,
+    graph: impl FnOnce() -> G,
+    name: &Name,
+) -> CommitAddr {
+    let parent_ca = reg.head(name);
+    let commit_ca = commit_graph(reg, timestamp, parent_ca, graph_ca, graph);
+    reg.set_head(name.clone(), commit_ca);
+    commit_ca
+}
+
+/// Commit the given graph to the given head.
+///
+/// If the graph doesn't exist, calls `graph()` to retrieve the graph for the
+/// registry.
+pub fn commit_graph_to_head<G>(
+    reg: &mut Registry<G>,
+    timestamp: Timestamp,
+    graph_ca: GraphAddr,
+    graph: impl FnOnce() -> G,
+    head: &mut Head,
+) -> CommitAddr {
+    let parent_ca = reg.head_commit_ca(head).unwrap();
+    let commit_ca = commit_graph(reg, timestamp, Some(parent_ca), graph_ca, graph);
+    point_head_at(reg, head, commit_ca);
+    commit_ca
+}
+
+/// Commit the given graph to the given head as a merge of `theirs` into the
+/// head's current commit.
+///
+/// If the graph doesn't exist, calls `graph()` to retrieve the graph for the
+/// registry.
+pub fn commit_merge_to_head<G>(
+    reg: &mut Registry<G>,
+    timestamp: Timestamp,
+    graph_ca: GraphAddr,
+    graph: impl FnOnce() -> G,
+    theirs: CommitAddr,
+    head: &mut Head,
+) -> CommitAddr {
+    let ours = reg.head_commit_ca(head).unwrap();
+    insert_graph_lazily(reg, graph_ca, graph);
+    let commit = Commit::new_merge(timestamp, ours, theirs, graph_ca);
+    let commit_ca = commit_addr(&commit);
+    reg.insert_commit_at(commit_ca, commit);
+    point_head_at(reg, head, commit_ca);
+    commit_ca
+}
+
+/// Commit the given graph to the given head as a canonical merge of the
+/// diverged tips `a` and `b` (see [`Registry::commit_merge_canonical`]).
+///
+/// If the graph doesn't exist, calls `graph()` to retrieve the graph for the
+/// registry.
+pub fn commit_merge_canonical<G>(
+    reg: &mut Registry<G>,
+    a: CommitAddr,
+    b: CommitAddr,
+    graph_ca: GraphAddr,
+    graph: impl FnOnce() -> G,
+    head: &mut Head,
+) -> CommitAddr {
+    let (first, second) = crate::sync::canonical_tips(reg.commits(), a, b);
+    let timestamp = crate::sync::merge_timestamp(reg.commits(), first, second);
+    insert_graph_lazily(reg, graph_ca, graph);
+    let commit = Commit::new_merge(timestamp, first, second, graph_ca);
+    let commit_ca = commit_addr(&commit);
+    reg.insert_commit_at(commit_ca, commit);
+    point_head_at(reg, head, commit_ca);
+    commit_ca
+}
+
+/// Point the head at the given commit: a branch head updates the heads
+/// section, a detached head is reassigned directly.
+pub fn point_head_at<G>(reg: &mut Registry<G>, head: &mut Head, commit_ca: CommitAddr) {
+    match *head {
+        Head::Commit(ref mut ca) => *ca = commit_ca,
+        Head::Branch(ref name) => {
+            reg.set_head(name.clone(), commit_ca);
+        }
+    }
+}
+
+/// Insert the graph at the given address, calling `graph()` only when the
+/// address is absent.
+fn insert_graph_lazily<G>(reg: &mut Registry<G>, graph_ca: GraphAddr, graph: impl FnOnce() -> G) {
+    if reg.graph(&graph_ca).is_none() {
+        reg.insert_graph_at(graph_ca, graph());
+    }
+}

--- a/crates/gantz_ca/src/reach.rs
+++ b/crates/gantz_ca/src/reach.rs
@@ -1,0 +1,416 @@
+//! The one reachability walk: liveness for prune, closure for export, and
+//! want-lists for sync all derive from here.
+//!
+//! Edge rules:
+//! - A commit contributes its parents and its graph.
+//! - A graph contributes whatever `graph_out` reports: nested graph
+//!   references and blob references. Only the application can see inside
+//!   node payloads, so this is the one caller-supplied part.
+//! - Blobs and section values are leaves.
+//!
+//! Roots are the entries of `Root`-liveness sections (the `heads` section
+//! at minimum) plus any extra seeds the caller supplies.
+//!
+//! Section entry liveness is NOT part of [`LiveSet`]: it is a pure function
+//! of the surviving content, so [`export`] and [`prune`] apply each
+//! section's stored [`Liveness`] rule against the filtered
+//! registry directly.
+
+use crate::{
+    BlobLiveness, CommitAddr, ContentAddr, GraphAddr, Liveness, Registry, SectionId, Value,
+};
+use std::collections::{BTreeMap, HashSet, VecDeque};
+
+/// The outgoing content references of a single graph, as reported by the
+/// application (it alone can interpret node payloads).
+#[derive(Clone, Debug, Default)]
+pub struct OutRefs {
+    /// Nested graph references (e.g. `Ref` nodes).
+    pub graphs: Vec<GraphAddr>,
+    /// Blob references, tagged with their blob section.
+    pub blobs: Vec<(SectionId, ContentAddr)>,
+}
+
+/// The live content of a registry: the closure of the roots (and any extra
+/// seeds) over the edge rules above.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct LiveSet {
+    pub commits: HashSet<CommitAddr>,
+    pub graphs: HashSet<GraphAddr>,
+    pub blobs: BTreeMap<SectionId, HashSet<ContentAddr>>,
+}
+
+impl LiveSet {
+    /// Whether the given blob is live.
+    pub fn blob_live(&self, section: &str, addr: &ContentAddr) -> bool {
+        self.blobs.get(section).is_some_and(|s| s.contains(addr))
+    }
+}
+
+/// The live closure of `reg` from its `Root`-liveness sections plus the
+/// given extra commit seeds.
+///
+/// `graph_out` maps a graph to its outgoing references (see [`OutRefs`]).
+/// Applications wrap their node-payload introspection here (nested `Ref`
+/// targets, blob references). Dangling seeds and references are tolerated
+/// and simply not walked.
+pub fn closure<G>(
+    reg: &Registry<G>,
+    extra_commits: impl IntoIterator<Item = CommitAddr>,
+    graph_out: impl Fn(&G) -> OutRefs,
+) -> LiveSet {
+    let mut live = LiveSet::default();
+    let mut commit_queue: VecDeque<CommitAddr> = VecDeque::new();
+    let mut graph_queue: VecDeque<GraphAddr> = VecDeque::new();
+
+    // Roots: every commit-valued entry of every Root-liveness section.
+    for section in reg.sections().values() {
+        if section.liveness != Liveness::Root {
+            continue;
+        }
+        for value in section.entries.values() {
+            if let Value::Commit(ca) = value {
+                commit_queue.push_back(*ca);
+            }
+        }
+    }
+    commit_queue.extend(extra_commits);
+
+    while let Some(ca) = commit_queue.pop_front() {
+        let Some(commit) = reg.commits().get(&ca) else {
+            continue;
+        };
+        if !live.commits.insert(ca) {
+            continue;
+        }
+        commit_queue.extend(commit.parents());
+        graph_queue.push_back(commit.graph);
+        while let Some(ga) = graph_queue.pop_front() {
+            let Some(graph) = reg.graph(&ga) else {
+                continue;
+            };
+            if !live.graphs.insert(ga) {
+                continue;
+            }
+            let out = graph_out(graph);
+            graph_queue.extend(out.graphs);
+            for (section, addr) in out.blobs {
+                live.blobs.entry(section).or_default().insert(addr);
+            }
+        }
+    }
+
+    // Blobs referenced by live section entries (Value::Blob indirections).
+    for section in reg.sections().values() {
+        for (key, value) in &section.entries {
+            if !entry_live(reg, section.liveness, key, &live) {
+                continue;
+            }
+            if let Value::Blob(blob_section, addr) = value {
+                live.blobs
+                    .entry(blob_section.clone())
+                    .or_default()
+                    .insert(*addr);
+            }
+        }
+    }
+
+    // Pinned blob stores are live wholesale.
+    for (id, store) in reg.blobs() {
+        if store.liveness == BlobLiveness::Pinned {
+            live.blobs
+                .entry(id.clone())
+                .or_default()
+                .extend(store.entries.keys().copied());
+        }
+    }
+
+    live
+}
+
+/// Export the live subset of the registry: content filtered by `live`,
+/// section entries filtered by their stored liveness against the exported
+/// content. Heads whose commit falls outside the export are dropped, and
+/// their `WithName` metadata with them.
+pub fn export<G: Clone>(reg: &Registry<G>, live: &LiveSet) -> Registry<G> {
+    let mut exported = reg.clone();
+    prune(&mut exported, live);
+    exported
+}
+
+/// Prune the registry down to the live set: dead content is removed, heads
+/// pointing outside the live set are dropped, each section's entries are
+/// filtered by its stored liveness rule against the surviving state, and
+/// invalid commit parents are detached. Emptied sections and blob stores
+/// are removed.
+pub fn prune<G>(reg: &mut Registry<G>, live: &LiveSet) {
+    reg.retain_live(live);
+}
+
+/// Whether a section entry is live against the given registry + live set.
+/// Used by [`closure`]'s blob-reference pass. `Root` entries are treated
+/// conservatively as live (their commit values were the walk's seeds).
+fn entry_live<G>(reg: &Registry<G>, liveness: Liveness, key: &crate::Key, live: &LiveSet) -> bool {
+    use crate::Key;
+    match liveness {
+        Liveness::Pinned | Liveness::Root => true,
+        Liveness::WithName => match key {
+            Key::Name(name) => reg.head(name).is_some_and(|ca| live.commits.contains(&ca)),
+            _ => false,
+        },
+        Liveness::WithCommit => match key {
+            Key::Commit(ca) => live.commits.contains(ca),
+            _ => false,
+        },
+        Liveness::WithGraph => match key {
+            Key::Graph(ga) => live.graphs.contains(ga),
+            _ => false,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ContentAddr, Key, MergePolicy, Name, registry::section_insert_datum};
+    use std::collections::BTreeMap;
+    use std::time::Duration;
+
+    fn graph_addr(n: u8) -> GraphAddr {
+        GraphAddr::from(ContentAddr::from([n; 32]))
+    }
+
+    fn name(s: &str) -> Name {
+        s.parse().unwrap()
+    }
+
+    /// A registry whose "graphs" are lists of nested graph addrs, so
+    /// `graph_out` can be pure data.
+    type TestGraph = Vec<GraphAddr>;
+
+    fn out(g: &TestGraph) -> OutRefs {
+        OutRefs {
+            graphs: g.clone(),
+            blobs: vec![],
+        }
+    }
+
+    /// Add a graph of raw nested addrs under a synthetic address (the test
+    /// graph type is plain data, so petgraph hashing does not apply).
+    fn add_test_graph(reg: &mut Registry<TestGraph>, n: u8, nested: TestGraph) -> GraphAddr {
+        let ga = graph_addr(n);
+        reg.insert_graph_at(ga, nested);
+        ga
+    }
+
+    #[test]
+    fn closure_walks_heads_parents_and_nested_graphs() {
+        let mut reg: Registry<TestGraph> = Registry::default();
+        let nested = add_test_graph(&mut reg, 1, vec![]);
+        let root_ga = add_test_graph(&mut reg, 2, vec![nested]);
+        let c1 = reg.commit_graph(Duration::from_secs(1), None, root_ga, || unreachable!());
+        let c2 = reg.commit_graph(Duration::from_secs(2), Some(c1), root_ga, || unreachable!());
+        reg.set_head(name("alpha"), c2);
+        let dead_ga = add_test_graph(&mut reg, 3, vec![graph_addr(99)]);
+        let _dead = reg.commit_graph(Duration::from_secs(3), None, dead_ga, || unreachable!());
+        let live = closure(&reg, [], out);
+        assert!(live.commits.contains(&c1));
+        assert!(live.commits.contains(&c2));
+        assert!(live.graphs.contains(&root_ga));
+        assert!(live.graphs.contains(&nested));
+        assert!(!live.graphs.contains(&dead_ga));
+        assert_eq!(live.commits.len(), 2);
+    }
+
+    #[test]
+    fn graphs_stay_live_through_content_refs_without_commits() {
+        let mut reg: Registry<TestGraph> = Registry::default();
+        let nested = add_test_graph(&mut reg, 1, vec![]);
+        let root_ga = add_test_graph(&mut reg, 2, vec![nested]);
+        let c = reg.commit_graph(Duration::from_secs(1), None, root_ga, || unreachable!());
+        reg.set_head(name("alpha"), c);
+        let live = closure(&reg, [], out);
+        prune(&mut reg, &live);
+        assert!(reg.graph(&nested).is_some());
+    }
+
+    #[test]
+    fn prune_drops_dead_content_and_sections_follow() {
+        let mut reg: Registry<TestGraph> = Registry::default();
+        let ga = add_test_graph(&mut reg, 1, vec![]);
+        let live_c = reg.commit_graph(Duration::from_secs(1), None, ga, || unreachable!());
+        let dead_c = reg.commit_graph(Duration::from_secs(2), None, ga, || unreachable!());
+        reg.set_head(name("alpha"), live_c);
+        for ca in [live_c, dead_c] {
+            section_insert_datum(
+                &mut reg,
+                "test.view",
+                MergePolicy::KeepExisting,
+                Liveness::WithCommit,
+                Key::Commit(ca),
+                &"view".to_string(),
+            )
+            .unwrap();
+        }
+        let live = closure(&reg, [], out);
+        prune(&mut reg, &live);
+        assert!(reg.commits().contains_key(&live_c));
+        assert!(!reg.commits().contains_key(&dead_c));
+        let section = reg.section("test.view").unwrap();
+        assert!(section.entries.contains_key(&Key::Commit(live_c)));
+        assert!(!section.entries.contains_key(&Key::Commit(dead_c)));
+    }
+
+    #[test]
+    fn prune_detaches_pruned_parents() {
+        let mut reg: Registry<TestGraph> = Registry::default();
+        let ga = add_test_graph(&mut reg, 1, vec![]);
+        let old = reg.commit_graph(Duration::from_secs(1), None, ga, || unreachable!());
+        let tip = reg.commit_graph(Duration::from_secs(2), Some(old), ga, || unreachable!());
+        reg.set_head(name("alpha"), tip);
+        let live = LiveSet {
+            commits: [tip].into_iter().collect(),
+            graphs: [ga].into_iter().collect(),
+            blobs: BTreeMap::new(),
+        };
+        prune(&mut reg, &live);
+        assert!(!reg.commits().contains_key(&old));
+        assert_eq!(reg.commits()[&tip].parent, None);
+    }
+
+    #[test]
+    fn blob_liveness_follows_content_refs() {
+        let mut reg: Registry<TestGraph> = Registry::default();
+        let used = reg.add_blob("dsp.buffer", BlobLiveness::ContentReferenced, &b"used"[..]);
+        let unused = reg.add_blob(
+            "dsp.buffer",
+            BlobLiveness::ContentReferenced,
+            &b"unused"[..],
+        );
+        let ga = add_test_graph(&mut reg, 1, vec![]);
+        let c = reg.commit_graph(Duration::from_secs(1), None, ga, || unreachable!());
+        reg.set_head(name("alpha"), c);
+        let graph_out = |_: &TestGraph| OutRefs {
+            graphs: vec![],
+            blobs: vec![("dsp.buffer".to_string(), used)],
+        };
+        let live = closure(&reg, [], graph_out);
+        assert!(live.blob_live("dsp.buffer", &used));
+        assert!(!live.blob_live("dsp.buffer", &unused));
+        prune(&mut reg, &live);
+        assert!(reg.blob("dsp.buffer", &used).is_some());
+        assert!(reg.blob("dsp.buffer", &unused).is_none());
+    }
+
+    #[test]
+    fn blob_liveness_follows_section_values() {
+        let mut reg: Registry<TestGraph> = Registry::default();
+        let pinned_by_section =
+            reg.add_blob("ui.assets", BlobLiveness::SectionReferenced, &b"icon"[..]);
+        let orphan = reg.add_blob("ui.assets", BlobLiveness::SectionReferenced, &b"old"[..]);
+        let ga = add_test_graph(&mut reg, 1, vec![]);
+        let c = reg.commit_graph(Duration::from_secs(1), None, ga, || unreachable!());
+        reg.set_head(name("alpha"), c);
+        reg.set_section_value(
+            "test.icons",
+            MergePolicy::KeepExisting,
+            Liveness::WithName,
+            Key::Name(name("alpha")),
+            Value::Blob("ui.assets".to_string(), pinned_by_section),
+        );
+        let live = closure(&reg, [], out);
+        assert!(live.blob_live("ui.assets", &pinned_by_section));
+        assert!(!live.blob_live("ui.assets", &orphan));
+    }
+
+    #[test]
+    fn export_filters_heads_to_exported_commits() {
+        let mut reg: Registry<TestGraph> = Registry::default();
+        let ga = add_test_graph(&mut reg, 1, vec![]);
+        let ca = reg.commit_graph(Duration::from_secs(1), None, ga, || unreachable!());
+        let cb = reg.commit_graph(Duration::from_secs(2), None, ga, || unreachable!());
+        reg.set_head(name("alpha"), ca);
+        reg.set_head(name("beta"), cb);
+        // Alpha's closure only.
+        let live = LiveSet {
+            commits: [ca].into_iter().collect(),
+            graphs: [ga].into_iter().collect(),
+            blobs: BTreeMap::new(),
+        };
+        let exported = export(&reg, &live);
+        assert_eq!(exported.head(&name("alpha")), Some(ca));
+        assert_eq!(exported.head(&name("beta")), None);
+        assert!(exported.commits().contains_key(&ca));
+        assert!(!exported.commits().contains_key(&cb));
+        // The source registry is untouched.
+        assert_eq!(reg.head(&name("beta")), Some(cb));
+    }
+
+    #[test]
+    fn export_keeps_with_name_metadata_for_exported_heads_only() {
+        let mut reg: Registry<TestGraph> = Registry::default();
+        let ga = add_test_graph(&mut reg, 1, vec![]);
+        let ca = reg.commit_graph(Duration::from_secs(1), None, ga, || unreachable!());
+        let cb = reg.commit_graph(Duration::from_secs(2), None, ga, || unreachable!());
+        reg.set_head(name("alpha"), ca);
+        reg.set_head(name("beta"), cb);
+        for n in ["alpha", "beta"] {
+            section_insert_datum(
+                &mut reg,
+                "test.description",
+                MergePolicy::KeepExisting,
+                Liveness::WithName,
+                Key::Name(name(n)),
+                &format!("doc for {n}"),
+            )
+            .unwrap();
+        }
+        let live = LiveSet {
+            commits: [ca].into_iter().collect(),
+            graphs: [ga].into_iter().collect(),
+            blobs: BTreeMap::new(),
+        };
+        let exported = export(&reg, &live);
+        let section = exported.section("test.description").unwrap();
+        assert!(section.entries.contains_key(&Key::Name(name("alpha"))));
+        assert!(!section.entries.contains_key(&Key::Name(name("beta"))));
+    }
+
+    #[test]
+    fn unknown_section_survives_export_and_merge() {
+        let mut reg: Registry<TestGraph> = Registry::default();
+        let ga = add_test_graph(&mut reg, 1, vec![]);
+        let ca = reg.commit_graph(Duration::from_secs(1), None, ga, || unreachable!());
+        reg.set_head(name("alpha"), ca);
+        section_insert_datum(
+            &mut reg,
+            "laser.palette",
+            MergePolicy::KeepExisting,
+            Liveness::Pinned,
+            Key::Name(name("show")),
+            &vec![255u8, 0, 128],
+        )
+        .unwrap();
+        let live = closure(&reg, [], out);
+        let exported = export(&reg, &live);
+        assert!(exported.section("laser.palette").is_some());
+        let mut other: Registry<TestGraph> = Registry::default();
+        other.merge(exported);
+        let section = other.section("laser.palette").unwrap();
+        assert_eq!(section.entries.len(), 1);
+        assert_eq!(section.liveness, Liveness::Pinned);
+    }
+
+    #[test]
+    fn export_of_nothing_is_empty() {
+        let mut reg: Registry<TestGraph> = Registry::default();
+        let ga = add_test_graph(&mut reg, 1, vec![]);
+        let ca = reg.commit_graph(Duration::from_secs(1), None, ga, || unreachable!());
+        reg.set_head(name("alpha"), ca);
+        let exported = export(&reg, &LiveSet::default());
+        assert!(exported.commits().is_empty());
+        assert!(exported.graphs().is_empty());
+        assert_eq!(exported.head(&name("alpha")), None);
+        assert!(exported.sections().is_empty());
+    }
+}

--- a/crates/gantz_ca/src/reach.rs
+++ b/crates/gantz_ca/src/reach.rs
@@ -59,22 +59,34 @@ pub fn closure<G>(
     extra_commits: impl IntoIterator<Item = CommitAddr>,
     graph_out: impl Fn(&G) -> OutRefs,
 ) -> LiveSet {
+    // Roots: every commit-valued entry of every Root-liveness section.
+    let roots = reg
+        .sections()
+        .values()
+        .filter(|section| section.liveness == Liveness::Root)
+        .flat_map(|section| section.entries.values())
+        .filter_map(|value| match value {
+            Value::Commit(ca) => Some(*ca),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    closure_from(reg, roots.into_iter().chain(extra_commits), graph_out)
+}
+
+/// The live closure of `reg` from ONLY the given commit seeds, ignoring the
+/// registry's own roots.
+///
+/// For minimal exports of a specific head set. [`closure`] is this plus the
+/// `Root`-liveness section seeds.
+pub fn closure_from<G>(
+    reg: &Registry<G>,
+    seeds: impl IntoIterator<Item = CommitAddr>,
+    graph_out: impl Fn(&G) -> OutRefs,
+) -> LiveSet {
     let mut live = LiveSet::default();
     let mut commit_queue: VecDeque<CommitAddr> = VecDeque::new();
     let mut graph_queue: VecDeque<GraphAddr> = VecDeque::new();
-
-    // Roots: every commit-valued entry of every Root-liveness section.
-    for section in reg.sections().values() {
-        if section.liveness != Liveness::Root {
-            continue;
-        }
-        for value in section.entries.values() {
-            if let Value::Commit(ca) = value {
-                commit_queue.push_back(*ca);
-            }
-        }
-    }
-    commit_queue.extend(extra_commits);
+    commit_queue.extend(seeds);
 
     while let Some(ca) = commit_queue.pop_front() {
         let Some(commit) = reg.commits().get(&ca) else {

--- a/crates/gantz_ca/src/registry.rs
+++ b/crates/gantz_ca/src/registry.rs
@@ -70,6 +70,9 @@ pub struct Heads;
 pub type Graphs<G> = HashMap<GraphAddr, G>;
 pub type Commits = HashMap<CommitAddr, Commit>;
 
+/// The id of the core [`Heads`] section.
+pub const HEADS_ID: &str = "heads";
+
 /// The result of merging an incoming registry into an existing one.
 #[derive(Clone, Debug, Default)]
 pub struct MergeReport {
@@ -84,7 +87,7 @@ pub struct MergeReport {
 }
 
 impl SectionDecl for Heads {
-    const ID: &'static str = "heads";
+    const ID: &'static str = HEADS_ID;
     const POLICY: MergePolicy = MergePolicy::Replace;
     const LIVENESS: Liveness = Liveness::Root;
     type Key = Name;

--- a/crates/gantz_ca/src/registry.rs
+++ b/crates/gantz_ca/src/registry.rs
@@ -1,6 +1,39 @@
-//! A registry tracking graphs, commits and names (branches).
+//! The registry: content-addressed content columns plus open metadata
+//! sections.
+//!
+//! The registry has exactly two parts:
+//!
+//! - The CONTENT columns ([`graphs`](Registry::graphs),
+//!   [`commits`](Registry::commits) and per-section
+//!   [`blobs`](Registry::blobs)): immutable, content-addressed, insert-only
+//!   (modulo [`prune`](crate::reach::prune)).
+//! - The [`sections`](Registry::sections): ALL mutable state. Heads
+//!   (branches) are the core-declared [`Heads`] section. Domains attach
+//!   their own metadata by declaring a [`SectionDecl`] in their own crate -
+//!   the registry core never learns domain types, and sections carry their
+//!   merge policy and liveness rules as data so unknown sections are
+//!   merged, pruned, exported and round-tripped correctly.
+//!
+//! Content forms a pure Merkle DAG: graphs reference nested graphs by
+//! [`GraphAddr`] and blobs by content address, so content identity depends
+//! only on content. Commits form the history DAG above it (timestamps live
+//! there). Names point at commits, naming lines of history.
+//!
+//! Registry invariant: commits are parent-closed and graph-complete. Every
+//! stored commit's parents are present or detached (never dangling) and its
+//! graph is present. Maintained by [`add_commit`](Registry::add_commit)
+//! (clears absent parents before hashing), [`sync::Staged::apply`]
+//! (validates or detaches) and [`prune`](crate::reach::prune) (detaches
+//! after removal).
+//!
+//! [`sync::Staged::apply`]: crate::sync::Staged
 
-use crate::{CaHash, Commit, CommitAddr, GraphAddr, Head, Timestamp, commit_addr, graph_addr};
+use crate::section::{TryFromKey, value_to_datum};
+use crate::{
+    BlobLiveness, BlobStore, Bytes, CaHash, Commit, CommitAddr, ContentAddr, GraphAddr, Head, Key,
+    Liveness, MergePolicy, Name, Section, SectionDecl, SectionId, Timestamp, Value, commit_addr,
+    datum::DatumError, graph_addr,
+};
 use petgraph::visit::{Data, GraphBase, IntoEdgeReferences, IntoNodeReferences, NodeIndexable};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -8,9 +41,9 @@ use std::{
     hash::Hash,
 };
 
-/// A registry of content-addressed graphs, commits of those graphs, and
-/// optional names for those commits.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+/// A registry of content-addressed graphs, commits of those graphs, blob
+/// stores, and metadata sections. See the module docs.
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(bound(serialize = "G: Serialize", deserialize = "G: Deserialize<'de>"))]
 pub struct Registry<G> {
     /// A mapping from graph addresses to graphs.
@@ -19,43 +52,73 @@ pub struct Registry<G> {
     /// A mapping from commit addresses to commits.
     #[serde(serialize_with = "crate::serde_sorted::serialize_map")]
     commits: HashMap<CommitAddr, Commit>,
-    /// A mapping from names to graph content addresses.
-    names: BTreeMap<String, CommitAddr>,
-    /// Optional human-facing descriptions for named graphs, keyed by name.
-    ///
-    /// A sibling of [`names`](Self::names): both are mutable, name-keyed
-    /// metadata rather than content. Empty by default and omitted from
-    /// serialized output, so older `.gantz` files load unchanged.
+    /// Content-addressed blob stores, one per section.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    descriptions: BTreeMap<String, String>,
+    blobs: BTreeMap<SectionId, BlobStore>,
+    /// Mutable metadata sections, `heads` among them.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    sections: BTreeMap<SectionId, Section>,
 }
+
+/// The core `heads` section: maps names to the commits at the tips of their
+/// lines of history.
+///
+/// Merge-replace (an incoming head wins, reported in [`MergeReport`]) and
+/// the roots of reachability.
+pub struct Heads;
 
 pub type Graphs<G> = HashMap<GraphAddr, G>;
 pub type Commits = HashMap<CommitAddr, Commit>;
-pub type Names = BTreeMap<String, CommitAddr>;
 
 /// The result of merging an incoming registry into an existing one.
 #[derive(Clone, Debug, Default)]
-pub struct MergeResult {
-    /// Names that were newly added.
-    pub names_added: Vec<String>,
-    /// Names that were replaced (pointed to a different commit): (name, old, new).
-    pub names_replaced: Vec<(String, CommitAddr, CommitAddr)>,
+pub struct MergeReport {
+    /// Head names that were newly added.
+    pub heads_added: Vec<Name>,
+    /// Head names that were repointed: (name, old, new).
+    pub heads_replaced: Vec<(Name, CommitAddr, CommitAddr)>,
+    /// Non-head section entries that were newly added.
+    pub sections_added: Vec<(SectionId, Key)>,
+    /// Non-head section entries replaced under a `Replace` policy section.
+    pub sections_replaced: Vec<(SectionId, Key)>,
+}
+
+impl SectionDecl for Heads {
+    const ID: &'static str = "heads";
+    const POLICY: MergePolicy = MergePolicy::Replace;
+    const LIVENESS: Liveness = Liveness::Root;
+    type Key = Name;
+    type Value = CommitAddr;
+
+    fn encode(value: &Self::Value) -> Result<Value, DatumError> {
+        Ok(Value::Commit(*value))
+    }
+
+    fn decode(value: &Value) -> Option<Self::Value> {
+        match value {
+            Value::Commit(ca) => Some(*ca),
+            _ => None,
+        }
+    }
 }
 
 impl<G> Registry<G> {
-    /// Construct the registry from its parts.
-    pub fn new(
+    /// Construct a registry from content columns and head mappings.
+    pub fn from_parts(
         graphs: HashMap<GraphAddr, G>,
         commits: HashMap<CommitAddr, Commit>,
-        names: BTreeMap<String, CommitAddr>,
+        heads: BTreeMap<Name, CommitAddr>,
     ) -> Self {
-        Self {
+        let mut reg = Self {
             graphs,
             commits,
-            names,
-            descriptions: BTreeMap::new(),
+            blobs: BTreeMap::new(),
+            sections: BTreeMap::new(),
+        };
+        for (name, ca) in heads {
+            reg.set_head(name, ca);
         }
+        reg
     }
 
     /// A mapping from graph addresses to graphs.
@@ -68,50 +131,111 @@ impl<G> Registry<G> {
         &self.commits
     }
 
-    /// A mapping from names to graph content addresses.
-    pub fn names(&self) -> &Names {
-        &self.names
+    /// The blob stores, keyed by section.
+    pub fn blobs(&self) -> &BTreeMap<SectionId, BlobStore> {
+        &self.blobs
     }
 
-    /// A mapping from names to their human-facing descriptions.
-    pub fn descriptions(&self) -> &BTreeMap<String, String> {
-        &self.descriptions
+    /// The metadata sections, keyed by section id.
+    pub fn sections(&self) -> &BTreeMap<SectionId, Section> {
+        &self.sections
     }
 
-    /// The description for the given name, if any.
-    pub fn description(&self, name: &str) -> Option<&str> {
-        self.descriptions.get(name).map(String::as_str)
+    /// The graph stored at the given address.
+    pub fn graph(&self, ga: &GraphAddr) -> Option<&G> {
+        self.graphs.get(ga)
     }
 
-    /// Set (or, when given an empty string, clear) the description for `name`.
-    pub fn set_description(&mut self, name: String, description: String) {
-        if description.is_empty() {
-            self.descriptions.remove(&name);
-        } else {
-            self.descriptions.insert(name, description);
+    /// The bytes stored at the given address in the given blob section.
+    pub fn blob(&self, section: &str, addr: &ContentAddr) -> Option<&Bytes> {
+        self.blobs.get(section).and_then(|store| store.get(addr))
+    }
+
+    /// The section with the given id, if any.
+    pub fn section(&self, id: &str) -> Option<&Section> {
+        self.sections.get(id)
+    }
+
+    /// The raw value stored under `key` in the section with the given id.
+    pub fn section_entry(&self, id: &str, key: &Key) -> Option<&Value> {
+        self.sections.get(id).and_then(|s| s.entries.get(key))
+    }
+
+    // -- Heads --
+
+    /// The commit at the tip of the named line of history.
+    pub fn head(&self, name: &Name) -> Option<CommitAddr> {
+        section_get::<Heads, G>(self, name)
+    }
+
+    /// All heads, ordered by name.
+    pub fn heads(&self) -> impl Iterator<Item = (&Name, CommitAddr)> + '_ {
+        self.sections
+            .get(Heads::ID)
+            .into_iter()
+            .flat_map(|s| s.entries.iter())
+            .filter_map(|(key, value)| match (key, value) {
+                (Key::Name(name), Value::Commit(ca)) => Some((name, *ca)),
+                _ => None,
+            })
+    }
+
+    /// Point the named head at the given commit.
+    ///
+    /// Returns the previous commit if the head existed.
+    pub fn set_head(&mut self, name: Name, ca: CommitAddr) -> Option<CommitAddr> {
+        let prev = section_insert_value::<G>(
+            self,
+            Heads::ID,
+            Heads::POLICY,
+            Heads::LIVENESS,
+            Key::Name(name),
+            Value::Commit(ca),
+        );
+        prev.as_ref().and_then(Heads::decode)
+    }
+
+    /// Remove the named head.
+    ///
+    /// Entries keyed by this name in `WithName`-liveness sections are
+    /// dropped with it (their subject is gone).
+    pub fn remove_head(&mut self, name: &Name) -> Option<CommitAddr> {
+        let key = Key::Name(name.clone());
+        let prev = self
+            .sections
+            .get_mut(Heads::ID)
+            .and_then(|s| s.entries.remove(&key));
+        for section in self.sections.values_mut() {
+            if section.liveness == Liveness::WithName {
+                section.entries.remove(&key);
+            }
         }
-    }
-
-    /// Lookup the commit for the given name.
-    pub fn named_commit(&self, name: &str) -> Option<&Commit> {
-        self.names.get(name).and_then(|ca| self.commits.get(ca))
+        prev.as_ref().and_then(Heads::decode)
     }
 
     /// Look-up the commit address pointed to by the given head.
-    pub fn head_commit_ca<'a>(&'a self, head: &'a Head) -> Option<&'a CommitAddr> {
-        head_commit_ca(&self.names, head)
+    pub fn head_commit_ca(&self, head: &Head) -> Option<CommitAddr> {
+        match head {
+            Head::Branch(name) => self.head(name),
+            Head::Commit(ca) => Some(*ca),
+        }
     }
 
     /// Look-up the commit pointed to by the given head.
-    pub fn head_commit<'a>(&'a self, head: &'a Head) -> Option<&'a Commit> {
+    pub fn head_commit(&self, head: &Head) -> Option<&Commit> {
         self.head_commit_ca(head)
             .and_then(|ca| self.commits.get(&ca))
     }
 
     /// Look-up the graph pointed to by the head.
-    pub fn head_graph<'a>(&'a self, head: &'a Head) -> Option<&'a G> {
+    pub fn head_graph(&self, head: &Head) -> Option<&G> {
         self.head_commit(head)
             .and_then(|commit| self.graphs.get(&commit.graph))
+    }
+
+    /// Lookup the commit for the given name.
+    pub fn named_commit(&self, name: &Name) -> Option<&Commit> {
+        self.head(name).and_then(|ca| self.commits.get(&ca))
     }
 
     /// Look-up the graph pointed to by the given commit address.
@@ -120,6 +244,8 @@ impl<G> Registry<G> {
             .get(ca)
             .and_then(|commit| self.graphs.get(&commit.graph))
     }
+
+    // -- Content mutation --
 
     /// Commit the graph at the given address.
     ///
@@ -132,7 +258,7 @@ impl<G> Registry<G> {
         graph_ca: GraphAddr,
         graph: impl FnOnce() -> G,
     ) -> CommitAddr {
-        commit_graph(self, timestamp, parent_ca, graph_ca, graph)
+        crate::ops::commit_graph(self, timestamp, parent_ca, graph_ca, graph)
     }
 
     /// Commit the graph to the given name.
@@ -144,16 +270,16 @@ impl<G> Registry<G> {
         timestamp: Timestamp,
         graph_ca: GraphAddr,
         graph: impl FnOnce() -> G,
-        name: &str,
+        name: &Name,
     ) -> CommitAddr {
-        commit_graph_to_name(self, timestamp, graph_ca, graph, name)
+        crate::ops::commit_graph_to_name(self, timestamp, graph_ca, graph, name)
     }
 
-    /// Commit the graph at the given address and update `head` to a new commit
-    /// pointing to the graph.
+    /// Commit the graph at the given address and update `head` to a new
+    /// commit pointing to the graph.
     ///
-    /// Only calls `graph` if no graph exists within the registry for the given
-    /// address.
+    /// Only calls `graph` if no graph exists within the registry for the
+    /// given address.
     ///
     /// NOTE: Assumes `graph_ca` is a correct address for the graph resulting
     /// from `graph()`.
@@ -164,17 +290,17 @@ impl<G> Registry<G> {
         graph: impl FnOnce() -> G,
         head: &mut Head,
     ) -> CommitAddr {
-        commit_graph_to_head(self, timestamp, graph_ca, graph, head)
+        crate::ops::commit_graph_to_head(self, timestamp, graph_ca, graph, head)
     }
 
     /// Commit the graph at the given address as a merge of `theirs` into the
     /// current head commit, and update `head` to the new merge commit.
     ///
-    /// The head's current commit becomes the first parent, `theirs` the merge
-    /// parent.
+    /// The head's current commit becomes the first parent, `theirs` the
+    /// merge parent.
     ///
-    /// Only calls `graph` if no graph exists within the registry for the given
-    /// address.
+    /// Only calls `graph` if no graph exists within the registry for the
+    /// given address.
     ///
     /// NOTE: Assumes `graph_ca` is a correct address for the graph resulting
     /// from `graph()`.
@@ -186,7 +312,7 @@ impl<G> Registry<G> {
         theirs: CommitAddr,
         head: &mut Head,
     ) -> CommitAddr {
-        commit_merge_to_head(self, timestamp, graph_ca, graph, theirs, head)
+        crate::ops::commit_merge_to_head(self, timestamp, graph_ca, graph, theirs, head)
     }
 
     /// Commit the graph at the given address as a *canonical* merge of the
@@ -195,18 +321,17 @@ impl<G> Registry<G> {
     /// Unlike [`commit_merge_to_head`](Self::commit_merge_to_head), which
     /// keeps the head's tip as the first parent, both the parent order and
     /// the timestamp here are pure functions of the two tips (see
-    /// `sync::canonical_tips` and
-    /// `sync::merge_timestamp`): peers that
-    /// merge the same pair independently mint the *identical* merge commit,
-    /// which is what lets their DAGs converge rather than re-diverge.
+    /// `sync::canonical_tips` and `sync::merge_timestamp`): peers that merge
+    /// the same pair independently mint the *identical* merge commit, which
+    /// is what lets their DAGs converge rather than re-diverge.
     ///
     /// The caller must have produced the graph by merging in the same
     /// canonical orientation (see
     /// [`sync::plan_sync_step`](crate::sync::plan_sync_step)), as the merged
     /// graph's node order depends on which side plays "ours".
     ///
-    /// Only calls `graph` if no graph exists within the registry for the given
-    /// address.
+    /// Only calls `graph` if no graph exists within the registry for the
+    /// given address.
     ///
     /// NOTE: Assumes `graph_ca` is a correct address for the graph resulting
     /// from `graph()`.
@@ -218,24 +343,17 @@ impl<G> Registry<G> {
         graph: impl FnOnce() -> G,
         head: &mut Head,
     ) -> CommitAddr {
-        commit_merge_canonical(self, a, b, graph_ca, graph, head)
-    }
-
-    /// Insert the given name mapping into the registry.
-    ///
-    /// Returns the previous mapping if one exists.
-    pub fn insert_name(&mut self, name: String, ca: CommitAddr) -> Option<CommitAddr> {
-        self.names.insert(name, ca)
+        crate::ops::commit_merge_canonical(self, a, b, graph_ca, graph, head)
     }
 
     /// Insert a commit, computing its address from the commit's contents.
     ///
-    /// A commit must not reference a parent that is not in the registry, so a
-    /// parent that is absent is cleared to `None` (and absent merge parents
-    /// are dropped) *before* the address is computed. Because parents are part
-    /// of the hashed content, the returned address reflects the cleared
-    /// parents: to preserve a chain's addresses, insert its commits
-    /// oldest-first so each parent is already present.
+    /// A commit must not reference a parent that is not in the registry, so
+    /// a parent that is absent is cleared to `None` (and absent merge
+    /// parents are dropped) *before* the address is computed. Because
+    /// parents are part of the hashed content, the returned address reflects
+    /// the cleared parents: to preserve a chain's addresses, insert its
+    /// commits oldest-first so each parent is already present.
     ///
     /// Returns the computed [`CommitAddr`], which always matches the stored
     /// commit.
@@ -266,6 +384,23 @@ impl<G> Registry<G> {
         self.graphs.entry(ca).or_insert(graph);
     }
 
+    /// Insert verified blob bytes under a claimed address, used only by
+    /// [`sync::Staged::apply`](crate::sync::Staged).
+    pub(crate) fn insert_blob_at(
+        &mut self,
+        section: SectionId,
+        liveness: BlobLiveness,
+        addr: ContentAddr,
+        bytes: Bytes,
+    ) {
+        self.blobs
+            .entry(section)
+            .or_insert_with(|| BlobStore::new(liveness))
+            .entries
+            .entry(addr)
+            .or_insert(bytes);
+    }
+
     /// Insert a graph, computing its address from the graph's contents.
     ///
     /// Returns the computed [`GraphAddr`], which always matches the graph.
@@ -287,96 +422,139 @@ impl<G> Registry<G> {
         ca
     }
 
-    /// Remove the given name from the registry.
+    /// Insert bytes into the named blob section, computing their address.
     ///
-    /// This does not remove the underlying commit, just the name mapping (and
-    /// any description associated with the name).
-    pub fn remove_name(&mut self, name: &str) -> Option<CommitAddr> {
-        self.descriptions.remove(name);
-        self.names.remove(name)
+    /// Creates the section with the given liveness if absent (an existing
+    /// section's stored liveness wins).
+    pub fn add_blob(
+        &mut self,
+        section: impl Into<SectionId>,
+        liveness: BlobLiveness,
+        bytes: impl Into<Bytes>,
+    ) -> ContentAddr {
+        self.blobs
+            .entry(section.into())
+            .or_insert_with(|| BlobStore::new(liveness))
+            .insert(bytes)
     }
 
-    /// Prune commits and graphs not in the required set.
+    /// Insert a raw value into the section with the given id, creating the
+    /// section (stamped with the given semantics) on first write. An
+    /// existing section's stored semantics win.
     ///
-    /// 1. Removes commits not in `required_commits`
-    /// 2. Removes graphs not referenced by any remaining commit
-    /// 3. Detaches invalid parent references
-    pub fn prune_unreachable(&mut self, required_commits: &HashSet<CommitAddr>) {
-        self.commits.retain(|ca, _| required_commits.contains(ca));
-        let used_graphs: HashSet<_> = self.commits.values().map(|c| c.graph).collect();
-        self.graphs.retain(|ca, _| used_graphs.contains(ca));
+    /// Returns the previous value, if any. Typed callers use
+    /// [`section_insert`].
+    pub fn set_section_value(
+        &mut self,
+        id: impl Into<SectionId>,
+        policy: MergePolicy,
+        liveness: Liveness,
+        key: Key,
+        value: Value,
+    ) -> Option<Value> {
+        self.sections
+            .entry(id.into())
+            .or_insert_with(|| Section::new(policy, liveness))
+            .entries
+            .insert(key, value)
+    }
+
+    /// Remove the entry under `key` from the section with the given id.
+    pub fn remove_section_entry(&mut self, id: &str, key: &Key) -> Option<Value> {
+        self.sections
+            .get_mut(id)
+            .and_then(|s| s.entries.remove(key))
+    }
+
+    /// Retain only the live content and the section entries whose stored
+    /// liveness rule holds against the surviving state. See
+    /// [`reach::prune`](crate::reach::prune).
+    pub(crate) fn retain_live(&mut self, live: &crate::reach::LiveSet) {
+        // Content columns.
+        self.commits.retain(|ca, _| live.commits.contains(ca));
+        self.graphs.retain(|ga, _| live.graphs.contains(ga));
+        for (id, store) in &mut self.blobs {
+            store.entries.retain(|addr, _| live.blob_live(id, addr));
+        }
+        // Root sections first (heads): entries follow their commit values,
+        // so the WithName pass below sees the surviving heads.
+        for section in self.sections.values_mut() {
+            if section.liveness != Liveness::Root {
+                continue;
+            }
+            section.entries.retain(|_, value| match value {
+                Value::Commit(ca) => live.commits.contains(ca),
+                _ => true,
+            });
+        }
+        let head_names: HashSet<Name> = self.heads().map(|(n, _)| n.clone()).collect();
+        for section in self.sections.values_mut() {
+            let liveness = section.liveness;
+            if liveness == Liveness::Root {
+                continue;
+            }
+            section.entries.retain(|key, _| match liveness {
+                Liveness::Root | Liveness::Pinned => true,
+                Liveness::WithName => {
+                    matches!(key, Key::Name(name) if head_names.contains(name))
+                }
+                Liveness::WithCommit => {
+                    matches!(key, Key::Commit(ca) if live.commits.contains(ca))
+                }
+                Liveness::WithGraph => {
+                    matches!(key, Key::Graph(ga) if live.graphs.contains(ga))
+                }
+            });
+        }
+        // Emptied sections and stores carry no data worth serializing. A
+        // later write re-stamps semantics from the writer's declaration.
+        self.sections.retain(|_, s| !s.entries.is_empty());
+        self.blobs.retain(|_, s| !s.entries.is_empty());
         detach_invalid_parents(&mut self.commits);
     }
 
     /// Merge an incoming registry into this one.
     ///
-    /// Graphs and commits are inserted idempotently (content-addressing means
-    /// duplicates are identical). Names are merged: absent names are added,
-    /// same-commit names are kept, different-commit names are replaced.
-    pub fn merge(&mut self, incoming: Registry<G>) -> MergeResult {
+    /// Graphs, commits and blobs are inserted idempotently
+    /// (content-addressing means duplicates are identical). Sections merge
+    /// per their stored policy: `Replace` entries are overwritten by
+    /// differing incoming entries (and reported), `KeepExisting` entries
+    /// keep the local value. An incoming section unknown locally is adopted
+    /// wholesale, semantics and all.
+    pub fn merge(&mut self, incoming: Registry<G>) -> MergeReport {
+        let mut report = MergeReport::default();
         self.graphs.extend(incoming.graphs);
         self.commits.extend(incoming.commits);
-        // Bring over descriptions for names we don't already describe locally,
-        // mirroring how `merge_with` keeps existing views/demos.
-        for (name, description) in incoming.descriptions {
-            self.descriptions.entry(name).or_insert(description);
+        for (id, store) in incoming.blobs {
+            self.blobs
+                .entry(id)
+                .or_insert_with(|| BlobStore::new(store.liveness))
+                .entries
+                .extend(store.entries);
         }
-        let mut result = MergeResult::default();
-        for (name, new_ca) in incoming.names {
-            match self.names.get(&name) {
-                Some(&existing_ca) if existing_ca == new_ca => {}
-                Some(&existing_ca) => {
-                    result
-                        .names_replaced
-                        .push((name.clone(), existing_ca, new_ca));
-                    self.names.insert(name, new_ca);
-                }
-                None => {
-                    result.names_added.push(name.clone());
-                    self.names.insert(name, new_ca);
+        for (id, section) in incoming.sections {
+            let local = self
+                .sections
+                .entry(id.clone())
+                .or_insert_with(|| Section::new(section.policy, section.liveness));
+            for (key, value) in section.entries {
+                match local.entries.get(&key) {
+                    Some(existing) if *existing == value => {}
+                    Some(existing) => match local.policy {
+                        MergePolicy::KeepExisting => {}
+                        MergePolicy::Replace => {
+                            report.record_replaced(&id, &key, existing, &value);
+                            local.entries.insert(key, value);
+                        }
+                    },
+                    None => {
+                        report.record_added(&id, &key);
+                        local.entries.insert(key, value);
+                    }
                 }
             }
         }
-        result
-    }
-}
-
-impl<G> Registry<G>
-where
-    G: Clone,
-{
-    /// Export a subset of the registry containing only the given commits and
-    /// their referenced graphs and names.
-    pub fn export(&self, required_commits: &HashSet<CommitAddr>) -> Registry<G> {
-        let commits: HashMap<CommitAddr, Commit> = self
-            .commits
-            .iter()
-            .filter(|(ca, _)| required_commits.contains(ca))
-            .map(|(&ca, commit)| (ca, commit.clone()))
-            .collect();
-        let used_graphs: HashSet<GraphAddr> = commits.values().map(|c| c.graph).collect();
-        let graphs: HashMap<GraphAddr, G> = self
-            .graphs
-            .iter()
-            .filter(|(ca, _)| used_graphs.contains(ca))
-            .map(|(&ca, g)| (ca, g.clone()))
-            .collect();
-        let names: BTreeMap<String, CommitAddr> = self
-            .names
-            .iter()
-            .filter(|(_, ca)| required_commits.contains(ca))
-            .map(|(name, &ca)| (name.clone(), ca))
-            .collect();
-        // Carry descriptions only for the names that survived the filter.
-        let descriptions: BTreeMap<String, String> = self
-            .descriptions
-            .iter()
-            .filter(|(name, _)| names.contains_key(name.as_str()))
-            .map(|(name, desc)| (name.clone(), desc.clone()))
-            .collect();
-        let mut exported = Registry::new(graphs, commits, names);
-        exported.descriptions = descriptions;
-        exported
+        report
     }
 }
 
@@ -403,125 +581,130 @@ where
     }
 }
 
-/// Look-up the commit address pointed to by the given head.
-fn head_commit_ca<'a>(names: &'a Names, head: &'a Head) -> Option<&'a CommitAddr> {
-    match head {
-        Head::Branch(name) => names.get(name),
-        Head::Commit(ca) => Some(ca),
-    }
-}
-
-/// Commit the given graph to the given head.
-///
-/// If the graph doesn't exist, calls `graph()` to retrieve the graph for the
-/// registry.
-fn commit_graph<G>(
-    reg: &mut Registry<G>,
-    timestamp: Timestamp,
-    parent_ca: Option<CommitAddr>,
-    graph_ca: GraphAddr,
-    graph: impl FnOnce() -> G,
-) -> CommitAddr {
-    reg.graphs.entry(graph_ca).or_insert_with(graph);
-    let commit = Commit::new(timestamp, parent_ca, graph_ca);
-    let commit_ca = commit_addr(&commit);
-    reg.commits.insert(commit_ca, commit);
-    commit_ca
-}
-
-/// Commit the given graph to the given name (branch).
-///
-/// If the graph doesn't exist, calls `graph()` to retrieve the graph for the
-/// registry.
-fn commit_graph_to_name<G>(
-    reg: &mut Registry<G>,
-    timestamp: Timestamp,
-    graph_ca: GraphAddr,
-    graph: impl FnOnce() -> G,
-    name: &str,
-) -> CommitAddr {
-    let parent_ca = reg.names.get(name).copied();
-    let commit_ca = commit_graph(reg, timestamp, parent_ca, graph_ca, graph);
-    reg.names.insert(name.to_string(), commit_ca);
-    commit_ca
-}
-
-/// Commit the given graph to the given head.
-///
-/// If the graph doesn't exist, calls `graph()` to retrieve the graph for the
-/// registry.
-fn commit_graph_to_head<G>(
-    reg: &mut Registry<G>,
-    timestamp: Timestamp,
-    graph_ca: GraphAddr,
-    graph: impl FnOnce() -> G,
-    head: &mut Head,
-) -> CommitAddr {
-    let parent_ca = *head_commit_ca(&reg.names, head).unwrap();
-    let commit_ca = commit_graph(reg, timestamp, Some(parent_ca), graph_ca, graph);
-    point_head_at(reg, head, commit_ca);
-    commit_ca
-}
-
-/// Commit the given graph to the given head as a merge of `theirs` into the
-/// head's current commit.
-///
-/// If the graph doesn't exist, calls `graph()` to retrieve the graph for the
-/// registry.
-fn commit_merge_to_head<G>(
-    reg: &mut Registry<G>,
-    timestamp: Timestamp,
-    graph_ca: GraphAddr,
-    graph: impl FnOnce() -> G,
-    theirs: CommitAddr,
-    head: &mut Head,
-) -> CommitAddr {
-    let ours = *head_commit_ca(&reg.names, head).unwrap();
-    reg.graphs.entry(graph_ca).or_insert_with(graph);
-    let commit = Commit::new_merge(timestamp, ours, theirs, graph_ca);
-    let commit_ca = commit_addr(&commit);
-    reg.commits.insert(commit_ca, commit);
-    point_head_at(reg, head, commit_ca);
-    commit_ca
-}
-
-/// Commit the given graph to the given head as a canonical merge of the
-/// diverged tips `a` and `b` (see [`Registry::commit_merge_canonical`]).
-///
-/// If the graph doesn't exist, calls `graph()` to retrieve the graph for the
-/// registry.
-fn commit_merge_canonical<G>(
-    reg: &mut Registry<G>,
-    a: CommitAddr,
-    b: CommitAddr,
-    graph_ca: GraphAddr,
-    graph: impl FnOnce() -> G,
-    head: &mut Head,
-) -> CommitAddr {
-    let (first, second) = crate::sync::canonical_tips(&reg.commits, a, b);
-    let timestamp = crate::sync::merge_timestamp(&reg.commits, first, second);
-    reg.graphs.entry(graph_ca).or_insert_with(graph);
-    let commit = Commit::new_merge(timestamp, first, second, graph_ca);
-    let commit_ca = commit_addr(&commit);
-    reg.commits.insert(commit_ca, commit);
-    point_head_at(reg, head, commit_ca);
-    commit_ca
-}
-
-/// Point the head at the given commit: a branch head updates the name mapping,
-/// a detached head is reassigned directly.
-fn point_head_at<G>(reg: &mut Registry<G>, head: &mut Head, commit_ca: CommitAddr) {
-    match *head {
-        Head::Commit(ref mut ca) => *ca = commit_ca,
-        Head::Branch(ref name) => {
-            reg.names.insert(name.to_string(), commit_ca);
+impl<G> Default for Registry<G> {
+    fn default() -> Self {
+        Self {
+            graphs: HashMap::new(),
+            commits: HashMap::new(),
+            blobs: BTreeMap::new(),
+            sections: BTreeMap::new(),
         }
     }
 }
 
-/// For all `parent` commits that are invalid (i.e. don't point to an existing
-/// commit), set them to `None`. Invalid merge parents are dropped likewise.
-fn detach_invalid_parents(commits: &mut Commits) {
+impl MergeReport {
+    fn record_added(&mut self, id: &str, key: &Key) {
+        if id == Heads::ID {
+            if let Key::Name(name) = key {
+                self.heads_added.push(name.clone());
+                return;
+            }
+        }
+        self.sections_added.push((id.to_string(), key.clone()));
+    }
+
+    fn record_replaced(&mut self, id: &str, key: &Key, old: &Value, new: &Value) {
+        if id == Heads::ID {
+            if let (Key::Name(name), Some(old), Some(new)) =
+                (key, Heads::decode(old), Heads::decode(new))
+            {
+                self.heads_replaced.push((name.clone(), old, new));
+                return;
+            }
+        }
+        self.sections_replaced.push((id.to_string(), key.clone()));
+    }
+}
+
+/// The typed value stored under `key` in `S`'s section, if present and of
+/// the declared shape.
+pub fn section_get<S: SectionDecl, G>(reg: &Registry<G>, key: &S::Key) -> Option<S::Value>
+where
+    S::Key: Clone,
+{
+    let key: Key = key.clone().into();
+    reg.section_entry(S::ID, &key).and_then(S::decode)
+}
+
+/// Insert a typed value under `key` in `S`'s section, creating the section
+/// (stamped with `S`'s declared semantics) on first write.
+pub fn section_insert<S: SectionDecl, G>(
+    reg: &mut Registry<G>,
+    key: S::Key,
+    value: &S::Value,
+) -> Result<(), DatumError> {
+    let value = S::encode(value)?;
+    section_insert_value(reg, S::ID, S::POLICY, S::LIVENESS, key.into(), value);
+    Ok(())
+}
+
+/// Remove the entry under `key` from `S`'s section.
+pub fn section_remove<S: SectionDecl, G>(reg: &mut Registry<G>, key: &S::Key) -> Option<S::Value>
+where
+    S::Key: Clone,
+{
+    let key: Key = key.clone().into();
+    reg.sections
+        .get_mut(S::ID)
+        .and_then(|s| s.entries.remove(&key))
+        .as_ref()
+        .and_then(S::decode)
+}
+
+/// Iterate `S`'s section entries in key order, decoding keys and values.
+/// Entries of an unexpected shape are skipped.
+pub fn section_iter<'a, S: SectionDecl, G>(
+    reg: &'a Registry<G>,
+) -> impl Iterator<Item = (S::Key, S::Value)> + 'a
+where
+    S::Key: 'a,
+    S::Value: 'a,
+{
+    reg.sections
+        .get(S::ID)
+        .into_iter()
+        .flat_map(|s| s.entries.iter())
+        .filter_map(|(key, value)| {
+            let key = S::Key::try_from_key(key)?;
+            let value = S::decode(value)?;
+            Some((key, value))
+        })
+}
+
+/// Encode and insert a datum-valued entry into the section with the given
+/// id, creating the section with the given semantics on first write.
+///
+/// A convenience for erased writers (e.g. format import). Typed callers use
+/// [`section_insert`].
+pub fn section_insert_datum<G>(
+    reg: &mut Registry<G>,
+    id: impl Into<SectionId>,
+    policy: MergePolicy,
+    liveness: Liveness,
+    key: Key,
+    value: &impl Serialize,
+) -> Result<(), DatumError> {
+    let value = value_to_datum(value)?;
+    section_insert_value(reg, &id.into(), policy, liveness, key, value);
+    Ok(())
+}
+
+/// See [`Registry::set_section_value`].
+fn section_insert_value<G>(
+    reg: &mut Registry<G>,
+    id: &str,
+    policy: MergePolicy,
+    liveness: Liveness,
+    key: Key,
+    value: Value,
+) -> Option<Value> {
+    reg.set_section_value(id, policy, liveness, key, value)
+}
+
+/// For all `parent` commits that are invalid (i.e. don't point to an
+/// existing commit), set them to `None`. Invalid merge parents are dropped
+/// likewise.
+pub(crate) fn detach_invalid_parents(commits: &mut Commits) {
     let present: HashSet<CommitAddr> = commits.keys().copied().collect();
     for commit in commits.values_mut() {
         if commit
@@ -548,8 +731,12 @@ mod tests {
         CommitAddr::from(ContentAddr::from([n; 32]))
     }
 
-    /// Build a simple registry with two independent commits (each with its own
-    /// graph) and a name pointing to one of them.
+    fn name(s: &str) -> Name {
+        s.parse().unwrap()
+    }
+
+    /// Build a simple registry with two independent commits (each with its
+    /// own graph) and a head pointing to one of them.
     fn test_registry() -> (Registry<String>, CommitAddr, CommitAddr) {
         let ga = graph_addr(1);
         let gb = graph_addr(2);
@@ -559,176 +746,216 @@ mod tests {
         let commit_b = Commit::new(Duration::from_secs(2), None, gb);
         let graphs = HashMap::from([(ga, "graph_a".to_string()), (gb, "graph_b".to_string())]);
         let commits = HashMap::from([(ca, commit_a), (cb, commit_b)]);
-        let names = BTreeMap::from([("alpha".to_string(), ca)]);
-        (Registry::new(graphs, commits, names), ca, cb)
+        let heads = BTreeMap::from([(name("alpha"), ca)]);
+        (Registry::from_parts(graphs, commits, heads), ca, cb)
     }
 
     #[test]
-    fn export_includes_required_commits_only() {
-        let (reg, ca, cb) = test_registry();
-        let required: HashSet<_> = [ca].into_iter().collect();
-        let exported = reg.export(&required);
-        assert!(exported.commits().contains_key(&ca));
-        assert!(!exported.commits().contains_key(&cb));
-        // Graph referenced by commit_a should be present.
-        let ga = reg.commits()[&ca].graph;
-        assert!(exported.graphs().contains_key(&ga));
-        // Graph referenced by commit_b should not.
-        let gb = reg.commits()[&cb].graph;
-        assert!(!exported.graphs().contains_key(&gb));
-    }
-
-    #[test]
-    fn export_filters_names() {
+    fn heads_read_back() {
         let (reg, ca, _cb) = test_registry();
-        let required: HashSet<_> = [ca].into_iter().collect();
-        let exported = reg.export(&required);
-        assert_eq!(exported.names().get("alpha"), Some(&ca));
-        assert_eq!(exported.names().len(), 1);
+        assert_eq!(reg.head(&name("alpha")), Some(ca));
+        let heads: Vec<_> = reg.heads().map(|(n, ca)| (n.clone(), ca)).collect();
+        assert_eq!(heads, vec![(name("alpha"), ca)]);
+        assert_eq!(reg.head_commit_ca(&Head::Branch(name("alpha"))), Some(ca));
+        assert_eq!(reg.head_commit_ca(&Head::Commit(ca)), Some(ca));
     }
 
     #[test]
-    fn export_excludes_names_for_unrequired_commits() {
-        let (reg, _ca, cb) = test_registry();
-        // Only require commit_b which has no name.
-        let required: HashSet<_> = [cb].into_iter().collect();
-        let exported = reg.export(&required);
-        assert!(exported.names().is_empty());
+    fn remove_head_drops_with_name_metadata() {
+        let (mut reg, _ca, _cb) = test_registry();
+        section_insert_datum(
+            &mut reg,
+            "test.description",
+            MergePolicy::KeepExisting,
+            Liveness::WithName,
+            Key::Name(name("alpha")),
+            &"doc".to_string(),
+        )
+        .unwrap();
+        assert!(
+            reg.section_entry("test.description", &Key::Name(name("alpha")))
+                .is_some()
+        );
+        reg.remove_head(&name("alpha"));
+        assert_eq!(reg.head(&name("alpha")), None);
+        assert!(
+            reg.section_entry("test.description", &Key::Name(name("alpha")))
+                .is_none()
+        );
     }
 
     #[test]
-    fn merge_adds_new_graphs_commits_names() {
+    fn merge_adds_new_graphs_commits_heads() {
         let (mut base, _ca, _cb) = test_registry();
         let gc = graph_addr(3);
         let cc = commit_addr_raw(30);
         let commit_c = Commit::new(Duration::from_secs(3), None, gc);
-        let incoming = Registry::new(
+        let incoming = Registry::from_parts(
             HashMap::from([(gc, "graph_c".to_string())]),
             HashMap::from([(cc, commit_c)]),
-            BTreeMap::from([("beta".to_string(), cc)]),
+            BTreeMap::from([(name("beta"), cc)]),
         );
-        let result = base.merge(incoming);
+        let report = base.merge(incoming);
         assert!(base.commits().contains_key(&cc));
         assert!(base.graphs().contains_key(&gc));
-        assert_eq!(base.names().get("beta"), Some(&cc));
-        assert_eq!(result.names_added, vec!["beta".to_string()]);
-        assert!(result.names_replaced.is_empty());
+        assert_eq!(base.head(&name("beta")), Some(cc));
+        assert_eq!(report.heads_added, vec![name("beta")]);
+        assert!(report.heads_replaced.is_empty());
     }
 
     #[test]
-    fn merge_same_name_same_commit_is_noop() {
+    fn merge_same_head_same_commit_is_noop() {
         let (mut base, ca, _cb) = test_registry();
         let ga = base.commits()[&ca].graph;
         let commit_a = base.commits()[&ca].clone();
-        let incoming = Registry::new(
+        let incoming = Registry::from_parts(
             HashMap::from([(ga, "graph_a".to_string())]),
             HashMap::from([(ca, commit_a)]),
-            BTreeMap::from([("alpha".to_string(), ca)]),
+            BTreeMap::from([(name("alpha"), ca)]),
         );
-        let result = base.merge(incoming);
-        assert!(result.names_added.is_empty());
-        assert!(result.names_replaced.is_empty());
+        let report = base.merge(incoming);
+        assert!(report.heads_added.is_empty());
+        assert!(report.heads_replaced.is_empty());
     }
 
     #[test]
-    fn merge_name_conflict_replaces() {
+    fn merge_head_conflict_replaces() {
         let (mut base, ca, cb) = test_registry();
-        // Incoming maps "alpha" to a different commit.
         let gb = base.commits()[&cb].graph;
         let commit_b = base.commits()[&cb].clone();
-        let incoming = Registry::new(
+        let incoming = Registry::from_parts(
             HashMap::from([(gb, "graph_b".to_string())]),
             HashMap::from([(cb, commit_b)]),
-            BTreeMap::from([("alpha".to_string(), cb)]),
+            BTreeMap::from([(name("alpha"), cb)]),
         );
-        let result = base.merge(incoming);
-        assert!(result.names_added.is_empty());
-        assert_eq!(result.names_replaced.len(), 1);
-        let (name, old, new) = &result.names_replaced[0];
-        assert_eq!(name, "alpha");
-        assert_eq!(*old, ca);
-        assert_eq!(*new, cb);
-        assert_eq!(base.names().get("alpha"), Some(&cb));
+        let report = base.merge(incoming);
+        assert!(report.heads_added.is_empty());
+        assert_eq!(report.heads_replaced, vec![(name("alpha"), ca, cb)]);
+        assert_eq!(base.head(&name("alpha")), Some(cb));
     }
 
     #[test]
-    fn export_empty_required_set_produces_empty_registry() {
-        let (reg, _ca, _cb) = test_registry();
-        let exported = reg.export(&HashSet::new());
-        assert!(exported.commits().is_empty());
-        assert!(exported.graphs().is_empty());
-        assert!(exported.names().is_empty());
+    fn merge_keep_existing_section_keeps_local() {
+        let (mut base, _ca, _cb) = test_registry();
+        section_insert_datum(
+            &mut base,
+            "test.description",
+            MergePolicy::KeepExisting,
+            Liveness::WithName,
+            Key::Name(name("alpha")),
+            &"local".to_string(),
+        )
+        .unwrap();
+        let mut incoming: Registry<String> = Registry::default();
+        section_insert_datum(
+            &mut incoming,
+            "test.description",
+            MergePolicy::KeepExisting,
+            Liveness::WithName,
+            Key::Name(name("alpha")),
+            &"imported".to_string(),
+        )
+        .unwrap();
+        section_insert_datum(
+            &mut incoming,
+            "test.description",
+            MergePolicy::KeepExisting,
+            Liveness::WithName,
+            Key::Name(name("beta")),
+            &"new".to_string(),
+        )
+        .unwrap();
+        let report = base.merge(incoming);
+        let local: Option<String> = crate::datum::from_datum(
+            match base
+                .section_entry("test.description", &Key::Name(name("alpha")))
+                .unwrap()
+            {
+                Value::Datum(d) => d.clone(),
+                _ => panic!(),
+            },
+        )
+        .ok();
+        assert_eq!(local.as_deref(), Some("local"));
+        assert_eq!(
+            report.sections_added,
+            vec![("test.description".to_string(), Key::Name(name("beta")))]
+        );
+        assert!(report.sections_replaced.is_empty());
+    }
+
+    #[test]
+    fn merge_adopts_unknown_sections_wholesale() {
+        let (mut base, _ca, _cb) = test_registry();
+        let mut incoming: Registry<String> = Registry::default();
+        // A section from a domain this "app" knows nothing about.
+        section_insert_datum(
+            &mut incoming,
+            "laser.palette",
+            MergePolicy::Replace,
+            Liveness::Pinned,
+            Key::Name(name("show")),
+            &vec![1u8, 2, 3],
+        )
+        .unwrap();
+        base.merge(incoming);
+        let section = base.section("laser.palette").unwrap();
+        assert_eq!(section.policy, MergePolicy::Replace);
+        assert_eq!(section.liveness, Liveness::Pinned);
+        assert_eq!(section.entries.len(), 1);
+    }
+
+    #[test]
+    fn merge_extends_blob_stores() {
+        let (mut base, _ca, _cb) = test_registry();
+        let mut incoming: Registry<String> = Registry::default();
+        let addr = incoming.add_blob("dsp.buffer", BlobLiveness::ContentReferenced, &b"pcm"[..]);
+        base.merge(incoming);
+        assert_eq!(
+            base.blob("dsp.buffer", &addr).map(|b| &b[..]),
+            Some(&b"pcm"[..])
+        );
+    }
+
+    #[test]
+    fn typed_section_round_trip_via_decl() {
+        struct Doc;
+        impl SectionDecl for Doc {
+            const ID: &'static str = "test.doc";
+            const POLICY: MergePolicy = MergePolicy::KeepExisting;
+            const LIVENESS: Liveness = Liveness::WithName;
+            type Key = Name;
+            type Value = String;
+        }
+        let (mut reg, _ca, _cb) = test_registry();
+        section_insert::<Doc, _>(&mut reg, name("alpha"), &"hello".to_string()).unwrap();
+        assert_eq!(
+            section_get::<Doc, _>(&reg, &name("alpha")),
+            Some("hello".to_string())
+        );
+        let all: Vec<_> = section_iter::<Doc, _>(&reg).collect();
+        assert_eq!(all, vec![(name("alpha"), "hello".to_string())]);
+        assert_eq!(
+            section_remove::<Doc, _>(&mut reg, &name("alpha")),
+            Some("hello".to_string())
+        );
+        assert_eq!(section_get::<Doc, _>(&reg, &name("alpha")), None);
     }
 
     #[test]
     fn add_commit_clears_absent_parent() {
-        let mut reg: Registry<String> =
-            Registry::new(HashMap::new(), HashMap::new(), BTreeMap::new());
+        let mut reg: Registry<String> = Registry::default();
         let ga = graph_addr(1);
         let absent_parent = commit_addr_raw(99);
-        // A commit naming a parent that is not present is stored as a root.
         let ca = reg.add_commit(Commit::new(Duration::from_secs(1), Some(absent_parent), ga));
         assert_eq!(reg.commits()[&ca].parent, None);
-        // Its address is that of the equivalent root commit.
         let root = Commit::new(Duration::from_secs(1), None, ga);
         assert_eq!(ca, crate::commit_addr(&root));
     }
 
     #[test]
-    fn set_description_round_trips_and_clears() {
-        let (mut reg, _ca, _cb) = test_registry();
-        reg.set_description("alpha".to_string(), "the alpha graph".to_string());
-        assert_eq!(reg.description("alpha"), Some("the alpha graph"));
-        // An empty string clears the entry.
-        reg.set_description("alpha".to_string(), String::new());
-        assert_eq!(reg.description("alpha"), None);
-    }
-
-    #[test]
-    fn remove_name_drops_description() {
-        let (mut reg, _ca, _cb) = test_registry();
-        reg.set_description("alpha".to_string(), "doc".to_string());
-        reg.remove_name("alpha");
-        assert_eq!(reg.description("alpha"), None);
-        assert!(reg.descriptions().is_empty());
-    }
-
-    #[test]
-    fn export_filters_descriptions_to_required_names() {
-        let (mut reg, ca, cb) = test_registry();
-        reg.set_description("alpha".to_string(), "doc".to_string());
-        // alpha points at `ca`; requiring only `cb` drops both the name and doc.
-        let exported = reg.export(&[cb].into_iter().collect());
-        assert!(exported.descriptions().is_empty());
-        // Requiring `ca` keeps the name and its description.
-        let exported = reg.export(&[ca].into_iter().collect());
-        assert_eq!(exported.description("alpha"), Some("doc"));
-    }
-
-    #[test]
-    fn merge_brings_over_new_descriptions_but_keeps_local() {
-        let (mut base, _ca, _cb) = test_registry();
-        base.set_description("alpha".to_string(), "local".to_string());
-        let gc = graph_addr(3);
-        let cc = commit_addr_raw(30);
-        let commit_c = Commit::new(Duration::from_secs(3), None, gc);
-        let mut incoming = Registry::new(
-            HashMap::from([(gc, "graph_c".to_string())]),
-            HashMap::from([(cc, commit_c)]),
-            BTreeMap::from([("beta".to_string(), cc)]),
-        );
-        incoming.set_description("beta".to_string(), "imported".to_string());
-        // Incoming also tries to overwrite alpha; the local description wins.
-        incoming.set_description("alpha".to_string(), "imported-alpha".to_string());
-        base.merge(incoming);
-        assert_eq!(base.description("beta"), Some("imported"));
-        assert_eq!(base.description("alpha"), Some("local"));
-    }
-
-    #[test]
     fn add_commit_keeps_present_parent() {
-        let mut reg: Registry<String> =
-            Registry::new(HashMap::new(), HashMap::new(), BTreeMap::new());
+        let mut reg: Registry<String> = Registry::default();
         let root = reg.add_commit(Commit::new(Duration::from_secs(1), None, graph_addr(1)));
         let child = reg.add_commit(Commit::new(
             Duration::from_secs(2),
@@ -740,8 +967,7 @@ mod tests {
 
     #[test]
     fn add_commit_drops_absent_merge_parents() {
-        let mut reg: Registry<String> =
-            Registry::new(HashMap::new(), HashMap::new(), BTreeMap::new());
+        let mut reg: Registry<String> = Registry::default();
         let root = reg.add_commit(Commit::new(Duration::from_secs(1), None, graph_addr(1)));
         let absent = commit_addr_raw(99);
         let merge = reg.add_commit(Commit::new_merge(
@@ -751,7 +977,6 @@ mod tests {
             graph_addr(2),
         ));
         assert!(reg.commits()[&merge].merge_parents.is_empty());
-        // Its address is that of the equivalent non-merge commit.
         let ordinary = Commit::new(Duration::from_secs(2), Some(root), graph_addr(2));
         assert_eq!(merge, crate::commit_addr(&ordinary));
     }
@@ -763,12 +988,12 @@ mod tests {
             Duration::from_secs(1),
             graph_addr(1),
             || "ours".to_string(),
-            "alpha",
+            &name("alpha"),
         );
         let theirs = reg.commit_graph(Duration::from_secs(2), None, graph_addr(2), || {
             "theirs".to_string()
         });
-        let mut head = Head::Branch("alpha".to_string());
+        let mut head = Head::Branch(name("alpha"));
         let merge = reg.commit_merge_to_head(
             Duration::from_secs(3),
             graph_addr(3),
@@ -779,30 +1004,42 @@ mod tests {
         let commit = &reg.commits()[&merge];
         assert_eq!(commit.parent, Some(ours));
         assert_eq!(commit.merge_parents, vec![theirs]);
-        assert_eq!(reg.names().get("alpha"), Some(&merge));
-        assert_eq!(reg.head_commit_ca(&head), Some(&merge));
+        assert_eq!(reg.head(&name("alpha")), Some(merge));
+        assert_eq!(reg.head_commit_ca(&head), Some(merge));
     }
 
     #[test]
-    fn prune_unreachable_detaches_pruned_merge_parents() {
-        let mut reg: Registry<String> = Registry::default();
-        let ours = reg.commit_graph(Duration::from_secs(1), None, graph_addr(1), || {
-            "ours".to_string()
-        });
-        let theirs = reg.commit_graph(Duration::from_secs(2), None, graph_addr(2), || {
-            "theirs".to_string()
-        });
-        let mut head = Head::Commit(ours);
-        let merge = reg.commit_merge_to_head(
-            Duration::from_secs(3),
-            graph_addr(3),
-            || "merged".to_string(),
-            theirs,
-            &mut head,
-        );
-        // Prune theirs' side of history.
-        reg.prune_unreachable(&[ours, merge].into_iter().collect());
-        assert_eq!(reg.commits()[&merge].parent, Some(ours));
-        assert!(reg.commits()[&merge].merge_parents.is_empty());
+    fn empty_sections_and_blobs_are_omitted_from_serialized_output() {
+        let (reg, _ca, _cb) = test_registry();
+        // `heads` is non-empty here, so `sections` serializes. A registry
+        // with no sections at all must omit both fields.
+        let bare: Registry<String> = Registry::default();
+        let s = ron::to_string(&bare).unwrap();
+        assert!(!s.contains("sections"));
+        assert!(!s.contains("blobs"));
+        let s = ron::to_string(&reg).unwrap();
+        assert!(s.contains("sections"));
+        assert!(!s.contains("blobs"));
+    }
+
+    #[test]
+    fn registry_serde_round_trips() {
+        let (mut reg, ca, _cb) = test_registry();
+        reg.add_blob("dsp.buffer", BlobLiveness::ContentReferenced, &b"pcm"[..]);
+        section_insert_datum(
+            &mut reg,
+            "egui.view",
+            MergePolicy::KeepExisting,
+            Liveness::WithCommit,
+            Key::Commit(ca),
+            &vec![1.0f64, 2.0],
+        )
+        .unwrap();
+        let s = ron::to_string(&reg).unwrap();
+        let back: Registry<String> = ron::de::from_str(&s).unwrap();
+        assert_eq!(back.commits(), reg.commits());
+        assert_eq!(back.graphs(), reg.graphs());
+        assert_eq!(back.sections(), reg.sections());
+        assert_eq!(back.blobs(), reg.blobs());
     }
 }

--- a/crates/gantz_ca/src/section.rs
+++ b/crates/gantz_ca/src/section.rs
@@ -41,8 +41,21 @@ pub trait SectionDecl {
     const LIVENESS: Liveness;
     /// The key type (converted through [`Key`]).
     type Key: Into<Key> + TryFromKey;
-    /// The value type (encoded through [`Datum`]).
+    /// The value type (encoded through [`Datum`] by default).
     type Value: Serialize + serde::de::DeserializeOwned;
+
+    /// Encode a typed value as a section [`Value`]. Defaults to an inline
+    /// datum. Override to use a typed [`Value`] form (e.g. the `heads`
+    /// section encodes values as [`Value::Commit`]).
+    fn encode(value: &Self::Value) -> Result<Value, datum::DatumError> {
+        value_to_datum(value)
+    }
+
+    /// Decode a typed value from a section [`Value`], `None` on shape
+    /// mismatch. Must invert [`encode`](Self::encode).
+    fn decode(value: &Value) -> Option<Self::Value> {
+        value_from_datum(value)
+    }
 }
 
 /// A typed declaration of a blob store section, implemented by the owning

--- a/crates/gantz_ca/src/section.rs
+++ b/crates/gantz_ca/src/section.rs
@@ -1,0 +1,407 @@
+//! The open extension surface of the registry: mutable metadata sections and
+//! content-addressed blob stores.
+//!
+//! A domain extends the registry by declaring a [`SectionDecl`] (keyed,
+//! mutable metadata such as descriptions or views) or a [`BlobDecl`]
+//! (content-addressed opaque bytes such as audio samples) in its own crate.
+//! The declaration is compile-time only: nothing registers at runtime, and
+//! the registry core never learns domain types.
+//!
+//! Section semantics travel AS DATA: the merge policy and liveness rule are
+//! stamped into the section when it is first written, so an application or
+//! peer without the owning domain compiled in still merges, prunes, exports
+//! and round-trips the section correctly without interpreting its values.
+//!
+//! Blob addresses are the blake3 hash of the raw bytes and nothing else (no
+//! kind tag, no framing) - see [`blob_addr`]. This keeps them bit-compatible
+//! with iroh-blobs content addressing, preserving verified-streaming
+//! transfer as a future option. Blob metadata belongs beside the blob (in a
+//! metadata section), never in the hashed bytes.
+
+use crate::{CommitAddr, ContentAddr, GraphAddr, datum::Datum};
+use crate::{Name, datum};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{collections::BTreeMap, sync::Arc};
+
+/// Identifies a section, by convention `<domain>.<kind>`
+/// (e.g. `egui.view`, `dsp.buffer`). The `heads` section is core.
+pub type SectionId = String;
+
+/// Cheaply clonable immutable blob bytes.
+pub type Bytes = Arc<[u8]>;
+
+/// A typed declaration of a metadata section, implemented by the owning
+/// domain crate. See the module docs.
+pub trait SectionDecl {
+    /// The section's identifier, by convention `<domain>.<kind>`.
+    const ID: &'static str;
+    /// The merge policy stamped into the section on first write.
+    const POLICY: MergePolicy;
+    /// The liveness rule stamped into the section on first write.
+    const LIVENESS: Liveness;
+    /// The key type (converted through [`Key`]).
+    type Key: Into<Key> + TryFromKey;
+    /// The value type (encoded through [`Datum`]).
+    type Value: Serialize + serde::de::DeserializeOwned;
+}
+
+/// A typed declaration of a blob store section, implemented by the owning
+/// domain crate.
+pub trait BlobDecl {
+    /// The section's identifier, by convention `<domain>.<kind>`.
+    const ID: &'static str;
+    /// The liveness rule stamped into the store on first write.
+    const LIVENESS: BlobLiveness;
+}
+
+/// Fallible conversion out of the erased [`Key`], used by typed accessors.
+pub trait TryFromKey: Sized {
+    fn try_from_key(key: &Key) -> Option<Self>;
+}
+
+/// What a section's entries are keyed by.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum Key {
+    /// Keyed by a head name (metadata that survives edits to the named line
+    /// of history, e.g. descriptions).
+    Name(Name),
+    /// Keyed by a commit (metadata about a specific history point, e.g.
+    /// scene views).
+    Commit(CommitAddr),
+    /// Keyed by a graph (metadata about specific content).
+    Graph(GraphAddr),
+    /// Keyed by an arbitrary content address (e.g. blob metadata).
+    Addr(ContentAddr),
+}
+
+/// A section entry's value.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum Value {
+    /// An inline, self-describing canonical value.
+    Datum(Datum),
+    /// An indirection into a blob store section, for large values.
+    Blob(SectionId, ContentAddr),
+    /// A typed pointer into history (the `heads` section's value form).
+    Commit(CommitAddr),
+}
+
+/// How a section's entries merge when an incoming registry is merged in.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum MergePolicy {
+    /// A present local entry wins (descriptions, demos, views).
+    KeepExisting,
+    /// A differing incoming entry replaces the local one, reported in the
+    /// merge result (the `heads` section).
+    Replace,
+}
+
+/// When a section entry is live. Dead entries are dropped by prune and
+/// omitted from exports.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum Liveness {
+    /// Entries are garbage-collection roots: their commit values (and
+    /// everything reachable from them) are kept alive (the `heads` section).
+    Root,
+    /// Live while the `heads` section contains the entry's `Key::Name`.
+    WithName,
+    /// Live while the entry's `Key::Commit` commit exists.
+    WithCommit,
+    /// Live while the entry's `Key::Graph` graph exists.
+    WithGraph,
+    /// Never automatically dropped.
+    Pinned,
+}
+
+/// When a blob store entry is live.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum BlobLiveness {
+    /// Live while referenced by live content (a graph node reference).
+    ContentReferenced,
+    /// Live while referenced by a live section entry ([`Value::Blob`]).
+    SectionReferenced,
+    /// Never automatically dropped.
+    Pinned,
+}
+
+/// A mutable, keyed metadata section. All registry mutability outside the
+/// content columns lives in sections.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Section {
+    /// The merge policy, stamped on first write. Stored metadata wins over
+    /// compile-time constants so mixed application versions agree.
+    pub policy: MergePolicy,
+    /// The liveness rule, stamped on first write.
+    pub liveness: Liveness,
+    /// The entries. A `BTreeMap` for deterministic serialization.
+    pub entries: BTreeMap<Key, Value>,
+}
+
+/// A content-addressed store of opaque canonical bytes.
+///
+/// Invariant: every key equals [`blob_addr`] of its bytes. [`insert`]
+/// computes the key, [`insert_at`] verifies a claimed key.
+///
+/// [`insert`]: Self::insert
+/// [`insert_at`]: Self::insert_at
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct BlobStore {
+    /// The liveness rule, stamped on first write.
+    pub liveness: BlobLiveness,
+    /// The entries. A `BTreeMap` for deterministic serialization.
+    #[serde(
+        serialize_with = "serialize_blob_entries",
+        deserialize_with = "deserialize_blob_entries"
+    )]
+    pub entries: BTreeMap<ContentAddr, Bytes>,
+}
+
+/// A blob claimed under an address it does not hash to.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BlobVerifyError {
+    pub claimed: ContentAddr,
+    pub actual: ContentAddr,
+}
+
+impl Section {
+    /// An empty section with the given stamped semantics.
+    pub fn new(policy: MergePolicy, liveness: Liveness) -> Self {
+        Self {
+            policy,
+            liveness,
+            entries: BTreeMap::new(),
+        }
+    }
+}
+
+impl BlobStore {
+    /// An empty store with the given stamped liveness.
+    pub fn new(liveness: BlobLiveness) -> Self {
+        Self {
+            liveness,
+            entries: BTreeMap::new(),
+        }
+    }
+
+    /// Insert bytes, computing their address. Idempotent: an existing entry
+    /// for the address is identical by construction.
+    pub fn insert(&mut self, bytes: impl Into<Bytes>) -> ContentAddr {
+        let bytes = bytes.into();
+        let addr = blob_addr(&bytes);
+        self.entries.entry(addr).or_insert(bytes);
+        addr
+    }
+
+    /// Insert bytes under a claimed address, verifying the claim.
+    pub fn insert_at(
+        &mut self,
+        claimed: ContentAddr,
+        bytes: impl Into<Bytes>,
+    ) -> Result<(), BlobVerifyError> {
+        let bytes = bytes.into();
+        let actual = blob_addr(&bytes);
+        if actual != claimed {
+            return Err(BlobVerifyError { claimed, actual });
+        }
+        self.entries.entry(claimed).or_insert(bytes);
+        Ok(())
+    }
+
+    /// The bytes stored at the given address, if any.
+    pub fn get(&self, addr: &ContentAddr) -> Option<&Bytes> {
+        self.entries.get(addr)
+    }
+}
+
+impl TryFromKey for Name {
+    fn try_from_key(key: &Key) -> Option<Self> {
+        match key {
+            Key::Name(name) => Some(name.clone()),
+            _ => None,
+        }
+    }
+}
+
+impl TryFromKey for CommitAddr {
+    fn try_from_key(key: &Key) -> Option<Self> {
+        match key {
+            Key::Commit(ca) => Some(*ca),
+            _ => None,
+        }
+    }
+}
+
+impl TryFromKey for GraphAddr {
+    fn try_from_key(key: &Key) -> Option<Self> {
+        match key {
+            Key::Graph(ga) => Some(*ga),
+            _ => None,
+        }
+    }
+}
+
+impl TryFromKey for ContentAddr {
+    fn try_from_key(key: &Key) -> Option<Self> {
+        match key {
+            Key::Addr(addr) => Some(*addr),
+            _ => None,
+        }
+    }
+}
+
+impl From<Name> for Key {
+    fn from(name: Name) -> Self {
+        Key::Name(name)
+    }
+}
+
+impl From<CommitAddr> for Key {
+    fn from(ca: CommitAddr) -> Self {
+        Key::Commit(ca)
+    }
+}
+
+impl From<GraphAddr> for Key {
+    fn from(ga: GraphAddr) -> Self {
+        Key::Graph(ga)
+    }
+}
+
+impl std::fmt::Display for BlobVerifyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "blob claimed as {} hashes to {}",
+            self.claimed, self.actual
+        )
+    }
+}
+
+impl std::error::Error for BlobVerifyError {}
+
+/// The content address of a blob: the blake3 hash of the raw bytes and
+/// NOTHING else. No kind tag, no length prefix, no framing: this is the
+/// iroh-blobs-compatible addressing rule. See the module docs.
+pub fn blob_addr(bytes: &[u8]) -> ContentAddr {
+    ContentAddr::from(*blake3::hash(bytes).as_bytes())
+}
+
+/// Encode a typed section value as an inline datum [`Value`].
+pub fn value_to_datum<T: Serialize>(value: &T) -> Result<Value, datum::DatumError> {
+    datum::to_datum(value).map(Value::Datum)
+}
+
+/// Decode a typed section value from a [`Value`], if it is an inline datum
+/// of the expected shape.
+pub fn value_from_datum<T: serde::de::DeserializeOwned>(value: &Value) -> Option<T> {
+    match value {
+        Value::Datum(datum) => datum::from_datum(datum.clone()).ok(),
+        _ => None,
+    }
+}
+
+/// Serialize blob entries with hex addresses and hex bytes when
+/// human-readable, raw bytes otherwise. Entries are ordered by address.
+fn serialize_blob_entries<S: Serializer>(
+    entries: &BTreeMap<ContentAddr, Bytes>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    use serde::ser::SerializeMap;
+    /// Serializes a byte slice via `serialize_bytes` (rather than serde's
+    /// default seq-of-u8 for slices).
+    struct AsBytes<'a>(&'a [u8]);
+    impl Serialize for AsBytes<'_> {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.serialize_bytes(self.0)
+        }
+    }
+    let human_readable = serializer.is_human_readable();
+    let mut map = serializer.serialize_map(Some(entries.len()))?;
+    for (addr, bytes) in entries {
+        if human_readable {
+            map.serialize_entry(addr, &hex::encode(&bytes[..]))?;
+        } else {
+            map.serialize_entry(addr, &AsBytes(bytes))?;
+        }
+    }
+    map.end()
+}
+
+/// Deserialize blob entries (see [`serialize_blob_entries`]).
+fn deserialize_blob_entries<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<BTreeMap<ContentAddr, Bytes>, D::Error> {
+    use serde::de::Error;
+    if deserializer.is_human_readable() {
+        let hex_entries = BTreeMap::<ContentAddr, String>::deserialize(deserializer)?;
+        hex_entries
+            .into_iter()
+            .map(|(addr, hex_str)| {
+                let bytes = hex::decode(&hex_str).map_err(D::Error::custom)?;
+                Ok((addr, Bytes::from(bytes)))
+            })
+            .collect()
+    } else {
+        let raw = BTreeMap::<ContentAddr, Vec<u8>>::deserialize(deserializer)?;
+        Ok(raw
+            .into_iter()
+            .map(|(addr, bytes)| (addr, Bytes::from(bytes)))
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blob_addr_is_raw_blake3() {
+        // The iroh interop guard: the address must be the plain blake3 hash
+        // of the raw bytes, with nothing folded into the preimage.
+        let bytes = b"hello gantz";
+        let addr = blob_addr(bytes);
+        assert_eq!(addr.as_ref(), blake3::hash(bytes).as_bytes());
+    }
+
+    #[test]
+    fn blob_store_verifies_claims() {
+        let mut store = BlobStore::new(BlobLiveness::ContentReferenced);
+        let addr = store.insert(&b"content"[..]);
+        assert!(store.insert_at(addr, &b"content"[..]).is_ok());
+        let err = store.insert_at(addr, &b"tampered"[..]).unwrap_err();
+        assert_eq!(err.claimed, addr);
+        assert_ne!(err.actual, addr);
+        assert_eq!(store.get(&addr).map(|b| &b[..]), Some(&b"content"[..]));
+    }
+
+    #[test]
+    fn blob_store_serde_round_trips() {
+        let mut store = BlobStore::new(BlobLiveness::SectionReferenced);
+        store.insert(&b"alpha"[..]);
+        store.insert(&b"beta"[..]);
+        let ron = ron::to_string(&store).unwrap();
+        let back: BlobStore = ron::de::from_str(&ron).unwrap();
+        assert_eq!(back, store);
+    }
+
+    #[test]
+    fn section_serde_round_trips_with_semantics() {
+        let mut section = Section::new(MergePolicy::KeepExisting, Liveness::WithName);
+        section.entries.insert(
+            Key::Name("synth".parse().unwrap()),
+            value_to_datum(&"a bass synth".to_string()).unwrap(),
+        );
+        let ron = ron::to_string(&section).unwrap();
+        let back: Section = ron::de::from_str(&ron).unwrap();
+        assert_eq!(back, section);
+        let decoded: String =
+            value_from_datum(&back.entries[&Key::Name("synth".parse().unwrap())]).unwrap();
+        assert_eq!(decoded, "a bass synth");
+    }
+
+    #[test]
+    fn typed_value_mismatch_decodes_to_none() {
+        let value = value_to_datum(&42u32).unwrap();
+        let decoded: Option<Vec<String>> = value_from_datum(&value);
+        assert!(decoded.is_none());
+    }
+}

--- a/crates/gantz_ca/src/sync.rs
+++ b/crates/gantz_ca/src/sync.rs
@@ -30,7 +30,8 @@
 //! [`BothModified::KeepNewest`]: crate::merge::BothModified::KeepNewest
 
 use crate::{
-    CaHash, Commit, CommitAddr, GraphAddr, Timestamp, commit_addr, graph_addr,
+    BlobLiveness, Bytes, CaHash, Commit, CommitAddr, ContentAddr, GraphAddr, SectionId, Timestamp,
+    blob_addr, commit_addr, graph_addr,
     history::{self, MergeAnalysis},
     registry::{Commits, Registry},
 };
@@ -85,6 +86,11 @@ pub enum VerifyError {
         claimed: GraphAddr,
         actual: GraphAddr,
     },
+    /// The blob's recomputed address differs from the claimed one.
+    Blob {
+        claimed: ContentAddr,
+        actual: ContentAddr,
+    },
 }
 
 /// An error preventing a [`Staged`] set from being applied to a registry.
@@ -121,9 +127,11 @@ pub struct Applied {
     pub commits: Vec<CommitAddr>,
     /// The graphs applied.
     pub graphs: Vec<GraphAddr>,
+    /// The blobs applied, as (section, address) pairs.
+    pub blobs: Vec<(SectionId, ContentAddr)>,
     /// The number of snapshot commits whose absent parents were detached on
     /// insert because the sender truncated history below them (the same
-    /// semantic a local [`Registry::prune_unreachable`] leaves behind).
+    /// semantic a local [`prune`](crate::reach::prune) leaves behind).
     pub truncated: usize,
 }
 
@@ -142,6 +150,7 @@ pub struct Applied {
 pub struct Staged<G> {
     commits: BTreeMap<CommitAddr, StagedCommit>,
     graphs: BTreeMap<GraphAddr, G>,
+    blobs: BTreeMap<(SectionId, ContentAddr), (BlobLiveness, Bytes)>,
     grandfathered: Vec<CommitAddr>,
 }
 
@@ -239,6 +248,28 @@ impl<G> Staged<G> {
         Ok(())
     }
 
+    /// Stage a blob for the given blob section, verifying that its raw
+    /// bytes hash to the claimed address. Always strict (blake3 of the
+    /// bytes is cheap).
+    ///
+    /// `liveness` stamps the section if the receiving registry does not
+    /// hold it yet (an existing section's stored liveness wins on apply).
+    pub fn insert_blob(
+        &mut self,
+        section: SectionId,
+        liveness: BlobLiveness,
+        claimed: ContentAddr,
+        bytes: impl Into<Bytes>,
+    ) -> Result<(), VerifyError> {
+        let bytes = bytes.into();
+        let actual = blob_addr(&bytes);
+        if actual != claimed {
+            return Err(VerifyError::Blob { claimed, actual });
+        }
+        self.blobs.insert((section, claimed), (liveness, bytes));
+        Ok(())
+    }
+
     /// The commits and graphs still required to complete `tip`'s closure,
     /// walking ancestry through the staged set and the registry.
     ///
@@ -307,6 +338,12 @@ impl<G> Staged<G> {
             reg.insert_graph_at(ga, graph);
             applied.graphs.push(ga);
         }
+        // Blobs are leaves with no referential invariants: apply alongside
+        // graphs, before any commit.
+        for ((section, addr), (liveness, bytes)) in self.blobs {
+            reg.insert_blob_at(section.clone(), liveness, addr, bytes);
+            applied.blobs.push((section, addr));
+        }
         let mut commits = self.commits;
         for ca in order {
             let Some(staged) = commits.remove(&ca) else {
@@ -343,6 +380,7 @@ impl<G> Default for Staged<G> {
         Self {
             commits: BTreeMap::new(),
             graphs: BTreeMap::new(),
+            blobs: BTreeMap::new(),
             grandfathered: Vec::new(),
         }
     }
@@ -356,6 +394,9 @@ impl fmt::Display for VerifyError {
             }
             Self::Graph { claimed, actual } => {
                 write!(f, "graph claimed as {claimed} hashes to {actual}")
+            }
+            Self::Blob { claimed, actual } => {
+                write!(f, "blob claimed as {claimed} hashes to {actual}")
             }
         }
     }

--- a/crates/gantz_ca/src/sync.rs
+++ b/crates/gantz_ca/src/sync.rs
@@ -30,8 +30,8 @@
 //! [`BothModified::KeepNewest`]: crate::merge::BothModified::KeepNewest
 
 use crate::{
-    BlobLiveness, Bytes, CaHash, Commit, CommitAddr, ContentAddr, GraphAddr, SectionId, Timestamp,
-    blob_addr, commit_addr, graph_addr,
+    BlobLiveness, Bytes, CaHash, Commit, CommitAddr, ContentAddr, GraphAddr, RawGraph, SectionId,
+    Timestamp, blob_addr, commit_addr, graph_addr,
     history::{self, MergeAnalysis},
     registry::{Commits, Registry},
 };
@@ -372,6 +372,22 @@ impl<G> Staged<G> {
             applied.commits.push(ca);
         }
         Ok(applied)
+    }
+}
+
+impl Staged<RawGraph> {
+    /// Stage a raw (undecodable) graph under a claimed address, TRUSTING an
+    /// upstream validator.
+    ///
+    /// A raw graph's address cannot be recomputed from its bytes (the
+    /// structural graph hash needs the decoded graph), so local verification
+    /// is impossible here: this path exists for serve-side relay stores that
+    /// hold what decoding peers verified. A receiving application peer must
+    /// always decode and re-verify through the typed
+    /// [`insert_graph`](Self::insert_graph) path, which is where the
+    /// security boundary lives.
+    pub fn insert_graph_claimed(&mut self, claimed: GraphAddr, bytes: impl Into<Bytes>) {
+        self.graphs.insert(claimed, RawGraph::new(claimed, bytes));
     }
 }
 
@@ -741,6 +757,26 @@ mod tests {
         let ok = Commit::new(Duration::from_secs(3), None, graph_addr_raw(1));
         staged.insert_commit_grandfathered(commit_addr(&ok), ok);
         assert_eq!(staged.grandfathered().len(), 1);
+    }
+
+    #[test]
+    fn staged_raw_graph_applies_under_claimed_addr() {
+        use crate::graph::GraphHash;
+        // A relay store holds graphs the process cannot decode: bytes apply
+        // under the claimed (upstream-validated) address as-is.
+        let mut reg = Registry::<RawGraph>::default();
+        let mut staged = Staged::<RawGraph>::new();
+        let ga = graph_addr_raw(1);
+        let commit = Commit::new(Duration::from_secs(1), None, ga);
+        let ca = commit_addr(&commit);
+        staged.insert_commit(ca, commit).unwrap();
+        staged.insert_graph_claimed(ga, &b"(app-serialized graph)"[..]);
+        assert!(staged.is_complete(&reg, ca));
+        let applied = staged.apply(&mut reg).unwrap();
+        assert_eq!(applied.graphs, vec![ga]);
+        let raw = reg.graph(&ga).unwrap();
+        assert_eq!(raw.graph_addr(), ga);
+        assert_eq!(&raw.bytes[..], b"(app-serialized graph)");
     }
 
     #[test]

--- a/crates/gantz_ca/tests/sync_convergence.rs
+++ b/crates/gantz_ca/tests/sync_convergence.rs
@@ -471,7 +471,12 @@ fn join_snapshot_tolerates_pruned_history() {
         g.add_node("b".to_string());
     });
     let tip = host.tip;
-    host.reg.prune_unreachable(&[tip].into_iter().collect());
+    let live = gantz_ca::LiveSet {
+        commits: [tip].into_iter().collect(),
+        graphs: [host.reg.commits()[&tip].graph].into_iter().collect(),
+        blobs: Default::default(),
+    };
+    gantz_ca::prune(&mut host.reg, &live);
     assert_ne!(
         commit_addr(&host.reg.commits()[&tip]),
         tip,

--- a/crates/gantz_collab/src/lib.rs
+++ b/crates/gantz_collab/src/lib.rs
@@ -3,8 +3,9 @@
 //! A *session* shares one named graph (and its registry dependency closure)
 //! between peers over [iroh]. This crate owns everything network-shaped and
 //! nothing node-shaped: graphs cross the wire (and sit in the served
-//! [`SessionStore`]) as opaque serialized blobs, so the crate stays agnostic
-//! of the application's node type. Validating, merging and applying received
+//! [`SessionRegistry`]) as opaque serialized blobs
+//! ([`gantz_ca::RawGraph`]), so the crate stays agnostic of the
+//! application's node type. Validating, merging and applying received
 //! content is the application layer's job, built on `gantz_ca::sync`.
 //!
 //! Two planes:
@@ -13,8 +14,8 @@
 //!   anti-entropy digests and presence. Small, broadcast, unordered.
 //! - **Requests** ([`SYNC_ALPN`], one request per QUIC bi-stream): join
 //!   snapshots, head listings and object fetches ([`SyncRequest`] /
-//!   [`SyncResponse`]), served from the session's [`SessionStore`] and gated
-//!   by its [`Access`] allowlist.
+//!   [`SyncResponse`]), served from the session's [`SessionRegistry`] and
+//!   gated by its [`Access`] allowlist.
 //!
 //! The [`runtime`] drives an iroh endpoint on a dedicated thread (native) or
 //! the browser's event loop (wasm), bridged to the application through plain
@@ -28,7 +29,10 @@
 #[doc(inline)]
 pub use identity::Identity;
 #[doc(inline)]
-pub use proto::{GossipMsg, Objects, SyncRequest, SyncResponse, Want, WireCommit, heads_digest};
+pub use proto::{
+    GossipMsg, Object, ObjectRef, Objects, SyncRequest, SyncResponse, Want, WireCommit,
+    heads_digest,
+};
 #[doc(inline)]
 pub use runtime::{
     Command, Event, Handle, Infra, PROTO_VERSION, RuntimeConfig, SYNC_ALPN, TOPIC_DOMAIN, spawn,
@@ -36,7 +40,7 @@ pub use runtime::{
 #[doc(inline)]
 pub use session::{Access, ConnState, PeerId, Role, Session, SessionId};
 #[doc(inline)]
-pub use store::{SessionEntry, SessionStore};
+pub use store::{SessionEntry, SessionRegistry};
 #[doc(inline)]
 pub use ticket::SessionTicket;
 

--- a/crates/gantz_collab/src/proto.rs
+++ b/crates/gantz_collab/src/proto.rs
@@ -1,26 +1,25 @@
 //! The wire protocol: gossip messages and request/response types.
 //!
 //! Everything here is plain serde encoded with [postcard] (compact,
-//! non-self-describing; `gantz_ca` addresses serialize as raw bytes).
-//! Graphs are the exception: the application's node type needs a
-//! self-describing format, so graphs travel inside [`Objects`] as opaque
-//! pre-serialized blobs the application encodes/decodes. The blob format is
-//! entirely the application's choice; it must be a *faithful* serde codec,
-//! since a received graph only applies if its deserialized content address
-//! verifies against the announced one. The gantz app uses the same RON
-//! encoding as its persisted registry (`bevy_gantz::storage`), so wire and
-//! persistence cannot drift. The human-facing `.gantz` text format is
-//! deliberately not used here: it is a name-resolving projection for
-//! import/export (its round-trip re-seeds names and re-roots commits),
+//! non-self-describing; `gantz_ca` addresses serialize as raw bytes and
+//! names as strings). Graphs are the exception: the application's node type
+//! needs a self-describing format, so graphs travel inside [`Objects`] as
+//! opaque pre-serialized blobs the application encodes/decodes. The blob
+//! format is entirely the application's choice; it must be a *faithful*
+//! serde codec, since a received graph only applies if its deserialized
+//! content address verifies against the announced one. The gantz app uses
+//! the same RON encoding as its persisted registry (`bevy_gantz::storage`),
+//! so wire and persistence cannot drift. The human-facing `.gantz` text
+//! format is deliberately not used here: it is a name-resolving projection
+//! for import/export (its round-trip re-seeds names and re-roots commits),
 //! while sync ships bare address-keyed graphs and moves names only through
 //! the convergence rules.
 //!
 //! [postcard]: https://docs.rs/postcard
 
 use crate::session::{PeerId, SessionId};
-use gantz_ca::{Commit, CommitAddr, GraphAddr};
+use gantz_ca::{BlobLiveness, Commit, CommitAddr, ContentAddr, GraphAddr, Name, SectionId};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use std::collections::BTreeMap;
 
 /// A message broadcast on a session's gossip topic.
 ///
@@ -35,7 +34,7 @@ pub enum GossipMsg {
         /// Per-origin sequence number, for stale-drop only: convergence
         /// never depends on delivery order.
         seq: u64,
-        changed: Vec<(String, CommitAddr, GraphAddr)>,
+        changed: Vec<(Name, CommitAddr, GraphAddr)>,
     },
     /// Anti-entropy: a digest of the announcing peer's scoped heads (see
     /// [`heads_digest`]).
@@ -58,22 +57,47 @@ pub enum GossipMsg {
     },
 }
 
-/// Objects a peer is missing (mirrors `gantz_ca::sync::Missing`).
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+/// A kind-tagged reference to one content-addressed object.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum ObjectRef {
+    Commit(CommitAddr),
+    Graph(GraphAddr),
+    /// A blob in the named blob section (the wire slot for asset transfer).
+    Blob {
+        section: SectionId,
+        addr: ContentAddr,
+    },
+}
+
+/// A fetched object under its claimed reference.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum Object {
+    Commit(CommitAddr, WireCommit),
+    /// A graph as an application-serialized (self-describing) blob.
+    Graph(GraphAddr, Vec<u8>),
+    /// Raw blob bytes, with the store liveness that stamps the section if
+    /// the receiver does not hold it yet.
+    Blob {
+        section: SectionId,
+        liveness: BlobLiveness,
+        addr: ContentAddr,
+        bytes: Vec<u8>,
+    },
+}
+
+/// Objects a peer is missing (the wire form of `gantz_ca::sync::Missing`).
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Want {
-    pub commits: Vec<CommitAddr>,
-    pub graphs: Vec<GraphAddr>,
+    pub refs: Vec<ObjectRef>,
 }
 
 /// Fetched session content.
 ///
 /// Order carries no meaning: receivers validate and topologically apply via
 /// `gantz_ca::sync::Staged`.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Objects {
-    pub commits: Vec<(CommitAddr, WireCommit)>,
-    /// Graphs as application-serialized blobs (self-describing, e.g. RON).
-    pub graphs: Vec<(GraphAddr, Vec<u8>)>,
+    pub objects: Vec<Object>,
 }
 
 /// [`Commit`] mirrored without serde field-skipping.
@@ -88,28 +112,6 @@ pub struct WireCommit {
     pub parent: Option<CommitAddr>,
     pub graph: GraphAddr,
     pub merge_parents: Vec<CommitAddr>,
-}
-
-impl From<Commit> for WireCommit {
-    fn from(c: Commit) -> Self {
-        Self {
-            timestamp: c.timestamp,
-            parent: c.parent,
-            graph: c.graph,
-            merge_parents: c.merge_parents,
-        }
-    }
-}
-
-impl From<WireCommit> for Commit {
-    fn from(c: WireCommit) -> Self {
-        Self {
-            timestamp: c.timestamp,
-            parent: c.parent,
-            graph: c.graph,
-            merge_parents: c.merge_parents,
-        }
-    }
 }
 
 /// A request over the [`SYNC_ALPN`](crate::SYNC_ALPN) plane; one request per
@@ -134,11 +136,11 @@ pub enum SyncResponse {
         accepted: bool,
     },
     Snapshot {
-        heads: Vec<(String, CommitAddr)>,
+        heads: Vec<(Name, CommitAddr)>,
         objects: Objects,
     },
     Heads {
-        heads: Vec<(String, CommitAddr)>,
+        heads: Vec<(Name, CommitAddr)>,
     },
     Objects(Objects),
     /// Unknown session, failed access check or protocol mismatch.
@@ -150,7 +152,29 @@ pub enum SyncResponse {
 impl Want {
     /// Whether nothing is wanted.
     pub fn is_empty(&self) -> bool {
-        self.commits.is_empty() && self.graphs.is_empty()
+        self.refs.is_empty()
+    }
+}
+
+impl From<Commit> for WireCommit {
+    fn from(c: Commit) -> Self {
+        Self {
+            timestamp: c.timestamp,
+            parent: c.parent,
+            graph: c.graph,
+            merge_parents: c.merge_parents,
+        }
+    }
+}
+
+impl From<WireCommit> for Commit {
+    fn from(c: WireCommit) -> Self {
+        Self {
+            timestamp: c.timestamp,
+            parent: c.parent,
+            graph: c.graph,
+            merge_parents: c.merge_parents,
+        }
     }
 }
 
@@ -166,14 +190,20 @@ pub fn decode<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, postcard::Error> {
     postcard::from_bytes(bytes)
 }
 
-/// The digest of a scoped `name -> tip` map, for [`GossipMsg::Digest`]
-/// anti-entropy: blake3 over the sorted `(name, tip)` pairs.
-pub fn heads_digest(heads: &BTreeMap<String, CommitAddr>) -> [u8; 32] {
+/// The digest of a `name -> tip` head map, for [`GossipMsg::Digest`]
+/// anti-entropy: blake3 over the `(name, tip)` pairs in iteration order.
+///
+/// Callers must supply a name-ordered iteration (e.g.
+/// `gantz_ca::Registry::heads`) so peers holding equal heads derive equal
+/// digests. Heads-only for now: a whole-sections digest would need a
+/// canonical section byte encoding, which the registry does not define yet.
+pub fn heads_digest<'a>(heads: impl IntoIterator<Item = (&'a Name, CommitAddr)>) -> [u8; 32] {
     let mut hasher = gantz_ca::Hasher::new();
     for (name, tip) in heads {
+        let name = name.to_string();
         hasher.update(&(name.len() as u64).to_be_bytes());
         hasher.update(name.as_bytes());
-        hasher.update(&gantz_ca::ContentAddr::from(*tip).0);
+        hasher.update(&gantz_ca::ContentAddr::from(tip).0);
     }
     hasher.finalize().into()
 }
@@ -181,6 +211,11 @@ pub fn heads_digest(heads: &BTreeMap<String, CommitAddr>) -> [u8; 32] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
+
+    fn name(s: &str) -> Name {
+        s.parse().unwrap()
+    }
 
     #[test]
     fn wire_types_round_trip() {
@@ -189,7 +224,7 @@ mod tests {
         let msg = GossipMsg::Tips {
             origin: PeerId([1; 32]),
             seq: 7,
-            changed: vec![("main".to_string(), ca, ga)],
+            changed: vec![(name("main"), ca, ga)],
         };
         let decoded: GossipMsg = decode(&encode(&msg)).unwrap();
         let GossipMsg::Tips {
@@ -202,17 +237,26 @@ mod tests {
         };
         assert_eq!(origin, PeerId([1; 32]));
         assert_eq!(seq, 7);
-        assert_eq!(changed, vec![("main".to_string(), ca, ga)]);
+        assert_eq!(changed, vec![(name("main"), ca, ga)]);
 
         let req = SyncRequest::Want {
             session: SessionId([2; 32]),
             want: Want {
-                commits: vec![ca],
-                graphs: vec![ga],
+                refs: vec![
+                    ObjectRef::Commit(ca),
+                    ObjectRef::Graph(ga),
+                    ObjectRef::Blob {
+                        section: "dsp.buffer".to_string(),
+                        addr: gantz_ca::ContentAddr::from([5; 32]),
+                    },
+                ],
             },
         };
         let decoded: SyncRequest = decode(&encode(&req)).unwrap();
-        assert!(matches!(decoded, SyncRequest::Want { .. }));
+        let SyncRequest::Want { want, .. } = decoded else {
+            panic!("wrong variant");
+        };
+        assert_eq!(want.refs.len(), 3);
     }
 
     #[test]
@@ -224,25 +268,35 @@ mod tests {
         let commit = Commit::new(std::time::Duration::from_secs(5), None, ga);
         let ca = gantz_ca::commit_addr(&commit);
         let objects = Objects {
-            commits: vec![(ca, commit.clone().into())],
-            graphs: vec![(ga, b"blob".to_vec())],
+            objects: vec![
+                Object::Commit(ca, commit.clone().into()),
+                Object::Graph(ga, b"blob".to_vec()),
+                Object::Blob {
+                    section: "dsp.buffer".to_string(),
+                    liveness: BlobLiveness::ContentReferenced,
+                    addr: gantz_ca::blob_addr(b"pcm"),
+                    bytes: b"pcm".to_vec(),
+                },
+            ],
         };
         let decoded: Objects = decode(&encode(&objects)).unwrap();
-        assert_eq!(decoded.commits, vec![(ca, commit.into())]);
-        assert_eq!(decoded.graphs, objects.graphs);
+        assert_eq!(decoded, objects);
     }
 
     #[test]
     fn heads_digest_is_order_independent_and_content_sensitive() {
         let ca = |n| CommitAddr::from(gantz_ca::ContentAddr::from([n; 32]));
-        let a: BTreeMap<String, CommitAddr> = [("a".to_string(), ca(1)), ("b".to_string(), ca(2))]
-            .into_iter()
-            .collect();
-        let b: BTreeMap<String, CommitAddr> = [("b".to_string(), ca(2)), ("a".to_string(), ca(1))]
-            .into_iter()
-            .collect();
-        assert_eq!(heads_digest(&a), heads_digest(&b));
-        let c: BTreeMap<String, CommitAddr> = [("a".to_string(), ca(9))].into_iter().collect();
-        assert_ne!(heads_digest(&a), heads_digest(&c));
+        let digest = |entries: &[(&str, CommitAddr)]| {
+            // A `BTreeMap` supplies the required name-ordered iteration
+            // regardless of insertion order.
+            let map: BTreeMap<Name, CommitAddr> =
+                entries.iter().map(|(n, ca)| (name(n), *ca)).collect();
+            heads_digest(map.iter().map(|(n, ca)| (n, *ca)))
+        };
+        let a = digest(&[("a", ca(1)), ("b", ca(2))]);
+        let b = digest(&[("b", ca(2)), ("a", ca(1))]);
+        assert_eq!(a, b);
+        let c = digest(&[("a", ca(9))]);
+        assert_ne!(a, c);
     }
 }

--- a/crates/gantz_collab/src/runtime.rs
+++ b/crates/gantz_collab/src/runtime.rs
@@ -9,8 +9,8 @@
 //!
 //! The runtime is deliberately dumb plumbing: it subscribes gossip topics,
 //! forwards messages both ways, fetches objects on request, and serves the
-//! [`SessionStore`](crate::SessionStore) to peers. All convergence decisions
-//! (what to announce, what to fetch, how to merge) live with the
+//! [`SessionRegistry`](crate::SessionRegistry) to peers. All convergence
+//! decisions (what to announce, what to fetch, how to merge) live with the
 //! application.
 //!
 //! # Infrastructure
@@ -28,10 +28,10 @@ use crate::{
     identity::Identity,
     proto::{self, GossipMsg, Objects, SyncRequest, SyncResponse, Want},
     session::{PeerId, SessionId},
-    store::{SessionEntry, Shared},
+    store::{self, SessionEntry, Shared},
     ticket::SessionTicket,
 };
-use gantz_ca::{Commit, CommitAddr, GraphAddr};
+use gantz_ca::{Commit, CommitAddr, Name, RawGraph};
 use iroh::{
     Endpoint, EndpointAddr, EndpointId, RelayMap, RelayMode,
     address_lookup::{PkarrPublisher, PkarrResolver},
@@ -129,9 +129,9 @@ pub enum Command {
     /// upserts. Unknown sessions are ignored with a warning.
     Update {
         session: SessionId,
-        heads: Vec<(String, CommitAddr)>,
+        heads: Vec<(Name, CommitAddr)>,
         commits: Vec<(CommitAddr, Commit)>,
-        graphs: Vec<(GraphAddr, Vec<u8>)>,
+        graphs: Vec<RawGraph>,
     },
     /// Start serving and gossiping a session. The session must already be
     /// [`Register`](Command::Register)ed. Emits [`Event::TicketReady`].
@@ -168,7 +168,7 @@ pub enum Event {
     /// ready for staged validation.
     Joined {
         session: SessionId,
-        heads: Vec<(String, CommitAddr)>,
+        heads: Vec<(Name, CommitAddr)>,
         objects: Objects,
     },
     /// A gossip message from a session peer.
@@ -248,19 +248,16 @@ impl SyncServer {
                 accepted: proto == PROTO_VERSION,
             },
             SyncRequest::Snapshot { .. } => {
-                let (heads, objects) = entry.store.snapshot();
+                let (heads, objects) = store::snapshot(&entry.store);
                 SyncResponse::Snapshot { heads, objects }
             }
             SyncRequest::Heads { .. } => {
-                let heads = entry
-                    .store
-                    .heads
-                    .iter()
-                    .map(|(n, ca)| (n.clone(), *ca))
-                    .collect();
+                let heads = entry.store.heads().map(|(n, ca)| (n.clone(), ca)).collect();
                 SyncResponse::Heads { heads }
             }
-            SyncRequest::Want { want, .. } => SyncResponse::Objects(entry.store.objects(&want)),
+            SyncRequest::Want { want, .. } => {
+                SyncResponse::Objects(store::objects(&entry.store, &want))
+            }
         }
     }
 }
@@ -391,7 +388,7 @@ async fn drive(
                     log::warn!("collab: update for an unregistered session");
                     continue;
                 };
-                entry.store.merge(heads, commits, graphs);
+                store::merge(&mut entry.store, heads, commits, graphs);
             }
             Command::Forget(session) => {
                 let mut state = shared.lock();

--- a/crates/gantz_collab/src/store.rs
+++ b/crates/gantz_collab/src/store.rs
@@ -1,38 +1,38 @@
 //! The served session content, owned by the network runtime.
 //!
-//! The application mirrors each session's scoped closure (commits, graphs as
-//! serialized blobs, and the scoped `name -> tip` map) into its
-//! [`SessionStore`] via [`Command::Register`](crate::Command::Register) and
+//! Each session serves a plain [`gantz_ca::Registry`] over [`RawGraph`]
+//! payloads: graphs sit at rest as application-serialized blobs under the
+//! addresses the application validated them against, keeping the crate
+//! agnostic of the node type. The application mirrors each session's scoped
+//! closure (commits, graphs, heads) into the store via
+//! [`Command::Register`](crate::Command::Register) and
 //! [`Command::Update`](crate::Command::Update); the runtime's request
 //! handler answers peers from it synchronously. Content-addressed keys make
 //! every insert idempotent, so updates may be re-sent freely.
+//!
+//! The store is a relay: it holds what the local application (a decoding
+//! peer) verified, under the claimed addresses. Receiving peers re-verify
+//! everything through the typed `gantz_ca::sync::Staged` path on their own
+//! side, which is where the security boundary lives.
 
 use crate::{
-    proto::{Objects, Want},
+    proto::{Object, ObjectRef, Objects, Want},
     session::{Access, PeerId, Session, SessionId},
 };
-use gantz_ca::{Commit, CommitAddr, GraphAddr};
+use gantz_ca::{Commit, CommitAddr, GraphHash, MergeReport, Name, RawGraph, Registry};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     sync::{Arc, Mutex, MutexGuard, PoisonError},
 };
 
-/// One session's served content.
-#[derive(Debug, Default)]
-pub struct SessionStore {
-    /// The scoped commit closure.
-    pub commits: HashMap<CommitAddr, Commit>,
-    /// The scoped graphs, as application-serialized (self-describing) blobs.
-    pub graphs: HashMap<GraphAddr, Vec<u8>>,
-    /// The scoped `name -> tip` map.
-    pub heads: BTreeMap<String, CommitAddr>,
-}
+/// One session's served content. See the module docs.
+pub type SessionRegistry = Registry<RawGraph>;
 
 /// A session's configuration plus its served content.
 #[derive(Debug)]
 pub struct SessionEntry {
     pub session: Session,
-    pub store: SessionStore,
+    pub store: SessionRegistry,
 }
 
 /// The state shared between the runtime's driver and its request-serving
@@ -52,50 +52,6 @@ pub(crate) struct SharedState {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct Shared(Arc<Mutex<SharedState>>);
 
-impl SessionStore {
-    /// Merge served content into the store: content-addressed commit/graph
-    /// inserts (idempotent) and per-name head upserts.
-    pub fn merge(
-        &mut self,
-        heads: impl IntoIterator<Item = (String, CommitAddr)>,
-        commits: impl IntoIterator<Item = (CommitAddr, Commit)>,
-        graphs: impl IntoIterator<Item = (GraphAddr, Vec<u8>)>,
-    ) {
-        self.commits.extend(commits);
-        self.graphs.extend(graphs);
-        self.heads.extend(heads);
-    }
-
-    /// The requested objects, where present.
-    pub fn objects(&self, want: &Want) -> Objects {
-        let commits = want
-            .commits
-            .iter()
-            .filter_map(|ca| self.commits.get(ca).map(|c| (*ca, c.clone().into())))
-            .collect();
-        let graphs = want
-            .graphs
-            .iter()
-            .filter_map(|ga| self.graphs.get(ga).map(|g| (*ga, g.clone())))
-            .collect();
-        Objects { commits, graphs }
-    }
-
-    /// The whole store as a join snapshot.
-    pub fn snapshot(&self) -> (Vec<(String, CommitAddr)>, Objects) {
-        let heads = self.heads.iter().map(|(n, ca)| (n.clone(), *ca)).collect();
-        let objects = Objects {
-            commits: self
-                .commits
-                .iter()
-                .map(|(ca, c)| (*ca, c.clone().into()))
-                .collect(),
-            graphs: self.graphs.iter().map(|(ga, g)| (*ga, g.clone())).collect(),
-        };
-        (heads, objects)
-    }
-}
-
 impl SessionEntry {
     /// Whether `peer` may read this session's content.
     pub fn allows(&self, peer: PeerId) -> bool {
@@ -112,5 +68,213 @@ impl Shared {
     /// an invalid shape.
     pub(crate) fn lock(&self) -> MutexGuard<'_, SharedState> {
         self.0.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// Merge served content into the store: content-addressed commit/graph
+/// inserts (idempotent) and per-name head upserts (an incoming tip wins,
+/// reported).
+///
+/// The content is trusted as-is under its claimed addresses (see the module
+/// docs): nothing is re-hashed, no parents are detached, so the store serves
+/// content byte-identical to what the application validated.
+pub fn merge(
+    store: &mut SessionRegistry,
+    heads: impl IntoIterator<Item = (Name, CommitAddr)>,
+    commits: impl IntoIterator<Item = (CommitAddr, Commit)>,
+    graphs: impl IntoIterator<Item = RawGraph>,
+) -> MergeReport {
+    let graphs = graphs.into_iter().map(|g| (g.graph_addr(), g)).collect();
+    let commits = commits.into_iter().collect();
+    let heads = heads.into_iter().collect();
+    store.merge(Registry::from_parts(graphs, commits, heads))
+}
+
+/// The requested objects, where present. Absent objects are skipped: the
+/// requester re-requests from another peer or re-heals on the next announce.
+pub fn objects(store: &SessionRegistry, want: &Want) -> Objects {
+    let objects = want
+        .refs
+        .iter()
+        .filter_map(|r| match r {
+            ObjectRef::Commit(ca) => store
+                .commits()
+                .get(ca)
+                .map(|c| Object::Commit(*ca, c.clone().into())),
+            ObjectRef::Graph(ga) => store
+                .graph(ga)
+                .map(|g| Object::Graph(*ga, g.bytes.to_vec())),
+            ObjectRef::Blob { section, addr } => store.blobs().get(section).and_then(|blobs| {
+                blobs.get(addr).map(|bytes| Object::Blob {
+                    section: section.clone(),
+                    liveness: blobs.liveness,
+                    addr: *addr,
+                    bytes: bytes.to_vec(),
+                })
+            }),
+        })
+        .collect();
+    Objects { objects }
+}
+
+/// The whole store as a join snapshot: every head, commit, graph and blob.
+pub fn snapshot(store: &SessionRegistry) -> (Vec<(Name, CommitAddr)>, Objects) {
+    let heads = store.heads().map(|(n, ca)| (n.clone(), ca)).collect();
+    let mut objects = Vec::new();
+    for (ca, c) in store.commits() {
+        objects.push(Object::Commit(*ca, c.clone().into()));
+    }
+    for (ga, g) in store.graphs() {
+        objects.push(Object::Graph(*ga, g.bytes.to_vec()));
+    }
+    for (section, blobs) in store.blobs() {
+        for (addr, bytes) in &blobs.entries {
+            objects.push(Object::Blob {
+                section: section.clone(),
+                liveness: blobs.liveness,
+                addr: *addr,
+                bytes: bytes.to_vec(),
+            });
+        }
+    }
+    (heads, Objects { objects })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gantz_ca::{BlobLiveness, ContentAddr, GraphAddr, commit_addr};
+    use std::time::Duration;
+
+    fn name(s: &str) -> Name {
+        s.parse().unwrap()
+    }
+
+    fn graph_addr(n: u8) -> GraphAddr {
+        GraphAddr::from(ContentAddr::from([n; 32]))
+    }
+
+    /// A store with one head over a two-commit chain and its graphs.
+    fn test_store() -> (SessionRegistry, CommitAddr, CommitAddr) {
+        let mut store = SessionRegistry::default();
+        let root = Commit::new(Duration::from_secs(1), None, graph_addr(1));
+        let root_ca = commit_addr(&root);
+        let tip = Commit::new(Duration::from_secs(2), Some(root_ca), graph_addr(2));
+        let tip_ca = commit_addr(&tip);
+        merge(
+            &mut store,
+            [(name("jam"), tip_ca)],
+            [(root_ca, root), (tip_ca, tip)],
+            [
+                RawGraph::new(graph_addr(1), &b"g1"[..]),
+                RawGraph::new(graph_addr(2), &b"g2"[..]),
+            ],
+        );
+        (store, root_ca, tip_ca)
+    }
+
+    #[test]
+    fn merge_is_idempotent() {
+        let (mut store, root_ca, tip_ca) = test_store();
+        let root = store.commits()[&root_ca].clone();
+        let tip = store.commits()[&tip_ca].clone();
+        let report = merge(
+            &mut store,
+            [(name("jam"), tip_ca)],
+            [(root_ca, root), (tip_ca, tip)],
+            [RawGraph::new(graph_addr(1), &b"g1"[..])],
+        );
+        assert!(report.heads_added.is_empty());
+        assert!(report.heads_replaced.is_empty());
+        assert_eq!(store.commits().len(), 2);
+        assert_eq!(store.graphs().len(), 2);
+    }
+
+    #[test]
+    fn merge_repoints_heads() {
+        let (mut store, root_ca, tip_ca) = test_store();
+        let report = merge(&mut store, [(name("jam"), root_ca)], [], []);
+        assert_eq!(report.heads_replaced, vec![(name("jam"), tip_ca, root_ca)]);
+        assert_eq!(store.head(&name("jam")), Some(root_ca));
+    }
+
+    #[test]
+    fn objects_filters_to_present() {
+        let (store, root_ca, _tip_ca) = test_store();
+        let absent_ca = CommitAddr::from(ContentAddr::from([9; 32]));
+        let want = Want {
+            refs: vec![
+                ObjectRef::Commit(root_ca),
+                ObjectRef::Commit(absent_ca),
+                ObjectRef::Graph(graph_addr(1)),
+                ObjectRef::Graph(graph_addr(9)),
+                ObjectRef::Blob {
+                    section: "dsp.buffer".to_string(),
+                    addr: ContentAddr::from([9; 32]),
+                },
+            ],
+        };
+        let objects = objects(&store, &want).objects;
+        assert_eq!(objects.len(), 2);
+        assert!(matches!(objects[0], Object::Commit(ca, _) if ca == root_ca));
+        assert!(
+            matches!(&objects[1], Object::Graph(ga, bytes) if *ga == graph_addr(1) && bytes == b"g1")
+        );
+    }
+
+    #[test]
+    fn objects_serves_blobs() {
+        let (mut store, _root_ca, _tip_ca) = test_store();
+        let addr = store.add_blob("dsp.buffer", BlobLiveness::ContentReferenced, &b"pcm"[..]);
+        let want = Want {
+            refs: vec![ObjectRef::Blob {
+                section: "dsp.buffer".to_string(),
+                addr,
+            }],
+        };
+        let objects = objects(&store, &want).objects;
+        assert_eq!(
+            objects,
+            vec![Object::Blob {
+                section: "dsp.buffer".to_string(),
+                liveness: BlobLiveness::ContentReferenced,
+                addr,
+                bytes: b"pcm".to_vec(),
+            }]
+        );
+    }
+
+    #[test]
+    fn snapshot_round_trips() {
+        let (mut store, _root_ca, tip_ca) = test_store();
+        store.add_blob("dsp.buffer", BlobLiveness::ContentReferenced, &b"pcm"[..]);
+        let (heads, objects) = snapshot(&store);
+        assert_eq!(heads, vec![(name("jam"), tip_ca)]);
+        // Rebuild a store from the snapshot's wire objects.
+        let mut rebuilt = SessionRegistry::default();
+        let mut commits = Vec::new();
+        let mut graphs = Vec::new();
+        for object in objects.objects {
+            match object {
+                Object::Commit(ca, c) => commits.push((ca, c.into())),
+                Object::Graph(ga, bytes) => graphs.push(RawGraph::new(ga, bytes)),
+                Object::Blob {
+                    section,
+                    liveness,
+                    bytes,
+                    ..
+                } => {
+                    rebuilt.add_blob(section, liveness, bytes);
+                }
+            }
+        }
+        merge(&mut rebuilt, heads, commits, graphs);
+        assert_eq!(rebuilt.commits(), store.commits());
+        assert_eq!(rebuilt.graphs(), store.graphs());
+        assert_eq!(rebuilt.blobs(), store.blobs());
+        assert_eq!(
+            rebuilt.heads().collect::<Vec<_>>(),
+            store.heads().collect::<Vec<_>>()
+        );
     }
 }

--- a/crates/gantz_collab/tests/localhost.rs
+++ b/crates/gantz_collab/tests/localhost.rs
@@ -4,10 +4,10 @@
 //! so it is ignored by default; run manually with
 //! `cargo test -p gantz_collab -- --ignored`.
 
-use gantz_ca::{Commit, ContentAddr, GraphAddr, commit_addr};
+use gantz_ca::{Commit, ContentAddr, GraphAddr, Name, RawGraph, commit_addr};
 use gantz_collab::{
-    Access, Command, Event, Handle, Identity, PeerId, Role, Session, SessionEntry, SessionId,
-    SessionStore, SessionTicket, Want,
+    Access, Command, Event, Handle, Identity, Object, ObjectRef, PeerId, Role, Session,
+    SessionEntry, SessionId, SessionRegistry, SessionTicket, Want, store,
 };
 use std::time::{Duration, Instant};
 
@@ -38,6 +38,7 @@ fn share_join_and_fetch_between_two_runtimes() {
     let commit = Commit::new(Duration::from_secs(1), None, graph_ca);
     let tip = commit_addr(&commit);
     let graph_blob = b"(fake serialized graph)".to_vec();
+    let jam: Name = "jam".parse().unwrap();
 
     // The host runtime serves one session with a single-commit store.
     let host = gantz_collab::spawn(Identity::generate(), Default::default());
@@ -45,10 +46,13 @@ fn share_join_and_fetch_between_two_runtimes() {
         Event::Ready { peer } => Some(peer),
         _ => None,
     });
-    let mut store = SessionStore::default();
-    store.commits.insert(tip, commit.clone());
-    store.graphs.insert(graph_ca, graph_blob.clone());
-    store.heads.insert("jam".to_string(), tip);
+    let mut served = SessionRegistry::default();
+    store::merge(
+        &mut served,
+        [(jam.clone(), tip)],
+        [(tip, commit.clone())],
+        [RawGraph::new(graph_ca, graph_blob.clone())],
+    );
     host.cmds
         .send_blocking(Command::Register(SessionEntry {
             session: Session {
@@ -58,7 +62,7 @@ fn share_join_and_fetch_between_two_runtimes() {
                 resolutions: Default::default(),
                 role: Role::Host,
             },
-            store,
+            store: served,
         }))
         .unwrap();
     host.cmds.send_blocking(Command::Share(session_id)).unwrap();
@@ -86,7 +90,7 @@ fn share_join_and_fetch_between_two_runtimes() {
                 resolutions: ticket.resolutions,
                 role: Role::Guest,
             },
-            store: SessionStore::default(),
+            store: SessionRegistry::default(),
         }))
         .unwrap();
     guest.cmds.send_blocking(Command::Join(ticket)).unwrap();
@@ -95,9 +99,14 @@ fn share_join_and_fetch_between_two_runtimes() {
         Event::Error { message, .. } => panic!("join failed: {message}"),
         _ => None,
     });
-    assert_eq!(heads, vec![("jam".to_string(), tip)]);
-    assert_eq!(objects.commits, vec![(tip, commit.clone().into())]);
-    assert_eq!(objects.graphs, vec![(graph_ca, graph_blob.clone())]);
+    assert_eq!(heads, vec![(jam.clone(), tip)]);
+    assert_eq!(
+        objects.objects,
+        vec![
+            Object::Commit(tip, commit.clone().into()),
+            Object::Graph(graph_ca, graph_blob.clone()),
+        ]
+    );
 
     // A targeted fetch over the request plane returns the same objects.
     guest
@@ -106,8 +115,7 @@ fn share_join_and_fetch_between_two_runtimes() {
             session: session_id,
             from: host_peer,
             want: Want {
-                commits: vec![tip],
-                graphs: vec![graph_ca],
+                refs: vec![ObjectRef::Commit(tip), ObjectRef::Graph(graph_ca)],
             },
         })
         .unwrap();
@@ -119,8 +127,13 @@ fn share_join_and_fetch_between_two_runtimes() {
         Event::Error { message, .. } => panic!("fetch failed: {message}"),
         _ => None,
     });
-    assert_eq!(fetched.commits, vec![(tip, commit.into())]);
-    assert_eq!(fetched.graphs, vec![(graph_ca, graph_blob)]);
+    assert_eq!(
+        fetched.objects,
+        vec![
+            Object::Commit(tip, commit.into()),
+            Object::Graph(graph_ca, graph_blob),
+        ]
+    );
 }
 
 #[test]
@@ -142,7 +155,7 @@ fn restricted_sessions_deny_unlisted_peers() {
                 resolutions: Default::default(),
                 role: Role::Host,
             },
-            store: SessionStore::default(),
+            store: SessionRegistry::default(),
         }))
         .unwrap();
     host.cmds.send_blocking(Command::Share(session_id)).unwrap();

--- a/crates/gantz_core/src/graph.rs
+++ b/crates/gantz_core/src/graph.rs
@@ -130,6 +130,48 @@ where
     addrs
 }
 
+/// Collect all blob references required by nodes in this graph, as
+/// `(blob section, content address)` pairs.
+pub fn required_blobs<'a, G>(
+    get_node: node::GetNode<'a>,
+    g: G,
+) -> HashSet<(gantz_ca::SectionId, gantz_ca::ContentAddr)>
+where
+    G: Data<EdgeWeight = Edge> + IntoEdgesDirected + IntoNodeReferences + NodeIndexable + Visitable,
+    G::NodeWeight: Node,
+{
+    let mut blobs = HashSet::new();
+    visit(
+        get_node,
+        g,
+        &[],
+        &mut visit::RequiredBlobs { blobs: &mut blobs },
+    );
+    blobs
+}
+
+/// The outgoing content references of this graph for reachability: every
+/// node-reported required address as a graph reference, plus every blob
+/// reference.
+///
+/// Addresses that are not graph addresses (e.g. builtin node addresses
+/// reported by function-value wrappers) simply fail to resolve during the
+/// walk and are ignored there.
+pub fn out_refs<'a, G>(get_node: node::GetNode<'a>, g: G) -> gantz_ca::OutRefs
+where
+    G: Data<EdgeWeight = Edge> + IntoEdgesDirected + IntoNodeReferences + NodeIndexable + Visitable,
+    G::NodeWeight: Node,
+{
+    let mut graphs: Vec<gantz_ca::GraphAddr> = required_addrs(get_node, g)
+        .into_iter()
+        .map(gantz_ca::GraphAddr::from)
+        .collect();
+    graphs.sort();
+    let mut blobs: Vec<_> = required_blobs(get_node, g).into_iter().collect();
+    blobs.sort();
+    gantz_ca::OutRefs { graphs, blobs }
+}
+
 /// Extract a subgraph containing only the selected nodes and edges between them.
 ///
 /// Nodes are visited in index order for determinism. Callers that need to

--- a/crates/gantz_core/src/lib.rs
+++ b/crates/gantz_core/src/lib.rs
@@ -1,13 +1,13 @@
 pub use builtin::{Builtin, BuiltinSet, Builtins, FromNode};
 pub use diagnostic::Diagnostic;
 pub use edge::Edge;
+pub use gantz_ca::datum;
 pub use node::Node;
 pub use steel;
 
 pub mod args;
 pub mod builtin;
 pub mod compile;
-pub mod datum;
 pub mod diagnostic;
 pub mod edge;
 pub mod graph;

--- a/crates/gantz_core/src/node.rs
+++ b/crates/gantz_core/src/node.rs
@@ -171,12 +171,25 @@ pub trait Node: std::any::Any {
 
     /// Returns the content addresses of external nodes this node requires.
     ///
-    /// Used during pruning to determine which commits/graphs are still in use.
-    /// Nodes that reference other graphs (like `Ref`, `NamedRef`) should return
-    /// the addresses they depend on.
+    /// Used during reachability (pruning, export closure) to determine which
+    /// graphs are still in use. Nodes that reference other graphs (like
+    /// `Ref`, `NamedRef`) should return the addresses they depend on - for
+    /// graph references this is the referenced graph's `GraphAddr`.
     ///
     /// By default, returns an empty vec (no external dependencies).
     fn required_addrs(&self) -> Vec<gantz_ca::ContentAddr> {
+        vec![]
+    }
+
+    /// Returns the blob references this node requires, as
+    /// `(blob section, content address)` pairs.
+    ///
+    /// The blob half of reachability: nodes referencing content-addressed
+    /// bytes (e.g. audio buffers) report them here so pruning and export
+    /// keep the blobs alive.
+    ///
+    /// By default, returns an empty vec (no blob dependencies).
+    fn required_blobs(&self) -> Vec<(gantz_ca::SectionId, gantz_ca::ContentAddr)> {
         vec![]
     }
 
@@ -450,6 +463,10 @@ macro_rules! impl_node_for_ptr {
 
             fn required_addrs(&self) -> Vec<gantz_ca::ContentAddr> {
                 (**self).required_addrs()
+            }
+
+            fn required_blobs(&self) -> Vec<(gantz_ca::SectionId, gantz_ca::ContentAddr)> {
+                (**self).required_blobs()
             }
 
             fn visit(&self, ctx: visit::Ctx<'_, '_>, visitor: &mut dyn Visitor) {

--- a/crates/gantz_core/src/node/fn_.rs
+++ b/crates/gantz_core/src/node/fn_.rs
@@ -102,6 +102,10 @@ impl<N: Node> Node for Fn<N> {
         self.0.required_addrs()
     }
 
+    fn required_blobs(&self) -> Vec<(gantz_ca::SectionId, gantz_ca::ContentAddr)> {
+        self.0.required_blobs()
+    }
+
     fn visit(&self, ctx: visit::Ctx<'_, '_>, visitor: &mut dyn node::Visitor) {
         self.0.visit(ctx, visitor);
     }

--- a/crates/gantz_core/src/node/pull.rs
+++ b/crates/gantz_core/src/node/pull.rs
@@ -89,4 +89,8 @@ impl<N: Node> Node for Pull<N> {
     fn required_addrs(&self) -> Vec<gantz_ca::ContentAddr> {
         self.node.required_addrs()
     }
+
+    fn required_blobs(&self) -> Vec<(gantz_ca::SectionId, gantz_ca::ContentAddr)> {
+        self.node.required_blobs()
+    }
 }

--- a/crates/gantz_core/src/node/push.rs
+++ b/crates/gantz_core/src/node/push.rs
@@ -87,4 +87,8 @@ impl<N: Node> Node for Push<N> {
     fn required_addrs(&self) -> Vec<gantz_ca::ContentAddr> {
         self.node.required_addrs()
     }
+
+    fn required_blobs(&self) -> Vec<(gantz_ca::SectionId, gantz_ca::ContentAddr)> {
+        self.node.required_blobs()
+    }
 }

--- a/crates/gantz_core/src/node/ref_.rs
+++ b/crates/gantz_core/src/node/ref_.rs
@@ -24,6 +24,12 @@ pub trait AsRefNode {
 
 /// A node that refers to another node in the environment by content address.
 ///
+/// Reference identity is CONTENT identity: a reference to another graph
+/// pins that graph's `GraphAddr`, so a referencing graph's own address
+/// depends only on the content it references, never on commit history or
+/// timestamps. (The address may also be a builtin node's content address -
+/// resolution decides, via the environment's node lookup.)
+///
 /// A reference optionally carries domain-extension data in `ext`: canonical
 /// [`Datum`]s keyed by a domain-prefixed string (e.g. `"plyphon.dsp-ref"`).
 /// Ext data serializes and content-addresses with the node, losslessly even

--- a/crates/gantz_core/src/node/state.rs
+++ b/crates/gantz_core/src/node/state.rs
@@ -139,6 +139,10 @@ where
     fn required_addrs(&self) -> Vec<gantz_ca::ContentAddr> {
         self.node.required_addrs()
     }
+
+    fn required_blobs(&self) -> Vec<(gantz_ca::SectionId, gantz_ca::ContentAddr)> {
+        self.node.required_blobs()
+    }
 }
 
 /// Sets the given node's state to the given value.

--- a/crates/gantz_core/src/reg.rs
+++ b/crates/gantz_core/src/reg.rs
@@ -1,17 +1,64 @@
-//! Utilities for working with [`gantz_ca::Registry`].
+//! Utilities for working with [`gantz_ca::Registry`]: node-aware
+//! reachability over the content DAG.
+//!
+//! These wrap [`gantz_ca::closure`] with the node layer's edge reporting
+//! ([`graph::out_refs`]): only this crate's callers can see inside node
+//! payloads to find nested graph and blob references.
 
 use crate::{Edge, Node, graph, node};
+use gantz_ca::Name;
 use petgraph::visit::{Data, IntoEdgesDirected, IntoNodeReferences, NodeIndexable, Visitable};
 use std::collections::{BTreeSet, HashSet};
 
-/// Export a registry subset containing the transitive dependencies of the given heads.
+/// The live set reachable from ALL of the registry's heads plus the given
+/// extra heads.
 ///
-/// Collects all required commits via [`required_commits`], then calls
-/// [`gantz_ca::Registry::export`] to produce the subset.
-pub fn export<'a, G>(
+/// Suitable for pruning: everything outside the returned set is unused.
+pub fn live<'a, G>(
+    get_node: node::GetNode<'a>,
+    reg: &gantz_ca::Registry<G>,
+    extra_heads: impl IntoIterator<Item = impl std::borrow::Borrow<gantz_ca::Head>>,
+) -> gantz_ca::LiveSet
+where
+    for<'g> &'g G: Data<EdgeWeight = Edge>
+        + IntoEdgesDirected
+        + IntoNodeReferences
+        + NodeIndexable
+        + Visitable,
+    for<'g> <&'g G as Data>::NodeWeight: Node,
+{
+    let extra = head_seeds(reg, extra_heads);
+    gantz_ca::closure(reg, extra, |g| graph::out_refs(get_node, g))
+}
+
+/// The live set reachable from ONLY the given heads.
+///
+/// Unlike [`live`], this does not seed from the registry's own heads - use
+/// it for the minimal closure of a specific head set (e.g. single-head
+/// export).
+pub fn live_for_heads<'a, G>(
     get_node: node::GetNode<'a>,
     reg: &gantz_ca::Registry<G>,
     heads: impl IntoIterator<Item = impl std::borrow::Borrow<gantz_ca::Head>>,
+) -> gantz_ca::LiveSet
+where
+    for<'g> &'g G: Data<EdgeWeight = Edge>
+        + IntoEdgesDirected
+        + IntoNodeReferences
+        + NodeIndexable
+        + Visitable,
+    for<'g> <&'g G as Data>::NodeWeight: Node,
+{
+    let seeds = head_seeds(reg, heads);
+    gantz_ca::closure_from(reg, seeds, |g| graph::out_refs(get_node, g))
+}
+
+/// Export a registry subset containing the transitive dependencies of all
+/// heads plus the given extra heads.
+pub fn export<'a, G>(
+    get_node: node::GetNode<'a>,
+    reg: &gantz_ca::Registry<G>,
+    extra_heads: impl IntoIterator<Item = impl std::borrow::Borrow<gantz_ca::Head>>,
 ) -> gantz_ca::Registry<G>
 where
     G: Clone,
@@ -22,16 +69,15 @@ where
         + Visitable,
     for<'g> <&'g G as Data>::NodeWeight: Node,
 {
-    let required = required_commits(get_node, reg, heads);
-    reg.export(&required)
+    gantz_ca::export(reg, &live(get_node, reg, extra_heads))
 }
 
-/// Export a registry subset containing only the transitive dependencies of the
-/// given heads, without including all named commits.
+/// Export a registry subset containing only the transitive dependencies of
+/// the given heads.
 ///
-/// Unlike [`export`], which seeds from all names (suitable for pruning), this
-/// produces the minimal registry for a specific set of heads — only the names
-/// whose commits are transitively reachable are included.
+/// Unlike [`export`], which seeds from all heads (suitable for pruning),
+/// this produces the minimal registry for a specific set of heads - only
+/// the heads whose commits are transitively reachable are included.
 pub fn export_heads<'a, G>(
     get_node: node::GetNode<'a>,
     reg: &gantz_ca::Registry<G>,
@@ -46,74 +92,18 @@ where
         + Visitable,
     for<'g> <&'g G as Data>::NodeWeight: Node,
 {
-    let required = required_commits_for_heads(get_node, reg, heads);
-    reg.export(&required)
-}
-
-/// Collect all commit addresses transitively required by named graphs and heads.
-///
-/// Starts from all named commits and head commits, then transitively follows
-/// references within graphs to build the complete set of required commits.
-pub fn required_commits<'a, G>(
-    get_node: node::GetNode<'a>,
-    reg: &gantz_ca::Registry<G>,
-    heads: impl IntoIterator<Item = impl std::borrow::Borrow<gantz_ca::Head>>,
-) -> HashSet<gantz_ca::CommitAddr>
-where
-    for<'g> &'g G: Data<EdgeWeight = Edge>
-        + IntoEdgesDirected
-        + IntoNodeReferences
-        + NodeIndexable
-        + Visitable,
-    for<'g> <&'g G as Data>::NodeWeight: Node,
-{
-    let mut seeds: Vec<_> = reg
-        .names()
-        .values()
-        .map(|&ca| gantz_ca::ContentAddr::from(ca))
-        .collect();
-    for head in heads {
-        if let Some(&ca) = reg.head_commit_ca(head.borrow()) {
-            seeds.push(gantz_ca::ContentAddr::from(ca));
-        }
-    }
-    transitive_commits(get_node, reg, seeds)
-}
-
-/// Collect commit addresses transitively required by the given heads only.
-///
-/// Unlike [`required_commits`], this does *not* seed the traversal from all
-/// named commits — only from the provided heads. Use this when you need the
-/// minimal set of commits reachable from a specific set of heads (e.g. for
-/// single-head export).
-pub fn required_commits_for_heads<'a, G>(
-    get_node: node::GetNode<'a>,
-    reg: &gantz_ca::Registry<G>,
-    heads: impl IntoIterator<Item = impl std::borrow::Borrow<gantz_ca::Head>>,
-) -> HashSet<gantz_ca::CommitAddr>
-where
-    for<'g> &'g G: Data<EdgeWeight = Edge>
-        + IntoEdgesDirected
-        + IntoNodeReferences
-        + NodeIndexable
-        + Visitable,
-    for<'g> <&'g G as Data>::NodeWeight: Node,
-{
-    let mut seeds = Vec::new();
-    for head in heads {
-        if let Some(&ca) = reg.head_commit_ca(head.borrow()) {
-            seeds.push(gantz_ca::ContentAddr::from(ca));
-        }
-    }
-    transitive_commits(get_node, reg, seeds)
+    gantz_ca::export(reg, &live_for_heads(get_node, reg, heads))
 }
 
 /// Find named graphs not referenced by any other graph in the registry.
 ///
 /// A name is "root" if no graph in the registry contains a node whose
-/// `required_addrs` points to that name's commit. Returns names in
+/// `required_addrs` points at the name's head graph. Returns names in
 /// alphabetical order.
-pub fn root_names<'a, G>(get_node: node::GetNode<'a>, reg: &gantz_ca::Registry<G>) -> Vec<String>
+///
+/// Note that reference identity is content identity: names whose heads
+/// share identical graph content are either all root or all referenced.
+pub fn root_names<'a, G>(get_node: node::GetNode<'a>, reg: &gantz_ca::Registry<G>) -> Vec<Name>
 where
     for<'g> &'g G: Data<EdgeWeight = Edge>
         + IntoEdgesDirected
@@ -122,51 +112,36 @@ where
         + Visitable,
     for<'g> <&'g G as Data>::NodeWeight: Node,
 {
-    // Collect all CommitAddrs referenced by any graph in the registry.
-    let mut referenced = HashSet::new();
-    for (commit_ca, _) in reg.commits() {
-        if let Some(graph) = reg.commit_graph_ref(commit_ca) {
-            for ca in graph::required_addrs(get_node, graph) {
-                referenced.insert(gantz_ca::CommitAddr::from(ca));
-            }
-        }
+    // Collect all graph addrs referenced by any graph in the registry.
+    let mut referenced: HashSet<gantz_ca::GraphAddr> = HashSet::new();
+    for graph in reg.graphs().values() {
+        referenced.extend(
+            graph::required_addrs(get_node, graph)
+                .into_iter()
+                .map(gantz_ca::GraphAddr::from),
+        );
     }
 
-    // Filter names to those whose commit is NOT referenced.
-    reg.names()
-        .iter()
-        .filter(|&(_, &commit_ca)| !referenced.contains(&commit_ca))
+    // Filter heads to those whose graph is NOT referenced.
+    reg.heads()
+        .filter(|(_, ca)| {
+            reg.commits()
+                .get(ca)
+                .is_none_or(|commit| !referenced.contains(&commit.graph))
+        })
         .map(|(name, _)| name.clone())
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect()
 }
 
-/// Traverse commit references starting from the given seed addresses.
-///
-/// Follows graph node references transitively to collect the complete set of
-/// reachable commits.
-fn transitive_commits<'a, G>(
-    get_node: node::GetNode<'a>,
+/// Resolve the given heads to their commit addresses.
+fn head_seeds<G>(
     reg: &gantz_ca::Registry<G>,
-    mut to_visit: Vec<gantz_ca::ContentAddr>,
-) -> HashSet<gantz_ca::CommitAddr>
-where
-    for<'g> &'g G: Data<EdgeWeight = Edge>
-        + IntoEdgesDirected
-        + IntoNodeReferences
-        + NodeIndexable
-        + Visitable,
-    for<'g> <&'g G as Data>::NodeWeight: Node,
-{
-    let mut required = HashSet::new();
-    while let Some(addr) = to_visit.pop() {
-        let commit_ca = gantz_ca::CommitAddr::from(addr);
-        if reg.commits().contains_key(&commit_ca) && required.insert(commit_ca) {
-            if let Some(graph) = reg.commit_graph_ref(&commit_ca) {
-                to_visit.extend(graph::required_addrs(get_node, graph));
-            }
-        }
-    }
-    required
+    heads: impl IntoIterator<Item = impl std::borrow::Borrow<gantz_ca::Head>>,
+) -> Vec<gantz_ca::CommitAddr> {
+    heads
+        .into_iter()
+        .filter_map(|head| reg.head_commit_ca(head.borrow()))
+        .collect()
 }

--- a/crates/gantz_core/src/visit.rs
+++ b/crates/gantz_core/src/visit.rs
@@ -45,6 +45,12 @@ pub(crate) struct RequiredAddrs<'a> {
     pub addrs: &'a mut HashSet<gantz_ca::ContentAddr>,
 }
 
+/// Visitor that collects all required blob references from nodes.
+pub(crate) struct RequiredBlobs<'a> {
+    /// The set of collected (blob section, address) pairs.
+    pub blobs: &'a mut HashSet<(gantz_ca::SectionId, gantz_ca::ContentAddr)>,
+}
+
 impl<'env, 'data> Ctx<'env, 'data> {
     /// Create a `Ctx` instance. Exclusively for use by `Visitor`
     /// implementations.
@@ -100,5 +106,11 @@ impl Visitor for Register<'_> {
 impl Visitor for RequiredAddrs<'_> {
     fn visit_pre(&mut self, _ctx: Ctx<'_, '_>, node: &dyn Node) {
         self.addrs.extend(node.required_addrs());
+    }
+}
+
+impl Visitor for RequiredBlobs<'_> {
+    fn visit_pre(&mut self, _ctx: Ctx<'_, '_>, node: &dyn Node) {
+        self.blobs.extend(node.required_blobs());
     }
 }

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -41,11 +41,18 @@ struct Environment {
 impl Environment {
     /// Look up a node by content address.
     fn node(&self, ca: &gantz_ca::ContentAddr) -> Option<&dyn gantz_core::Node> {
-        // Try commit lookup (for graph refs stored as CommitAddr).
-        let commit_ca = gantz_ca::CommitAddr::from(*ca);
+        // Graph refs pin graph addresses: a graph in the registry IS a node.
+        let graph_ca = gantz_ca::GraphAddr::from(*ca);
         self.registry
-            .commit_graph_ref(&commit_ca)
+            .graph(&graph_ca)
             .map(|g| g as &dyn gantz_core::Node)
+    }
+
+    /// The graph address at the tip of the named line of history: the
+    /// address a `Ref` to the name should pin.
+    fn head_graph_addr(&self, name: &gantz_ca::Name) -> Option<gantz_ca::GraphAddr> {
+        let head_ca = self.registry.head(name)?;
+        self.registry.commits().get(&head_ca).map(|c| c.graph)
     }
 }
 
@@ -60,12 +67,12 @@ impl gantz_egui::NodeTypeRegistry for Environment {
     fn node_types(&self) -> Vec<&str> {
         let mut types = vec![gantz_egui::widget::gantz::NESTED_GRAPH_TYPE];
         types.extend(self.primitives.keys().map(|s| &s[..]));
+        // A root name is its single segment.
         types.extend(
             self.registry
-                .names()
-                .keys()
-                .filter(|n| !n.contains(gantz_egui::node::NESTED_SEP))
-                .map(|s| &s[..]),
+                .heads()
+                .filter(|(n, _)| !n.is_nested())
+                .map(|(n, _)| n.segments()[0].as_str()),
         );
         types.sort();
         types.dedup();
@@ -76,12 +83,11 @@ impl gantz_egui::NodeTypeRegistry for Environment {
 impl Environment {
     /// Create a node of the given type name.
     fn new_node(&self, node_type: &str) -> Option<Box<dyn Node>> {
-        self.registry
-            .names()
-            .get(node_type)
-            .map(|commit_ca| {
-                let ref_ = gantz_core::node::Ref::new((*commit_ca).into());
-                let named = gantz_egui::node::NamedRef::new(node_type.to_string(), ref_);
+        let name: gantz_ca::Name = node_type.parse().expect("infallible");
+        self.head_graph_addr(&name)
+            .map(|graph_ca| {
+                let ref_ = gantz_core::node::Ref::new(graph_ca.into());
+                let named = gantz_egui::node::NamedRef::new(name.clone(), ref_);
                 Box::new(named) as Box<dyn Node>
             })
             .or_else(|| self.primitives.get(node_type).map(|f| (f)()))
@@ -97,25 +103,26 @@ impl gantz_egui::widget::graph_select::GraphRegistry for Environment {
         commits
     }
 
-    fn names(&self) -> &BTreeMap<String, gantz_ca::CommitAddr> {
-        &self.registry.names()
+    fn names(&self) -> Vec<(gantz_ca::Name, gantz_ca::CommitAddr)> {
+        self.registry
+            .heads()
+            .map(|(n, ca)| (n.clone(), ca))
+            .collect()
     }
 }
 
 // Provide the `NameRegistry` implementation required by `gantz_egui::node::NamedRef`.
 impl gantz_egui::node::NameRegistry for Environment {
     fn name_ca(&self, name: &str) -> Option<gantz_ca::ContentAddr> {
-        // Return CommitAddr (as ContentAddr) for graph nodes.
-        self.registry
-            .names()
-            .get(name)
-            .map(|commit_ca| (*commit_ca).into())
+        // The addr a `Ref` should pin: the name's head graph addr.
+        let name: gantz_ca::Name = name.parse().expect("infallible");
+        self.head_graph_addr(&name).map(Into::into)
     }
 
     fn node_exists(&self, ca: &gantz_ca::ContentAddr) -> bool {
-        // Check if the commit exists in the registry.
-        let commit_ca = gantz_ca::CommitAddr::from(*ca);
-        self.registry.commit_graph_ref(&commit_ca).is_some()
+        // Check if the graph exists in the registry.
+        let graph_ca = gantz_ca::GraphAddr::from(*ca);
+        self.registry.graph(&graph_ca).is_some()
     }
 }
 
@@ -127,13 +134,12 @@ impl gantz_egui::node::FnNodeNames for Environment {
         let get_node = |ca: &gantz_ca::ContentAddr| self.node(ca);
         let meta_ctx = gantz_core::node::MetaCtx::new(&get_node);
         self.registry
-            .names()
-            .keys()
-            .filter(|name| {
-                let Some(commit_ca) = self.registry.names().get(*name) else {
+            .heads()
+            .filter(|(name, _)| {
+                let Some(graph_ca) = self.head_graph_addr(name) else {
                     return false;
                 };
-                let Some(graph) = self.registry.commit_graph_ref(commit_ca) else {
+                let Some(graph) = self.registry.graph(&graph_ca) else {
                     return false;
                 };
                 let stateful = graph.stateful(meta_ctx);
@@ -141,7 +147,7 @@ impl gantz_egui::node::FnNodeNames for Environment {
                 let single_output = graph.n_outputs(meta_ctx) == 1;
                 !stateful && !branching && single_output
             })
-            .cloned()
+            .map(|(name, _)| name.to_string())
             .collect()
     }
 }
@@ -149,15 +155,13 @@ impl gantz_egui::node::FnNodeNames for Environment {
 // Provide the `Registry` implementation required by the Gantz widget.
 impl gantz_egui::Registry for Environment {
     fn node(&self, ca: &gantz_ca::ContentAddr) -> Option<&dyn gantz_core::Node> {
-        // Try commit lookup (for graph refs stored as CommitAddr).
-        let commit_ca = gantz_ca::CommitAddr::from(*ca);
-        self.registry
-            .commit_graph_ref(&commit_ca)
-            .map(|g| g as &dyn gantz_core::Node)
+        Environment::node(self, ca)
     }
 
     fn would_ref_cycle(&self, target: &str, editing: &str) -> bool {
-        gantz_egui::cycle::would_cycle(&self.registry, target, editing)
+        let target: gantz_ca::Name = target.parse().expect("infallible");
+        let editing: gantz_ca::Name = editing.parse().expect("infallible");
+        gantz_egui::cycle::would_cycle(&self.registry, &target, &editing)
     }
 
     fn socket_doc(
@@ -170,8 +174,8 @@ impl gantz_egui::Registry for Environment {
         use petgraph::visit::{IntoNodeReferences, NodeRef};
         // Resolve the referenced graph and read the ix-th inlet/outlet marker's
         // own doc.
-        let commit_ca = gantz_ca::CommitAddr::from(*ca);
-        let graph = self.registry.commit_graph_ref(&commit_ca)?;
+        let graph_ca = gantz_ca::GraphAddr::from(*ca);
+        let graph = self.registry.graph(&graph_ca)?;
         let get_node = |c: &gantz_ca::ContentAddr| self.node(c);
         let meta_ctx = gantz_core::node::MetaCtx::new(&get_node);
         let node_ref = graph
@@ -211,9 +215,10 @@ impl gantz_egui::Registry for Environment {
                     .collect::<Vec<_>>()
             };
 
-        if let Some(commit_ca) = self.registry.names().get(name) {
-            if let Some(graph) = self.registry.commit_graph_ref(commit_ca) {
-                let ca: gantz_ca::ContentAddr = (*commit_ca).into();
+        let parsed: gantz_ca::Name = name.parse().expect("infallible");
+        if let Some(graph_ca) = self.head_graph_addr(&parsed) {
+            if let Some(graph) = self.registry.graph(&graph_ca) {
+                let ca: gantz_ca::ContentAddr = graph_ca.into();
                 let socket = |kind: SocketKind, ix: usize| {
                     gantz_egui::Registry::socket_doc(self, &ca, kind, ix)
                 };
@@ -229,8 +234,9 @@ impl gantz_egui::Registry for Environment {
         info
     }
 
-    fn graph_description(&self, name: &str) -> Option<&str> {
-        self.registry.description(name)
+    fn graph_description(&self, name: &str) -> Option<String> {
+        let name: gantz_ca::Name = name.parse().expect("infallible");
+        gantz_egui::section::description(&self.registry, &name)
     }
 
     fn node_description(&self, name: &str) -> Option<std::borrow::Cow<'static, str>> {
@@ -241,11 +247,9 @@ impl gantz_egui::Registry for Environment {
                 "Create a new nested graph. Its inlets and outlets become this node's sockets.",
             ));
         }
-        if self.registry.names().contains_key(name) {
-            return self
-                .registry
-                .description(name)
-                .map(|s| Cow::Owned(s.to_string()));
+        let parsed: gantz_ca::Name = name.parse().expect("infallible");
+        if self.registry.head(&parsed).is_some() {
+            return gantz_egui::section::description(&self.registry, &parsed).map(Cow::Owned);
         }
         self.new_node(name)
             .and_then(|n| n.description())
@@ -532,10 +536,9 @@ impl App {
     const GRAPH_ADDRS_KEY: &str = "graph-addrs";
     /// All known graph addresses.
     const COMMIT_ADDRS_KEY: &str = "commit-addrs";
-    /// The key at which the mapping from names to graph CAs is stored.
-    const NAMES_KEY: &str = "graph-names";
-    /// The key at which the mapping from names to descriptions is stored.
-    const DESCRIPTIONS_KEY: &str = "graph-descriptions";
+    /// The key at which the registry's metadata sections (heads, views,
+    /// descriptions, demos) are stored.
+    const SECTIONS_KEY: &str = "registry-sections";
     /// The key at which the list of open heads is stored.
     const OPEN_HEADS_KEY: &str = "open-heads";
 
@@ -554,12 +557,19 @@ impl App {
                 let commit_addrs = load_commit_addrs(storage);
                 let graphs = load_graphs(storage, graph_addrs.iter().copied());
                 let commits = load_commits(storage, commit_addrs.iter().copied());
-                let names = load_names(storage);
                 let open_heads = load_open_heads(storage);
                 let gantz = load_gantz_gui_state(storage);
-                let mut registry = Registry::new(graphs, commits, names);
-                for (name, description) in load_descriptions(storage) {
-                    registry.set_description(name, description);
+                let mut registry = Registry::from_parts(graphs, commits, BTreeMap::new());
+                for (id, section) in load_sections(storage) {
+                    for (key, value) in section.entries {
+                        registry.set_section_value(
+                            id.clone(),
+                            section.policy,
+                            section.liveness,
+                            key,
+                            value,
+                        );
+                    }
                 }
                 (registry, open_heads, gantz)
             })
@@ -595,11 +605,13 @@ impl App {
             primitives,
         };
 
-        // Prune unused graphs now that we have the environment for node lookups.
-        let get_node = |ca: &gantz_ca::ContentAddr| env.node(ca);
-        let heads_for_prune = heads.iter().map(|(h, _, _)| h);
-        let required = gantz_core::reg::required_commits(&get_node, &env.registry, heads_for_prune);
-        env.registry.prune_unreachable(&required);
+        // Prune unused content now that we have the environment for node lookups.
+        let live = {
+            let get_node = |ca: &gantz_ca::ContentAddr| env.node(ca);
+            let heads_for_prune = heads.iter().map(|(h, _, _)| h);
+            gantz_core::reg::live(&get_node, &env.registry, heads_for_prune)
+        };
+        gantz_ca::prune(&mut env.registry, &live);
 
         // VM setup - initialize a VM for each open head.
         let compile_config = gantz_core::compile::Config::default();
@@ -658,13 +670,7 @@ impl eframe::App for App {
             if head_commit.graph != new_graph_ca {
                 committed = true;
                 let old_head = head.clone();
-                let old_commit_ca = self
-                    .state
-                    .env
-                    .registry
-                    .head_commit_ca(head)
-                    .copied()
-                    .unwrap();
+                let old_commit_ca = self.state.env.registry.head_commit_ca(head).unwrap();
                 let new_commit_ca = self.state.env.registry.commit_graph_to_head(
                     timestamp(),
                     new_graph_ca,
@@ -713,8 +719,7 @@ impl eframe::App for App {
         save_commit_addrs(storage, &addrs);
         save_commits(storage, &self.state.env.registry.commits());
 
-        save_names(storage, &self.state.env.registry.names());
-        save_descriptions(storage, self.state.env.registry.descriptions());
+        save_sections(storage, self.state.env.registry.sections());
 
         // Save all open heads.
         let heads: Vec<_> = self.state.heads.iter().map(|(h, _, _)| h.clone()).collect();
@@ -816,30 +821,20 @@ fn save_commit(
     log::debug!("Successfully persisted commit {key}");
 }
 
-/// Save the graph names to storage.
-fn save_names(storage: &mut dyn eframe::Storage, names: &BTreeMap<String, gantz_ca::CommitAddr>) {
-    let graph_names_str = match ron::to_string(names) {
+/// Save the registry's metadata sections to storage.
+fn save_sections(
+    storage: &mut dyn eframe::Storage,
+    sections: &BTreeMap<gantz_ca::SectionId, gantz_ca::Section>,
+) {
+    let sections_str = match ron::to_string(sections) {
         Err(e) => {
-            log::error!("Failed to serialize graph names: {e}");
+            log::error!("Failed to serialize registry sections: {e}");
             return;
         }
         Ok(s) => s,
     };
-    storage.set_string(App::NAMES_KEY, graph_names_str);
-    log::debug!("Successfully persisted graph names");
-}
-
-/// Save the graph descriptions to storage.
-fn save_descriptions(storage: &mut dyn eframe::Storage, descriptions: &BTreeMap<String, String>) {
-    let descriptions_str = match ron::to_string(descriptions) {
-        Err(e) => {
-            log::error!("Failed to serialize graph descriptions: {e}");
-            return;
-        }
-        Ok(s) => s,
-    };
-    storage.set_string(App::DESCRIPTIONS_KEY, descriptions_str);
-    log::debug!("Successfully persisted graph descriptions");
+    storage.set_string(App::SECTIONS_KEY, sections_str);
+    log::debug!("Successfully persisted registry sections");
 }
 
 /// Save the gantz GUI state.
@@ -969,37 +964,21 @@ fn load_commit(
     }
 }
 
-/// Load the graph names from storage.
-fn load_names(storage: &dyn eframe::Storage) -> BTreeMap<String, gantz_ca::CommitAddr> {
-    let Some(graph_names_str) = storage.get_string(App::NAMES_KEY) else {
-        log::debug!("No existing graph names list to load");
+/// Load the registry's metadata sections from storage.
+fn load_sections(
+    storage: &dyn eframe::Storage,
+) -> BTreeMap<gantz_ca::SectionId, gantz_ca::Section> {
+    let Some(sections_str) = storage.get_string(App::SECTIONS_KEY) else {
+        log::debug!("No existing registry sections to load");
         return BTreeMap::default();
     };
-    match ron::de::from_str(&graph_names_str) {
-        Ok(names) => {
-            log::debug!("Successfully loaded graph names from storage");
-            names
+    match ron::de::from_str(&sections_str) {
+        Ok(sections) => {
+            log::debug!("Successfully loaded registry sections from storage");
+            sections
         }
         Err(e) => {
-            log::error!("Failed to deserialize graph names: {e}");
-            BTreeMap::default()
-        }
-    }
-}
-
-/// Load the graph descriptions from storage.
-fn load_descriptions(storage: &dyn eframe::Storage) -> BTreeMap<String, String> {
-    let Some(descriptions_str) = storage.get_string(App::DESCRIPTIONS_KEY) else {
-        log::debug!("No existing graph descriptions to load");
-        return BTreeMap::default();
-    };
-    match ron::de::from_str(&descriptions_str) {
-        Ok(descriptions) => {
-            log::debug!("Successfully loaded graph descriptions from storage");
-            descriptions
-        }
-        Err(e) => {
-            log::error!("Failed to deserialize graph descriptions: {e}");
+            log::error!("Failed to deserialize registry sections: {e}");
             BTreeMap::default()
         }
     }
@@ -1130,7 +1109,7 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
             continue;
         };
         let editing = match &head {
-            gantz_ca::Head::Branch(name) => Some(name.clone()),
+            gantz_ca::Head::Branch(name) => Some(name.to_string()),
             gantz_ca::Head::Commit(_) => None,
         };
         let head_state = state.gantz.open_heads.entry(head).or_default();
@@ -1180,8 +1159,7 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
             continue;
         };
         let (_, graph, gv) = &mut state.heads[ix];
-        let text =
-            gantz_egui::ops::copy_nodes(&state.env.registry, &HashMap::new(), graph, gv, &nodes);
+        let text = gantz_egui::ops::copy_nodes(&state.env.registry, graph, gv, &nodes);
         if let Some(text) = text {
             ctx.copy_text(text);
         }
@@ -1194,7 +1172,7 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
         // In eframe, Event::Paste provides text directly.
         let Some(text) = text else { continue };
         let editing = match &head {
-            gantz_ca::Head::Branch(name) => Some(name.clone()),
+            gantz_ca::Head::Branch(name) => Some(name.to_string()),
             gantz_ca::Head::Commit(_) => None,
         };
         let head_state = state.gantz.open_heads.entry(head).or_default();
@@ -1202,8 +1180,6 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
         let pasted = gantz_egui::ops::paste(
             &mut state.env.registry,
             editing.as_deref(),
-            &mut HashMap::new(),
-            &mut HashMap::new(),
             graph,
             gv,
             head_state,
@@ -1228,7 +1204,6 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
         let vm = &mut state.vms[ix];
         let text = gantz_egui::ops::cut_nodes(
             &state.env.registry,
-            &HashMap::new(),
             graph,
             vm,
             gv,
@@ -1245,7 +1220,7 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
             continue;
         };
         let editing = match &head {
-            gantz_ca::Head::Branch(name) => Some(name.clone()),
+            gantz_ca::Head::Branch(name) => Some(name.to_string()),
             gantz_ca::Head::Commit(_) => None,
         };
         let head_state = state.gantz.open_heads.entry(head).or_default();
@@ -1253,8 +1228,6 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
         let duplicated = gantz_egui::ops::duplicate_nodes(
             &mut state.env.registry,
             editing.as_deref(),
-            &mut HashMap::new(),
-            &mut HashMap::new(),
             graph,
             gv,
             head_state,
@@ -1286,7 +1259,6 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
             let (h, graph, view) = &mut state.heads[ix];
             gantz_egui::ops::merge_head(
                 &mut state.env.registry,
-                &HashMap::new(),
                 timestamp(),
                 h,
                 graph,
@@ -1346,19 +1318,14 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
     for (head, gantz_egui::ExportHead) in responses.take() {
         let Some(head) = head else { continue };
         let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
-        let text = match gantz_egui::export::export_heads_sexpr(
-            &get_node,
-            &state.env.registry,
-            &HashMap::new(),
-            &HashMap::new(),
-            [&head],
-        ) {
-            Ok(s) => s,
-            Err(e) => {
-                log::error!("ExportHead: failed to serialize: {e}");
-                continue;
-            }
-        };
+        let text =
+            match gantz_egui::export::export_heads_sexpr(&get_node, &state.env.registry, [&head]) {
+                Ok(s) => s,
+                Err(e) => {
+                    log::error!("ExportHead: failed to serialize: {e}");
+                    continue;
+                }
+            };
         let default_name = gantz_egui::export::default_filename(&head);
         let ext = gantz_egui::export::FILE_EXTENSION;
         let dialog = rfd::AsyncFileDialog::new()
@@ -1379,9 +1346,8 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
         let named_heads: Vec<gantz_ca::Head> = state
             .env
             .registry
-            .names()
-            .keys()
-            .map(|name| gantz_ca::Head::Branch(name.clone()))
+            .heads()
+            .map(|(name, _)| gantz_ca::Head::Branch(name.clone()))
             .collect();
         if named_heads.is_empty() {
             log::info!("ExportAllNamed: no named graphs to export");
@@ -1390,8 +1356,6 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
         let text = match gantz_egui::export::export_heads_sexpr(
             &get_node,
             &state.env.registry,
-            &HashMap::new(),
-            &HashMap::new(),
             named_heads.iter(),
         ) {
             Ok(s) => s,
@@ -1452,12 +1416,12 @@ fn gui(ui: &mut egui::Ui, state: &mut State) -> gantz_egui::Responses {
         for (head, _, _) in &mut state.heads {
             if let gantz_ca::Head::Branch(head_name) = &*head {
                 if *head_name == name {
-                    let commit_ca = *state.env.registry.head_commit_ca(head).unwrap();
+                    let commit_ca = state.env.registry.head_commit_ca(head).unwrap();
                     *head = gantz_ca::Head::Commit(commit_ca);
                 }
             }
         }
-        state.env.registry.remove_name(&name);
+        state.env.registry.remove_head(&name);
     }
 
     // Single click: replace the focused head with the selected one.
@@ -1493,10 +1457,11 @@ fn gui(ui: &mut egui::Ui, state: &mut State) -> gantz_egui::Responses {
 
     // Handle a graph description edit (keyed by the graph's name).
     if let Some((gantz_ca::Head::Branch(name), description)) = &response.description_changed {
-        state
-            .env
-            .registry
-            .set_description(name.clone(), description.clone());
+        gantz_egui::section::set_description(
+            &mut state.env.registry,
+            name.clone(),
+            description.clone(),
+        );
     }
 
     // Handle import button click.
@@ -1531,8 +1496,8 @@ fn gui(ui: &mut egui::Ui, state: &mut State) -> gantz_egui::Responses {
 /// Deserializes the export, merges into the registry, and optionally opens
 /// the unique root head.
 fn import_bytes(state: &mut State, bytes: Vec<u8>, open_head: bool) {
-    let export = match gantz_egui::export::parse_export::<Box<dyn Node>>(&bytes) {
-        Ok(e) => e,
+    let imported = match gantz_egui::export::parse_export::<Box<dyn Node>>(&bytes) {
+        Ok(reg) => reg,
         Err(e) => {
             log::error!("Import: {e}");
             return;
@@ -1541,21 +1506,16 @@ fn import_bytes(state: &mut State, bytes: Vec<u8>, open_head: bool) {
 
     let root_name = if open_head {
         let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
-        gantz_egui::export::unique_root_name(&get_node, &export)
+        gantz_egui::export::unique_root_name(&get_node, &imported)
     } else {
         None
     };
 
-    let result = gantz_egui::export::merge_with(
-        &mut state.env.registry,
-        &mut HashMap::new(),
-        &mut HashMap::new(),
-        export,
-    );
+    let report = state.env.registry.merge(imported);
     log::info!(
         "Imported: {} names added, {} replaced",
-        result.names_added.len(),
-        result.names_replaced.len(),
+        report.heads_added.len(),
+        report.heads_replaced.len(),
     );
 
     if let Some(name) = root_name {
@@ -1661,7 +1621,7 @@ fn navigate_head(
             replace_head(ctx, state, gantz_ca::Head::Commit(target));
         }
         gantz_ca::Head::Branch(name) => {
-            state.env.registry.insert_name(name.clone(), target);
+            state.env.registry.set_head(name.clone(), target);
             refresh_branch_head(state);
         }
     }
@@ -1770,7 +1730,7 @@ fn create_branch_from_head(
     new_name: String,
 ) {
     // Get the commit CA from the original head.
-    let Some(commit_ca) = state.env.registry.head_commit_ca(original_head).copied() else {
+    let Some(commit_ca) = state.env.registry.head_commit_ca(original_head) else {
         log::error!("Failed to get commit address for head: {:?}", original_head);
         return;
     };
@@ -1787,20 +1747,13 @@ fn create_branch_from_head(
             });
 
     // Insert the new branch name pointing to the fresh commit.
-    state
-        .env
-        .registry
-        .insert_name(new_name.clone(), new_commit_ca);
+    let new_name: gantz_ca::Name = new_name.parse().expect("infallible");
+    state.env.registry.set_head(new_name.clone(), new_commit_ca);
 
     // Inherit the original graph's description, if any.
     if let gantz_ca::Head::Branch(orig_name) = original_head {
-        if let Some(desc) = state
-            .env
-            .registry
-            .description(orig_name)
-            .map(str::to_string)
-        {
-            state.env.registry.set_description(new_name.clone(), desc);
+        if let Some(desc) = gantz_egui::section::description(&state.env.registry, orig_name) {
+            gantz_egui::section::set_description(&mut state.env.registry, new_name.clone(), desc);
         }
     }
 

--- a/crates/gantz_egui/src/cycle.rs
+++ b/crates/gantz_egui/src/cycle.rs
@@ -8,7 +8,7 @@
 //! load-time `CycleInRefs` check.
 
 use crate::sync::AsNamedRef;
-use gantz_ca::Registry;
+use gantz_ca::{Name, Registry};
 use gantz_core::node::graph::Graph;
 use std::collections::HashSet;
 
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 /// A cycle exists when `editing` is reachable from `target` through named
 /// references at any depth - including the trivial `target == editing`. Names
 /// that resolve to no graph (e.g. builtins) simply contribute no edges.
-pub fn would_cycle<N>(registry: &Registry<Graph<N>>, target: &str, editing: &str) -> bool
+pub fn would_cycle<N>(registry: &Registry<Graph<N>>, target: &Name, editing: &Name) -> bool
 where
     N: AsNamedRef,
 {
@@ -31,10 +31,10 @@ where
         if !visited.insert(name) {
             continue;
         }
-        let Some(&commit) = registry.names().get(name) else {
+        let Some(graph) = registry.named_commit(name).map(|c| c.graph) else {
             continue;
         };
-        let Some(graph) = registry.commit_graph_ref(&commit) else {
+        let Some(graph) = registry.graph(&graph) else {
             continue;
         };
         for weight in graph.node_weights() {
@@ -51,23 +51,34 @@ mod tests {
     use super::*;
     use crate::node::NamedRef;
 
+    fn name(s: &str) -> Name {
+        s.parse().unwrap()
+    }
+
     /// Commit a graph of `NamedRef`s (one per referenced name) under `name`.
-    fn commit_named_refs(registry: &mut Registry<Graph<NamedRef>>, name: &str, refs: &[&str]) {
+    fn commit_named_refs(
+        registry: &mut Registry<Graph<NamedRef>>,
+        graph_name: &str,
+        refs: &[&str],
+    ) {
         let mut graph = Graph::<NamedRef>::default();
         for &r in refs {
             // The referenced content address is irrelevant to the name-based
-            // walk; point each ref at the target name's current commit if known,
+            // walk; point each ref at the target name's head graph if known,
             // else a placeholder derived from an empty graph.
             let ca: gantz_ca::ContentAddr = registry
-                .names()
-                .get(r)
-                .copied()
-                .map(Into::into)
+                .named_commit(&name(r))
+                .map(|c| c.graph.into())
                 .unwrap_or_else(|| gantz_ca::graph_addr(&Graph::<NamedRef>::default()).into());
-            graph.add_node(NamedRef::new(r.to_string(), gantz_core::node::Ref::new(ca)));
+            graph.add_node(NamedRef::new(name(r), gantz_core::node::Ref::new(ca)));
         }
         let graph_ca = gantz_ca::graph_addr(&graph);
-        registry.commit_graph_to_name(std::time::Duration::ZERO, graph_ca, || graph, name);
+        registry.commit_graph_to_name(
+            std::time::Duration::ZERO,
+            graph_ca,
+            || graph,
+            &name(graph_name),
+        );
     }
 
     #[test]
@@ -81,12 +92,12 @@ mod tests {
         commit_named_refs(&mut registry, "c", &[]);
 
         // Self-reference.
-        assert!(would_cycle(&registry, "a", "a"));
+        assert!(would_cycle(&registry, &name("a"), &name("a")));
         // `b` reaches `a`, so referencing `b` from `a` closes the loop.
-        assert!(would_cycle(&registry, "b", "a"));
+        assert!(would_cycle(&registry, &name("b"), &name("a")));
         // `c` references nothing - safe.
-        assert!(!would_cycle(&registry, "c", "a"));
+        assert!(!would_cycle(&registry, &name("c"), &name("a")));
         // An unknown / builtin name resolves to no graph - safe.
-        assert!(!would_cycle(&registry, "not-a-name", "a"));
+        assert!(!would_cycle(&registry, &name("not-a-name"), &name("a")));
     }
 }

--- a/crates/gantz_egui/src/export.rs
+++ b/crates/gantz_egui/src/export.rs
@@ -1,13 +1,14 @@
-//! Export/import representation for sharing node sets between gantz instances.
+//! Export/import helpers for sharing node sets between gantz instances.
 //!
-//! The [`Export`] type bundles a [`gantz_ca::Registry`] subset with optional
-//! [`crate::SceneView`] layout data. Serialization uses the `.gantz` S-expression text
-//! format (see [`crate::format`]) under the `.gantz` file extension.
+//! An export is a [`gantz_ca::Registry`] subset: all GUI metadata (views,
+//! demos, descriptions) rides the registry's sections, so no side-band bundle
+//! type is needed. Serialization uses the `.gantz` S-expression text format
+//! (see [`crate::format`]) under the `.gantz` file extension.
 
-use gantz_ca::{CaHash, CommitAddr, registry::MergeResult};
+use gantz_ca::{CaHash, GraphAddr, Name};
 use gantz_core::node::{self, GetNode, graph::Graph};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 /// File extension for gantz export files (without the leading dot).
 pub const FILE_EXTENSION: &str = "gantz";
@@ -38,56 +39,13 @@ impl std::error::Error for ParseExportError {
     }
 }
 
-/// A serializable bundle of a registry subset and its associated view state.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct Export<G> {
-    pub registry: gantz_ca::Registry<G>,
-    #[serde(default, serialize_with = "gantz_ca::serde_sorted::serialize_map")]
-    pub views: HashMap<CommitAddr, crate::SceneView>,
-    /// Maps a graph *name* to its associated demo graph name (a `demo-*` name).
-    ///
-    /// Keyed by name (rather than commit) so the association survives an edit:
-    /// editing a graph mints a new commit but keeps the name.
-    #[serde(default)]
-    pub demos: HashMap<String, String>,
-}
-
-/// Produce an [`Export`] by filtering views to commits, and demos to names,
-/// present in the registry.
-pub fn export_with<G>(
-    registry: gantz_ca::Registry<G>,
-    all_views: &HashMap<CommitAddr, crate::SceneView>,
-    all_demos: &HashMap<String, String>,
-) -> Export<G>
-where
-    G: Clone,
-{
-    let commits = registry.commits();
-    let views = all_views
-        .iter()
-        .filter(|(ca, _)| commits.contains_key(ca))
-        .map(|(&ca, v)| (ca, v.clone()))
-        .collect();
-    let names = registry.names();
-    let demos = all_demos
-        .iter()
-        .filter(|(name, _)| names.contains_key(name.as_str()))
-        .map(|(name, demo)| (name.clone(), demo.clone()))
-        .collect();
-    Export {
-        registry,
-        views,
-        demos,
-    }
-}
-
-/// Parse the raw bytes of a `.gantz` file into an [`Export`].
+/// Parse the raw bytes of a `.gantz` file into a registry.
 ///
 /// The file is the `.gantz` S-expression text format (see [`crate::format`]).
 /// Graphs the document does not commit explicitly (hand-authored graphs with no
 /// `(commits ...)` entry) are stamped with the current time. Use
 /// [`parse_export_at`] to stamp them with a fixed timestamp instead.
-pub fn parse_export<N>(bytes: &[u8]) -> Result<Export<Graph<N>>, ParseExportError>
+pub fn parse_export<N>(bytes: &[u8]) -> Result<gantz_ca::Registry<Graph<N>>, ParseExportError>
 where
     N: Serialize + DeserializeOwned + CaHash + gantz_format::NodeSugar + 'static,
 {
@@ -98,15 +56,13 @@ where
 /// given timestamp rather than the current time.
 ///
 /// A fixed timestamp makes the resulting commit addresses reproducible across
-/// loads. This matters for content that is re-parsed and whose graphs reference
-/// each other by content address - e.g. the baked-in base, which is parsed both
-/// at startup and on demo reset: a wall-clock timestamp would give each parse
-/// distinct commit addresses, so a reset demo's `ref`s would point at commits
-/// absent from the already-loaded registry.
+/// loads. This matters for content that is re-parsed and whose commits should
+/// line up with an already-loaded registry - e.g. the baked-in base, which is
+/// parsed both at startup and on demo reset.
 pub fn parse_export_at<N>(
     bytes: &[u8],
     now: gantz_ca::Timestamp,
-) -> Result<Export<Graph<N>>, ParseExportError>
+) -> Result<gantz_ca::Registry<Graph<N>>, ParseExportError>
 where
     N: Serialize + DeserializeOwned + CaHash + gantz_format::NodeSugar + 'static,
 {
@@ -115,14 +71,14 @@ where
 }
 
 /// Like [`parse_export_at`], resolving names the document does not define
-/// through `seed` (externally-known name -> head commit associations). Lets a
+/// through `seed` (externally-known name -> head graph associations). Lets a
 /// base source reference graphs another source defines - see
 /// [`gantz_format::from_str_seeded`].
 pub fn parse_export_seeded_at<N>(
     bytes: &[u8],
     now: gantz_ca::Timestamp,
-    seed: &std::collections::BTreeMap<String, gantz_ca::CommitAddr>,
-) -> Result<Export<Graph<N>>, ParseExportError>
+    seed: &std::collections::BTreeMap<String, GraphAddr>,
+) -> Result<gantz_ca::Registry<Graph<N>>, ParseExportError>
 where
     N: Serialize + DeserializeOwned + CaHash + gantz_format::NodeSugar + 'static,
 {
@@ -137,35 +93,35 @@ fn now() -> gantz_ca::Timestamp {
         .unwrap_or_default()
 }
 
-/// The unique root name of an export, if it has exactly one.
+/// The unique root name of an exported registry, if it has exactly one.
 ///
 /// `get_node` resolves node lookups outside the export (e.g. builtins).
-pub fn unique_root_name<N>(get_node: GetNode, export: &Export<Graph<N>>) -> Option<String>
+pub fn unique_root_name<N>(
+    get_node: GetNode,
+    registry: &gantz_ca::Registry<Graph<N>>,
+) -> Option<Name>
 where
     N: gantz_core::Node,
 {
-    let mut roots = gantz_core::reg::root_names(get_node, &export.registry);
+    let mut roots = gantz_core::reg::root_names(get_node, registry);
     (roots.len() == 1).then(|| roots.pop().unwrap())
 }
 
-/// Build and serialize an [`Export`] for the given heads as `.gantz` text.
+/// Serialize an export for the given heads as `.gantz` text.
 ///
 /// Covers both export-head and export-all-named: the export contains the heads'
-/// transitively required commits along with their views and demos. File IO
-/// stays with the caller.
+/// transitively required content along with their views, demos and
+/// descriptions. File IO stays with the caller.
 pub fn export_heads_sexpr<N>(
     get_node: GetNode,
     registry: &gantz_ca::Registry<Graph<N>>,
-    all_views: &HashMap<CommitAddr, crate::SceneView>,
-    all_demos: &HashMap<String, String>,
     heads: impl IntoIterator<Item = impl std::borrow::Borrow<gantz_ca::Head>>,
 ) -> Result<String, crate::format::FormatError>
 where
     N: Serialize + DeserializeOwned + gantz_core::Node + Clone + gantz_format::NodeSugar,
 {
     let export_registry = gantz_core::reg::export_heads(get_node, registry, heads);
-    let export = export_with(export_registry, all_views, all_demos);
-    crate::format::to_string(&export)
+    crate::format::to_string(&export_registry)
 }
 
 /// As [`export_heads_sexpr`], but serializes in the inline-name format (see
@@ -175,16 +131,13 @@ where
 pub fn export_heads_sexpr_named<N>(
     get_node: GetNode,
     registry: &gantz_ca::Registry<Graph<N>>,
-    all_views: &HashMap<CommitAddr, crate::SceneView>,
-    all_demos: &HashMap<String, String>,
     heads: impl IntoIterator<Item = impl std::borrow::Borrow<gantz_ca::Head>>,
 ) -> Result<String, crate::format::FormatError>
 where
     N: Serialize + DeserializeOwned + gantz_core::Node + Clone + gantz_format::NodeSugar,
 {
     let export_registry = gantz_core::reg::export_heads(get_node, registry, heads);
-    let export = export_with(export_registry, all_views, all_demos);
-    crate::format::to_string_named(&export)
+    crate::format::to_string_named(&export_registry)
 }
 
 /// As [`export_heads_sexpr_named`], but exports EXACTLY the given names with
@@ -196,57 +149,40 @@ where
 /// resolves them through the seeded parse (see [`parse_export_seeded_at`]).
 pub fn export_names_sexpr_named<N>(
     registry: &gantz_ca::Registry<Graph<N>>,
-    all_views: &HashMap<CommitAddr, crate::SceneView>,
-    all_demos: &HashMap<String, String>,
     names: impl IntoIterator<Item = impl AsRef<str>>,
 ) -> Result<String, crate::format::FormatError>
 where
     N: Serialize + DeserializeOwned + gantz_core::Node + Clone + gantz_format::NodeSugar,
 {
-    let requested: std::collections::HashSet<String> = names
+    let requested: HashSet<Name> = names
         .into_iter()
-        .map(|name| name.as_ref().to_string())
+        .map(|name| name.as_ref().parse().expect("infallible"))
         .collect();
-    let required: std::collections::HashSet<gantz_ca::CommitAddr> = requested
-        .iter()
-        .filter_map(|name| registry.names().get(name).copied())
-        .collect();
-    let mut export_registry = registry.export(&required);
-    // `export` keeps every name whose commit survives - identical graphs
+    let mut live = gantz_ca::LiveSet::default();
+    for name in &requested {
+        let Some(head_ca) = registry.head(name) else {
+            continue;
+        };
+        let Some(commit) = registry.commits().get(&head_ca) else {
+            continue;
+        };
+        live.commits.insert(head_ca);
+        live.graphs.insert(commit.graph);
+    }
+    let mut export_registry = gantz_ca::export(registry, &live);
+    // The export keeps every head whose commit survives - identical graphs
     // across sources share commits, so a foreign name could ride along.
-    // Restrict to exactly the requested names (their descriptions follow).
-    let extra: Vec<String> = export_registry
-        .names()
-        .keys()
-        .filter(|name| !requested.contains(*name))
-        .cloned()
+    // Restrict to exactly the requested names (their `WithName` metadata,
+    // descriptions included, drops with them).
+    let extra: Vec<Name> = export_registry
+        .heads()
+        .filter(|(name, _)| !requested.contains(name))
+        .map(|(name, _)| name.clone())
         .collect();
     for name in extra {
-        export_registry.remove_name(&name);
-        export_registry.set_description(name, String::new());
+        export_registry.remove_head(&name);
     }
-    let export = export_with(export_registry, all_views, all_demos);
-    crate::format::to_string_named(&export)
-}
-
-/// Merge an [`Export`] into an existing registry, views and demos maps.
-///
-/// Incoming views and demos for new commits are inserted; existing entries for
-/// known commits are kept.
-pub fn merge_with<G>(
-    registry: &mut gantz_ca::Registry<G>,
-    views: &mut HashMap<CommitAddr, crate::SceneView>,
-    demos: &mut HashMap<String, String>,
-    export: Export<G>,
-) -> MergeResult {
-    let result = registry.merge(export.registry);
-    for (ca, v) in export.views {
-        views.entry(ca).or_insert(v);
-    }
-    for (name, d) in export.demos {
-        demos.entry(name).or_insert(d);
-    }
-    result
+    crate::format::to_string_named(&export_registry)
 }
 
 /// Derive a default export filename from a [`gantz_ca::Head`].
@@ -320,8 +256,9 @@ impl std::error::Error for ParseCopiedError {
 /// A clipboard payload for copied graph nodes.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Copied<N> {
-    /// Registry dependencies referenced by copied nodes (e.g. Ref nodes).
-    pub export: Export<Graph<N>>,
+    /// Registry dependencies referenced by copied nodes (e.g. Ref nodes),
+    /// along with the heads (and their metadata) naming them.
+    pub registry: gantz_ca::Registry<Graph<N>>,
     /// The subgraph of selected nodes and their internal edges.
     pub graph: Graph<N>,
     /// Positions of nodes in the subgraph.
@@ -329,9 +266,13 @@ pub struct Copied<N> {
 }
 
 /// Build a [`Copied`] payload from the selected nodes in a graph.
+///
+/// The payload registry carries the transitive closure of the graphs the
+/// selected nodes reference, plus the heads (and `WithName`/`WithCommit`
+/// metadata) whose tips point at those graphs, so pasting into another
+/// registry restores names and views.
 pub fn copy<N>(
     registry: &gantz_ca::Registry<Graph<N>>,
-    all_views: &HashMap<CommitAddr, crate::SceneView>,
     graph: &Graph<N>,
     selected: &HashSet<node::graph::NodeIx>,
     layout: &egui_graph::Layout,
@@ -353,35 +294,55 @@ where
         }
     }
 
-    // Collect registry deps transitively: the commits the selected nodes
-    // reference, and the commits *those* graphs reference in turn (a nested
+    // Collect registry deps transitively: the graphs the selected nodes
+    // reference, and the graphs *those* graphs reference in turn (a nested
     // graph that itself contains nested graphs), so the whole subtree travels
-    // with the clipboard.
-    let mut required_commits = HashSet::new();
-    let mut stack: Vec<CommitAddr> = subgraph
+    // with the clipboard. Blob references ride along likewise.
+    let mut live = gantz_ca::LiveSet::default();
+    let mut stack: Vec<GraphAddr> = subgraph
         .node_weights()
         .flat_map(|n| n.required_addrs())
-        .map(CommitAddr::from)
-        .filter(|ca| registry.commits().contains_key(ca))
+        .map(GraphAddr::from)
+        .filter(|ga| registry.graph(ga).is_some())
         .collect();
-    while let Some(commit_ca) = stack.pop() {
-        if !required_commits.insert(commit_ca) {
+    for (section, addr) in subgraph.node_weights().flat_map(|n| n.required_blobs()) {
+        live.blobs.entry(section).or_default().insert(addr);
+    }
+    while let Some(graph_ca) = stack.pop() {
+        if !live.graphs.insert(graph_ca) {
             continue;
         }
-        if let Some(nested) = registry.commit_graph_ref(&commit_ca) {
-            for ca in nested.node_weights().flat_map(|n| n.required_addrs()) {
-                let dep = CommitAddr::from(ca);
-                if registry.commits().contains_key(&dep) {
-                    stack.push(dep);
-                }
+        let Some(nested) = registry.graph(&graph_ca) else {
+            continue;
+        };
+        for ca in nested.node_weights().flat_map(|n| n.required_addrs()) {
+            let dep = GraphAddr::from(ca);
+            if registry.graph(&dep).is_some() {
+                stack.push(dep);
             }
         }
+        for (section, addr) in nested.node_weights().flat_map(|n| n.required_blobs()) {
+            live.blobs.entry(section).or_default().insert(addr);
+        }
     }
-    let export_registry = registry.export(&required_commits);
-    let export = export_with(export_registry, all_views, &HashMap::new());
+
+    // Include each collected graph's naming heads (tip commits), so
+    // paste-merge restores names and the text format's commits table still
+    // describes the named graphs.
+    live.commits.extend(
+        registry
+            .heads()
+            .filter(|(_, ca)| {
+                registry
+                    .commits()
+                    .get(ca)
+                    .is_some_and(|commit| live.graphs.contains(&commit.graph))
+            })
+            .map(|(_, ca)| ca),
+    );
 
     Copied {
-        export,
+        registry: gantz_ca::export(registry, &live),
         graph: subgraph,
         positions,
     }
@@ -394,8 +355,6 @@ where
 /// target graph.
 pub fn paste<N>(
     registry: &mut gantz_ca::Registry<Graph<N>>,
-    views: &mut HashMap<CommitAddr, crate::SceneView>,
-    demos: &mut HashMap<String, String>,
     target_graph: &mut Graph<N>,
     target_layout: &mut egui_graph::Layout,
     copied: &Copied<N>,
@@ -404,7 +363,7 @@ pub fn paste<N>(
 where
     N: Clone,
 {
-    merge_with(registry, views, demos, copied.export.clone());
+    registry.merge(copied.registry.clone());
     let new_indices = gantz_core::graph::add_subgraph(target_graph, &copied.graph);
 
     // Map positions from subgraph indices to target indices with offset.
@@ -421,42 +380,34 @@ where
 
 /// Serialize a [`Copied`] payload as a `.gantz` document.
 ///
-/// The copied subgraph rides as a graph named `clipboard` - its positions stored
-/// as that graph's layout view - alongside the registry dependencies, so the
-/// whole payload is one ordinary `.gantz` document. [`copied_from_str`] reverses
-/// this.
+/// The copied subgraph rides as a graph named `clipboard` - its positions
+/// stored as the clipboard commit's view section entry - alongside the
+/// registry dependencies, so the whole payload is one ordinary `.gantz`
+/// document. [`copied_from_str`] reverses this.
 pub fn copied_to_string<N>(copied: &Copied<N>) -> Result<String, crate::format::FormatError>
 where
     N: Serialize + DeserializeOwned + CaHash + Clone + gantz_format::NodeSugar + 'static,
 {
     // Add the subgraph to the dependency registry as a fresh root commit named
     // `CLIPBOARD_NAME`. A fixed timestamp keeps the payload deterministic.
-    let mut registry = copied.export.registry.clone();
+    let mut registry = copied.registry.clone();
     let g_addr = registry.add_graph(copied.graph.clone());
     let commit_ca = registry.add_commit(gantz_ca::Commit::new(
         std::time::Duration::ZERO,
         None,
         g_addr,
     ));
-    registry.insert_name(CLIPBOARD_NAME.to_string(), commit_ca);
+    registry.set_head(CLIPBOARD_NAME.parse().expect("infallible"), commit_ca);
 
-    // Carry the positions as the clipboard graph's layout view. The camera is
+    // Carry the positions as the clipboard commit's view. The camera is
     // irrelevant for a clipboard payload, so use the default.
-    let mut views = copied.export.views.clone();
-    views.insert(
-        commit_ca,
-        crate::SceneView {
-            camera: crate::Camera::default(),
-            layout: copied.positions.clone(),
-        },
-    );
-
-    let export = Export {
-        registry,
-        views,
-        demos: copied.export.demos.clone(),
+    let view = crate::SceneView {
+        camera: crate::Camera::default(),
+        layout: copied.positions.clone(),
     };
-    crate::format::to_string(&export)
+    crate::section::set_view(&mut registry, commit_ca, &view);
+
+    crate::format::to_string(&registry)
 }
 
 /// Parse a clipboard payload produced by [`copied_to_string`].
@@ -465,45 +416,49 @@ where
 /// dependencies.
 pub fn copied_from_str<N>(text: &str) -> Result<Copied<N>, ParseCopiedError>
 where
-    N: Serialize + DeserializeOwned + CaHash + Clone + gantz_format::NodeSugar + 'static,
+    N: Serialize
+        + DeserializeOwned
+        + CaHash
+        + Clone
+        + gantz_core::Node
+        + gantz_format::NodeSugar
+        + 'static,
 {
-    let mut export = crate::format::from_str::<N>(text, now()).map_err(ParseCopiedError::Format)?;
+    let registry = crate::format::from_str::<N>(text, now()).map_err(ParseCopiedError::Format)?;
 
-    let clip_ca = export
-        .registry
-        .names()
-        .get(CLIPBOARD_NAME)
-        .copied()
+    let clipboard: Name = CLIPBOARD_NAME.parse().expect("infallible");
+    let clip_ca = registry
+        .head(&clipboard)
         .ok_or(ParseCopiedError::NotClipboard)?;
-    let graph = export
-        .registry
+    let graph = registry
         .commit_graph_ref(&clip_ca)
         .cloned()
         .ok_or(ParseCopiedError::NotClipboard)?;
-    let positions = export
-        .views
-        .get(&clip_ca)
-        .map(|view| view.layout.clone())
+    let positions = crate::section::view(&registry, &clip_ca)
+        .map(|view| view.layout)
         .unwrap_or_default();
 
-    // Everything but the clipboard commit is a dependency. `export` filters
-    // names to the kept commits, so the `clipboard` name drops out with it.
-    let deps: HashSet<CommitAddr> = export
-        .registry
+    // Everything reachable outside the clipboard commit is a dependency. The
+    // export filters heads (and views) to the kept commits, so the
+    // `clipboard` name and its view entry drop out with it.
+    let dep_commits: Vec<gantz_ca::CommitAddr> = registry
         .commits()
         .keys()
         .copied()
         .filter(|&ca| ca != clip_ca)
         .collect();
-    let registry = export.registry.export(&deps);
-    export.views.remove(&clip_ca);
+    let get_node = |ca: &gantz_ca::ContentAddr| {
+        registry
+            .graph(&GraphAddr::from(*ca))
+            .map(|g| g as &dyn gantz_core::Node)
+    };
+    let live = gantz_ca::closure_from(&registry, dep_commits, |g| {
+        gantz_core::graph::out_refs(&get_node, g)
+    });
+    let deps = gantz_ca::export(&registry, &live);
 
     Ok(Copied {
-        export: Export {
-            registry,
-            views: export.views,
-            demos: export.demos,
-        },
+        registry: deps,
         graph,
         positions,
     })
@@ -512,117 +467,210 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gantz_ca::{Commit, ContentAddr};
-    use std::{collections::BTreeMap, time::Duration};
+    use gantz_ca::{Commit, CommitAddr, ContentAddr};
+    use std::collections::HashMap;
+    use std::time::Duration;
 
-    fn graph_addr(n: u8) -> gantz_ca::GraphAddr {
-        gantz_ca::GraphAddr::from(ContentAddr::from([n; 32]))
+    fn graph_addr(n: u8) -> GraphAddr {
+        GraphAddr::from(ContentAddr::from([n; 32]))
     }
 
     fn commit_addr_raw(n: u8) -> CommitAddr {
         CommitAddr::from(ContentAddr::from([n; 32]))
     }
 
-    fn test_export() -> Export<String> {
+    fn name(s: &str) -> Name {
+        s.parse().unwrap()
+    }
+
+    fn test_registry() -> gantz_ca::Registry<String> {
         let ga = graph_addr(1);
         let ca = commit_addr_raw(10);
         let commit = Commit::new(Duration::from_secs(1), None, ga);
-        let registry = gantz_ca::Registry::new(
+        gantz_ca::Registry::from_parts(
             HashMap::from([(ga, "graph_a".to_string())]),
             HashMap::from([(ca, commit)]),
-            BTreeMap::from([("alpha".to_string(), ca)]),
-        );
-        Export {
-            registry,
-            views: HashMap::new(),
-            demos: HashMap::new(),
-        }
+            std::collections::BTreeMap::from([(name("alpha"), ca)]),
+        )
     }
 
     #[test]
     fn export_merge_recovers_data() {
-        let export = test_export();
+        let export = test_registry();
         let mut target = gantz_ca::Registry::<String>::default();
-        let mut views = HashMap::new();
-        let mut demos = HashMap::new();
-        let result = merge_with(&mut target, &mut views, &mut demos, export);
-        assert_eq!(result.names_added, vec!["alpha".to_string()]);
-        assert!(result.names_replaced.is_empty());
+        let report = target.merge(export);
+        assert_eq!(report.heads_added, vec![name("alpha")]);
+        assert!(report.heads_replaced.is_empty());
         let ca = commit_addr_raw(10);
         assert!(target.commits().contains_key(&ca));
-        assert_eq!(target.names().get("alpha"), Some(&ca));
+        assert_eq!(target.head(&name("alpha")), Some(ca));
     }
 
     #[test]
-    fn export_with_filters_views() {
-        let ga = graph_addr(1);
+    fn merge_keeps_existing_views() {
+        let mut registry = test_registry();
         let ca = commit_addr_raw(10);
-        let cb = commit_addr_raw(20);
-        let commit = Commit::new(Duration::from_secs(1), None, ga);
-        let registry = gantz_ca::Registry::new(
-            HashMap::from([(ga, "g".to_string())]),
-            HashMap::from([(ca, commit)]),
-            BTreeMap::new(),
-        );
-        let mut all_views = HashMap::new();
-        all_views.insert(ca, crate::SceneView::default());
-        all_views.insert(cb, crate::SceneView::default()); // cb not in registry
-        let export = export_with(registry, &all_views, &HashMap::new());
-        assert!(export.views.contains_key(&ca));
-        assert!(!export.views.contains_key(&cb));
-    }
-
-    #[test]
-    fn export_with_filters_demos() {
-        let ga = graph_addr(1);
-        let ca = commit_addr_raw(10);
-        let commit = Commit::new(Duration::from_secs(1), None, ga);
-        let registry = gantz_ca::Registry::new(
-            HashMap::from([(ga, "g".to_string())]),
-            HashMap::from([(ca, commit)]),
-            BTreeMap::from([("alpha".to_string(), ca)]),
-        );
-        let all_demos = HashMap::from([
-            ("alpha".to_string(), "demo-alpha".to_string()),
-            // `beta` is not a name in the registry, so it is dropped.
-            ("beta".to_string(), "demo-beta".to_string()),
-        ]);
-        let export = export_with(registry, &HashMap::new(), &all_demos);
-        assert_eq!(
-            export.demos.get("alpha").map(String::as_str),
-            Some("demo-alpha")
-        );
-        assert!(!export.demos.contains_key("beta"));
-    }
-
-    #[test]
-    fn merge_with_keeps_existing_views() {
-        let ga = graph_addr(1);
-        let ca = commit_addr_raw(10);
-        let commit = Commit::new(Duration::from_secs(1), None, ga);
-        let mut registry = gantz_ca::Registry::new(
-            HashMap::from([(ga, "g".to_string())]),
-            HashMap::from([(ca, commit.clone())]),
-            BTreeMap::new(),
-        );
         let mut existing_view = crate::SceneView::default();
         existing_view
             .layout
             .insert(egui_graph::NodeId(0), Default::default());
-        let mut views = HashMap::from([(ca, existing_view)]);
-        let mut demos = HashMap::new();
-        let export = Export {
-            registry: gantz_ca::Registry::new(
-                HashMap::from([(ga, "g".to_string())]),
-                HashMap::from([(ca, commit)]),
-                BTreeMap::new(),
-            ),
-            views: HashMap::from([(ca, crate::SceneView::default())]),
-            demos: HashMap::new(),
+        crate::section::set_view(&mut registry, ca, &existing_view);
+
+        let mut incoming = test_registry();
+        crate::section::set_view(&mut incoming, ca, &crate::SceneView::default());
+        registry.merge(incoming);
+
+        // Existing view (with 1 layout entry) is preserved, not replaced.
+        let view = crate::section::view(&registry, &ca).unwrap();
+        assert_eq!(view.layout.len(), 1);
+    }
+
+    #[test]
+    fn merge_keeps_existing_descriptions_and_demos() {
+        let mut registry = test_registry();
+        crate::section::set_description(&mut registry, name("alpha"), "local".to_string());
+        crate::section::set_demo(&mut registry, name("alpha"), "demo-a".to_string());
+
+        let mut incoming = test_registry();
+        crate::section::set_description(&mut incoming, name("alpha"), "imported".to_string());
+        crate::section::set_demo(&mut incoming, name("alpha"), "demo-b".to_string());
+        crate::section::set_description(&mut incoming, name("beta"), "new".to_string());
+        registry.merge(incoming);
+
+        assert_eq!(
+            crate::section::description(&registry, &name("alpha")).as_deref(),
+            Some("local"),
+        );
+        assert_eq!(
+            crate::section::demo(&registry, &name("alpha")).as_deref(),
+            Some("demo-a"),
+        );
+        assert_eq!(
+            crate::section::description(&registry, &name("beta")).as_deref(),
+            Some("new"),
+        );
+    }
+
+    /// Copying a `NamedRef` carries the referenced graph, its naming head
+    /// and `WithName` metadata through the clipboard text round-trip, with
+    /// positions riding the clipboard commit's view section entry.
+    #[test]
+    fn clipboard_round_trip_carries_positions_and_deps() {
+        use crate::test_node::{TestGraph, TestNode, expr, named_ref};
+
+        let mut reg = gantz_ca::Registry::<TestGraph>::default();
+        let mut leaf_g = TestGraph::default();
+        leaf_g.add_node(expr("(+ 1 1)"));
+        let leaf_ga = gantz_ca::graph_addr(&leaf_g);
+        reg.commit_graph_to_name(Duration::from_secs(1), leaf_ga, || leaf_g, &name("leaf"));
+        crate::section::set_description(&mut reg, name("leaf"), "a leaf".to_string());
+
+        // The working graph: a ref to `leaf` plus a plain expr node.
+        let mut working = TestGraph::default();
+        let a = working.add_node(named_ref("leaf", leaf_ga));
+        let b = working.add_node(expr("(+ 2 2)"));
+        let mut layout = egui_graph::Layout::default();
+        layout.insert(egui_graph::NodeId(a.index() as u64), egui::pos2(1.0, 2.0));
+        layout.insert(egui_graph::NodeId(b.index() as u64), egui::pos2(3.0, 4.0));
+        let selected: HashSet<_> = working.node_indices().collect();
+
+        let copied = copy(&reg, &working, &selected, &layout);
+        assert!(copied.registry.graph(&leaf_ga).is_some());
+        assert!(copied.registry.head(&name("leaf")).is_some());
+
+        let text = copied_to_string(&copied).unwrap();
+        let back: Copied<Box<dyn TestNode>> = copied_from_str(&text).unwrap();
+
+        // The subgraph and its positions survive.
+        assert_eq!(back.graph.node_count(), 2);
+        for ix in [a, b] {
+            let id = egui_graph::NodeId(ix.index() as u64);
+            assert_eq!(back.positions.get(&id), copied.positions.get(&id));
+        }
+
+        // The deps registry restores the referenced graph, its name and
+        // metadata, and carries no clipboard head.
+        assert!(back.registry.graph(&leaf_ga).is_some());
+        assert!(back.registry.head(&name("leaf")).is_some());
+        assert_eq!(
+            crate::section::description(&back.registry, &name("leaf")).as_deref(),
+            Some("a leaf"),
+        );
+        assert!(
+            back.registry
+                .head(&CLIPBOARD_NAME.parse().unwrap())
+                .is_none()
+        );
+
+        // Pasting merges the deps so the ref resolves in the target.
+        let mut target_reg = gantz_ca::Registry::<TestGraph>::default();
+        let mut target_graph = TestGraph::default();
+        let mut target_layout = egui_graph::Layout::default();
+        let new = paste(
+            &mut target_reg,
+            &mut target_graph,
+            &mut target_layout,
+            &back,
+            egui::vec2(10.0, 10.0),
+        );
+        assert_eq!(new.len(), 2);
+        assert!(target_reg.graph(&leaf_ga).is_some());
+        assert!(target_reg.head(&name("leaf")).is_some());
+        assert_eq!(
+            target_layout.get(&egui_graph::NodeId(new[0].index() as u64)),
+            Some(&egui::pos2(11.0, 12.0)),
+        );
+    }
+
+    /// Exporting heads as text carries transitive deps and sections through
+    /// a parse + merge into a fresh registry.
+    #[test]
+    fn export_heads_text_round_trip() {
+        use crate::test_node::{TestGraph, TestNode, expr, named_ref};
+
+        let mut reg = gantz_ca::Registry::<TestGraph>::default();
+        let mut leaf_g = TestGraph::default();
+        leaf_g.add_node(expr("(+ 1 1)"));
+        let leaf_ga = gantz_ca::graph_addr(&leaf_g);
+        reg.commit_graph_to_name(Duration::from_secs(1), leaf_ga, || leaf_g, &name("leaf"));
+        let mut root_g = TestGraph::default();
+        root_g.add_node(named_ref("leaf", leaf_ga));
+        let root_ga = gantz_ca::graph_addr(&root_g);
+        let root_ca =
+            reg.commit_graph_to_name(Duration::from_secs(2), root_ga, || root_g, &name("root"));
+        crate::section::set_description(&mut reg, name("root"), "the root".to_string());
+        let mut view = crate::SceneView::default();
+        view.layout
+            .insert(egui_graph::NodeId(0), egui::pos2(5.0, 6.0));
+        crate::section::set_view(&mut reg, root_ca, &view);
+
+        let get_node = |ca: &ContentAddr| {
+            reg.graph(&GraphAddr::from(*ca))
+                .map(|g| g as &dyn gantz_core::Node)
         };
-        merge_with(&mut registry, &mut views, &mut demos, export);
-        // Existing view (with 1 layout entry) should be preserved, not replaced.
-        assert_eq!(views[&ca].layout.len(), 1);
+        let heads = [
+            gantz_ca::Head::Branch(name("root")),
+            gantz_ca::Head::Branch(name("leaf")),
+        ];
+        let text = export_heads_sexpr(&get_node, &reg, heads.iter()).unwrap();
+
+        let parsed =
+            parse_export_at::<Box<dyn TestNode>>(text.as_bytes(), Duration::from_secs(9)).unwrap();
+        let mut fresh = gantz_ca::Registry::<TestGraph>::default();
+        let report = fresh.merge(parsed);
+        assert_eq!(report.heads_added.len(), 2);
+        assert!(fresh.graph(&leaf_ga).is_some());
+        assert!(fresh.graph(&root_ga).is_some());
+        assert_eq!(fresh.head(&name("root")), Some(root_ca));
+        assert_eq!(
+            crate::section::description(&fresh, &name("root")).as_deref(),
+            Some("the root"),
+        );
+        let view = crate::section::view(&fresh, &root_ca).expect("view survives");
+        assert_eq!(
+            view.layout.get(&egui_graph::NodeId(0)).copied(),
+            Some(egui::pos2(5.0, 6.0)),
+        );
     }
 
     #[test]

--- a/crates/gantz_egui/src/format.rs
+++ b/crates/gantz_egui/src/format.rs
@@ -1,94 +1,98 @@
-//! The Export-level `.gantz` format.
+//! The GUI layer of the `.gantz` format.
 //!
 //! [`gantz_format`] owns the layout-agnostic registry format. This module
-//! layers GUI view state on top - `(layout ...)` and `(demo ...)` forms - using
-//! the format's [`sexpr`] toolkit and the resolution
-//! context returned by [`gantz_format::from_str`]/[`gantz_format::to_string`].
-//! It produces and consumes a full [`Export`] (registry + views + demos), so
-//! existing `crate::format::{from_str, to_string}` call sites are unchanged.
+//! renders the GUI's registry sections (see [`crate::section`]) as friendly
+//! forms - `(descriptions ...)`, `(layout ...)` and `(demo ...)` - using the
+//! format's [`sexpr`] toolkit and the resolution context returned by
+//! [`gantz_format::from_str`]/[`gantz_format::to_string`], and applies those
+//! forms back into the registry's sections on parse.
 
-use crate::export::Export;
-use gantz_ca::{CaHash, CommitAddr, Timestamp};
+use gantz_ca::{CaHash, GraphAddr, Name, Registry, Timestamp};
 use gantz_core::node::graph::Graph;
 use gantz_format::sexpr;
 use gantz_format::{Addr, Form, GraphLabels, Loaded};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use std::collections::HashMap;
 
 pub use gantz_format::FormatError;
 
-/// Parse a `.gantz` document into an [`Export`] (registry + views + demos).
+/// The section ids this module renders itself as friendly forms (passed as
+/// `claimed` to [`gantz_format::to_string`], which then skips their generic
+/// `(section ...)` output).
+const CLAIMED: &[&str] = &[
+    crate::section::DESCRIPTIONS_ID,
+    crate::section::VIEWS_ID,
+    crate::section::DEMOS_ID,
+];
+
+/// Parse a `.gantz` document into a registry, applying the GUI-layer friendly
+/// forms (`descriptions`, `layout`, `demo`) into its sections.
 ///
 /// `now` provides the timestamp for any graph the document does not commit
 /// explicitly (hand-authored graphs).
-pub fn from_str<N>(text: &str, now: Timestamp) -> Result<Export<Graph<N>>, FormatError>
+pub fn from_str<N>(text: &str, now: Timestamp) -> Result<Registry<Graph<N>>, FormatError>
 where
     N: Serialize + DeserializeOwned + CaHash + gantz_format::NodeSugar + 'static,
 {
     let loaded = gantz_format::from_str::<N>(text, now)?;
-    Ok(export_from_loaded(loaded))
+    Ok(registry_from_loaded(loaded))
 }
 
 /// [`from_str`], resolving names the document does not define through `seed`
-/// (externally-known name -> head commit associations). See
+/// (externally-known name -> head graph associations). See
 /// [`gantz_format::from_str_seeded`].
 pub fn from_str_seeded<N>(
     text: &str,
     now: Timestamp,
-    seed: &std::collections::BTreeMap<String, CommitAddr>,
-) -> Result<Export<Graph<N>>, FormatError>
+    seed: &std::collections::BTreeMap<String, GraphAddr>,
+) -> Result<Registry<Graph<N>>, FormatError>
 where
     N: Serialize + DeserializeOwned + CaHash + gantz_format::NodeSugar + 'static,
 {
     let loaded = gantz_format::from_str_seeded::<N>(text, now, seed)?;
-    Ok(export_from_loaded(loaded))
+    Ok(registry_from_loaded(loaded))
 }
 
-/// Apply the GUI-layer extra forms (`layout`, `demo`) to a loaded registry.
-fn export_from_loaded<N: 'static>(loaded: Loaded<N>) -> Export<Graph<N>> {
-    let mut views: HashMap<CommitAddr, crate::SceneView> = HashMap::new();
-    let mut demos: HashMap<String, String> = HashMap::new();
-    for form in &loaded.extra {
+/// Apply the GUI-layer extra forms (`descriptions`, `layout`, `demo`) to a
+/// loaded registry's sections.
+fn registry_from_loaded<N: 'static>(mut loaded: Loaded<N>) -> Registry<Graph<N>> {
+    let extra = std::mem::take(&mut loaded.extra);
+    for form in &extra {
         match form.head.as_str() {
-            "layout" => apply_layout(form, &loaded, &mut views),
-            "demo" => apply_demo(form, &loaded, &mut demos),
+            "descriptions" => apply_descriptions(form, &mut loaded),
+            "layout" => apply_layout(form, &mut loaded),
+            "demo" => apply_demo(form, &mut loaded),
             other => log::warn!("ignoring unrecognised `.gantz` form `{other}`"),
         }
     }
-    Export {
-        registry: loaded.registry,
-        views,
-        demos,
-    }
+    loaded.registry
 }
 
-/// Serialize an [`Export`] to a `.gantz` document.
-pub fn to_string<N>(export: &Export<Graph<N>>) -> Result<String, FormatError>
+/// Serialize a registry to a `.gantz` document.
+pub fn to_string<N>(registry: &Registry<Graph<N>>) -> Result<String, FormatError>
 where
     N: Serialize + DeserializeOwned + gantz_format::NodeSugar,
 {
-    let dumped = gantz_format::to_string::<N>(&export.registry)?;
+    let dumped = gantz_format::to_string::<N>(registry, CLAIMED)?;
     // Each top-level block is a section; they are joined with a blank line.
     let mut sections = vec![dumped.text.trim_end().to_string()];
 
-    // `(layout ...)` per graph that has a top-level view, keyed by graph id.
-    let mut views: Vec<_> = export.views.iter().collect();
-    views.sort_by_key(|(ca, _)| **ca);
-    for (commit_ca, view) in views {
-        let Some(commit) = export.registry.commits().get(commit_ca) else {
+    // `(descriptions ...)`, in name order.
+    sections.extend(descriptions_text(registry));
+
+    // `(layout ...)` per commit that has a stored view, keyed by graph id.
+    for (commit_ca, view) in crate::section::views(registry) {
+        let Some(commit) = registry.commits().get(&commit_ca) else {
             continue;
         };
         if let Some(labels) = dumped.graphs.get(&commit.graph) {
-            sections.push(layout_text(labels, view, false));
+            sections.push(layout_text(labels, &view, false));
         }
     }
 
     // `(demo <name> ...)` per named graph that has a demo, in name order.
-    let mut demos: Vec<_> = export.demos.iter().collect();
-    demos.sort_by(|a, b| a.0.cmp(b.0));
-    for (name, demo) in demos {
-        sections.push(format!("(demo {} {})", name, sexpr::quote(demo)));
+    for (name, demo) in crate::section::demos(registry) {
+        sections.push(format!("(demo {} {})", name, sexpr::quote(&demo)));
     }
 
     let mut result = sections.join("\n\n");
@@ -96,36 +100,37 @@ where
     Ok(result)
 }
 
-/// Serialize an [`Export`] in the inline-name format (see
+/// Serialize a registry in the inline-name format (see
 /// [`gantz_format::to_string_named`]): graphs named inline, no commits/names
 /// tables, references by name. The `(layout ...)` and `(demo ...)` forms are
 /// emitted in graph-name order so the output is stable across address changes -
 /// suited to a hand-editable, git-friendly base file.
-pub fn to_string_named<N>(export: &Export<Graph<N>>) -> Result<String, FormatError>
+pub fn to_string_named<N>(registry: &Registry<Graph<N>>) -> Result<String, FormatError>
 where
     N: Serialize + DeserializeOwned + gantz_format::NodeSugar,
 {
-    let dumped = gantz_format::to_string_named::<N>(&export.registry)?;
+    let dumped = gantz_format::to_string_named::<N>(registry, CLAIMED)?;
     let mut sections = vec![dumped.text.trim_end().to_string()];
 
+    // `(descriptions ...)`, in name order.
+    sections.extend(descriptions_text(registry));
+
     // `(layout ...)` per named graph that has a view, in name order.
-    for (_name, commit_ca) in export.registry.names() {
+    for (_name, commit_ca) in registry.heads() {
         let (Some(view), Some(commit)) = (
-            export.views.get(commit_ca),
-            export.registry.commits().get(commit_ca),
+            crate::section::view(registry, &commit_ca),
+            registry.commits().get(&commit_ca),
         ) else {
             continue;
         };
         if let Some(labels) = dumped.graphs.get(&commit.graph) {
-            sections.push(layout_text(labels, view, true));
+            sections.push(layout_text(labels, &view, true));
         }
     }
 
     // `(demo <name> ...)` per named graph that has a demo, in name order.
-    for (name, _commit_ca) in export.registry.names() {
-        if let Some(demo) = export.demos.get(name) {
-            sections.push(format!("(demo {} {})", name, sexpr::quote(demo)));
-        }
+    for (name, demo) in crate::section::demos(registry) {
+        sections.push(format!("(demo {} {})", name, sexpr::quote(&demo)));
     }
 
     let mut result = sections.join("\n\n");
@@ -133,13 +138,49 @@ where
     Ok(result)
 }
 
-// -- layout ------------------------------------------------------------------
+// -- descriptions -------------------------------------------------------------
 
-fn apply_layout<N>(
-    form: &Form,
-    loaded: &Loaded<N>,
-    views: &mut HashMap<CommitAddr, crate::SceneView>,
-) {
+fn apply_descriptions<N: 'static>(form: &Form, loaded: &mut Loaded<N>) {
+    let src = &form.raw;
+    let Ok(forms) = sexpr::read(src) else { return };
+    let Some(args) = forms.first().and_then(sexpr::list_args) else {
+        return;
+    };
+    // args = [descriptions, (<name> "<text>")...]
+    for entry in &args[1..] {
+        let Some(eargs) = sexpr::list_args(entry) else {
+            continue;
+        };
+        let (Some(name), Some(text)) = (
+            eargs.first().and_then(sexpr::as_symbol),
+            eargs.get(1).and_then(sexpr::as_string),
+        ) else {
+            continue;
+        };
+        // Only retain descriptions for names this document actually defines.
+        if loaded.names.contains_key(&name) {
+            let name: Name = name.parse().expect("infallible");
+            crate::section::set_description(&mut loaded.registry, name, text);
+        }
+    }
+}
+
+/// The `(descriptions ...)` form for the registry's description section, in
+/// name order. `None` when there are no descriptions.
+fn descriptions_text<N>(registry: &Registry<Graph<N>>) -> Option<String> {
+    let mut entries = crate::section::descriptions(registry).peekable();
+    entries.peek()?;
+    let mut s = "(descriptions".to_string();
+    for (name, text) in entries {
+        s.push_str(&format!("\n  ({} {})", name, sexpr::quote(&text)));
+    }
+    s.push(')');
+    Some(s)
+}
+
+// -- layout --------------------------------------------------------------------
+
+fn apply_layout<N: 'static>(form: &Form, loaded: &mut Loaded<N>) {
     let src = &form.raw;
     let Ok(forms) = sexpr::read(src) else { return };
     let Some(args) = forms.first().and_then(sexpr::list_args) else {
@@ -202,7 +243,7 @@ fn apply_layout<N>(
     }
 
     let view = crate::SceneView { camera, layout };
-    views.insert(head, view);
+    crate::section::set_view(&mut loaded.registry, head, &view);
 }
 
 /// `bare_id` writes the graph id as a bare symbol (the inline-name format, where
@@ -247,7 +288,7 @@ fn layout_text(labels: &GraphLabels, view: &crate::SceneView, bare_id: bool) -> 
 
 // -- demos -------------------------------------------------------------------
 
-fn apply_demo<N>(form: &Form, loaded: &Loaded<N>, demos: &mut HashMap<String, String>) {
+fn apply_demo<N: 'static>(form: &Form, loaded: &mut Loaded<N>) {
     let src = &form.raw;
     let Ok(forms) = sexpr::read(src) else { return };
     let Some(args) = forms.first().and_then(sexpr::list_args) else {
@@ -262,7 +303,8 @@ fn apply_demo<N>(form: &Form, loaded: &Loaded<N>, demos: &mut HashMap<String, St
     };
     // Only retain demos for names this document's registry actually defines.
     if loaded.names.contains_key(&name) {
-        demos.insert(name, demo);
+        let name: Name = name.parse().expect("infallible");
+        crate::section::set_demo(&mut loaded.registry, name, demo);
     }
 }
 
@@ -273,4 +315,112 @@ fn addr_of(e: &sexpr::ExprKind) -> Option<Addr> {
     sexpr::as_string(e)
         .map(Addr::Concrete)
         .or_else(|| sexpr::as_symbol(e).map(Addr::Label))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_node::{TestGraph, TestNode, expr, named_ref};
+    use gantz_ca::CommitAddr;
+    use std::time::Duration;
+
+    fn name(s: &str) -> Name {
+        s.parse().unwrap()
+    }
+
+    /// A registry with a `leaf` expr graph, a `root` graph referencing it,
+    /// and a description, demo and view attached to `root`.
+    fn test_registry() -> (Registry<TestGraph>, CommitAddr) {
+        let mut reg = Registry::default();
+
+        let mut leaf_g = TestGraph::default();
+        leaf_g.add_node(expr("(+ 1 1)"));
+        let leaf_ga = gantz_ca::graph_addr(&leaf_g);
+        reg.commit_graph_to_name(Duration::from_secs(1), leaf_ga, || leaf_g, &name("leaf"));
+
+        let mut root_g = TestGraph::default();
+        root_g.add_node(named_ref("leaf", leaf_ga));
+        let root_ga = gantz_ca::graph_addr(&root_g);
+        let root_ca =
+            reg.commit_graph_to_name(Duration::from_secs(2), root_ga, || root_g, &name("root"));
+
+        crate::section::set_description(&mut reg, name("root"), "the root".to_string());
+        crate::section::set_demo(&mut reg, name("root"), "demo-root".to_string());
+        let view = crate::SceneView {
+            camera: crate::Camera {
+                center: egui::pos2(3.0, 4.0),
+                zoom: 2.0,
+            },
+            layout: [(egui_graph::NodeId(0), egui::pos2(10.0, 20.0))]
+                .into_iter()
+                .collect(),
+        };
+        crate::section::set_view(&mut reg, root_ca, &view);
+
+        (reg, root_ca)
+    }
+
+    fn assert_sections_survive(parsed: &Registry<TestGraph>) {
+        assert!(parsed.head(&name("leaf")).is_some());
+        let root_ca = parsed.head(&name("root")).expect("root head survives");
+        assert_eq!(
+            crate::section::description(parsed, &name("root")).as_deref(),
+            Some("the root"),
+        );
+        assert_eq!(
+            crate::section::demo(parsed, &name("root")).as_deref(),
+            Some("demo-root"),
+        );
+        let view = crate::section::view(parsed, &root_ca).expect("view survives");
+        assert_eq!(
+            view.layout.get(&egui_graph::NodeId(0)).copied(),
+            Some(egui::pos2(10.0, 20.0)),
+        );
+        assert_eq!(view.camera.center, egui::pos2(3.0, 4.0));
+        assert_eq!(view.camera.zoom, 2.0);
+    }
+
+    /// Descriptions, demos and views survive an address-based text
+    /// round-trip via their friendly forms.
+    #[test]
+    fn sections_round_trip_through_text() {
+        let (reg, root_ca) = test_registry();
+        let text = to_string(&reg).unwrap();
+        // Claimed sections must not also appear as generic forms.
+        assert!(!text.contains("(section"));
+        assert!(text.contains("(descriptions"));
+        assert!(text.contains("(layout"));
+        assert!(text.contains("(demo root"));
+        let parsed: Registry<TestGraph> =
+            from_str::<Box<dyn TestNode>>(&text, Duration::from_secs(9)).unwrap();
+        // The commits table preserves the head commit exactly.
+        assert_eq!(parsed.head(&name("root")), Some(root_ca));
+        assert_sections_survive(&parsed);
+    }
+
+    /// The same survives the inline-name format, where commits are
+    /// synthesized on load.
+    #[test]
+    fn sections_round_trip_through_named_text() {
+        let (reg, _root_ca) = test_registry();
+        let text = to_string_named(&reg).unwrap();
+        assert!(!text.contains("(section"));
+        let parsed: Registry<TestGraph> =
+            from_str::<Box<dyn TestNode>>(&text, Duration::from_secs(9)).unwrap();
+        assert_sections_survive(&parsed);
+    }
+
+    /// A registry with no GUI sections emits no friendly forms.
+    #[test]
+    fn empty_sections_emit_no_forms() {
+        let mut reg = Registry::<TestGraph>::default();
+        let mut g = TestGraph::default();
+        g.add_node(expr("(+ 1 1)"));
+        let ga = gantz_ca::graph_addr(&g);
+        reg.commit_graph_to_name(Duration::from_secs(1), ga, || g, &name("only"));
+        let text = to_string(&reg).unwrap();
+        assert!(!text.contains("(descriptions"));
+        assert!(!text.contains("(layout"));
+        assert!(!text.contains("(demo"));
+    }
 }

--- a/crates/gantz_egui/src/impls/apply.rs
+++ b/crates/gantz_egui/src/impls/apply.rs
@@ -1,8 +1,8 @@
 use crate::{NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind};
 
 impl NodeUi for gantz_core::node::Apply {
-    fn name(&self, _: &dyn Registry) -> &str {
-        "apply"
+    fn name(&self, _: &dyn Registry) -> std::borrow::Cow<'_, str> {
+        "apply".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_egui/src/impls/bang.rs
+++ b/crates/gantz_egui/src/impls/bang.rs
@@ -3,8 +3,8 @@ use crate::{
 };
 
 impl NodeUi for gantz_std::Bang {
-    fn name(&self, _: &dyn Registry) -> &str {
-        "!"
+    fn name(&self, _: &dyn Registry) -> std::borrow::Cow<'_, str> {
+        "!".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_egui/src/impls/branch.rs
+++ b/crates/gantz_egui/src/impls/branch.rs
@@ -95,8 +95,8 @@ impl<'a> egui::Widget for BranchEdit<'a> {
 }
 
 impl NodeUi for gantz_core::node::Branch {
-    fn name(&self, _: &dyn crate::Registry) -> &str {
-        "branch"
+    fn name(&self, _: &dyn crate::Registry) -> std::borrow::Cow<'_, str> {
+        "branch".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_egui/src/impls/delay.rs
+++ b/crates/gantz_egui/src/impls/delay.rs
@@ -1,8 +1,8 @@
 use crate::{NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind};
 
 impl NodeUi for gantz_core::node::Delay {
-    fn name(&self, _: &dyn Registry) -> &str {
-        "delay"
+    fn name(&self, _: &dyn Registry) -> std::borrow::Cow<'_, str> {
+        "delay".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_egui/src/impls/expr.rs
+++ b/crates/gantz_egui/src/impls/expr.rs
@@ -95,8 +95,8 @@ impl<'a> egui::Widget for ExprEdit<'a> {
 }
 
 impl NodeUi for gantz_core::node::Expr {
-    fn name(&self, _: &dyn crate::Registry) -> &str {
-        "expr"
+    fn name(&self, _: &dyn crate::Registry) -> std::borrow::Cow<'_, str> {
+        "expr".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_egui/src/impls/identity.rs
+++ b/crates/gantz_egui/src/impls/identity.rs
@@ -1,8 +1,8 @@
 use crate::{NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind};
 
 impl NodeUi for gantz_core::node::Identity {
-    fn name(&self, _: &dyn Registry) -> &str {
-        gantz_core::node::IDENTITY_NAME
+    fn name(&self, _: &dyn Registry) -> std::borrow::Cow<'_, str> {
+        gantz_core::node::IDENTITY_NAME.into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_egui/src/impls/inlet.rs
+++ b/crates/gantz_egui/src/impls/inlet.rs
@@ -5,8 +5,8 @@ use crate::{
 use gantz_core::node;
 
 impl NodeUi for gantz_core::node::graph::Inlet {
-    fn name(&self, _: &dyn Registry) -> &str {
-        "in"
+    fn name(&self, _: &dyn Registry) -> std::borrow::Cow<'_, str> {
+        "in".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_egui/src/impls/log.rs
+++ b/crates/gantz_egui/src/impls/log.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 impl NodeUi for gantz_std::log::Log {
-    fn name(&self, _: &dyn Registry) -> &str {
+    fn name(&self, _: &dyn Registry) -> std::borrow::Cow<'_, str> {
         match self.level {
             log::Level::Error => "error",
             log::Level::Warn => "warn",
@@ -12,6 +12,7 @@ impl NodeUi for gantz_std::log::Log {
             log::Level::Debug => "debug",
             log::Level::Trace => "trace",
         }
+        .into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_egui/src/impls/number.rs
+++ b/crates/gantz_egui/src/impls/number.rs
@@ -6,8 +6,8 @@ use gantz_std::number::Number;
 use steel::SteelVal;
 
 impl NodeUi for Number {
-    fn name(&self, _: &dyn Registry) -> &str {
-        "number"
+    fn name(&self, _: &dyn Registry) -> std::borrow::Cow<'_, str> {
+        "number".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_egui/src/impls/outlet.rs
+++ b/crates/gantz_egui/src/impls/outlet.rs
@@ -5,8 +5,8 @@ use crate::{
 use gantz_core::node;
 
 impl NodeUi for gantz_core::node::graph::Outlet {
-    fn name(&self, _: &dyn Registry) -> &str {
-        "out"
+    fn name(&self, _: &dyn Registry) -> std::borrow::Cow<'_, str> {
+        "out".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -19,8 +19,11 @@ pub mod node;
 pub mod ops;
 pub mod reg;
 pub mod response;
+pub mod section;
 pub mod sugar;
 pub mod sync;
+#[cfg(test)]
+mod test_node;
 pub mod ui_tree;
 pub mod view;
 pub mod widget;
@@ -81,7 +84,7 @@ pub trait Registry: NameRegistry + FnNodeNames + NodeTypeRegistry + GraphRegistr
     }
 
     /// Get the demo graph name associated with the graph of the given name.
-    fn demo_graph(&self, name: &str) -> Option<&str> {
+    fn demo_graph(&self, name: &str) -> Option<String> {
         let _ = name;
         None
     }
@@ -120,8 +123,8 @@ pub trait Registry: NameRegistry + FnNodeNames + NodeTypeRegistry + GraphRegistr
     ///
     /// Used to seed the description editor in the graph config pane. The
     /// standard [`RegistryRef`] impl reads it from the content-addressed
-    /// registry; the default has none.
-    fn graph_description(&self, name: &str) -> Option<&str> {
+    /// registry's description section; the default has none.
+    fn graph_description(&self, name: &str) -> Option<String> {
         let _ = name;
         None
     }
@@ -327,7 +330,7 @@ pub struct HeadDataMut<'a, N> {
 /// only costs a redundant hash, so when in doubt, mark it.
 pub trait NodeUi {
     /// The name used to present the node within the inspector.
-    fn name(&self, _registry: &dyn Registry) -> &str;
+    fn name(&self, _registry: &dyn Registry) -> Cow<'_, str>;
 
     /// Instantiate the `Ui` for the given node.
     ///
@@ -403,7 +406,7 @@ pub trait NodeUi {
     }
 
     /// Look up the demo graph name associated with this node, if any.
-    fn demo_graph<'a>(&self, _registry: &'a dyn Registry) -> Option<&'a str> {
+    fn demo_graph(&self, _registry: &dyn Registry) -> Option<String> {
         None
     }
 
@@ -669,7 +672,7 @@ impl<'a, N> NodeUi for &'a mut N
 where
     N: ?Sized + NodeUi,
 {
-    fn name(&self, registry: &dyn Registry) -> &str {
+    fn name(&self, registry: &dyn Registry) -> Cow<'_, str> {
         (**self).name(registry)
     }
 
@@ -705,7 +708,7 @@ where
         (**self).flow(registry)
     }
 
-    fn demo_graph<'b>(&self, registry: &'b dyn Registry) -> Option<&'b str> {
+    fn demo_graph(&self, registry: &dyn Registry) -> Option<String> {
         (**self).demo_graph(registry)
     }
 
@@ -737,7 +740,7 @@ macro_rules! impl_node_ui_for_ptr {
         where
             T: ?Sized + NodeUi,
         {
-            fn name(&self, registry: &dyn Registry) -> &str {
+            fn name(&self, registry: &dyn Registry) -> Cow<'_, str> {
                 (**self).name(registry)
             }
 
@@ -769,7 +772,7 @@ macro_rules! impl_node_ui_for_ptr {
                 (**self).flow(registry)
             }
 
-            fn demo_graph<'a>(&self, registry: &'a dyn Registry) -> Option<&'a str> {
+            fn demo_graph(&self, registry: &dyn Registry) -> Option<String> {
                 (**self).demo_graph(registry)
             }
 

--- a/crates/gantz_egui/src/merge.rs
+++ b/crates/gantz_egui/src/merge.rs
@@ -54,26 +54,25 @@ impl MergePreview {
 /// Skips ours' own name and nested (`parent:child`) graphs. Candidates are
 /// ordered by name (the registry's name order).
 pub fn merge_candidates<N>(reg: &ca::Registry<Graph<N>>, ours: &ca::Head) -> Vec<MergeCandidate> {
-    let Some(&ours_tip) = reg.head_commit_ca(ours) else {
+    let Some(ours_tip) = reg.head_commit_ca(ours) else {
         return vec![];
     };
     let our_name = match ours {
-        ca::Head::Branch(name) => Some(name.as_str()),
+        ca::Head::Branch(name) => Some(name),
         ca::Head::Commit(_) => None,
     };
     let commits = reg.commits();
-    reg.names()
-        .iter()
-        .filter(|(name, _)| Some(name.as_str()) != our_name)
-        .filter(|(name, _)| !name.contains(crate::node::NESTED_SEP))
-        .filter_map(|(name, &theirs)| {
+    reg.heads()
+        .filter(|(name, _)| Some(*name) != our_name)
+        .filter(|(name, _)| !name.is_nested())
+        .filter_map(|(name, theirs)| {
             let (base, fast_forward) = match ca::analyze(commits, ours_tip, theirs) {
                 ca::MergeAnalysis::Diverged(base) => (base, false),
                 ca::MergeAnalysis::FastForward => (ours_tip, true),
                 ca::MergeAnalysis::AlreadyUpToDate | ca::MergeAnalysis::Unrelated => return None,
             };
             Some(MergeCandidate {
-                name: name.clone(),
+                name: name.to_string(),
                 theirs,
                 base,
                 fast_forward,
@@ -96,8 +95,8 @@ pub fn merge_preview<N>(
 where
     N: Clone + ca::CaHash + AsNamedRef,
 {
-    let ours_tip = *reg.head_commit_ca(ours)?;
-    let theirs_tip = *reg.names().get(source)?;
+    let ours_tip = reg.head_commit_ca(ours)?;
+    let theirs_tip = reg.head(&source.parse().expect("infallible"))?;
     match ca::merge_commits(reg, ours_tip, theirs_tip, resolutions).ok()? {
         ca::MergeResolution::Diverged {
             theirs_diff,

--- a/crates/gantz_egui/src/node.rs
+++ b/crates/gantz_egui/src/node.rs
@@ -9,7 +9,7 @@ pub use fn_named_ref::{FnNamedRef, FnNodeNames};
 #[doc(inline)]
 pub use gantz_core::node::{Id, state};
 pub use inspect::Inspect;
-pub use named_ref::{NESTED_SEP, NameRegistry, NamedRef, missing_color, outdated_color};
+pub use named_ref::{NameRegistry, NamedRef, missing_color, outdated_color};
 pub use plot::{Plot, PlotMode, PlotStyle};
 pub use ref_ext::RefExtUi;
 
@@ -35,10 +35,8 @@ where
     vec![
         Builtin::new("comment", || N::from_node(Comment::default())),
         Builtin::new("fn", move || {
-            let named_ref = NamedRef::new(
-                gantz_core::node::IDENTITY_NAME.to_string(),
-                gantz_core::node::Ref::new(identity_ca),
-            );
+            let name = gantz_core::node::IDENTITY_NAME.parse().expect("infallible");
+            let named_ref = NamedRef::new(name, gantz_core::node::Ref::new(identity_ca));
             N::from_node(gantz_core::node::Fn::new(named_ref))
         }),
         Builtin::new("inspect", || N::from_node(Inspect::default())),

--- a/crates/gantz_egui/src/node/comment.rs
+++ b/crates/gantz_egui/src/node/comment.rs
@@ -74,8 +74,8 @@ impl gantz_core::Node for Comment {
 }
 
 impl NodeUi for Comment {
-    fn name(&self, _registry: &dyn crate::Registry) -> &str {
-        "comment"
+    fn name(&self, _registry: &dyn crate::Registry) -> std::borrow::Cow<'_, str> {
+        "comment".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_egui/src/node/fn_named_ref.rs
+++ b/crates/gantz_egui/src/node/fn_named_ref.rs
@@ -23,19 +23,20 @@ pub trait FnNodeNames: NameRegistry {
 }
 
 impl NodeUi for FnNamedRef {
-    fn name(&self, _registry: &dyn Registry) -> &str {
-        "fn"
+    fn name(&self, _registry: &dyn Registry) -> std::borrow::Cow<'_, str> {
+        "fn".into()
     }
 
     fn ui(&mut self, ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {
         let registry = ctx.registry();
+        let name_str = self.0.name().to_string();
         let ref_ca = self.0.content_addr();
 
         // Check if the referenced CA exists in registry.
         let is_missing = !registry.node_exists(&ref_ca);
 
         // Check if outdated (name points to different CA).
-        let current_ca = registry.name_ca(self.0.name());
+        let current_ca = registry.name_ca(&name_str);
         let is_outdated = !is_missing && current_ca.map(|ca| ca != ref_ca).unwrap_or(false);
 
         // Auto-sync if enabled and outdated (skip if missing). A silent
@@ -54,7 +55,7 @@ impl NodeUi for FnNamedRef {
         let is_missing = !registry.node_exists(&ref_ca);
         let is_outdated = !is_missing
             && registry
-                .name_ca(self.0.name())
+                .name_ca(&name_str)
                 .map(|ca| ca != ref_ca)
                 .unwrap_or(false);
 
@@ -62,11 +63,11 @@ impl NodeUi for FnNamedRef {
             ui.horizontal(|ui| {
                 let fn_res = ui.add(egui::Label::new("λ").selectable(false));
                 let name_text = if is_missing {
-                    egui::RichText::new(self.0.name()).color(missing_color())
+                    egui::RichText::new(&name_str).color(missing_color())
                 } else if is_outdated {
-                    egui::RichText::new(self.0.name()).color(outdated_color())
+                    egui::RichText::new(&name_str).color(outdated_color())
                 } else {
-                    egui::RichText::new(self.0.name())
+                    egui::RichText::new(&name_str)
                 };
                 let name_res = ui.add(egui::Label::new(name_text).selectable(false));
                 fn_res.union(name_res)
@@ -95,14 +96,15 @@ impl NodeUi for FnNamedRef {
                 let registry = ctx.registry();
                 let salt = format!("λ-node-select-{:?}", ctx.path());
                 let names = registry.fn_node_names();
+                let current = self.0.name().to_string();
                 egui::ComboBox::from_id_salt(salt)
-                    .selected_text(self.0.name())
+                    .selected_text(&current)
                     .show_ui(ui, |ui| {
                         for name in names.iter() {
-                            if ui.selectable_label(self.0.name() == name, name).clicked() {
+                            if ui.selectable_label(current == *name, name).clicked() {
                                 if let Some(ca) = registry.name_ca(name) {
-                                    self.0 =
-                                        NamedRef::new(name.clone(), gantz_core::node::Ref::new(ca));
+                                    let name = name.parse().expect("infallible");
+                                    self.0 = NamedRef::new(name, gantz_core::node::Ref::new(ca));
                                     resp.mark_changed();
                                 }
                             }

--- a/crates/gantz_egui/src/node/inspect.rs
+++ b/crates/gantz_egui/src/node/inspect.rs
@@ -39,8 +39,8 @@ impl gantz_core::Node for Inspect {
 }
 
 impl NodeUi for Inspect {
-    fn name(&self, _: &dyn crate::Registry) -> &str {
-        "inspect"
+    fn name(&self, _: &dyn crate::Registry) -> std::borrow::Cow<'_, str> {
+        "inspect".into()
     }
 
     fn ui(&mut self, mut ctx: NodeCtx, uictx: egui_graph::NodeCtx) -> NodeUiResponse {

--- a/crates/gantz_egui/src/node/named_ref.rs
+++ b/crates/gantz_egui/src/node/named_ref.rs
@@ -4,10 +4,11 @@ use crate::{
     BranchNode, ContextMenuResponse, InspectorRowsResponse, NodeCtx, NodeUi, NodeUiResponse,
     OpenHead, ReplaceHead, SocketDoc, widget::node_inspector,
 };
-use gantz_ca::CaHash;
+use gantz_ca::{CaHash, Name};
 use gantz_core::node::{self, ExprCtx, ExprResult, MetaCtx, Node, RegCtx};
 use gantz_nodetag::NodeTag;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 /// The warning color used for outdated references.
 pub fn outdated_color() -> egui::Color32 {
@@ -30,7 +31,7 @@ pub struct NamedRef {
     /// The underlying reference by content address.
     ref_: gantz_core::node::Ref,
     /// The human-readable name associated with this reference.
-    name: String,
+    name: Name,
     /// Whether to automatically sync to the latest commit.
     ///
     /// Part of the content address: toggling it is a genuine edit, so the
@@ -48,16 +49,9 @@ pub trait NameRegistry {
     fn node_exists(&self, ca: &gantz_ca::ContentAddr) -> bool;
 }
 
-/// The separator reserved for nested-graph names (`parent:child`).
-///
-/// A `NamedRef` whose name contains this character is a *nested* graph: it is
-/// hidden from the root graph-select list and its `sync` toggle is forced on so
-/// edits to the child always propagate back to its parent.
-pub const NESTED_SEP: char = ':';
-
 impl NamedRef {
     /// Construct a `NamedRef` node (auto-sync disabled).
-    pub fn new(name: String, ref_: gantz_core::node::Ref) -> Self {
+    pub fn new(name: Name, ref_: gantz_core::node::Ref) -> Self {
         Self {
             ref_,
             name,
@@ -69,7 +63,7 @@ impl NamedRef {
     ///
     /// Used for nested graphs, whose parent must always follow the child's
     /// latest commit.
-    pub fn with_sync(name: String, ref_: gantz_core::node::Ref) -> Self {
+    pub fn with_sync(name: Name, ref_: gantz_core::node::Ref) -> Self {
         Self {
             ref_,
             name,
@@ -78,13 +72,17 @@ impl NamedRef {
     }
 
     /// The human-readable name associated with this reference.
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &Name {
         &self.name
     }
 
     /// Whether this reference names a nested graph (`parent:child`).
+    ///
+    /// A `NamedRef` naming a nested graph is hidden from the root
+    /// graph-select list and its `sync` toggle is forced on so edits to the
+    /// child always propagate back to its parent.
     pub fn is_nested(&self) -> bool {
-        self.name.contains(NESTED_SEP)
+        self.name.is_nested()
     }
 
     /// The underlying reference.
@@ -125,20 +123,21 @@ impl NamedRef {
     }
 
     /// Re-point this reference at a renamed target: change the stored name and
-    /// repoint at the renamed graph's commit. Used by the rename cascade so a
-    /// renamed parent keeps referencing its (also-renamed) children.
-    pub fn rename(&mut self, name: String, ca: gantz_ca::ContentAddr) {
+    /// repoint at the renamed graph's head graph address. Used by the rename
+    /// cascade so a renamed parent keeps referencing its (also-renamed)
+    /// children.
+    pub fn rename(&mut self, name: Name, ca: gantz_ca::ContentAddr) {
         self.name = name;
         self.ref_ = self.ref_.retarget(ca);
     }
 
-    /// Bring the reference up to date with the name's current commit.
+    /// Bring the reference up to date with the name's current head graph.
     ///
     /// When sync is enabled and `resolve(name)` differs from the current
     /// reference, the reference is repointed at the resolved address. Returns
     /// `true` if the reference changed. This is the single implementation shared
     /// by the inspector UI and the headless propagation pass.
-    pub fn resync(&mut self, resolve: impl Fn(&str) -> Option<gantz_ca::ContentAddr>) -> bool {
+    pub fn resync(&mut self, resolve: impl Fn(&Name) -> Option<gantz_ca::ContentAddr>) -> bool {
         if !self.sync {
             return false;
         }
@@ -215,12 +214,12 @@ impl Node for NamedRef {
 }
 
 impl NodeUi for NamedRef {
-    fn name(&self, _registry: &dyn crate::Registry) -> &str {
-        &self.name
+    fn name(&self, _registry: &dyn crate::Registry) -> Cow<'_, str> {
+        Cow::Owned(self.name.to_string())
     }
 
-    fn demo_graph<'a>(&self, registry: &'a dyn crate::Registry) -> Option<&'a str> {
-        registry.demo_graph(&self.name)
+    fn demo_graph(&self, registry: &dyn crate::Registry) -> Option<String> {
+        registry.demo_graph(&self.name.to_string())
     }
 
     fn nav_head(&self, _registry: &dyn crate::Registry) -> Option<gantz_ca::Head> {
@@ -248,29 +247,30 @@ impl NodeUi for NamedRef {
             changed = true;
         }
 
-        // Auto-sync if enabled and the name points at a newer commit. This is a
+        // Auto-sync if enabled and the name points at newer content. This is a
         // silent mutation (no widget touched) that still changes the node's CA.
-        if self.resync(|name| registry.name_ca(name)) {
+        if self.resync(|name| registry.name_ca(&name.to_string())) {
             changed = true;
         }
 
         // Recalculate after potential sync.
+        let name_str = self.name.to_string();
         let ref_ca = self.ref_.content_addr();
         let is_missing = !registry.node_exists(&ref_ca);
         let is_outdated = !is_missing
             && registry
-                .name_ca(&self.name)
+                .name_ca(&name_str)
                 .map(|ca| ca != ref_ca)
                 .unwrap_or(false);
 
         // Regular frame, error color if missing, warning color if outdated.
         let framed = uictx.framed(|ui, _sockets| {
             let name_text = if is_missing {
-                egui::RichText::new(&self.name).color(missing_color())
+                egui::RichText::new(&name_str).color(missing_color())
             } else if is_outdated {
-                egui::RichText::new(&self.name).color(outdated_color())
+                egui::RichText::new(&name_str).color(outdated_color())
             } else {
-                egui::RichText::new(&self.name)
+                egui::RichText::new(&name_str)
             };
             ui.add(egui::Label::new(name_text).selectable(false))
         });
@@ -410,9 +410,9 @@ impl NodeUi for NamedRef {
     }
 }
 
-/// The name's current commit CA when this reference is *outdated*: it exists,
-/// auto-sync is off, and the name now points at a different commit. `None`
-/// otherwise (missing, synced, or already up to date).
+/// The name's current head graph CA when this reference is *outdated*: it
+/// exists, auto-sync is off, and the name now points at different content.
+/// `None` otherwise (missing, synced, or already up to date).
 fn outdated_latest(
     named: &NamedRef,
     registry: &dyn crate::Registry,
@@ -424,7 +424,7 @@ fn outdated_latest(
     if !registry.node_exists(&ref_ca) {
         return None;
     }
-    match registry.name_ca(&named.name) {
+    match registry.name_ca(&named.name.to_string()) {
         Some(latest) if latest != ref_ca => Some(latest),
         _ => None,
     }

--- a/crates/gantz_egui/src/node/plot.rs
+++ b/crates/gantz_egui/src/node/plot.rs
@@ -335,8 +335,8 @@ impl Plot {
 }
 
 impl NodeUi for Plot {
-    fn name(&self, _: &dyn Registry) -> &str {
-        "plot"
+    fn name(&self, _: &dyn Registry) -> std::borrow::Cow<'_, str> {
+        "plot".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_egui/src/node/ref_ext.rs
+++ b/crates/gantz_egui/src/node/ref_ext.rs
@@ -64,11 +64,10 @@ mod tests {
         type G = gantz_core::node::graph::Graph<NamedRef>;
         let registry = gantz_ca::Registry::<G>::default();
         let builtins = gantz_core::BuiltinSet::<NamedRef>::from_specs([]);
-        let demos = std::collections::HashMap::new();
-        let reg_ref = crate::RegistryRef::new(&registry, &builtins, &demos);
+        let reg_ref = crate::RegistryRef::new(&registry, &builtins);
         let mut vm = gantz_core::steel::steel_vm::engine::Engine::new_base();
         let mut named = NamedRef::new(
-            "x".to_string(),
+            "x".parse().unwrap(),
             gantz_core::node::Ref::new([0u8; 32].into()),
         );
         let exts: [&dyn RefExtUi; 1] = [&StubExt];

--- a/crates/gantz_egui/src/ops.rs
+++ b/crates/gantz_egui/src/ops.rs
@@ -10,17 +10,20 @@ use crate::sync::AsNamedRef;
 use crate::widget::gantz::OpenHeadState;
 use crate::widget::graph_scene::NodeIndex;
 use crate::{CreateNode, InspectEdge, PastePos, export, node::NamedRef};
-use gantz_ca::{CaHash, CommitAddr};
+use gantz_ca::{CaHash, CommitAddr, GraphAddr, Name};
 use gantz_core::node::{self, GetNode, graph::Graph};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use std::collections::{HashMap, HashSet};
 use steel::steel_vm::engine::Engine;
 
-/// Branch a named node: create a new commit for the given content address
-/// (original commit as parent), insert the new name pointing at it, and
-/// replace the node at `path` with a [`NamedRef`] referencing the fresh
-/// commit. `path`'s last element is the node's index within the graph.
+/// Branch a named node: commit the graph at the given (graph) content address
+/// under a new name, and replace the node at `path` with a [`NamedRef`]
+/// referencing it. `path`'s last element is the node's index within the
+/// graph.
+///
+/// The newest existing commit pointing at the graph (if any) becomes the new
+/// commit's parent, preserving the fork point's history.
 pub fn branch_node<N>(
     registry: &mut gantz_ca::Registry<Graph<N>>,
     timestamp: std::time::Duration,
@@ -31,16 +34,17 @@ pub fn branch_node<N>(
 ) where
     N: From<NamedRef> + AsNamedRef,
 {
-    let commit_ca = CommitAddr::from(ca);
-    let Some(commit) = registry.commits().get(&commit_ca) else {
-        log::error!("BranchNode: commit not found for {commit_ca:?}");
+    let graph_addr = GraphAddr::from(ca);
+    if registry.graph(&graph_addr).is_none() {
+        log::error!("BranchNode: graph not found for {graph_addr:?}");
         return;
-    };
-    let graph_addr = commit.graph;
-    let new_commit_ca = registry.commit_graph(timestamp, Some(commit_ca), graph_addr, || {
+    }
+    let parent = newest_commit_for_graph(registry, graph_addr);
+    let new_commit_ca = registry.commit_graph(timestamp, parent, graph_addr, || {
         unreachable!("graph already exists in registry")
     });
-    registry.insert_name(new_name.clone(), new_commit_ca);
+    let name: Name = new_name.parse().expect("infallible");
+    registry.set_head(name.clone(), new_commit_ca);
 
     // Replace the NamedRef node in the working graph.
     let Some(&node_ix) = path.last() else {
@@ -52,15 +56,29 @@ pub fn branch_node<N>(
     // identical, so domain flags still apply. `sync` deliberately resets - a
     // fork pins.
     let new_ref = match graph.node_weight(node_id).and_then(N::as_named_ref) {
-        Some(old) => old.ref_().retarget(new_commit_ca.into()),
-        None => node::Ref::new(new_commit_ca.into()),
+        Some(old) => old.ref_().retarget(graph_addr.into()),
+        None => node::Ref::new(graph_addr.into()),
     };
-    let named_ref = NamedRef::new(new_name, new_ref);
+    let named_ref = NamedRef::new(name, new_ref);
     if let Some(node) = graph.node_weight_mut(node_id) {
         *node = N::from(named_ref);
     } else {
         log::error!("BranchNode: node not found at index {node_ix}");
     }
+}
+
+/// The newest commit pointing at the given graph, if any (ties broken by
+/// address for determinism).
+fn newest_commit_for_graph<G>(
+    registry: &gantz_ca::Registry<G>,
+    graph_addr: GraphAddr,
+) -> Option<CommitAddr> {
+    registry
+        .commits()
+        .iter()
+        .filter(|(_, commit)| commit.graph == graph_addr)
+        .max_by_key(|(ca, commit)| (commit.timestamp, **ca))
+        .map(|(ca, _)| *ca)
 }
 
 /// Serialize the current selection to a `.gantz` clipboard payload.
@@ -70,7 +88,6 @@ pub fn branch_node<N>(
 /// responsibility.
 pub fn copy_nodes<N>(
     registry: &gantz_ca::Registry<Graph<N>>,
-    all_views: &HashMap<CommitAddr, crate::SceneView>,
     graph: &Graph<N>,
     head_view: &crate::SceneView,
     selection: &HashSet<NodeIndex>,
@@ -87,7 +104,7 @@ where
     if selection.is_empty() {
         return None;
     }
-    let copied = export::copy(registry, all_views, graph, selection, &head_view.layout);
+    let copied = export::copy(registry, graph, selection, &head_view.layout);
     match export::copied_to_string(&copied) {
         Ok(text) => Some(text),
         Err(e) => {
@@ -119,7 +136,11 @@ where
     // Refuse references that would form a cycle back to the editing graph; with
     // sync on such a cycle recommits endlessly (see `crate::cycle`). A nameless
     // (detached commit) head can't be the target of a name-based cycle.
-    if editing.is_some_and(|editing| crate::cycle::would_cycle(registry, &node_type, editing)) {
+    if editing.is_some_and(|editing| {
+        let target: Name = node_type.parse().expect("infallible");
+        let editing: Name = editing.parse().expect("infallible");
+        crate::cycle::would_cycle(registry, &target, &editing)
+    }) {
         log::warn!("CreateNode: '{node_type}' would create a reference cycle; skipping");
         return None;
     }
@@ -162,17 +183,16 @@ pub fn create_nested_graph<N>(
     view: &mut crate::SceneView,
     head_state: &mut OpenHeadState,
     pos: Option<egui::Pos2>,
-    parent: &str,
+    parent: &Name,
 ) -> Option<NodeIndex>
 where
     N: gantz_core::Node + From<NamedRef> + CaHash,
 {
     // Pick the first free `<parent>:<n>` leaf name.
-    let sep = crate::node::NESTED_SEP;
     let mut n = 1u32;
     let name = loop {
-        let candidate = format!("{parent}{sep}{n}");
-        if !registry.names().contains_key(&candidate) {
+        let candidate = parent.child(n.to_string());
+        if registry.head(&candidate).is_none() {
             break candidate;
         }
         n += 1;
@@ -181,12 +201,12 @@ where
     // Commit a fresh empty graph under the chosen name.
     let nested_graph = Graph::<N>::default();
     let graph_ca = gantz_ca::graph_addr(&nested_graph);
-    let commit_ca = registry.commit_graph_to_name(timestamp, graph_ca, || nested_graph, &name);
+    registry.commit_graph_to_name(timestamp, graph_ca, || nested_graph, &name);
 
     // Insert a synced reference to the new nested graph. The referenced graph is
     // empty, so the node has no state to register here; the next `vm::sync`
     // recompile re-registers the whole working graph.
-    let named_ref = NamedRef::with_sync(name, node::Ref::new(commit_ca.into()));
+    let named_ref = NamedRef::with_sync(name, node::Ref::new(graph_ca.into()));
     let node_ix = graph.add_node(N::from(named_ref));
 
     // Position the new node under the pointer, falling back to the center of the
@@ -310,7 +330,6 @@ pub fn remove_nodes<N>(
 /// next recompile.
 pub fn cut_nodes<N>(
     registry: &gantz_ca::Registry<Graph<N>>,
-    all_views: &HashMap<CommitAddr, crate::SceneView>,
     graph: &mut Graph<N>,
     vm: &mut Engine,
     head_view: &mut crate::SceneView,
@@ -326,7 +345,7 @@ where
         + gantz_format::NodeSugar
         + 'static,
 {
-    let text = copy_nodes(registry, all_views, graph, head_view, nodes)?;
+    let text = copy_nodes(registry, graph, head_view, nodes)?;
     remove_nodes(
         graph,
         vm,
@@ -401,8 +420,6 @@ pub fn inspect_edge<N>(
 pub fn paste<N>(
     registry: &mut gantz_ca::Registry<Graph<N>>,
     editing: Option<&str>,
-    all_views: &mut HashMap<CommitAddr, crate::SceneView>,
-    all_demos: &mut HashMap<String, String>,
     graph: &mut Graph<N>,
     head_view: &mut crate::SceneView,
     head_state: &mut OpenHeadState,
@@ -410,7 +427,8 @@ pub fn paste<N>(
     pos: &PastePos,
 ) -> bool
 where
-    N: Clone
+    N: gantz_core::Node
+        + Clone
         + Serialize
         + DeserializeOwned
         + CaHash
@@ -432,11 +450,12 @@ where
     // a refused paste mutates nothing. A nameless (detached commit) head can't
     // be a name-based cycle target.
     if let Some(editing) = editing {
+        let editing: Name = editing.parse().expect("infallible");
         if let Some(named) = copied
             .graph
             .node_weights()
             .filter_map(|n| n.as_named_ref())
-            .find(|nr| crate::cycle::would_cycle(registry, nr.name(), editing))
+            .find(|nr| crate::cycle::would_cycle(registry, nr.name(), &editing))
         {
             log::warn!(
                 "Paste: '{}' would create a reference cycle in '{editing}'; skipping paste",
@@ -448,15 +467,7 @@ where
 
     let offset = crate::resolve_paste_offset(pos, &copied.positions);
 
-    let new_indices = export::paste(
-        registry,
-        all_views,
-        all_demos,
-        graph,
-        &mut head_view.layout,
-        &copied,
-        offset,
-    );
+    let new_indices = export::paste(registry, graph, &mut head_view.layout, &copied, offset);
 
     // Update selection to the pasted nodes.
     head_state.scene.interaction.selection.nodes = new_indices.into_iter().collect();
@@ -473,8 +484,6 @@ where
 pub fn duplicate_nodes<N>(
     registry: &mut gantz_ca::Registry<Graph<N>>,
     editing: Option<&str>,
-    all_views: &mut HashMap<CommitAddr, crate::SceneView>,
-    all_demos: &mut HashMap<String, String>,
     graph: &mut Graph<N>,
     head_view: &mut crate::SceneView,
     head_state: &mut OpenHeadState,
@@ -490,14 +499,12 @@ where
         + gantz_format::NodeSugar
         + 'static,
 {
-    let Some(text) = copy_nodes(registry, all_views, graph, head_view, nodes) else {
+    let Some(text) = copy_nodes(registry, graph, head_view, nodes) else {
         return false;
     };
     paste(
         registry,
         editing,
-        all_views,
-        all_demos,
         graph,
         head_view,
         head_state,
@@ -516,7 +523,7 @@ pub fn undo<G>(
     redo_stacks: &mut HashMap<gantz_ca::Head, Vec<CommitAddr>>,
     head: &gantz_ca::Head,
 ) -> Option<CommitAddr> {
-    let commit_ca = registry.head_commit_ca(head).copied()?;
+    let commit_ca = registry.head_commit_ca(head)?;
     let parent = registry.commits().get(&commit_ca)?.parent?;
     redo_stacks.entry(head.clone()).or_default().push(commit_ca);
     Some(parent)
@@ -601,9 +608,10 @@ pub enum MergeHeadOutcome {
 /// On a true merge this migrates the index-keyed VM state, layout and
 /// selection through the merged graph's node mapping (an identity mapping
 /// whenever the source branch removed no nodes), seeds layout for merged-in
-/// nodes from the source branch's persisted view in `all_views` (falling back
-/// to placement near the view centre), and commits the result with two
-/// parents via [`gantz_ca::Registry::commit_merge_to_head`] - upholding the
+/// nodes from the source branch's persisted view in the registry's view
+/// section (falling back to placement near the view centre), and commits the
+/// result with two parents via
+/// [`gantz_ca::Registry::commit_merge_to_head`] - upholding the
 /// committed-working-graph invariant, so callers must not commit again.
 ///
 /// Conflicts refuse the merge unless `auto_resolve` accepts the given
@@ -612,7 +620,6 @@ pub enum MergeHeadOutcome {
 #[allow(clippy::too_many_arguments)]
 pub fn merge_head<N>(
     registry: &mut gantz_ca::Registry<Graph<N>>,
-    all_views: &HashMap<CommitAddr, crate::SceneView>,
     timestamp: gantz_ca::Timestamp,
     head: &mut gantz_ca::Head,
     graph: &mut Graph<N>,
@@ -627,11 +634,11 @@ where
     N: Clone + CaHash + AsNamedRef,
 {
     let node_id = |ix: usize| egui_graph::NodeId::from_u64(ix as u64);
-    let Some(&ours_tip) = registry.head_commit_ca(head) else {
+    let Some(ours_tip) = registry.head_commit_ca(head) else {
         log::error!("MergeHead: no commit for head {head}");
         return MergeHeadOutcome::Noop;
     };
-    let Some(&theirs_tip) = registry.names().get(source) else {
+    let Some(theirs_tip) = registry.head(&source.parse().expect("infallible")) else {
         log::error!("MergeHead: unknown source branch '{source}'");
         return MergeHeadOutcome::Noop;
     };
@@ -694,9 +701,10 @@ where
     // Seed layout for merged-in nodes from the source branch's persisted view
     // (positions are compatible: both branches share the base's coordinates),
     // falling back to placement near the view centre.
-    let theirs_view = all_views.get(&theirs_tip);
+    let theirs_view = crate::section::view(registry, &theirs_tip);
     for (i, &(m, t)) in theirs_only.iter().enumerate() {
         let pos = theirs_view
+            .as_ref()
             .and_then(|v| v.layout.get(&node_id(t)).copied())
             .unwrap_or_else(|| head_view.camera.center + egui::vec2(20.0, 20.0) * i as f32);
         head_view.layout.insert(node_id(m), pos);
@@ -729,18 +737,17 @@ where
 /// layout commit.
 ///
 /// Returns the new commit address when a layout commit was created, else `None`
-/// (no baseline view yet - i.e. the head commit's layout has not been seeded -
-/// or no node-position change). Seeding `views[new]`, clearing the redo stack
-/// and migrating GUI state stay with the caller.
+/// (no baseline view yet - i.e. the head commit's view section entry has not
+/// been seeded - or no node-position change). Seeding the new commit's view,
+/// clearing the redo stack and migrating GUI state stay with the caller.
 pub fn commit_layout<G>(
     registry: &mut gantz_ca::Registry<G>,
-    views: &HashMap<CommitAddr, crate::SceneView>,
     timestamp: gantz_ca::Timestamp,
     head: &mut gantz_ca::Head,
     live: &crate::SceneView,
 ) -> Option<CommitAddr> {
-    let head_commit_ca = *registry.head_commit_ca(head)?;
-    let baseline = views.get(&head_commit_ca)?;
+    let head_commit_ca = registry.head_commit_ca(head)?;
+    let baseline = crate::section::view(registry, &head_commit_ca)?;
     if baseline.layout == live.layout {
         return None;
     }
@@ -907,9 +914,9 @@ mod tests {
         let ours_ca = reg.commit_graph(secs(2), Some(base_ca), gantz_ca::graph_addr(&g), || g);
         let g = test_graph(theirs);
         let theirs_ca = reg.commit_graph(secs(3), Some(base_ca), gantz_ca::graph_addr(&g), || g);
-        reg.insert_name("alpha".to_string(), ours_ca);
-        reg.insert_name("beta".to_string(), theirs_ca);
-        (reg, gantz_ca::Head::Branch("alpha".to_string()))
+        reg.set_head("alpha".parse().unwrap(), ours_ca);
+        reg.set_head("beta".parse().unwrap(), theirs_ca);
+        (reg, gantz_ca::Head::Branch("alpha".parse().unwrap()))
     }
 
     #[allow(clippy::type_complexity)]
@@ -924,7 +931,6 @@ mod tests {
     ) -> MergeHeadOutcome {
         merge_head(
             reg,
-            &HashMap::new(),
             std::time::Duration::from_secs(9),
             head,
             graph,
@@ -942,8 +948,8 @@ mod tests {
     #[test]
     fn merge_head_applies_theirs_and_commits_two_parents() {
         let (mut reg, mut head) = diverged_registry(&[1, 2], &[1, 20], &[1, 2, 3]);
-        let ours_tip = *reg.head_commit_ca(&head).unwrap();
-        let theirs_tip = reg.names()["beta"];
+        let ours_tip = reg.head_commit_ca(&head).unwrap();
+        let theirs_tip = reg.head(&"beta".parse().unwrap()).unwrap();
         let mut graph = test_graph(&[1, 20]);
         let mut vm = Engine::new_base();
         let mut view = crate::SceneView::default();
@@ -977,7 +983,7 @@ mod tests {
         let commit = &reg.commits()[&new_commit];
         assert_eq!(commit.parent, Some(ours_tip));
         assert_eq!(commit.merge_parents, vec![theirs_tip]);
-        assert_eq!(reg.head_commit_ca(&head), Some(&new_commit));
+        assert_eq!(reg.head_commit_ca(&head), Some(new_commit));
     }
 
     // Theirs removed a node: ours' surviving state/layout/selection migrate
@@ -1028,7 +1034,7 @@ mod tests {
     #[test]
     fn merge_head_refuses_conflicts_unless_auto_resolve() {
         let (mut reg, mut head) = diverged_registry(&[1, 2], &[1, 20], &[1, 30]);
-        let ours_tip = *reg.head_commit_ca(&head).unwrap();
+        let ours_tip = reg.head_commit_ca(&head).unwrap();
         let mut graph = test_graph(&[1, 20]);
         let mut vm = Engine::new_base();
         let mut view = crate::SceneView::default();
@@ -1048,7 +1054,7 @@ mod tests {
         };
         assert!(!reasons.is_empty());
         // Nothing moved.
-        assert_eq!(reg.head_commit_ca(&head), Some(&ours_tip));
+        assert_eq!(reg.head_commit_ca(&head), Some(ours_tip));
         assert_eq!(
             graph.node_weights().map(|n| n.0).collect::<Vec<_>>(),
             [1, 20]
@@ -1069,7 +1075,7 @@ mod tests {
             graph.node_weights().map(|n| n.0).collect::<Vec<_>>(),
             [1, 20]
         );
-        assert_ne!(reg.head_commit_ca(&head), Some(&ours_tip));
+        assert_ne!(reg.head_commit_ca(&head), Some(ours_tip));
     }
 
     // A source branch that is strictly ahead fast-forwards without a commit.
@@ -1081,9 +1087,9 @@ mod tests {
         let base_ca = reg.commit_graph(secs(1), None, gantz_ca::graph_addr(&g), || g);
         let g = test_graph(&[1, 2]);
         let theirs_ca = reg.commit_graph(secs(2), Some(base_ca), gantz_ca::graph_addr(&g), || g);
-        reg.insert_name("alpha".to_string(), base_ca);
-        reg.insert_name("beta".to_string(), theirs_ca);
-        let mut head = gantz_ca::Head::Branch("alpha".to_string());
+        reg.set_head("alpha".parse().unwrap(), base_ca);
+        reg.set_head("beta".parse().unwrap(), theirs_ca);
+        let mut head = gantz_ca::Head::Branch("alpha".parse().unwrap());
         let mut graph = test_graph(&[1]);
         let mut vm = Engine::new_base();
         let mut view = crate::SceneView::default();
@@ -1103,7 +1109,7 @@ mod tests {
         };
         assert_eq!(target, theirs_ca);
         // Nothing mutated: navigation is the caller's job.
-        assert_eq!(reg.names()["alpha"], base_ca);
+        assert_eq!(reg.head(&"alpha".parse().unwrap()), Some(base_ca));
         assert_eq!(graph.node_count(), 1);
     }
 }

--- a/crates/gantz_egui/src/reg.rs
+++ b/crates/gantz_egui/src/reg.rs
@@ -1,6 +1,6 @@
 //! Registry reference for node lookup and trait implementations.
 //!
-//! Provides [`RegistryRef`] — a unified view combining a content-addressed
+//! Provides [`RegistryRef`] - a unified view combining a content-addressed
 //! registry with builtin nodes, implementing the various registry traits
 //! required by gantz_egui widgets.
 
@@ -13,7 +13,7 @@ use gantz_core::node::{self, graph::Graph};
 use gantz_core::{Builtins, Node};
 use petgraph::visit::{IntoNodeReferences, NodeRef};
 use std::borrow::Cow;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 /// Registry reference providing unified node access.
 ///
@@ -23,20 +23,20 @@ use std::collections::{BTreeMap, HashMap};
 pub struct RegistryRef<'a, N: 'static + Send + Sync> {
     ca_registry: &'a ca::Registry<Graph<N>>,
     builtins: &'a dyn Builtins<Node = N>,
-    demos: &'a HashMap<String, String>,
 }
 
+/// Named heads (branches), ordered by name.
+pub type Names = BTreeMap<ca::Name, ca::CommitAddr>;
+
 impl<'a, N: 'static + Send + Sync> RegistryRef<'a, N> {
-    /// Construct from a CA registry, builtins provider and demo associations.
+    /// Construct from a CA registry and builtins provider.
     pub fn new(
         ca_registry: &'a ca::Registry<Graph<N>>,
         builtins: &'a dyn Builtins<Node = N>,
-        demos: &'a HashMap<String, String>,
     ) -> Self {
         Self {
             ca_registry,
             builtins,
-            demos,
         }
     }
 
@@ -54,10 +54,11 @@ impl<'a, N: 'static + Send + Sync> RegistryRef<'a, N> {
 impl<N: 'static + Node + Send + Sync> RegistryRef<'_, N> {
     /// Look up a node by content address.
     ///
-    /// Checks commit graphs in the registry first, then falls back to builtins.
+    /// Checks graphs in the registry first (a graph in the registry IS a
+    /// node), then falls back to builtins.
     pub fn node(&self, ca: &ca::ContentAddr) -> Option<&dyn Node> {
-        let commit_ca = ca::CommitAddr::from(*ca);
-        if let Some(graph) = self.ca_registry.commit_graph_ref(&commit_ca) {
+        let graph_ca = ca::GraphAddr::from(*ca);
+        if let Some(graph) = self.ca_registry.graph(&graph_ca) {
             return Some(graph as &dyn Node);
         }
         self.builtins.instance(ca).map(|n| n as &dyn Node)
@@ -65,18 +66,17 @@ impl<N: 'static + Node + Send + Sync> RegistryRef<'_, N> {
 
     /// Create a node of the given type name.
     ///
-    /// Checks registry names first (creating a [`crate::node::NamedRef`]),
-    /// then falls back to builtins.
+    /// Checks registry names first (creating a [`crate::node::NamedRef`]
+    /// pinning the name's head graph), then falls back to builtins.
     pub fn create_node(&self, node_type: &str) -> Option<N>
     where
         N: From<crate::node::NamedRef>,
     {
-        self.ca_registry
-            .names()
-            .get(node_type)
-            .map(|commit_ca| {
-                let ref_ = gantz_core::node::Ref::new((*commit_ca).into());
-                let named = crate::node::NamedRef::new(node_type.to_string(), ref_);
+        let name: ca::Name = node_type.parse().expect("infallible");
+        head_graph_addr(self.ca_registry, &name)
+            .map(|graph_addr| {
+                let ref_ = gantz_core::node::Ref::new(graph_addr.into());
+                let named = crate::node::NamedRef::new(name.clone(), ref_);
                 N::from(named)
             })
             .or_else(|| self.builtins.create(node_type))
@@ -93,13 +93,13 @@ impl<N: 'static + Node + Send + Sync> NodeTypeRegistry for RegistryRef<'_, N> {
         let mut types = vec![crate::widget::gantz::NESTED_GRAPH_TYPE];
         types.extend(self.builtins.names());
         // Nested graphs are hidden from the root graph-select list, so don't
-        // offer them as creatable node types either.
+        // offer them as creatable node types either. A root name is its
+        // single segment.
         types.extend(
             self.ca_registry
-                .names()
-                .keys()
-                .filter(|n| !n.contains(crate::node::NESTED_SEP))
-                .map(|s| &s[..]),
+                .heads()
+                .filter(|(name, _)| !name.is_nested())
+                .map(|(name, _)| name.segments()[0].as_str()),
         );
         types.sort();
         types.dedup();
@@ -114,17 +114,20 @@ impl<N: 'static + Node + Send + Sync> GraphRegistry for RegistryRef<'_, N> {
         commits
     }
 
-    fn names(&self) -> &BTreeMap<String, ca::CommitAddr> {
-        self.ca_registry.names()
+    fn names(&self) -> Vec<(ca::Name, ca::CommitAddr)> {
+        self.ca_registry
+            .heads()
+            .map(|(name, ca)| (name.clone(), ca))
+            .collect()
     }
 }
 
 impl<N: 'static + Node + Send + Sync> NameRegistry for RegistryRef<'_, N> {
     fn name_ca(&self, name: &str) -> Option<ca::ContentAddr> {
-        if let Some(commit_ca) = self.ca_registry.names().get(name) {
-            return Some((*commit_ca).into());
-        }
-        self.builtins.content_addr(name)
+        let parsed: ca::Name = name.parse().expect("infallible");
+        head_graph_addr(self.ca_registry, &parsed)
+            .map(Into::into)
+            .or_else(|| self.builtins.content_addr(name))
     }
 
     fn node_exists(&self, ca: &ca::ContentAddr) -> bool {
@@ -139,7 +142,7 @@ impl<N: 'static + Node + Send + Sync> FnNodeNames for RegistryRef<'_, N> {
             .names()
             .into_iter()
             .filter_map(|name| self.builtins.content_addr(name).map(|_| name.to_string()));
-        let registry_names = self.ca_registry.names().keys().cloned();
+        let registry_names = self.ca_registry.heads().map(|(name, _)| name.to_string());
         let all_names = builtin_names.chain(registry_names);
 
         let get_node = |ca: &ca::ContentAddr| self.node(ca);
@@ -171,16 +174,17 @@ where
     }
 
     fn would_ref_cycle(&self, target: &str, editing: &str) -> bool {
-        crate::cycle::would_cycle(self.ca_registry, target, editing)
+        let target: ca::Name = target.parse().expect("infallible");
+        let editing: ca::Name = editing.parse().expect("infallible");
+        crate::cycle::would_cycle(self.ca_registry, &target, &editing)
     }
 
-    fn demo_graph(&self, name: &str) -> Option<&str> {
-        // User-graph associations (from Export) are keyed by name; builtins
-        // expose their own demo by builtin name.
-        self.demos
-            .get(name)
-            .map(String::as_str)
-            .or_else(|| self.builtins.demo_graph(name))
+    fn demo_graph(&self, name: &str) -> Option<String> {
+        // User-graph associations live in the demo section, keyed by name;
+        // builtins expose their own demo by builtin name.
+        let parsed: ca::Name = name.parse().expect("infallible");
+        crate::section::demo(self.ca_registry, &parsed)
+            .or_else(|| self.builtins.demo_graph(name).map(str::to_string))
     }
 
     fn socket_doc(
@@ -191,8 +195,8 @@ where
     ) -> Option<crate::SocketDoc> {
         // Resolve the referenced graph and read the ix-th inlet/outlet marker's
         // own doc (docs live on the `Inlet`/`Outlet` nodes).
-        let commit_ca = ca::CommitAddr::from(*ca);
-        let graph = self.ca_registry.commit_graph_ref(&commit_ca)?;
+        let graph_ca = ca::GraphAddr::from(*ca);
+        let graph = self.ca_registry.graph(&graph_ca)?;
         let get_node = |c: &ca::ContentAddr| self.node(c);
         let meta_ctx = node::MetaCtx::new(&get_node);
         let node_ref = graph
@@ -236,11 +240,12 @@ where
                     .collect::<Vec<_>>()
             };
 
-        if let Some(commit_ca) = self.ca_registry.names().get(name) {
+        let parsed: ca::Name = name.parse().expect("infallible");
+        if let Some(graph_addr) = head_graph_addr(self.ca_registry, &parsed) {
             // A named graph: socket docs resolved from the referenced graph's
             // inlet/outlet markers.
-            if let Some(graph) = self.ca_registry.commit_graph_ref(commit_ca) {
-                let ca: ca::ContentAddr = (*commit_ca).into();
+            if let Some(graph) = self.ca_registry.graph(&graph_addr) {
+                let ca: ca::ContentAddr = graph_addr.into();
                 let socket =
                     |kind: SocketKind, ix: usize| Registry::socket_doc(self, &ca, kind, ix);
                 info.inputs = collect(graph.n_inputs(meta_ctx), SocketKind::Input, &socket);
@@ -256,8 +261,9 @@ where
         info
     }
 
-    fn graph_description(&self, name: &str) -> Option<&str> {
-        self.ca_registry.description(name)
+    fn graph_description(&self, name: &str) -> Option<String> {
+        let parsed: ca::Name = name.parse().expect("infallible");
+        crate::section::description(self.ca_registry, &parsed)
     }
 
     fn merge_candidates(&self, ours: &ca::Head) -> Vec<crate::merge::MergeCandidate> {
@@ -279,15 +285,20 @@ where
                 "Create a new nested graph. Its inlets and outlets become this node's sockets.",
             ));
         }
-        if self.ca_registry.names().contains_key(name) {
-            return self
-                .ca_registry
-                .description(name)
-                .map(|s| Cow::Owned(s.to_string()));
+        let parsed: ca::Name = name.parse().expect("infallible");
+        if self.ca_registry.head(&parsed).is_some() {
+            return crate::section::description(self.ca_registry, &parsed).map(Cow::Owned);
         }
         self.builtins
             .create(name)
             .and_then(|n| n.description())
             .map(Cow::Borrowed)
     }
+}
+
+/// The graph address at the tip of the named line of history: the address a
+/// [`Ref`](gantz_core::node::Ref) to the name should pin.
+pub fn head_graph_addr<G>(reg: &ca::Registry<G>, name: &ca::Name) -> Option<ca::GraphAddr> {
+    let head_ca = reg.head(name)?;
+    reg.commits().get(&head_ca).map(|commit| commit.graph)
 }

--- a/crates/gantz_egui/src/response.rs
+++ b/crates/gantz_egui/src/response.rs
@@ -313,7 +313,7 @@ mod tests {
 
     #[test]
     fn extend_tags_payloads_with_the_head() {
-        let head = gantz_ca::Head::Branch("main".to_string());
+        let head = gantz_ca::Head::Branch("main".parse().unwrap());
         let mut rs = Responses::default();
         rs.extend(Some(&head), [DynResponse::new(A(1))]);
         let mut taken = rs.take::<A>();

--- a/crates/gantz_egui/src/section.rs
+++ b/crates/gantz_egui/src/section.rs
@@ -1,0 +1,120 @@
+//! The GUI's registry metadata sections: graph descriptions, demo
+//! associations and per-commit scene views.
+//!
+//! Each section is declared via [`gantz_ca::SectionDecl`], so the data rides
+//! the registry through merge, prune, export and the `.gantz` text format
+//! (see [`crate::format`] for the friendly text forms).
+
+use crate::SceneView;
+use gantz_ca::{
+    CommitAddr, Liveness, MergePolicy, Name, Registry, SectionDecl, section_get, section_insert,
+    section_iter, section_remove,
+};
+
+/// Human-readable descriptions for named graphs.
+pub struct Descriptions;
+
+/// Demo associations: a graph name mapped to its demo graph's name.
+///
+/// Keyed by name (rather than commit) so the association survives an edit:
+/// editing a graph mints a new commit but keeps the name.
+pub struct Demos;
+
+/// Persisted scene views (camera + node layout), keyed by commit.
+pub struct Views;
+
+/// The id of the [`Descriptions`] section.
+pub const DESCRIPTIONS_ID: &str = "gantz.description";
+
+/// The id of the [`Demos`] section.
+pub const DEMOS_ID: &str = "egui.demo";
+
+/// The id of the [`Views`] section.
+pub const VIEWS_ID: &str = "egui.view";
+
+impl SectionDecl for Descriptions {
+    const ID: &'static str = DESCRIPTIONS_ID;
+    const POLICY: MergePolicy = MergePolicy::KeepExisting;
+    const LIVENESS: Liveness = Liveness::WithName;
+    type Key = Name;
+    type Value = String;
+}
+
+impl SectionDecl for Demos {
+    const ID: &'static str = DEMOS_ID;
+    const POLICY: MergePolicy = MergePolicy::KeepExisting;
+    const LIVENESS: Liveness = Liveness::WithName;
+    type Key = Name;
+    type Value = String;
+}
+
+impl SectionDecl for Views {
+    const ID: &'static str = VIEWS_ID;
+    const POLICY: MergePolicy = MergePolicy::KeepExisting;
+    const LIVENESS: Liveness = Liveness::WithCommit;
+    type Key = CommitAddr;
+    type Value = SceneView;
+}
+
+/// The stored description for the named graph, if any.
+pub fn description<G>(reg: &Registry<G>, name: &Name) -> Option<String> {
+    section_get::<Descriptions, G>(reg, name)
+}
+
+/// Store a description for the named graph. An empty string removes the
+/// entry.
+pub fn set_description<G>(reg: &mut Registry<G>, name: Name, description: String) {
+    if description.is_empty() {
+        section_remove::<Descriptions, G>(reg, &name);
+    } else {
+        section_insert::<Descriptions, G>(reg, name, &description)
+            .expect("a `String` always encodes as a datum");
+    }
+}
+
+/// All stored descriptions, in name order.
+pub fn descriptions<G>(reg: &Registry<G>) -> impl Iterator<Item = (Name, String)> + '_ {
+    section_iter::<Descriptions, G>(reg)
+}
+
+/// The demo graph name associated with the named graph, if any.
+pub fn demo<G>(reg: &Registry<G>, name: &Name) -> Option<String> {
+    section_get::<Demos, G>(reg, name)
+}
+
+/// Associate the named graph with the given demo graph name.
+pub fn set_demo<G>(reg: &mut Registry<G>, name: Name, demo: String) {
+    section_insert::<Demos, G>(reg, name, &demo).expect("a `String` always encodes as a datum");
+}
+
+/// Remove the named graph's demo association.
+pub fn remove_demo<G>(reg: &mut Registry<G>, name: &Name) -> Option<String> {
+    section_remove::<Demos, G>(reg, name)
+}
+
+/// All demo associations, in name order.
+pub fn demos<G>(reg: &Registry<G>) -> impl Iterator<Item = (Name, String)> + '_ {
+    section_iter::<Demos, G>(reg)
+}
+
+/// The stored scene view for the given commit, if any.
+pub fn view<G>(reg: &Registry<G>, ca: &CommitAddr) -> Option<SceneView> {
+    section_get::<Views, G>(reg, ca)
+}
+
+/// Store a scene view for the given commit.
+pub fn set_view<G>(reg: &mut Registry<G>, ca: CommitAddr, view: &SceneView) {
+    if let Err(e) = section_insert::<Views, G>(reg, ca, view) {
+        log::error!("failed to encode scene view for {ca}: {e}");
+    }
+}
+
+/// Remove the stored scene view for the given commit.
+pub fn remove_view<G>(reg: &mut Registry<G>, ca: &CommitAddr) -> Option<SceneView> {
+    section_remove::<Views, G>(reg, ca)
+}
+
+/// All stored scene views, in commit order.
+pub fn views<G>(reg: &Registry<G>) -> impl Iterator<Item = (CommitAddr, SceneView)> + '_ {
+    section_iter::<Views, G>(reg)
+}

--- a/crates/gantz_egui/src/sync.rs
+++ b/crates/gantz_egui/src/sync.rs
@@ -7,8 +7,8 @@
 //! counterpart of the inspector's render-time auto-sync, and the mechanism by
 //! which editing a nested graph propagates up to its parents.
 
-use crate::node::{NESTED_SEP, NamedRef};
-use gantz_ca::{CaHash, CommitAddr, Registry};
+use crate::node::NamedRef;
+use gantz_ca::{CaHash, CommitAddr, GraphAddr, Name, Registry};
 use gantz_core::node::graph::Graph;
 use std::collections::HashMap;
 use std::time::Duration;
@@ -36,16 +36,11 @@ pub trait AsNamedRef {
 #[derive(Clone, Debug)]
 pub struct Moved {
     /// The name whose commit moved.
-    pub name: String,
+    pub name: Name,
     /// The commit the name pointed at before.
     pub old_commit: CommitAddr,
     /// The commit the name points at now.
     pub new_commit: CommitAddr,
-}
-
-/// The number of `:`-separated segments in a name (a nested graph's depth).
-fn depth(name: &str) -> usize {
-    name.matches(NESTED_SEP).count()
 }
 
 /// Apply `mutate` to every inner [`NamedRef`] of a clone of `graph`, returning
@@ -73,7 +68,7 @@ where
 fn commit_rewritten<N>(
     registry: &mut Registry<Graph<N>>,
     timestamp: Duration,
-    name: &str,
+    name: &Name,
     source_commit: CommitAddr,
     mutate: impl FnMut(&mut NamedRef) -> bool,
 ) -> Option<Moved>
@@ -87,22 +82,34 @@ where
     let graph_ca = gantz_ca::graph_addr(&g);
     let new_commit = registry.commit_graph_to_name(timestamp, graph_ca, || g, name);
     Some(Moved {
-        name: name.to_string(),
+        name: name.clone(),
         old_commit: source_commit,
         new_commit,
     })
 }
 
-/// Repoint a [`NamedRef`] whose name was renamed, per a `old -> (new, commit)`
+/// Repoint a [`NamedRef`] whose name was renamed, per a `old -> (new, graph)`
 /// map. Returns whether it changed.
-fn remap_ref(named_ref: &mut NamedRef, remap: &HashMap<String, (String, CommitAddr)>) -> bool {
+fn remap_ref(named_ref: &mut NamedRef, remap: &HashMap<Name, (Name, GraphAddr)>) -> bool {
     match remap.get(named_ref.name()) {
-        Some((new_name, new_commit)) => {
-            named_ref.rename(new_name.clone(), (*new_commit).into());
+        Some((new_name, new_graph)) => {
+            named_ref.rename(new_name.clone(), (*new_graph).into());
             true
         }
         None => false,
     }
+}
+
+/// The renamed counterpart of `descendant` when `old` is renamed to `new`:
+/// `new`'s segments followed by `descendant`'s segments past `old`'s.
+fn renamed(descendant: &Name, old: &Name, new: &Name) -> Name {
+    let segments: Vec<String> = new
+        .segments()
+        .iter()
+        .chain(&descendant.segments()[old.segments().len()..])
+        .cloned()
+        .collect();
+    Name::from(segments)
 }
 
 /// Give a freshly-forked graph independent nested children.
@@ -119,30 +126,28 @@ fn remap_ref(named_ref: &mut NamedRef, remap: &HashMap<String, (String, CommitAd
 pub fn fork_nested<N>(
     registry: &mut Registry<Graph<N>>,
     timestamp: Duration,
-    old: &str,
-    new: &str,
+    old: &Name,
+    new: &Name,
 ) -> Vec<Moved>
 where
     N: Clone + CaHash + AsNamedRefMut,
 {
-    let old_prefix = format!("{old}{NESTED_SEP}");
-    let mut descendants: Vec<String> = registry
-        .names()
-        .keys()
-        .filter(|n| n.starts_with(&old_prefix))
-        .cloned()
+    let mut descendants: Vec<Name> = registry
+        .heads()
+        .filter(|(n, _)| n.starts_with(old) && *n != old)
+        .map(|(n, _)| n.clone())
         .collect();
-    descendants.sort_by(|a, b| depth(b).cmp(&depth(a)).then_with(|| a.cmp(b)));
+    descendants.sort_by(|a, b| b.depth().cmp(&a.depth()).then_with(|| a.cmp(b)));
 
-    // old descendant name -> (new name, new commit).
-    let mut remap: HashMap<String, (String, CommitAddr)> = HashMap::new();
+    // old descendant name -> (new name, new graph).
+    let mut remap: HashMap<Name, (Name, GraphAddr)> = HashMap::new();
     let mut moves = Vec::new();
 
     // Each descendant is copied (under a fresh `new:*` name) with its references
     // to already-copied descendants repointed.
     for d in &descendants {
-        let d_new = format!("{new}{}", &d[old.len()..]);
-        let Some(&commit) = registry.names().get(d) else {
+        let d_new = renamed(d, old, new);
+        let Some(commit) = registry.head(d) else {
             continue;
         };
         let Some(graph) = registry.commit_graph_ref(&commit) else {
@@ -151,7 +156,7 @@ where
         let (g, _) = rewrite_refs(graph, |nr| remap_ref(nr, &remap));
         let graph_ca = gantz_ca::graph_addr(&g);
         let new_commit = registry.commit_graph_to_name(timestamp, graph_ca, || g, &d_new);
-        remap.insert(d.clone(), (d_new.clone(), new_commit));
+        remap.insert(d.clone(), (d_new.clone(), graph_ca));
         moves.push(Moved {
             name: d_new,
             old_commit: commit,
@@ -160,7 +165,7 @@ where
     }
 
     // Repoint the already-created `new` root's references to its own children.
-    if let Some(&root_commit) = registry.names().get(new) {
+    if let Some(root_commit) = registry.head(new) {
         moves.extend(commit_rewritten(
             registry,
             timestamp,
@@ -189,15 +194,18 @@ where
     N: Clone + CaHash + AsNamedRefMut,
 {
     // Deepest names first: a child is updated before the parent that refs it.
-    let mut order: Vec<String> = registry.names().keys().cloned().collect();
-    order.sort_by(|a, b| depth(b).cmp(&depth(a)).then_with(|| a.cmp(b)));
+    let mut order: Vec<Name> = registry.heads().map(|(n, _)| n.clone()).collect();
+    order.sort_by(|a, b| b.depth().cmp(&a.depth()).then_with(|| a.cmp(b)));
 
-    // A name -> current commit snapshot, kept in step with commits we make so a
-    // referrer resolves its children to their freshly-committed addresses.
-    let mut current: HashMap<String, CommitAddr> = registry
-        .names()
-        .iter()
-        .map(|(n, ca)| (n.clone(), *ca))
+    // A name -> current head graph snapshot, kept in step with commits we
+    // make so a referrer resolves its children to their freshly-committed
+    // content.
+    let mut current: HashMap<Name, (CommitAddr, GraphAddr)> = registry
+        .heads()
+        .filter_map(|(n, ca)| {
+            let graph = registry.commits().get(&ca)?.graph;
+            Some((n.clone(), (ca, graph)))
+        })
         .collect();
 
     let mut moves = Vec::new();
@@ -205,14 +213,23 @@ where
     for _ in 0..max_passes {
         let mut changed_any = false;
         for name in &order {
-            let Some(&commit_ca) = current.get(name) else {
+            let Some(&(commit_ca, _)) = current.get(name) else {
                 continue;
             };
-            let resolve = |m: &str| current.get(m).copied().map(gantz_ca::ContentAddr::from);
+            let resolve = |m: &Name| {
+                current
+                    .get(m)
+                    .map(|&(_, graph)| gantz_ca::ContentAddr::from(graph))
+            };
             if let Some(moved) = commit_rewritten(registry, timestamp, name, commit_ca, |nr| {
                 nr.resync(&resolve)
             }) {
-                current.insert(name.clone(), moved.new_commit);
+                let graph = registry
+                    .commits()
+                    .get(&moved.new_commit)
+                    .expect("freshly committed")
+                    .graph;
+                current.insert(name.clone(), (moved.new_commit, graph));
                 moves.push(moved);
                 changed_any = true;
             }
@@ -237,21 +254,20 @@ where
 pub fn promote_nested<N>(
     registry: &mut Registry<Graph<N>>,
     timestamp: Duration,
-    old_nested: &str,
-    new_name: &str,
+    old_nested: &Name,
+    new_name: &Name,
 ) -> Vec<Moved>
 where
     N: Clone + CaHash + AsNamedRefMut,
 {
     // The parent referencing the nested graph: the name with the last leaf
     // stripped (`A:1` -> `A`, `A:1:2` -> `A:1`).
-    let Some((parent, _)) = old_nested.rsplit_once(NESTED_SEP) else {
+    let Some(parent) = old_nested.parent() else {
         return Vec::new();
     };
-    let parent = parent.to_string();
-    let (Some(&new_commit), Some(&parent_commit)) = (
-        registry.names().get(new_name),
-        registry.names().get(&parent),
+    let (Some(new_graph), Some(parent_commit)) = (
+        registry.named_commit(new_name).map(|c| c.graph),
+        registry.head(&parent),
     ) else {
         return Vec::new();
     };
@@ -265,7 +281,7 @@ where
         parent_commit,
         |nr| {
             if nr.name() == old_nested {
-                nr.rename(new_name.to_string(), new_commit.into());
+                nr.rename(new_name.clone(), new_graph.into());
                 true
             } else {
                 false
@@ -275,15 +291,13 @@ where
 
     // Drop the orphaned nested name and its descendants (their content survives
     // as the new root graph copy).
-    let child_prefix = format!("{old_nested}{NESTED_SEP}");
-    let orphans: Vec<String> = registry
-        .names()
-        .keys()
-        .filter(|n| n.as_str() == old_nested || n.starts_with(&child_prefix))
-        .cloned()
+    let orphans: Vec<Name> = registry
+        .heads()
+        .filter(|(n, _)| n.starts_with(old_nested))
+        .map(|(n, _)| n.clone())
         .collect();
     for orphan in orphans {
-        registry.remove_name(&orphan);
+        registry.remove_head(&orphan);
     }
 
     moves

--- a/crates/gantz_egui/src/test_node.rs
+++ b/crates/gantz_egui/src/test_node.rs
@@ -1,0 +1,45 @@
+//! A minimal node set for exercising the format/export round-trip paths in
+//! unit tests: an `Expr` leaf plus `NamedRef` for graph references.
+
+use crate::node::NamedRef;
+use dyn_clone::DynClone;
+use gantz_core::node::graph::Graph;
+use std::any::Any;
+
+pub trait TestNode: Any + DynClone + gantz_ca::CaHash + gantz_core::Node {}
+
+pub type TestGraph = Graph<Box<dyn TestNode>>;
+
+dyn_clone::clone_trait_object!(TestNode);
+
+impl TestNode for gantz_core::node::Expr {}
+impl TestNode for NamedRef {}
+impl TestNode for Box<dyn TestNode> {}
+
+gantz_format::impl_node_set_serde! {
+    dyn TestNode {
+        gantz_core::node::Expr,
+        crate::node::NamedRef,
+    }
+}
+
+impl gantz_format::NodeSugar for Box<dyn TestNode> {
+    fn sugar() -> gantz_format::Sugars<'static> {
+        gantz_format::Sugars(vec![&gantz_format::CoreSugar])
+    }
+}
+
+impl crate::sync::AsNamedRef for Box<dyn TestNode> {
+    fn as_named_ref(&self) -> Option<&NamedRef> {
+        ((&**self) as &dyn Any).downcast_ref::<NamedRef>()
+    }
+}
+
+pub fn expr(src: &str) -> Box<dyn TestNode> {
+    Box::new(gantz_core::node::Expr::new(src).unwrap())
+}
+
+pub fn named_ref(name: &str, graph_ca: gantz_ca::GraphAddr) -> Box<dyn TestNode> {
+    let ref_ = gantz_core::node::Ref::new(graph_ca.into());
+    Box::new(NamedRef::new(name.parse().unwrap(), ref_))
+}

--- a/crates/gantz_egui/src/widget/edge_style.rs
+++ b/crates/gantz_egui/src/widget/edge_style.rs
@@ -132,7 +132,7 @@ mod tests {
             color: blue,
         };
         let styles: [&dyn EdgeStyle; 3] = [&a, &b, &c];
-        let head = gantz_ca::Head::Branch("test".to_string());
+        let head = gantz_ca::Head::Branch("test".parse().unwrap());
         let ctx = |src_node| EdgeStyleCtx {
             head: &head,
             src: (src_node, 0),

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -54,8 +54,7 @@ pub trait NodeTypeRegistry {
 /// The top-level gantz widget.
 pub struct Gantz<'a> {
     env: &'a dyn Registry,
-    base_names: &'a gantz_ca::registry::Names,
-    demos: Option<&'a HashMap<String, String>>,
+    base_names: &'a crate::reg::Names,
     log_source: Option<LogSource>,
     perf_vm: Option<&'a mut widget::PerfCapture>,
     perf_gui: Option<&'a mut widget::PerfCapture>,
@@ -569,7 +568,7 @@ where
     state: &'a mut GantzState,
     access: &'a mut Access,
     focused_head: usize,
-    base_names: &'a gantz_ca::registry::Names,
+    base_names: &'a crate::reg::Names,
     response: &'a mut GantzResponse,
 }
 
@@ -583,7 +582,7 @@ where
     state: &'a mut GantzState,
     access: &'a mut Access,
     focused_head: usize,
-    base_names: &'a gantz_ca::registry::Names,
+    base_names: &'a crate::reg::Names,
     gantz_response: &'a mut GantzResponse,
     /// Panes detached into windows. The tab context menu pushes to this when a
     /// pane is popped out.
@@ -761,7 +760,7 @@ impl GantzResponse {
     }
 
     /// The given graph name was removed.
-    pub fn graph_name_removed(&self) -> Option<String> {
+    pub fn graph_name_removed(&self) -> Option<gantz_ca::Name> {
         self.graph_select
             .as_ref()
             .and_then(|g| g.name_removed.clone())
@@ -783,11 +782,10 @@ impl GantzResponse {
 
 impl<'a> Gantz<'a> {
     /// Instantiate the full top-level gantz widget.
-    pub fn new(env: &'a dyn Registry, base_names: &'a gantz_ca::registry::Names) -> Self {
+    pub fn new(env: &'a dyn Registry, base_names: &'a crate::reg::Names) -> Self {
         Self {
             env,
             base_names,
-            demos: None,
             log_source: None,
             perf_vm: None,
             perf_gui: None,
@@ -807,12 +805,6 @@ impl<'a> Gantz<'a> {
     /// (the default) or leaves them to the host as native OS windows.
     pub fn pane_window_mode(mut self, mode: PaneWindowMode) -> Self {
         self.pane_window_mode = mode;
-        self
-    }
-
-    /// Provide demo graph associations for the config dropdown.
-    pub fn demos(mut self, demos: &'a HashMap<String, String>) -> Self {
-        self.demos = Some(demos);
         self
     }
 
@@ -1411,33 +1403,32 @@ where
                 let immutable = head_immutable(&head, gantz.base_immutable, base_names);
 
                 // Collect demo-* names for the dropdown.
-                let demo_names_vec: Vec<&str> = names
-                    .keys()
-                    .filter(|n| n.starts_with("demo-"))
-                    .map(|n| n.as_str())
+                let demo_names: Vec<String> = names
+                    .iter()
+                    .filter(|(n, _)| widget::graph_select::is_demo(n))
+                    .map(|(n, _)| n.to_string())
                     .collect();
+                let demo_names_vec: Vec<&str> = demo_names.iter().map(|s| s.as_str()).collect();
 
                 // Look up the current demo association for this head.
                 let current_demo = match &head {
-                    gantz_ca::Head::Branch(name) => {
-                        gantz.demos.and_then(|d| d.get(name)).map(|s| s.as_str())
-                    }
+                    gantz_ca::Head::Branch(name) => gantz.env.demo_graph(&name.to_string()),
                     _ => None,
                 };
 
                 // The graph's current description (named graphs only).
                 let current_description = match &head {
-                    gantz_ca::Head::Branch(name) => gantz.env.graph_description(name),
+                    gantz_ca::Head::Branch(name) => gantz.env.graph_description(&name.to_string()),
                     _ => None,
                 };
 
                 let res = pane_ui(ui, |ui| {
-                    let mut config = widget::GraphConfig::new(&head, head_state, names)
+                    let mut config = widget::GraphConfig::new(&head, head_state, &names)
                         .is_base(is_base)
                         .immutable(immutable)
                         .demo_names(&demo_names_vec)
-                        .current_demo(current_demo)
-                        .current_description(current_description)
+                        .current_demo(current_demo.as_deref())
+                        .current_description(current_description.as_deref())
                         .merge_env(gantz.env, merge_resolutions);
                     // The base source dropdown, when authoring context was
                     // supplied (see `Gantz::base_sources`).
@@ -1445,7 +1436,7 @@ where
                     {
                         let current = ctx
                             .name_sources
-                            .get(name.as_str())
+                            .get(&name.to_string())
                             .copied()
                             .unwrap_or(ctx.default_source);
                         config = config.base_sources(ctx.sources, Some(current));
@@ -1597,10 +1588,11 @@ where
 
                 // Skip node palette when immutable.
                 if !focused_immutable {
-                    let editing = match &fh {
-                        gantz_ca::Head::Branch(name) => Some(name.as_str()),
+                    let editing_name = match &fh {
+                        gantz_ca::Head::Branch(name) => Some(name.to_string()),
                         _ => None,
                     };
+                    let editing = editing_name.as_deref();
                     // The pointer position over the focused head's scene
                     // (graph coords) recorded this frame; new nodes are placed
                     // here. `Copy`, so no borrow is held across the call.
@@ -1641,14 +1633,7 @@ where
             paint_gantz_file_hover_overlay(ui);
 
             let heads = access.heads();
-            let res = graph_select(
-                gantz.env,
-                heads,
-                *focused_head,
-                *base_names,
-                gantz.demos,
-                ui,
-            );
+            let res = graph_select(gantz.env, heads, *focused_head, *base_names, ui);
 
             if res.inner.export_all {
                 gantz_response.responses.push(None, ExportAllNamed);
@@ -2000,7 +1985,7 @@ where
     /// Per-head node index remappings from this frame's deletions, applied to
     /// the top-level tree's node views after layout (see `migrate_node_view_paths`).
     reindexes: &'a mut Vec<(gantz_ca::Head, crate::ops::Reindex)>,
-    base_names: &'a gantz_ca::registry::Names,
+    base_names: &'a crate::reg::Names,
     base_immutable: bool,
     /// Extension-pane toggle entries for the scene's "Panes" context submenu
     /// (see [`ext_pane_entries`]).
@@ -2094,7 +2079,7 @@ where
             let name_res = head.as_ref().map(|h| {
                 ui.scope(|ui| {
                     ui.set_max_width(ui.available_width().min(150.0));
-                    widget::head_name_edit(h, &mut edit_state.edit_text, names, ui)
+                    widget::head_name_edit(h, &mut edit_state.edit_text, &names, ui)
                 })
                 .inner
             });
@@ -2147,7 +2132,7 @@ where
                 if let Some(GraphPane(head)) = tiles.get_pane(&tile_id) {
                     // Initialize edit text based on head type.
                     let initial_text = match head {
-                        gantz_ca::Head::Branch(name) => name.clone(),
+                        gantz_ca::Head::Branch(name) => name.to_string(),
                         gantz_ca::Head::Commit(_) => String::new(),
                     };
                     edit_state.editing_tile_id = Some(tile_id);
@@ -3144,14 +3129,12 @@ fn graph_select(
     env: &dyn Registry,
     heads: &[gantz_ca::Head],
     focused_head: usize,
-    base_names: &gantz_ca::registry::Names,
-    demos: Option<&HashMap<String, String>>,
+    base_names: &crate::reg::Names,
     ui: &mut egui::Ui,
 ) -> egui::InnerResponse<widget::graph_select::GraphSelectResponse> {
     pane_ui(ui, |ui| {
         widget::GraphSelect::new(env, heads, base_names)
             .focused_head(focused_head)
-            .demos(demos)
             .show(ui)
     })
 }
@@ -3263,12 +3246,11 @@ fn name_breadcrumb(
     let gantz_ca::Head::Branch(name) = head else {
         return responses;
     };
-    let sep = crate::node::NESTED_SEP;
-    if !name.contains(sep) {
+    if !name.is_nested() {
         return responses; // a root graph has no ancestor levels
     }
-    let segs: Vec<&str> = name.split(sep).collect();
-    let sep_str = sep.to_string();
+    let segs: Vec<&str> = name.segments().iter().map(|s| s.as_str()).collect();
+    let sep_str = gantz_ca::name::SEP.to_string();
     let space = ui.style().interaction.interact_radius * 3.0;
     // Sit to the right of the floating sidebar toggle, which occupies the very
     // bottom-left corner of the scene, so the levels stay on the bottom row.
@@ -3304,7 +3286,7 @@ fn name_breadcrumb(
                             let resp = ui.add(button(&label)).on_hover_text(hover);
                             if resp.clicked() && !is_current {
                                 responses.push(DynResponse::new(ReplaceHead(
-                                    gantz_ca::Head::Branch(prefix),
+                                    gantz_ca::Head::Branch(prefix.parse().expect("infallible")),
                                 )));
                             }
                         });
@@ -3397,10 +3379,11 @@ fn trace_view(
 fn head_immutable(
     head: &gantz_ca::Head,
     base_immutable: bool,
-    base_names: &gantz_ca::registry::Names,
+    base_names: &crate::reg::Names,
 ) -> bool {
     let is_base = matches!(head, gantz_ca::Head::Branch(name) if base_names.contains_key(name));
-    let is_demo = matches!(head, gantz_ca::Head::Branch(name) if name.starts_with("demo-"));
+    let is_demo =
+        matches!(head, gantz_ca::Head::Branch(name) if widget::graph_select::is_demo(name));
     base_immutable && is_base && !is_demo
 }
 
@@ -3588,7 +3571,7 @@ mod tests {
 
     fn node_view(head: &str, path: &[node::Id]) -> Pane {
         Pane::NodeView(NodeViewPane {
-            head: gantz_ca::Head::Branch(head.to_string()),
+            head: gantz_ca::Head::Branch(head.parse().unwrap()),
             path: path.to_vec(),
             ty_name: "plot".to_string(),
         })
@@ -3603,7 +3586,7 @@ mod tests {
 
         let plot = node_view("main", &[3]);
         let same_node_number = Pane::NodeView(NodeViewPane {
-            head: gantz_ca::Head::Branch("main".to_string()),
+            head: gantz_ca::Head::Branch("main".parse().unwrap()),
             path: vec![3],
             ty_name: "number".to_string(),
         });
@@ -3623,7 +3606,7 @@ mod tests {
         push_windowed(
             &mut windowed,
             Pane::NodeView(NodeViewPane {
-                head: gantz_ca::Head::Branch("main".to_string()),
+                head: gantz_ca::Head::Branch("main".parse().unwrap()),
                 path: vec![3],
                 ty_name: "number".to_string(),
             }),
@@ -3636,7 +3619,7 @@ mod tests {
     /// panes are untouched.
     #[test]
     fn migrate_windowed_node_views_drops_and_rewrites() {
-        let head = gantz_ca::Head::Branch("main".to_string());
+        let head = gantz_ca::Head::Branch("main".parse().unwrap());
         let mut windowed = vec![
             node_view("main", &[1]),  // removed node -> dropped
             node_view("main", &[3]),  // swapped 3 -> 1
@@ -3663,7 +3646,7 @@ mod tests {
         assert!(
             windowed
                 .iter()
-                .any(|p| matches!(p, Pane::NodeView(nv) if matches!(&nv.head, gantz_ca::Head::Branch(n) if n == "other")))
+                .any(|p| matches!(p, Pane::NodeView(nv) if matches!(&nv.head, gantz_ca::Head::Branch(n) if n.to_string() == "other")))
         );
         assert_eq!(windowed.len(), 4);
     }

--- a/crates/gantz_egui/src/widget/graph_config.rs
+++ b/crates/gantz_egui/src/widget/graph_config.rs
@@ -11,7 +11,7 @@ use super::head_name_edit::{head_name, head_name_edit};
 pub struct GraphConfig<'a> {
     head: &'a gantz_ca::Head,
     head_state: &'a mut OpenHeadState,
-    names: &'a gantz_ca::registry::Names,
+    names: &'a [(gantz_ca::Name, gantz_ca::CommitAddr)],
     is_base: bool,
     immutable: bool,
     demo_names: &'a [&'a str],
@@ -49,7 +49,7 @@ impl<'a> GraphConfig<'a> {
     pub fn new(
         head: &'a gantz_ca::Head,
         head_state: &'a mut OpenHeadState,
-        names: &'a gantz_ca::registry::Names,
+        names: &'a [(gantz_ca::Name, gantz_ca::CommitAddr)],
     ) -> Self {
         Self {
             head,
@@ -124,8 +124,10 @@ impl<'a> GraphConfig<'a> {
 
     pub fn show(self, ui: &mut egui::Ui) -> GraphConfigResponse {
         let is_named = matches!(self.head, gantz_ca::Head::Branch(_));
-        let is_demo =
-            matches!(&self.head, gantz_ca::Head::Branch(name) if name.starts_with("demo-"));
+        let is_demo = matches!(
+            &self.head,
+            gantz_ca::Head::Branch(name) if super::graph_select::is_demo(name)
+        );
 
         // Per-head temp state for the name editor.
         let edit_id = egui::Id::new("graph_config_name_edit").with(self.head);
@@ -385,7 +387,7 @@ fn merge_select(
                 return;
             }
             let ours_tip = match head {
-                gantz_ca::Head::Branch(name) => env.names().get(name).copied(),
+                gantz_ca::Head::Branch(name) => env.name_head(name),
                 gantz_ca::Head::Commit(ca) => Some(*ca),
             };
             for candidate in candidates {

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -733,7 +733,7 @@ where
             if let Some(name) = demo_name {
                 if demo_btn.on_hover_text(format!("opens {name}")).clicked() {
                     responses.push(DynResponse::new(OpenHead(gantz_ca::Head::Branch(
-                        name.to_string(),
+                        name.parse().expect("infallible"),
                     ))));
                     ui.close();
                 }

--- a/crates/gantz_egui/src/widget/graph_select.rs
+++ b/crates/gantz_egui/src/widget/graph_select.rs
@@ -1,7 +1,8 @@
 //! A simple widget for selecting between, naming and creating new graphs.
 
 use super::head_row::{HeadRowType, head_row};
-use std::collections::{HashMap, HashSet};
+use gantz_ca::Name;
+use std::collections::HashSet;
 
 /// The glyph for the filter-options button (swap if it doesn't render).
 const FILTER_GLYPH: &str = "⛭";
@@ -12,9 +13,7 @@ pub struct GraphSelect<'a> {
     registry: &'a dyn crate::Registry,
     heads: &'a [gantz_ca::Head],
     focused_head: Option<usize>,
-    base_names: &'a gantz_ca::registry::Names,
-    /// Demo associations (graph name -> demo name), for the row context menu.
-    demos: Option<&'a HashMap<String, String>>,
+    base_names: &'a crate::reg::Names,
 }
 
 #[derive(Clone)]
@@ -40,8 +39,15 @@ impl Default for GraphSelectState {
 pub trait GraphRegistry {
     /// All selectable commit addresses.
     fn commits(&self) -> Vec<(&gantz_ca::CommitAddr, &gantz_ca::Commit)>;
-    /// An iterator yielding all name -> CA pairs.
-    fn names(&self) -> &gantz_ca::registry::Names;
+    /// All name -> head commit pairs, in name order.
+    fn names(&self) -> Vec<(Name, gantz_ca::CommitAddr)>;
+    /// The head commit for the given name, if any.
+    fn name_head(&self, name: &Name) -> Option<gantz_ca::CommitAddr> {
+        self.names()
+            .into_iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, ca)| ca)
+    }
 }
 
 /// Commands emitted from the `GraphSelect` widget.
@@ -64,7 +70,7 @@ pub struct GraphSelectResponse {
     /// Ctrl+click on a head that is already open: close this head.
     pub closed: Option<gantz_ca::Head>,
     /// The name mapping was removed.
-    pub name_removed: Option<String>,
+    pub name_removed: Option<Name>,
 }
 
 impl GraphSelectResponse {
@@ -99,7 +105,7 @@ impl<'a> GraphSelect<'a> {
     pub fn new(
         registry: &'a dyn crate::Registry,
         heads: &'a [gantz_ca::Head],
-        base_names: &'a gantz_ca::registry::Names,
+        base_names: &'a crate::reg::Names,
     ) -> Self {
         let id = egui::Id::new("gantz-graph-select");
         Self {
@@ -108,19 +114,11 @@ impl<'a> GraphSelect<'a> {
             id,
             focused_head: None,
             base_names,
-            demos: None,
         }
     }
 
     pub fn with_id(mut self, id: egui::Id) -> Self {
         self.id = id;
-        self
-    }
-
-    /// Provide demo associations so a graph's row context menu can offer to
-    /// open its associated demo.
-    pub fn demos(mut self, demos: Option<&'a HashMap<String, String>>) -> Self {
-        self.demos = demos;
         self
     }
 
@@ -165,7 +163,6 @@ impl<'a> GraphSelect<'a> {
         });
 
         let names = self.registry.names();
-        let demos = self.demos;
         // Captured by `show_named` to surface each named graph's description and
         // input/output docs on hover.
         let registry = self.registry;
@@ -181,11 +178,11 @@ impl<'a> GraphSelect<'a> {
                 // 1. User-named, non-demo
                 // 2. Base-named, non-demo
                 // 3. All demos (alphabetical, regardless of user/base)
-                let is_base = |name: &str| self.base_names.contains_key(name);
-                let is_demo = |name: &str| name.starts_with("demo-");
+                let is_base = |name: &Name| self.base_names.contains_key(name);
+                let is_demo = self::is_demo;
                 // Nested graphs (`parent:child`) are hidden from the root list;
                 // they are reached by navigating into their parent.
-                let is_nested = |name: &str| name.contains(crate::node::NESTED_SEP);
+                let is_nested = |name: &Name| name.is_nested();
                 let matches_filter = |name: &str| {
                     state.name_filter.is_empty()
                         || state
@@ -200,25 +197,31 @@ impl<'a> GraphSelect<'a> {
                 // handle clicks.
                 let show_named =
                     |ui: &mut egui::Ui,
-                     name: &str,
+                     name: &Name,
                      ca: &gantz_ca::CommitAddr,
-                     row_type: HeadRowType<'_>,
+                     base: bool,
                      heads: &[gantz_ca::Head],
                      focused_head: Option<usize>,
                      response: &mut GraphSelectResponse| {
-                        let head = gantz_ca::Head::Branch(name.to_string());
+                        let name_str = name.to_string();
+                        let row_type = if base {
+                            HeadRowType::Base(&name_str)
+                        } else {
+                            HeadRowType::Named(&name_str)
+                        };
+                        let head = gantz_ca::Head::Branch(name.clone());
                         let mut res = head_row(heads, &head, row_type, ca, focused_head, ui);
                         // Show the graph's description + input/output docs on hover.
                         res.row = res.row.on_hover_ui(|ui| {
                             // Re-assert wrap width every frame (see `socket_hover`).
                             let max_width = ui.spacing().tooltip_width;
                             ui.set_max_width(max_width);
-                            crate::node_info_ui(&registry.command_info(name), ui);
+                            crate::node_info_ui(&registry.command_info(&name_str), ui);
                         });
                         // Deletable iff the row offers an `×` (named, non-base).
                         let deletable = res.delete.is_some();
                         // The associated demo to offer, if any.
-                        let demo = demos.and_then(|d| d.get(name)).cloned();
+                        let demo = registry.demo_graph(&name_str);
                         res.row.context_menu(|ui| {
                             if ui.button("open").clicked() {
                                 response.replaced = Some(head.clone());
@@ -234,13 +237,14 @@ impl<'a> GraphSelect<'a> {
                                     .on_hover_text("open the associated demo in a new tab")
                                     .clicked()
                                 {
-                                    response.opened =
-                                        Some(gantz_ca::Head::Branch(demo_name.clone()));
+                                    response.opened = Some(gantz_ca::Head::Branch(
+                                        demo_name.parse().expect("infallible"),
+                                    ));
                                     ui.close();
                                 }
                             }
                             if deletable && ui.button("delete").clicked() {
-                                response.name_removed = Some(name.to_string());
+                                response.name_removed = Some(name.clone());
                                 ui.close();
                             }
                         });
@@ -248,7 +252,7 @@ impl<'a> GraphSelect<'a> {
                             click_head(ui, heads, focused_head, head, response);
                         } else if let Some(delete) = res.delete {
                             if delete.clicked() {
-                                response.name_removed = Some(name.to_string());
+                                response.name_removed = Some(name.clone());
                             }
                         }
                     };
@@ -258,7 +262,7 @@ impl<'a> GraphSelect<'a> {
                     .iter()
                     .filter(|(n, _)| !is_base(n) && !is_demo(n) && !is_nested(n))
                 {
-                    if !matches_filter(name) {
+                    if !matches_filter(&name.to_string()) {
                         continue;
                     }
                     visited.insert(*ca);
@@ -266,7 +270,7 @@ impl<'a> GraphSelect<'a> {
                         ui,
                         name,
                         ca,
-                        HeadRowType::Named(name),
+                        false,
                         self.heads,
                         self.focused_head,
                         &mut response,
@@ -278,7 +282,7 @@ impl<'a> GraphSelect<'a> {
                     .iter()
                     .filter(|(n, _)| state.show_base && is_base(n) && !is_demo(n) && !is_nested(n))
                 {
-                    if !matches_filter(name) {
+                    if !matches_filter(&name.to_string()) {
                         continue;
                     }
                     visited.insert(*ca);
@@ -286,7 +290,7 @@ impl<'a> GraphSelect<'a> {
                         ui,
                         name,
                         ca,
-                        HeadRowType::Base(name),
+                        true,
                         self.heads,
                         self.focused_head,
                         &mut response,
@@ -299,20 +303,15 @@ impl<'a> GraphSelect<'a> {
                     .iter()
                     .filter(|(n, _)| state.show_demo && is_demo(n) && !is_nested(n))
                 {
-                    if !matches_filter(name) {
+                    if !matches_filter(&name.to_string()) {
                         continue;
                     }
                     visited.insert(*ca);
-                    let row_type = if is_base(name) {
-                        HeadRowType::Base(name)
-                    } else {
-                        HeadRowType::Named(name)
-                    };
                     show_named(
                         ui,
                         name,
                         ca,
-                        row_type,
+                        is_base(name),
                         self.heads,
                         self.focused_head,
                         &mut response,
@@ -388,6 +387,13 @@ impl<'a> GraphSelect<'a> {
 
         response
     }
+}
+
+/// Whether the name follows the `demo-*` naming convention for demo graphs.
+pub(crate) fn is_demo(name: &Name) -> bool {
+    name.segments()
+        .first()
+        .is_some_and(|s| s.starts_with("demo-"))
 }
 
 /// Update `response` for a click on the row for `head`.

--- a/crates/gantz_egui/src/widget/head_name_edit.rs
+++ b/crates/gantz_egui/src/widget/head_name_edit.rs
@@ -21,13 +21,13 @@ pub struct HeadNameEditResponse {
 pub fn head_name_edit(
     head: &gantz_ca::Head,
     name: &mut String,
-    names: &gantz_ca::registry::Names,
+    names: &[(gantz_ca::Name, gantz_ca::CommitAddr)],
     ui: &mut egui::Ui,
 ) -> HeadNameEditResponse {
-    let name_exists = names.contains_key(name.as_str());
-    let is_current_name = matches!(head, gantz_ca::Head::Branch(n) if n == name);
+    let name_exists = names.iter().any(|(n, _)| n.to_string() == *name);
+    let is_current_name = matches!(head, gantz_ca::Head::Branch(n) if n.to_string() == *name);
     let is_empty = name.is_empty();
-    let has_separator = name.contains(crate::node::NESTED_SEP);
+    let has_separator = name.contains(gantz_ca::name::SEP);
     let is_invalid = is_empty || (!is_current_name && (name_exists || has_separator));
 
     let text_color = if is_invalid && !is_current_name {
@@ -44,7 +44,7 @@ pub fn head_name_edit(
     if has_separator && !is_current_name {
         response = response.on_hover_text(format!(
             "'{}' is reserved for nested graphs; use a plain name",
-            crate::node::NESTED_SEP,
+            gantz_ca::name::SEP,
         ));
     }
 
@@ -70,7 +70,7 @@ pub fn head_name_edit(
 
 pub fn head_name(head: &gantz_ca::Head) -> String {
     match head {
-        gantz_ca::Head::Branch(n) => n.clone(),
+        gantz_ca::Head::Branch(n) => n.to_string(),
         gantz_ca::Head::Commit(_) => String::new(),
     }
 }

--- a/crates/gantz_egui/src/widget/history_view.rs
+++ b/crates/gantz_egui/src/widget/history_view.rs
@@ -99,7 +99,7 @@ impl<'a> HistoryView<'a> {
                 // Get the focused head's commit address and walk parent chain.
                 let focused_ca = self.focused_head.and_then(|idx| {
                     self.heads.get(idx).and_then(|head| match head {
-                        gantz_ca::Head::Branch(name) => self.registry.names().get(name).copied(),
+                        gantz_ca::Head::Branch(name) => self.registry.name_head(name),
                         gantz_ca::Head::Commit(ca) => Some(*ca),
                     })
                 });

--- a/crates/gantz_format/src/lib.rs
+++ b/crates/gantz_format/src/lib.rs
@@ -80,17 +80,17 @@ where
 }
 
 /// [`from_str`], resolving names the document does not define through `seed`
-/// (externally-known name -> head commit associations).
+/// (externally-known name -> head graph associations).
 ///
 /// Lets a document reference graphs defined elsewhere, e.g. a domain's base
 /// source referencing another source's graphs. The document's own names
-/// shadow the seed. Note a seeded reference embeds the seeded commit address
+/// shadow the seed. Note a seeded reference embeds the seeded graph address
 /// in the built node, so the referring graph's content address depends on
 /// it - callers wanting reproducible addresses must seed reproducible ones.
 pub fn from_str_seeded<N>(
     text: &str,
     now: Timestamp,
-    seed: &std::collections::BTreeMap<String, gantz_ca::CommitAddr>,
+    seed: &std::collections::BTreeMap<String, gantz_ca::GraphAddr>,
 ) -> Result<Loaded<N>, FormatError>
 where
     N: Serialize + DeserializeOwned + CaHash + NodeSugar + 'static,
@@ -102,44 +102,53 @@ where
 /// Serialize a registry to `.gantz` text (with gantz's built-in node keywords),
 /// returning the text along with the per-graph label context an extender needs
 /// to emit its own forms.
-pub fn to_string<N>(registry: &Registry<Graph<N>>) -> Result<Dumped, FormatError>
+///
+/// Metadata sections are written as generic `(section ...)` forms, except
+/// the ids in `claimed`, which the caller renders itself with friendly
+/// forms (e.g. `(descriptions ...)`).
+pub fn to_string<N>(registry: &Registry<Graph<N>>, claimed: &[&str]) -> Result<Dumped, FormatError>
 where
     N: Serialize + DeserializeOwned + NodeSugar,
 {
-    to_string_with(registry, &N::sugar())
+    to_string_with(registry, &N::sugar(), claimed)
 }
 
 /// Serialize a registry to `.gantz` text using a custom keyword [`Sugar`].
 pub fn to_string_with<N>(
     registry: &Registry<Graph<N>>,
     sugar: &dyn Sugar,
+    claimed: &[&str],
 ) -> Result<Dumped, FormatError>
 where
     N: Serialize + DeserializeOwned,
 {
-    raise::raise(registry, sugar)
+    raise::raise(registry, sugar, claimed)
 }
 
 /// Serialize a registry in the inline-name format: each named graph is emitted
 /// under its registry name, with no `(commits ...)` / `(names ...)` tables and
 /// references resolved by name. Intended for hand-editable, churn-free files
-/// such as the baked-in base.
-pub fn to_string_named<N>(registry: &Registry<Graph<N>>) -> Result<Dumped, FormatError>
+/// such as the baked-in base. See [`to_string`] for `claimed`.
+pub fn to_string_named<N>(
+    registry: &Registry<Graph<N>>,
+    claimed: &[&str],
+) -> Result<Dumped, FormatError>
 where
     N: Serialize + DeserializeOwned + NodeSugar,
 {
-    to_string_named_with(registry, &N::sugar())
+    to_string_named_with(registry, &N::sugar(), claimed)
 }
 
 /// As [`to_string_named`], with a custom keyword [`Sugar`].
 pub fn to_string_named_with<N>(
     registry: &Registry<Graph<N>>,
     sugar: &dyn Sugar,
+    claimed: &[&str],
 ) -> Result<Dumped, FormatError>
 where
     N: Serialize + DeserializeOwned,
 {
-    raise::raise_named(registry, sugar)
+    raise::raise_named(registry, sugar, claimed)
 }
 
 #[cfg(test)]
@@ -191,7 +200,8 @@ mod tests {
         // `from_str`/`to_string` would instead require a `NodeSugar` impl.)
         let loaded = from_str_with::<Box<dyn Widget>>(text, std::time::Duration::ZERO, &CoreSugar)
             .expect("parse without NodeSugar");
-        let dumped = to_string_with(&loaded.registry, &CoreSugar).expect("write without NodeSugar");
+        let dumped =
+            to_string_with(&loaded.registry, &CoreSugar, &[]).expect("write without NodeSugar");
 
         // The node survived the round-trip through the generic form.
         assert!(
@@ -206,7 +216,7 @@ mod tests {
             from_str_with::<Box<dyn Widget>>(&dumped.text, std::time::Duration::ZERO, &CoreSugar)
                 .expect("reparse");
         assert_eq!(
-            to_string_with(&reloaded.registry, &CoreSugar)
+            to_string_with(&reloaded.registry, &CoreSugar, &[])
                 .expect("rewrite")
                 .text,
             dumped.text,
@@ -239,7 +249,7 @@ mod tests {
 
         // The merge parent survives a write + reparse; non-merge commits carry
         // no `merge-parents` clause.
-        let dumped = to_string_with(&loaded.registry, &CoreSugar).expect("write merge commit");
+        let dumped = to_string_with(&loaded.registry, &CoreSugar, &[]).expect("write merge commit");
         assert_eq!(dumped.text.matches("(merge-parents").count(), 1);
         let reloaded =
             from_str_with::<Box<dyn Widget>>(&dumped.text, std::time::Duration::ZERO, &CoreSugar)
@@ -295,8 +305,8 @@ mod seed_tests {
         }
     }
 
-    fn seed_commit() -> gantz_ca::CommitAddr {
-        gantz_ca::CommitAddr::from(gantz_ca::ContentAddr::from([7u8; 32]))
+    fn seed_graph() -> gantz_ca::GraphAddr {
+        gantz_ca::GraphAddr::from(gantz_ca::ContentAddr::from([7u8; 32]))
     }
 
     fn ref_addr_of(loaded: &Loaded<Box<dyn RefNode>>, name: &str) -> gantz_ca::ContentAddr {
@@ -313,7 +323,7 @@ mod seed_tests {
     }
 
     /// A reference to a name the document does not define fails with
-    /// `MissingDependency` unseeded, and resolves to the seeded commit
+    /// `MissingDependency` unseeded, and resolves to the seeded graph
     /// address when seeded.
     #[test]
     fn seed_resolves_foreign_names() {
@@ -329,19 +339,19 @@ mod seed_tests {
             "unexpected error: {err:?}",
         );
 
-        let seed = [("foreign".to_string(), seed_commit())]
+        let seed = [("foreign".to_string(), seed_graph())]
             .into_iter()
             .collect();
         let loaded = from_str_seeded::<Box<dyn RefNode>>(text, now, &seed).expect("seeded parse");
         assert_eq!(
             ref_addr_of(&loaded, "use-foreign"),
-            gantz_ca::ContentAddr::from(seed_commit()),
-            "the built ref must embed the seeded commit address",
+            gantz_ca::ContentAddr::from(seed_graph()),
+            "the built ref must embed the seeded graph address",
         );
     }
 
     /// The pinned-address arm heals through the seed too: a stale pinned
-    /// address whose name only the seed knows resolves to the seeded commit.
+    /// address whose name only the seed knows resolves to the seeded graph.
     #[test]
     fn seed_heals_stale_pinned_addr() {
         let stale = "ee".repeat(32);
@@ -354,13 +364,13 @@ mod seed_tests {
         };
         assert!(matches!(&err.kind, ErrorKind::MissingDependency(_)));
 
-        let seed = [("foreign".to_string(), seed_commit())]
+        let seed = [("foreign".to_string(), seed_graph())]
             .into_iter()
             .collect();
         let loaded = from_str_seeded::<Box<dyn RefNode>>(&text, now, &seed).expect("seeded parse");
         assert_eq!(
             ref_addr_of(&loaded, "use-foreign"),
-            gantz_ca::ContentAddr::from(seed_commit()),
+            gantz_ca::ContentAddr::from(seed_graph()),
         );
     }
 }

--- a/crates/gantz_format/src/lower.rs
+++ b/crates/gantz_format/src/lower.rs
@@ -11,8 +11,9 @@ use crate::datum::{Datum, from_datum};
 use crate::error::{ErrorKind, FormatError};
 use crate::model::{
     Addr, CommitDecl, Document, Form, GraphBody, GraphDef, NameDecl, NodeDecl, NodeSpec, RefSpec,
+    SectionKey,
 };
-use gantz_ca::{CaHash, Commit, CommitAddr, ContentAddr, Registry, Timestamp};
+use gantz_ca::{CaHash, Commit, CommitAddr, ContentAddr, GraphAddr, Key, Registry, Timestamp};
 use gantz_core::edge::Edge;
 use gantz_core::node::graph::{Graph, NodeIx};
 use gantz_core::node::{Input, Output};
@@ -36,17 +37,23 @@ pub struct Loaded<N> {
 }
 
 /// Read-only reference-resolution context, threaded through graph building.
+///
+/// References resolve to GRAPH addresses (content identity): a by-name
+/// reference resolves to the graph at the name's head, a pinned address is
+/// a graph address.
 struct Resolve<'a> {
-    /// name -> head commit, for already-built graphs.
-    names: &'a HashMap<String, CommitAddr>,
-    /// commit id -> commit, for resolving pinned references by id.
-    commit_ids: &'a HashMap<Addr, CommitAddr>,
-    /// every commit built so far, for resolving concrete-address prefixes.
-    known: &'a [CommitAddr],
-    /// Externally-known names, consulted as a fallback after the document's
-    /// own names. Lets a document reference graphs defined elsewhere (e.g. a
-    /// domain base source referencing another source's graphs).
-    seed: &'a BTreeMap<String, CommitAddr>,
+    /// name -> head graph, for already-built graphs.
+    name_graphs: &'a HashMap<String, GraphAddr>,
+    /// commit id -> that commit's graph, for resolving pinned references by
+    /// commit label.
+    commit_graphs: &'a HashMap<Addr, GraphAddr>,
+    /// every graph built so far, for resolving concrete-address prefixes.
+    known: &'a [GraphAddr],
+    /// Externally-known name -> head graph associations, consulted as a
+    /// fallback after the document's own names. Lets a document reference
+    /// graphs defined elsewhere (e.g. a domain base source referencing
+    /// another source's graphs).
+    seed: &'a BTreeMap<String, GraphAddr>,
 }
 
 /// Lower a parsed [`Document`] into a [`Loaded`] registry, synthesising root
@@ -59,16 +66,16 @@ where
 }
 
 /// [`lower`], resolving names the document does not define through `seed`
-/// (externally-known name -> head commit associations).
+/// (externally-known name -> head graph associations).
 ///
 /// The document's own names shadow the seed. A seeded reference embeds the
-/// seeded commit address in the built node, so the referring graph's content
+/// seeded graph address in the built node, so the referring graph's content
 /// address depends on it - callers wanting reproducible addresses must seed
 /// reproducible ones.
 pub fn lower_seeded<N>(
     doc: Document,
     now: Timestamp,
-    seed: &BTreeMap<String, CommitAddr>,
+    seed: &BTreeMap<String, GraphAddr>,
 ) -> Result<Loaded<N>, FormatError>
 where
     // `'static` is required by content-addressing (`Registry::add_graph`), whose
@@ -80,7 +87,7 @@ where
         graphs,
         commits,
         names: name_decls,
-        descriptions,
+        sections,
         extra,
     } = doc;
 
@@ -108,32 +115,37 @@ where
         compute_name_to_graph_id(&graphs, &name_decls, &commit_for_graph, &graph_of_commit);
     let order = topo_order(&graphs, &graphs_by_id, &name_to_graph_id)?;
 
-    let mut registry: Registry<Graph<N>> =
-        Registry::new(HashMap::new(), HashMap::new(), BTreeMap::new());
+    let mut registry: Registry<Graph<N>> = Registry::default();
     let mut names: HashMap<String, CommitAddr> = HashMap::new();
+    let mut name_graphs: HashMap<String, GraphAddr> = HashMap::new();
     let mut commit_ids: HashMap<Addr, CommitAddr> = HashMap::new();
-    let mut known: Vec<CommitAddr> = Vec::new();
+    let mut commit_graphs: HashMap<Addr, GraphAddr> = HashMap::new();
+    let mut known_commits: Vec<CommitAddr> = Vec::new();
+    let mut known_graphs: Vec<GraphAddr> = Vec::new();
     let mut graph_head: HashMap<Addr, CommitAddr> = HashMap::new();
     let mut index: HashMap<Addr, HashMap<String, usize>> = HashMap::new();
 
     for id in &order {
         let def = graphs_by_id[id];
         let resolve = Resolve {
-            names: &names,
-            commit_ids: &commit_ids,
-            known: &known,
+            name_graphs: &name_graphs,
+            commit_graphs: &commit_graphs,
+            known: &known_graphs,
             seed,
         };
         let (graph, index_map) = build_graph::<N>(&def.body, &resolve)?;
         let g_addr = registry.add_graph(graph);
+        known_graphs.push(g_addr);
         index.insert(id.clone(), index_map);
 
         // Build the head commit: from the table where present, else a fresh root.
         let head = match commit_for_graph.get(id) {
-            Some(decl) => build_commit(&mut registry, decl, g_addr, &commit_ids, &mut known),
+            Some(decl) => {
+                build_commit(&mut registry, decl, g_addr, &commit_ids, &mut known_commits)
+            }
             None => {
                 let ca = registry.add_commit(Commit::new(now, None, g_addr));
-                known.push(ca);
+                known_commits.push(ca);
                 ca
             }
         };
@@ -143,11 +155,13 @@ where
         // plus an auto-name for an un-committed label graph (hand-authored).
         let mut register = |name: String| {
             names.insert(name.clone(), head);
-            registry.insert_name(name, head);
+            name_graphs.insert(name.clone(), g_addr);
+            registry.set_head(name.parse().expect("infallible"), head);
         };
         match commit_for_graph.get(id) {
             Some(decl) => {
                 commit_ids.insert(decl.id.clone(), head);
+                commit_graphs.insert(decl.id.clone(), g_addr);
                 if let Some(ns) = names_of_commit.get(&decl.id) {
                     ns.iter().for_each(|n| register(n.clone()));
                 }
@@ -160,9 +174,20 @@ where
         }
     }
 
-    // Apply name-keyed descriptions (independent of how each name registered).
-    for decl in descriptions {
-        registry.set_description(decl.name, decl.description);
+    // Apply generic metadata sections, semantics as declared in the text.
+    for section in sections {
+        for (key, value) in section.entries {
+            let Some(key) = lower_section_key(key) else {
+                continue;
+            };
+            registry.set_section_value(
+                section.id.clone(),
+                section.policy,
+                section.liveness,
+                key,
+                gantz_ca::Value::Datum(value),
+            );
+        }
     }
 
     Ok(Loaded {
@@ -172,6 +197,17 @@ where
         names,
         extra,
     })
+}
+
+/// Convert a text-form section key to a registry key. Malformed hex keys
+/// are dropped (advisory metadata degrades, it never fails a load).
+fn lower_section_key(key: SectionKey) -> Option<Key> {
+    match key {
+        SectionKey::Name(name) => Some(Key::Name(name.parse().expect("infallible"))),
+        SectionKey::Commit(hex) => Some(Key::Commit(hex.parse::<ContentAddr>().ok()?.into())),
+        SectionKey::Graph(hex) => Some(Key::Graph(hex.parse::<ContentAddr>().ok()?.into())),
+        SectionKey::Addr(hex) => Some(Key::Addr(hex.parse().ok()?)),
+    }
 }
 
 // -- graph construction ------------------------------------------------------
@@ -242,30 +278,28 @@ where
 }
 
 fn resolve_ref_value(refspec: &RefSpec, resolve: &Resolve) -> Result<Datum, FormatError> {
-    let commit_ca = match &refspec.addr {
+    let graph_ca = match &refspec.addr {
         None => resolve
-            .names
+            .name_graphs
             .get(&refspec.name)
             .or_else(|| resolve.seed.get(&refspec.name))
             .copied()
             .ok_or_else(|| FormatError::new(ErrorKind::MissingDependency(refspec.name.clone())))?,
         Some(Addr::Label(label)) => resolve
-            .commit_ids
+            .commit_graphs
             .get(&Addr::Label(label.clone()))
             .copied()
             .ok_or_else(|| FormatError::new(ErrorKind::MissingDependency(label.clone())))?,
-        // A pinned address is advisory: if it no longer resolves (e.g. the
-        // commit healed because the format keeps only the head commit per
-        // graph, so a parent was dropped and the address recomputed), fall
-        // back to the reference's name. This keeps `NamedRef`s - including
-        // nested-graph refs in a copy/paste payload - resolving across the
-        // address drift (#232).
-        Some(Addr::Concrete(hex)) => resolve_commit(hex, resolve.known)
-            .or_else(|| resolve.names.get(&refspec.name).copied())
+        // A pinned address is advisory: if it no longer resolves, fall back
+        // to the reference's name. Content addressing makes this rare (a
+        // graph address is independent of commit re-rooting), but a document
+        // may pin a graph version it does not itself carry.
+        Some(Addr::Concrete(hex)) => resolve_graph(hex, resolve.known)
+            .or_else(|| resolve.name_graphs.get(&refspec.name).copied())
             .or_else(|| resolve.seed.get(&refspec.name).copied())
             .ok_or_else(|| FormatError::new(ErrorKind::MissingDependency(hex.clone())))?,
     };
-    let content: ContentAddr = commit_ca.into();
+    let content: ContentAddr = graph_ca.into();
     let hex = content.to_string();
     let tag = if refspec.func {
         "FnNamedRef"
@@ -457,6 +491,22 @@ fn resolve_commit(hex: &str, known: &[CommitAddr]) -> Option<CommitAddr> {
         .iter()
         .copied()
         .filter(|ca| ContentAddr::from(*ca).to_string().starts_with(hex))
+        .collect();
+    matches.sort();
+    matches.dedup();
+    match matches.as_slice() {
+        [only] => Some(*only),
+        _ => None,
+    }
+}
+
+/// Resolve a concrete address (full hex or unambiguous prefix) to a *present*
+/// graph. A prefix is ambiguous only when it matches two distinct graphs.
+fn resolve_graph(hex: &str, known: &[GraphAddr]) -> Option<GraphAddr> {
+    let mut matches: Vec<GraphAddr> = known
+        .iter()
+        .copied()
+        .filter(|ga| ContentAddr::from(*ga).to_string().starts_with(hex))
         .collect();
     matches.sort();
     matches.dedup();

--- a/crates/gantz_format/src/model.rs
+++ b/crates/gantz_format/src/model.rs
@@ -18,8 +18,8 @@ pub struct Document {
     pub commits: Vec<CommitDecl>,
     /// Name -> commit mappings.
     pub names: Vec<NameDecl>,
-    /// Name -> human-facing description mappings.
-    pub descriptions: Vec<DescriptionDecl>,
+    /// Generic metadata sections (`(section ...)` forms).
+    pub sections: Vec<SectionForm>,
     /// Unrecognised top-level forms, preserved verbatim for extenders.
     pub extra: Vec<Form>,
 }
@@ -148,11 +148,37 @@ pub struct NameDecl {
     pub commit: Addr,
 }
 
-/// A single entry in the `(descriptions ...)` table.
+/// A generic metadata section form:
+/// `(section "<id>" (policy <p>) (liveness <l>) (entry <key> <datum>) ...)`.
+///
+/// Carries a registry section - including sections from domains the reading
+/// application does not know - with its merge policy and liveness rule as
+/// data, so unknown sections round-trip through text.
 #[derive(Clone, Debug)]
-pub struct DescriptionDecl {
-    /// The registry name (branch) the description applies to.
-    pub name: String,
-    /// The human-facing description text.
-    pub description: String,
+pub struct SectionForm {
+    /// The section id, e.g. `"laser.palette"`.
+    pub id: String,
+    /// The section's merge policy.
+    pub policy: gantz_ca::MergePolicy,
+    /// The section's liveness rule.
+    pub liveness: gantz_ca::Liveness,
+    /// The entries: a key plus an inline datum value.
+    pub entries: Vec<(SectionKey, Datum)>,
+}
+
+/// A section entry key in text form.
+///
+/// Address keys are FULL hex (no prefix resolution): section entries are
+/// advisory metadata, so a key whose subject was re-rooted simply goes dead
+/// and is dropped by the next prune.
+#[derive(Clone, Debug)]
+pub enum SectionKey {
+    /// Keyed by a registry name.
+    Name(String),
+    /// Keyed by a commit address (full hex).
+    Commit(String),
+    /// Keyed by a graph address (full hex).
+    Graph(String),
+    /// Keyed by an arbitrary content address (full hex).
+    Addr(String),
 }

--- a/crates/gantz_format/src/parse.rs
+++ b/crates/gantz_format/src/parse.rs
@@ -10,8 +10,8 @@
 use crate::datum::{Datum, datum_from_expr};
 use crate::error::{ErrorKind, FormatError};
 use crate::model::{
-    Addr, CommitDecl, Conn, DescriptionDecl, Document, Endpoint, Form, GraphBody, GraphDef,
-    NameDecl, NodeDecl, NodeSpec, RefSpec,
+    Addr, CommitDecl, Conn, Document, Endpoint, Form, GraphBody, GraphDef, NameDecl, NodeDecl,
+    NodeSpec, RefSpec, SectionForm, SectionKey,
 };
 use crate::sexpr::{self, as_keyword, as_string, as_symbol, err_at, list_args, span_src};
 use crate::sugar::{Sugar, SugarArgs};
@@ -37,9 +37,7 @@ pub fn parse(src: &str, sugar: &dyn Sugar) -> Result<Document, FormatError> {
                 .push(parse_graph_def(&args[1..], form, src, sugar)?),
             "commits" => doc.commits.extend(parse_commits_table(&args[1..], src)?),
             "names" => doc.names.extend(parse_names_table(&args[1..], src)?),
-            "descriptions" => doc
-                .descriptions
-                .extend(parse_descriptions_table(&args[1..], src)?),
+            "section" => doc.sections.push(parse_section(&args[1..], form, src)?),
             // Preserve anything else (e.g. `layout`, `demo`) for an extender.
             other => doc.extra.push(Form {
                 head: other.to_string(),
@@ -310,43 +308,154 @@ fn parse_names_table(args: &[ExprKind], src: &str) -> Result<Vec<NameDecl>, Form
     Ok(names)
 }
 
-fn parse_descriptions_table(
+/// Parse a `(section "<id>" (policy <p>) (liveness <l>) (entry <key> <datum>) ...)`
+/// form. Policy and liveness are required so unknown-domain sections carry
+/// their semantics through text.
+fn parse_section(
     args: &[ExprKind],
+    form: &ExprKind,
     src: &str,
-) -> Result<Vec<DescriptionDecl>, FormatError> {
-    let mut descriptions = Vec::new();
-    for item in args {
+) -> Result<SectionForm, FormatError> {
+    let id = args.first().and_then(as_string).ok_or_else(|| {
+        err_at(
+            form,
+            src,
+            ErrorKind::Malformed("section requires a string id".into()),
+        )
+    })?;
+    let mut policy = None;
+    let mut liveness = None;
+    let mut entries = Vec::new();
+    for item in &args[1..] {
         let iargs = list_args(item).ok_or_else(|| {
             err_at(
                 item,
                 src,
-                ErrorKind::Malformed("description entry must be (name \"text\")".into()),
+                ErrorKind::Malformed("section item must be a list".into()),
             )
         })?;
-        if iargs.len() != 2 {
-            return Err(err_at(
-                item,
-                src,
-                ErrorKind::Malformed("description entry must be (name \"text\")".into()),
-            ));
+        match iargs.first().and_then(as_symbol).as_deref() {
+            Some("policy") => {
+                let sym = iargs.get(1).and_then(as_symbol);
+                policy = Some(match sym.as_deref() {
+                    Some("keep-existing") => gantz_ca::MergePolicy::KeepExisting,
+                    Some("replace") => gantz_ca::MergePolicy::Replace,
+                    _ => {
+                        return Err(err_at(
+                            item,
+                            src,
+                            ErrorKind::Malformed("policy must be keep-existing or replace".into()),
+                        ));
+                    }
+                });
+            }
+            Some("liveness") => {
+                let sym = iargs.get(1).and_then(as_symbol);
+                liveness = Some(match sym.as_deref() {
+                    Some("root") => gantz_ca::Liveness::Root,
+                    Some("with-name") => gantz_ca::Liveness::WithName,
+                    Some("with-commit") => gantz_ca::Liveness::WithCommit,
+                    Some("with-graph") => gantz_ca::Liveness::WithGraph,
+                    Some("pinned") => gantz_ca::Liveness::Pinned,
+                    _ => {
+                        return Err(err_at(
+                            item,
+                            src,
+                            ErrorKind::Malformed(
+                                "liveness must be root, with-name, with-commit, with-graph \
+                                 or pinned"
+                                    .into(),
+                            ),
+                        ));
+                    }
+                });
+            }
+            Some("entry") => {
+                if iargs.len() != 3 {
+                    return Err(err_at(
+                        item,
+                        src,
+                        ErrorKind::Malformed("entry must be (entry <key> <datum>)".into()),
+                    ));
+                }
+                let key = parse_section_key(&iargs[1], src)?;
+                let value = datum_from_expr(&iargs[2], src);
+                entries.push((key, value));
+            }
+            _ => {
+                return Err(err_at(
+                    item,
+                    src,
+                    ErrorKind::Malformed(
+                        "section item must be (policy ...), (liveness ...) or (entry ...)".into(),
+                    ),
+                ));
+            }
         }
-        let name = as_symbol(&iargs[0]).ok_or_else(|| {
-            err_at(
-                &iargs[0],
-                src,
-                ErrorKind::Malformed("description name must be a symbol".into()),
-            )
-        })?;
-        let description = as_string(&iargs[1]).ok_or_else(|| {
-            err_at(
-                &iargs[1],
-                src,
-                ErrorKind::Malformed("description must be a string".into()),
-            )
-        })?;
-        descriptions.push(DescriptionDecl { name, description });
     }
-    Ok(descriptions)
+    let policy = policy.ok_or_else(|| {
+        err_at(
+            form,
+            src,
+            ErrorKind::Malformed("section requires a (policy ...)".into()),
+        )
+    })?;
+    let liveness = liveness.ok_or_else(|| {
+        err_at(
+            form,
+            src,
+            ErrorKind::Malformed("section requires a (liveness ...)".into()),
+        )
+    })?;
+    Ok(SectionForm {
+        id,
+        policy,
+        liveness,
+        entries,
+    })
+}
+
+/// Parse a section entry key: `(name <symbol>)`, `(commit "<hex>")`,
+/// `(graph "<hex>")` or `(addr "<hex>")`.
+fn parse_section_key(e: &ExprKind, src: &str) -> Result<SectionKey, FormatError> {
+    let args = list_args(e).ok_or_else(|| {
+        err_at(
+            e,
+            src,
+            ErrorKind::Malformed("section key must be a list".into()),
+        )
+    })?;
+    let malformed = || {
+        err_at(
+            e,
+            src,
+            ErrorKind::Malformed(
+                "section key must be (name <symbol>), (commit \"<hex>\"), (graph \"<hex>\") \
+                 or (addr \"<hex>\")"
+                    .into(),
+            ),
+        )
+    };
+    if args.len() != 2 {
+        return Err(malformed());
+    }
+    let kind = args.first().and_then(as_symbol).ok_or_else(malformed)?;
+    match kind.as_str() {
+        "name" => {
+            let name = as_symbol(&args[1])
+                .or_else(|| as_string(&args[1]))
+                .ok_or_else(malformed)?;
+            Ok(SectionKey::Name(name))
+        }
+        "commit" => Ok(SectionKey::Commit(
+            as_string(&args[1]).ok_or_else(malformed)?,
+        )),
+        "graph" => Ok(SectionKey::Graph(
+            as_string(&args[1]).ok_or_else(malformed)?,
+        )),
+        "addr" => Ok(SectionKey::Addr(as_string(&args[1]).ok_or_else(malformed)?)),
+        _ => Err(malformed()),
+    }
 }
 
 fn parse_commit_entry(
@@ -501,22 +610,46 @@ mod tests {
     }
 
     #[test]
-    fn round_trips_descriptions() {
+    fn descriptions_form_lands_in_extra() {
+        // `(descriptions ...)` is an extender's friendly form now (the gui
+        // layer maps it to the `gantz.description` section), so the core
+        // parser preserves it verbatim like any unrecognised form.
         let text = "\
 (graph mul (m (expr 1)))
 (descriptions
   (mul \"multiply two numbers\"))";
         let doc = parse(text, &CoreSugar).expect("parse");
-        assert_eq!(doc.descriptions.len(), 1);
-        assert_eq!(doc.descriptions[0].name, "mul");
-        assert_eq!(doc.descriptions[0].description, "multiply two numbers");
+        assert_eq!(doc.extra.len(), 1);
+        assert_eq!(doc.extra[0].head, "descriptions");
+    }
 
-        // write -> parse preserves the description verbatim.
+    #[test]
+    fn round_trips_sections() {
+        // A section from a domain this parser knows nothing about carries
+        // its semantics as data and round-trips through write -> parse.
+        let text = "\
+(graph mul (m (expr 1)))
+(section \"laser.palette\"
+  (policy keep-existing)
+  (liveness with-name)
+  (entry (name mul) \"warm\"))";
+        let doc = parse(text, &CoreSugar).expect("parse");
+        assert_eq!(doc.sections.len(), 1);
+        let section = &doc.sections[0];
+        assert_eq!(section.id, "laser.palette");
+        assert!(matches!(
+            section.policy,
+            gantz_ca::MergePolicy::KeepExisting
+        ));
+        assert!(matches!(section.liveness, gantz_ca::Liveness::WithName));
+        assert_eq!(section.entries.len(), 1);
+        assert!(matches!(&section.entries[0].0, SectionKey::Name(n) if n == "mul"));
+
         let written = crate::writer::write_document(&doc, &CoreSugar);
         let reparsed = parse(&written, &CoreSugar).expect("reparse");
-        assert_eq!(reparsed.descriptions.len(), 1);
-        assert_eq!(reparsed.descriptions[0].name, "mul");
-        assert_eq!(reparsed.descriptions[0].description, "multiply two numbers");
+        assert_eq!(reparsed.sections.len(), 1);
+        assert_eq!(reparsed.sections[0].id, "laser.palette");
+        assert_eq!(reparsed.sections[0].entries.len(), 1);
     }
 
     #[test]

--- a/crates/gantz_format/src/raise.rs
+++ b/crates/gantz_format/src/raise.rs
@@ -11,11 +11,11 @@
 use crate::datum::{Datum, to_datum};
 use crate::error::FormatError;
 use crate::model::{
-    Addr, CommitDecl, Conn, DescriptionDecl, Document, Endpoint, GraphBody, GraphDef, NameDecl,
-    NodeDecl, NodeSpec, RefSpec,
+    Addr, CommitDecl, Conn, Document, Endpoint, GraphBody, GraphDef, NameDecl, NodeDecl, NodeSpec,
+    RefSpec, SectionForm, SectionKey,
 };
 use crate::sugar::Sugar;
-use gantz_ca::{ContentAddr, GraphAddr, Registry};
+use gantz_ca::{ContentAddr, GraphAddr, Key, Registry, Value};
 use gantz_core::node::graph::Graph;
 use petgraph::visit::EdgeRef;
 use serde::Serialize;
@@ -39,7 +39,17 @@ pub struct GraphLabels {
 }
 
 /// Raise a registry into serialized text plus per-graph label context.
-pub fn raise<N>(registry: &Registry<Graph<N>>, sugar: &dyn Sugar) -> Result<Dumped, FormatError>
+///
+/// `claimed` names the section ids the caller renders itself with friendly
+/// forms (e.g. `gantz.description` as `(descriptions ...)`); those are
+/// skipped here, every other section is emitted as a generic
+/// `(section ...)` form so unknown-domain data round-trips through text.
+/// The `heads` section is always covered by the `(names ...)` table.
+pub fn raise<N>(
+    registry: &Registry<Graph<N>>,
+    sugar: &dyn Sugar,
+    claimed: &[&str],
+) -> Result<Dumped, FormatError>
 where
     // Raising only ever *serializes* nodes, hence no `DeserializeOwned` bound.
     N: Serialize,
@@ -88,26 +98,52 @@ where
         });
     }
 
-    for (name, c_addr) in registry.names() {
+    for (name, c_addr) in registry.heads() {
         doc.names.push(NameDecl {
-            name: name.clone(),
-            commit: Addr::Concrete(short_hex(*c_addr)),
+            name: name.to_string(),
+            commit: Addr::Concrete(short_hex(c_addr)),
         });
     }
 
-    push_descriptions(&mut doc, registry);
+    push_sections(&mut doc, registry, claimed);
 
     let text = crate::writer::write_document(&doc, sugar);
     Ok(Dumped { text, graphs })
 }
 
-/// Push the registry's name-keyed descriptions onto the document, so both the
-/// full and inline-name formats round-trip them via a `(descriptions ...)` form.
-fn push_descriptions<N>(doc: &mut Document, registry: &Registry<Graph<N>>) {
-    for (name, description) in registry.descriptions() {
-        doc.descriptions.push(DescriptionDecl {
-            name: name.clone(),
-            description: description.clone(),
+/// Push the registry's metadata sections onto the document as generic
+/// `(section ...)` forms, skipping `heads` (covered by the names table),
+/// the caller's `claimed` ids, and non-datum values (blob indirections do
+/// not travel through text yet).
+fn push_sections<N>(doc: &mut Document, registry: &Registry<Graph<N>>, claimed: &[&str]) {
+    for (id, section) in registry.sections() {
+        if id == gantz_ca::registry::HEADS_ID || claimed.contains(&id.as_str()) {
+            continue;
+        }
+        let entries: Vec<(SectionKey, Datum)> = section
+            .entries
+            .iter()
+            .filter_map(|(key, value)| {
+                let key = match key {
+                    Key::Name(name) => SectionKey::Name(name.to_string()),
+                    Key::Commit(ca) => SectionKey::Commit(ContentAddr::from(*ca).to_string()),
+                    Key::Graph(ga) => SectionKey::Graph(ContentAddr::from(*ga).to_string()),
+                    Key::Addr(addr) => SectionKey::Addr(addr.to_string()),
+                };
+                match value {
+                    Value::Datum(d) => Some((key, d.clone())),
+                    Value::Blob(..) | Value::Commit(_) => None,
+                }
+            })
+            .collect();
+        if entries.is_empty() {
+            continue;
+        }
+        doc.sections.push(SectionForm {
+            id: id.clone(),
+            policy: section.policy,
+            liveness: section.liveness,
+            entries,
         });
     }
 }
@@ -124,6 +160,7 @@ fn push_descriptions<N>(doc: &mut Document, registry: &Registry<Graph<N>>) {
 pub fn raise_named<N>(
     registry: &Registry<Graph<N>>,
     sugar: &dyn Sugar,
+    claimed: &[&str],
 ) -> Result<Dumped, FormatError>
 where
     N: Serialize,
@@ -131,8 +168,8 @@ where
     let mut doc = Document::default();
     let mut graphs = HashMap::new();
 
-    for (name, c_addr) in registry.names() {
-        let Some(commit) = registry.commits().get(c_addr) else {
+    for (name, c_addr) in registry.heads() {
+        let Some(commit) = registry.commits().get(&c_addr) else {
             continue;
         };
         let Some(graph) = registry.graphs().get(&commit.graph) else {
@@ -140,19 +177,19 @@ where
         };
         let (body, labels) = graph_to_body::<N>(graph, sugar, false)?;
         doc.graphs.push(GraphDef {
-            id: Addr::Label(name.clone()),
+            id: Addr::Label(name.to_string()),
             body,
         });
         graphs.insert(
             commit.graph,
             GraphLabels {
-                id: name.clone(),
+                id: name.to_string(),
                 labels,
             },
         );
     }
 
-    push_descriptions(&mut doc, registry);
+    push_sections(&mut doc, registry, claimed);
 
     let text = crate::writer::write_document(&doc, sugar);
     Ok(Dumped { text, graphs })

--- a/crates/gantz_format/src/writer.rs
+++ b/crates/gantz_format/src/writer.rs
@@ -7,8 +7,8 @@
 
 use crate::datum::{Datum, datum_text};
 use crate::model::{
-    Addr, CommitDecl, Conn, DescriptionDecl, Document, Endpoint, GraphBody, NameDecl, NodeDecl,
-    NodeSpec,
+    Addr, CommitDecl, Conn, Document, Endpoint, GraphBody, NameDecl, NodeDecl, NodeSpec,
+    SectionForm, SectionKey,
 };
 use crate::sexpr::quote;
 use crate::sugar::Sugar;
@@ -29,8 +29,8 @@ pub fn write_document(doc: &Document, sugar: &dyn Sugar) -> String {
         write_names(&mut out, &doc.names);
         out.push_str("\n\n");
     }
-    if !doc.descriptions.is_empty() {
-        write_descriptions(&mut out, &doc.descriptions);
+    for section in &doc.sections {
+        write_section(&mut out, section);
         out.push_str("\n\n");
     }
     let trimmed = out.trim_end();
@@ -166,10 +166,30 @@ fn write_names(out: &mut String, names: &[NameDecl]) {
     out.push(')');
 }
 
-fn write_descriptions(out: &mut String, descriptions: &[DescriptionDecl]) {
-    out.push_str("(descriptions");
-    for d in descriptions {
-        out.push_str(&format!("\n  ({} {})", d.name, quote(&d.description)));
+fn write_section(out: &mut String, section: &SectionForm) {
+    let policy = match section.policy {
+        gantz_ca::MergePolicy::KeepExisting => "keep-existing",
+        gantz_ca::MergePolicy::Replace => "replace",
+    };
+    let liveness = match section.liveness {
+        gantz_ca::Liveness::Root => "root",
+        gantz_ca::Liveness::WithName => "with-name",
+        gantz_ca::Liveness::WithCommit => "with-commit",
+        gantz_ca::Liveness::WithGraph => "with-graph",
+        gantz_ca::Liveness::Pinned => "pinned",
+    };
+    out.push_str(&format!(
+        "(section {}\n  (policy {policy})\n  (liveness {liveness})",
+        quote(&section.id)
+    ));
+    for (key, value) in &section.entries {
+        let key = match key {
+            SectionKey::Name(name) => format!("(name {name})"),
+            SectionKey::Commit(hex) => format!("(commit {})", quote(hex)),
+            SectionKey::Graph(hex) => format!("(graph {})", quote(hex)),
+            SectionKey::Addr(hex) => format!("(addr {})", quote(hex)),
+        };
+        out.push_str(&format!("\n  (entry {key} {})", datum_text(value)));
     }
     out.push(')');
 }

--- a/crates/gantz_plyphon/src/egui/edge_style.rs
+++ b/crates/gantz_plyphon/src/egui/edge_style.rs
@@ -109,7 +109,7 @@ mod tests {
         // A boundary/unmaterialised signal output (no recorded shape).
         info.signal_outputs.insert((4, 0), None);
         info.signal_inputs.insert((1, 0));
-        let head = gantz_ca::Head::Branch("test".to_string());
+        let head = gantz_ca::Head::Branch("test".parse().unwrap());
         let style = DspEdgeStyle {
             heads: [(head.clone(), Arc::new(info))].into_iter().collect(),
         };
@@ -140,7 +140,7 @@ mod tests {
         // feed) keeps the default.
         assert!(style.edge_styling(&ctx((2, 0), (1, 0))).is_none());
         // An unknown head keeps the default.
-        let other = gantz_ca::Head::Branch("other".to_string());
+        let other = gantz_ca::Head::Branch("other".parse().unwrap());
         let ctx = EdgeStyleCtx::new(&other, (0, 0), (1, 0));
         assert!(style.edge_styling(&ctx).is_none());
     }

--- a/crates/gantz_plyphon/src/egui/node/bus.rs
+++ b/crates/gantz_plyphon/src/egui/node/bus.rs
@@ -4,8 +4,8 @@ use crate::node::Bus;
 use gantz_egui::{NodeCtx, NodeUi, NodeUiResponse, Registry, SocketDoc, SocketKind};
 
 impl NodeUi for Bus {
-    fn name(&self, _: &dyn Registry) -> &str {
-        "~bus"
+    fn name(&self, _: &dyn Registry) -> std::borrow::Cow<'_, str> {
+        "~bus".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_plyphon/src/egui/node/lag.rs
+++ b/crates/gantz_plyphon/src/egui/node/lag.rs
@@ -8,8 +8,8 @@ use gantz_egui::{
 };
 
 impl NodeUi for Lag {
-    fn name(&self, _: &dyn Registry) -> &str {
-        "~lag"
+    fn name(&self, _: &dyn Registry) -> std::borrow::Cow<'_, str> {
+        "~lag".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_plyphon/src/egui/node/out.rs
+++ b/crates/gantz_plyphon/src/egui/node/out.rs
@@ -8,8 +8,8 @@ use gantz_egui::{
 };
 
 impl NodeUi for Out {
-    fn name(&self, _: &dyn Registry) -> &str {
-        "~out"
+    fn name(&self, _: &dyn Registry) -> std::borrow::Cow<'_, str> {
+        "~out".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_plyphon/src/egui/node/pack.rs
+++ b/crates/gantz_plyphon/src/egui/node/pack.rs
@@ -7,8 +7,8 @@ use gantz_egui::{
 };
 
 impl NodeUi for Pack {
-    fn name(&self, _: &dyn Registry) -> &str {
-        "~pack"
+    fn name(&self, _: &dyn Registry) -> std::borrow::Cow<'_, str> {
+        "~pack".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_plyphon/src/egui/node/scope_out.rs
+++ b/crates/gantz_plyphon/src/egui/node/scope_out.rs
@@ -8,8 +8,8 @@ use gantz_egui::{
 };
 
 impl NodeUi for ScopeOut {
-    fn name(&self, _: &dyn Registry) -> &str {
-        "~scopeout"
+    fn name(&self, _: &dyn Registry) -> std::borrow::Cow<'_, str> {
+        "~scopeout".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_plyphon/src/egui/node/sin_osc.rs
+++ b/crates/gantz_plyphon/src/egui/node/sin_osc.rs
@@ -8,8 +8,8 @@ use gantz_egui::{
 };
 
 impl NodeUi for SinOsc {
-    fn name(&self, _: &dyn Registry) -> &str {
-        "~sinosc"
+    fn name(&self, _: &dyn Registry) -> std::borrow::Cow<'_, str> {
+        "~sinosc".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_plyphon/src/egui/node/sum.rs
+++ b/crates/gantz_plyphon/src/egui/node/sum.rs
@@ -7,8 +7,8 @@ use gantz_egui::{
 };
 
 impl NodeUi for Sum {
-    fn name(&self, _: &dyn Registry) -> &str {
-        "~sum"
+    fn name(&self, _: &dyn Registry) -> std::borrow::Cow<'_, str> {
+        "~sum".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_plyphon/src/egui/node/unpack.rs
+++ b/crates/gantz_plyphon/src/egui/node/unpack.rs
@@ -7,8 +7,8 @@ use gantz_egui::{
 };
 
 impl NodeUi for Unpack {
-    fn name(&self, _: &dyn Registry) -> &str {
-        "~unpack"
+    fn name(&self, _: &dyn Registry) -> std::borrow::Cow<'_, str> {
+        "~unpack".into()
     }
 
     fn description(&self) -> Option<&'static str> {

--- a/crates/gantz_plyphon/src/egui/ref_ext.rs
+++ b/crates/gantz_plyphon/src/egui/ref_ext.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 /// references whose graph contains DSP nodes (directly or transitively).
 #[derive(Debug, Default)]
 pub struct DspRefExtUi {
-    /// The commit addresses of DSP graphs, precomputed where the concrete
-    /// node type is known (see [`dsp_commits`](crate::dsp_commits)).
+    /// The graph addresses of DSP graphs, precomputed where the concrete
+    /// node type is known (see [`dsp_graphs`](crate::dsp_graphs)).
     pub dsp_graphs: Arc<HashSet<ContentAddr>>,
 }
 

--- a/crates/gantz_plyphon/src/flatten.rs
+++ b/crates/gantz_plyphon/src/flatten.rs
@@ -231,8 +231,8 @@ where
 }
 
 /// [`flatten`] resolving [`AsRefNode`] nodes through the content-addressed
-/// registry (a reference's content address is the referenced graph's commit
-/// address).
+/// registry (a reference's content address is the referenced graph's
+/// `GraphAddr`).
 ///
 /// How each ref lowers is decided here: a ref whose child (transitively)
 /// contains DSP nodes lowers as [`RefKind::Instance`] by default - its child
@@ -257,18 +257,18 @@ where
                 .unwrap_or_default()
                 .inline;
             let kind = if !inline
-                && crate::ref_ext::is_dsp_commit(registry, ca.into(), &mut dsp_memo.borrow_mut())
+                && crate::ref_ext::is_dsp_graph(registry, ca.into(), &mut dsp_memo.borrow_mut())
             {
                 RefKind::Instance
             } else {
                 RefKind::Inline
             };
-            (ca, kind, registry.commit_graph_ref(&ca.into()))
+            (ca, kind, registry.graph(&ca.into()))
         })
     };
     let get_node = |ca: &ContentAddr| {
         registry
-            .commit_graph_ref(&(*ca).into())
+            .graph(&(*ca).into())
             .map(|g| g as &dyn gantz_core::Node)
     };
     flatten(&get_node, graph, &resolve)
@@ -300,7 +300,7 @@ where
             continue;
         }
         let graph = registry
-            .commit_graph_ref(&ca.into())
+            .graph(&ca.into())
             .ok_or(FlattenError::Unresolved(ca))?;
         let child = flatten_from_registry(graph, registry)?;
         queue.extend(marker_cas(&child));

--- a/crates/gantz_plyphon/src/lib.rs
+++ b/crates/gantz_plyphon/src/lib.rs
@@ -38,7 +38,7 @@ pub use instance::{
 };
 pub use node::{Bus, Lag, Out, Pack, ScopeOut, SinOsc, Sum, Unpack};
 pub use port_info::{RootPortInfo, root_port_info};
-pub use ref_ext::{DSP_REF_EXT_KEY, DspRefExt, dsp_commits};
+pub use ref_ext::{DSP_REF_EXT_KEY, DspRefExt, dsp_graphs};
 pub use sugar::PlyphonSugar;
 // `self::` disambiguates from the extern `egui` crate at the crate root.
 #[cfg(feature = "egui")]

--- a/crates/gantz_plyphon/src/port_info.rs
+++ b/crates/gantz_plyphon/src/port_info.rs
@@ -9,7 +9,7 @@
 //! unreachable through the GUI's erased registry, so callers (e.g. a bevy
 //! provider system) compute this where the concrete node type is known and
 //! hand the result to the UI - the same shape as
-//! [`dsp_commits`][crate::ref_ext::dsp_commits].
+//! [`dsp_graphs`][crate::ref_ext::dsp_graphs].
 //!
 //! Classification is structural, mirroring how flattening lowers the graph
 //! (see [`flatten`][crate::flatten()]): a concrete DSP node's ports come
@@ -49,7 +49,7 @@ pub struct RootPortInfo {
 /// Memoized reference probes, shared across one [`root_port_info`] pass so
 /// repeated references stay linear overall. Stacks guard reference cycles:
 /// a chain re-entering a graph it is already resolving through contributes
-/// nothing (mirroring [`dsp_commits`][crate::ref_ext::dsp_commits]).
+/// nothing (mirroring [`dsp_graphs`][crate::ref_ext::dsp_graphs]).
 #[derive(Default)]
 struct Memos {
     inlets: HashMap<ContentAddr, Vec<bool>>,
@@ -72,7 +72,7 @@ where
 {
     let get_node = |ca: &ContentAddr| {
         registry
-            .commit_graph_ref(&(*ca).into())
+            .graph(&(*ca).into())
             .map(|g| g as &dyn gantz_core::Node)
     };
     let ctx = MetaCtx::new(&get_node);
@@ -158,7 +158,7 @@ where
     if memos.inlet_stack.contains(&ca) {
         return Vec::new();
     }
-    let Some(graph) = registry.commit_graph_ref(&ca.into()) else {
+    let Some(graph) = registry.graph(&ca.into()) else {
         memos.inlets.insert(ca, Vec::new());
         return Vec::new();
     };
@@ -199,7 +199,7 @@ where
     N: gantz_core::Node,
 {
     registry
-        .commit_graph_ref(&ca.into())
+        .graph(&ca.into())
         .map(|g| g.node_indices().filter(|&n| g[n].outlet(ctx)).count())
         .unwrap_or(0)
 }
@@ -226,7 +226,7 @@ where
     if memos.outlet_stack.contains(&key) {
         return Vec::new();
     }
-    let Some(graph) = registry.commit_graph_ref(&ca.into()) else {
+    let Some(graph) = registry.graph(&ca.into()) else {
         memos.outlets.insert(key, Vec::new());
         return Vec::new();
     };

--- a/crates/gantz_plyphon/src/ref_ext.rs
+++ b/crates/gantz_plyphon/src/ref_ext.rs
@@ -8,7 +8,7 @@
 //! nodes.
 
 use crate::ToNodeDsp;
-use gantz_ca::{CommitAddr, ContentAddr};
+use gantz_ca::{ContentAddr, GraphAddr};
 use gantz_core::node::AsRefNode;
 use gantz_core::node::graph::Graph;
 use serde::{Deserialize, Serialize};
@@ -31,70 +31,70 @@ pub struct DspRefExt {
     pub inline: bool,
 }
 
-/// The commit addresses (as [`ContentAddr`]s, the form
+/// The graph addresses (as [`ContentAddr`]s, the form
 /// [`Ref::content_addr`](gantz_core::node::Ref::content_addr) reports) of
-/// every registry commit whose graph contains DSP nodes, directly or
-/// transitively through references.
+/// every registry graph containing DSP nodes, directly or transitively
+/// through references.
 ///
 /// Requires the concrete node type: typed probes like [`ToNodeDsp`] are
 /// unreachable through the GUI's erased registry, so callers (e.g. a bevy
 /// provider system) compute this where `N` is known and hand the set to
 /// `DspRefExtUi`.
-pub fn dsp_commits<N>(registry: &gantz_ca::Registry<Graph<N>>) -> HashSet<ContentAddr>
+pub fn dsp_graphs<N>(registry: &gantz_ca::Registry<Graph<N>>) -> HashSet<ContentAddr>
 where
     N: ToNodeDsp + AsRefNode,
 {
-    let mut memo: HashMap<CommitAddr, bool> = HashMap::new();
+    let mut memo: HashMap<GraphAddr, bool> = HashMap::new();
     registry
-        .commits()
+        .graphs()
         .keys()
         .copied()
         .collect::<Vec<_>>()
         .into_iter()
-        .filter(|&ca| is_dsp_commit(registry, ca, &mut memo))
+        .filter(|&ga| is_dsp_graph(registry, ga, &mut memo))
         .map(ContentAddr::from)
         .collect()
 }
 
-/// Whether the graph committed at `ca` contains a DSP node, directly or
-/// transitively through references. Memoized in `memo` so repeated probes over
-/// one registry (e.g. per ref during a flatten) stay linear overall.
-pub(crate) fn is_dsp_commit<N>(
+/// Whether the graph at `ga` contains a DSP node, directly or transitively
+/// through references. Memoized in `memo` so repeated probes over one
+/// registry (e.g. per ref during a flatten) stay linear overall.
+pub(crate) fn is_dsp_graph<N>(
     registry: &gantz_ca::Registry<Graph<N>>,
-    ca: CommitAddr,
-    memo: &mut HashMap<CommitAddr, bool>,
+    ga: GraphAddr,
+    memo: &mut HashMap<GraphAddr, bool>,
 ) -> bool
 where
     N: ToNodeDsp + AsRefNode,
 {
-    let mut stack: Vec<CommitAddr> = Vec::new();
-    is_dsp(registry, ca, memo, &mut stack)
+    let mut stack: Vec<GraphAddr> = Vec::new();
+    is_dsp(registry, ga, memo, &mut stack)
 }
 
-/// Whether the graph at `ca` contains a DSP node, directly or transitively
-/// through references. Memoized per commit; reference cycles are treated as
+/// Whether the graph at `ga` contains a DSP node, directly or transitively
+/// through references. Memoized per graph; reference cycles are treated as
 /// non-DSP at the point of re-entry (a cycle cannot introduce a DSP node that
 /// its members do not already contain).
 fn is_dsp<N>(
     registry: &gantz_ca::Registry<Graph<N>>,
-    ca: CommitAddr,
-    memo: &mut HashMap<CommitAddr, bool>,
-    stack: &mut Vec<CommitAddr>,
+    ga: GraphAddr,
+    memo: &mut HashMap<GraphAddr, bool>,
+    stack: &mut Vec<GraphAddr>,
 ) -> bool
 where
     N: ToNodeDsp + AsRefNode,
 {
-    if let Some(&known) = memo.get(&ca) {
+    if let Some(&known) = memo.get(&ga) {
         return known;
     }
-    if stack.contains(&ca) {
+    if stack.contains(&ga) {
         return false;
     }
-    let Some(graph) = registry.commit_graph_ref(&ca) else {
-        memo.insert(ca, false);
+    let Some(graph) = registry.graph(&ga) else {
+        memo.insert(ga, false);
         return false;
     };
-    stack.push(ca);
+    stack.push(ga);
     let dsp = graph
         .node_indices()
         .any(|ix| graph[ix].to_node_dsp().is_some())
@@ -104,6 +104,6 @@ where
                 .is_some_and(|r| is_dsp(registry, r.content_addr().into(), memo, stack))
         });
     stack.pop();
-    memo.insert(ca, dsp);
+    memo.insert(ga, dsp);
     dsp
 }

--- a/crates/gantz_plyphon/tests/port_info.rs
+++ b/crates/gantz_plyphon/tests/port_info.rs
@@ -90,12 +90,13 @@ impl CaHash for N {
     }
 }
 
-/// Commit `graph`, returning its commit address as a `ContentAddr` (the form
+/// Commit `graph`, returning its graph address as a `ContentAddr` (the form
 /// `Ref::content_addr` reports).
 fn commit(registry: &mut gantz_ca::Registry<Graph<N>>, graph: Graph<N>) -> ContentAddr {
     let now = std::time::Duration::from_secs(1);
     let addr = gantz_ca::graph_addr(&graph);
-    registry.commit_graph(now, None, addr, || graph).into()
+    registry.commit_graph(now, None, addr, || graph);
+    addr.into()
 }
 
 fn shape(width: usize, rate: Rate) -> PortShape {

--- a/crates/gantz_plyphon/tests/ref_ext.rs
+++ b/crates/gantz_plyphon/tests/ref_ext.rs
@@ -1,11 +1,11 @@
-//! Tests for `dsp_commits` - the DSP-graph discovery backing the `inline`
+//! Tests for `dsp_graphs` - the DSP-graph discovery backing the `inline`
 //! ref-extension UI - and for the `DspRefExt`-driven lowering decision in
 //! `flatten_from_registry`.
 
 use gantz_ca::{CaHash, ContentAddr};
 use gantz_core::node::graph::Graph;
 use gantz_core::node::{AsRefNode, ExprCtx, ExprResult, MetaCtx, Ref, parse_expr};
-use gantz_plyphon::{NodeDsp, SinOsc, ToNodeDsp, dsp_commits};
+use gantz_plyphon::{NodeDsp, SinOsc, ToNodeDsp, dsp_graphs};
 
 /// A minimal node standing in for the app's node set: one DSP node, the
 /// reference node, boundary nodes and a non-DSP stand-in.
@@ -72,25 +72,25 @@ impl CaHash for N {
     }
 }
 
-/// Commit `graph` under `name`, returning its commit address as a
+/// Commit `graph` under `name`, returning its graph address as a
 /// `ContentAddr` (the form `Ref::content_addr` reports).
 fn commit(registry: &mut gantz_ca::Registry<Graph<N>>, name: &str, graph: Graph<N>) -> ContentAddr {
     let now = std::time::Duration::from_secs(1);
     let addr = gantz_ca::graph_addr(&graph);
     let ca = registry.commit_graph(now, None, addr, || graph);
-    registry.insert_name(name.to_string(), ca);
-    ca.into()
+    registry.set_head(name.parse().expect("infallible"), ca);
+    addr.into()
 }
 
 fn ref_node(ca: ContentAddr) -> N {
     N::Ref(Ref::new(ca))
 }
 
-/// `dsp_commits` finds directly-DSP graphs and graphs that only reach DSP
+/// `dsp_graphs` finds directly-DSP graphs and graphs that only reach DSP
 /// transitively through references, and excludes non-DSP graphs and
 /// references to missing addresses.
 #[test]
-fn dsp_commits_discovers_direct_and_transitive() {
+fn dsp_graphs_discovers_direct_and_transitive() {
     let mut registry = gantz_ca::Registry::<Graph<N>>::default();
 
     // A graph containing a DSP node directly.
@@ -118,7 +118,7 @@ fn dsp_commits_discovers_direct_and_transitive() {
     dangling.add_node(ref_node(ContentAddr::from([9u8; 32])));
     let dangling_ca = commit(&mut registry, "dangling", dangling);
 
-    let set = dsp_commits(&registry);
+    let set = dsp_graphs(&registry);
     assert!(set.contains(&dsp_ca));
     assert!(set.contains(&wrapper_ca), "one hop through a ref");
     assert!(set.contains(&wrapper2_ca), "two hops through refs");


### PR DESCRIPTION
This rewrites `gantz_ca::Registry` around a more general content addressed store, replacing the old "one typed map per kind" shape that forced every new kind of data (descriptions, assets, views, demos) to touch merge, export, prune, serde, persistence, the text format and the app crates.

Closes #319 

## The model

The registry is now exactly two parts:

- **Content columns**: immutable, content-addressed, insert-only (modulo prune). Graphs, commits, and per-section blob stores.
- **Metadata sections**: ALL mutable state. Each section stores its merge policy and liveness rule as data, so an application without the owning domain compiled in still merges, prunes, exports and round-trips that section correctly. Heads (names) are just the core-declared `heads` section, keyed by a new structured `Name` type (the `NESTED_SEP` substring conventions are gone).

Content forms a pure Merkle DAG: `Ref` nodes now pin the referenced graph's `GraphAddr` rather than a `CommitAddr`, so content identity depends only on content, never on commit history or timestamps. Commits form the history DAG above it, and names point at commits.

A domain extends the registry by declaring a `SectionDecl` or `BlobDecl` in its own crate. The core never learns domain types.

## Key changes

- **One reachability walk** (`gantz_ca::closure` + an app-supplied edge reporter built from `Node::required_addrs`/`required_blobs`) drives prune, export closure, clipboard dependency collection and sync want lists, replacing roughly five bespoke traversals. Asset-scoped export and prune fall out for free.
- **Convergence machinery untouched**: `Staged` verification (now with strict blob staging), canonical merges and history walks kept their bodies. All sync convergence tests pass unmodified.
- **The paste-repoints-name bug is fixed by construction**: re-rooting commits on clipboard parse no longer changes reference identity, and `NamedRef` outdatedness is content-aware. The fixed-timestamp workarounds (base, clipboard) became unnecessary.
- **Blob addresses are the raw blake3 of the bytes**, with nothing folded into the preimage. This keeps them bit-compatible with iroh-blobs addressing, preserving verified-streaming asset transfer as a future option. Commit and graph hashes gained kind discriminators, domain-separating the address spaces.
- **gui data rides the registry**: descriptions, demos and views are sections declared in `gantz_egui`. The `Export` bundle and its views/demos parameter threading are deleted. Demos now persist across sessions (previously lost) and section liveness fixes the old demo leak on name removal.
- **The text format** gained generic `(section ...)` forms so unknown-domain sections survive text round-trips, while the friendly `(descriptions ...)`/`(layout ...)`/`(demo ...)` forms remain, owned by the gui layer.
- **Persistence** generalizes to append-only per-address content blobs plus per-section metadata blobs, with change tracking so unchanged saves write nothing. The bespoke views persistence path is deleted.
- **Collab**: `SessionStore` is deleted. The serve store is the same `Registry` holding `RawGraph` (blob-at-rest) payloads under validated addresses, with the receiving peer's typed `Staged` remaining the security boundary.

## Breaking

All content addresses change (kind discriminators, `Name` hashing, graph-pinned refs), so existing persisted stores and address-pinned `.gantz` files do not load. The inline-named base sources resolve by name and load unchanged.