### PR TITLE
feat(egui): Cache reified node instances per head

### DIFF
--- a/crates/bevy_gantz/src/vm.rs
+++ b/crates/bevy_gantz/src/vm.rs
@@ -45,12 +45,20 @@ pub struct CompiledInputs(pub Option<Inputs>);
 /// When `true`, [`validate_committed`] hashes every open head's working graph
 /// each frame and warns if it differs from the head's committed graph CA - i.e.
 /// a system mutated the working graph without committing it, violating the
-/// [`WorkingGraph`](head::WorkingGraph) commit-before-return invariant.
+/// [`WorkingGraph`](head::WorkingGraph) commit-before-return invariant. The UI
+/// layer also feeds this flag to its per-node change-tracking validator.
 ///
-/// Defaults to `false` (no extra hashing); enable at runtime to debug a
-/// suspected missing commit.
-#[derive(Default, Resource)]
+/// Defaults to `true` in debug builds (the UI's node-instance cache would
+/// otherwise mask a missed `changed` flag rather than visibly dropping the
+/// edit) and `false` in release (no extra hashing). Toggleable at runtime.
+#[derive(Resource)]
 pub struct ValidateCommitted(pub bool);
+
+impl Default for ValidateCommitted {
+    fn default() -> Self {
+        Self(cfg!(debug_assertions))
+    }
+}
 
 /// Event to trigger evaluation of an entrypoint.
 #[derive(Event)]

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -1114,12 +1114,17 @@ pub fn on_cut_nodes(
     mut clipboard: ResMut<bevy_egui::EguiClipboard>,
     mut cmds: Commands,
     mut heads: Query<
-        (&mut head::HeadRef, &mut head::WorkingGraph, &mut GraphView),
+        (
+            &mut head::HeadRef,
+            &mut head::WorkingGraph,
+            &mut GraphView,
+            &mut HeadNodeInstances,
+        ),
         With<head::OpenHead>,
     >,
 ) {
     let event = trigger.event();
-    let Ok((mut head_ref, mut wg, mut gv)) = heads.get_mut(event.head) else {
+    let Ok((mut head_ref, mut wg, mut gv, mut instances)) = heads.get_mut(event.head) else {
         log::error!("CutNodes: head not found for entity {:?}", event.head);
         return;
     };
@@ -1138,6 +1143,7 @@ pub fn on_cut_nodes(
         vm,
         &mut gv,
         &mut head_state.scene.interaction.selection,
+        &mut instances.0,
         &event.data.0,
         &codec.0,
     );

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -224,6 +224,14 @@ pub struct HeadGuiState(pub gantz_egui::widget::gantz::OpenHeadState);
 #[derive(Component, Default, Clone)]
 pub struct GraphView(pub gantz_egui::SceneView);
 
+/// Per-head cache of reified node instances for the working graph.
+///
+/// Reset wholesale on head navigation (`on_head_changed`) - not required for
+/// correctness (each entry's witness check self-heals) but bounds memory when
+/// the graph is replaced outright.
+#[derive(Component, Default)]
+pub struct HeadNodeInstances(pub gantz_egui::node::NodeInstances);
+
 // ----------------------------------------------------------------------------
 // Resources
 // ----------------------------------------------------------------------------
@@ -431,6 +439,7 @@ impl RegisterResponseExt for App {
 pub struct OpenHeadViews {
     pub core: head::OpenHeadData,
     pub view: &'static mut GraphView,
+    pub instances: &'static mut HeadNodeInstances,
 }
 
 // ----------------------------------------------------------------------------
@@ -502,6 +511,7 @@ impl gantz_egui::HeadAccess for HeadAccess<'_, '_, '_> {
             graph: &mut *data.core.working_graph,
             view: &mut *data.view,
             vm,
+            instances: &mut data.instances.0,
         }))
     }
 
@@ -604,7 +614,8 @@ pub fn on_head_opened(
 
     cmds.entity(event.entity)
         .insert(HeadGuiState::default())
-        .insert(GraphView(head_view));
+        .insert(GraphView(head_view))
+        .insert(HeadNodeInstances::default());
 }
 
 /// Migrate GUI state for changed head and reset components.
@@ -671,7 +682,8 @@ pub fn on_head_changed(
 
     cmds.entity(event.entity)
         .insert(HeadGuiState::default())
-        .insert(GraphView(head_view));
+        .insert(GraphView(head_view))
+        .insert(HeadNodeInstances::default());
 }
 
 /// Remove GUI state for closed head.

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -183,6 +183,7 @@ struct DemoHeadAccess<'a> {
     compile_errors: &'a [Option<String>],
     diagnostics: &'a [Vec<gantz_core::Diagnostic>],
     vms: &'a mut Vec<Engine>,
+    instances: &'a mut Vec<gantz_egui::node::NodeInstances>,
 }
 
 impl<'a> DemoHeadAccess<'a> {
@@ -192,6 +193,7 @@ impl<'a> DemoHeadAccess<'a> {
         compile_errors: &'a [Option<String>],
         diagnostics: &'a [Vec<gantz_core::Diagnostic>],
         vms: &'a mut Vec<Engine>,
+        instances: &'a mut Vec<gantz_egui::node::NodeInstances>,
     ) -> Self {
         let head_keys: Vec<_> = data.iter().map(|(h, _, _)| h.clone()).collect();
         let head_to_ix: HashMap<_, _> = head_keys
@@ -207,6 +209,7 @@ impl<'a> DemoHeadAccess<'a> {
             compile_errors,
             diagnostics,
             vms,
+            instances,
         }
     }
 }
@@ -224,7 +227,13 @@ impl<'a> HeadAccess for DemoHeadAccess<'a> {
         let ix = *self.head_to_ix.get(head)?;
         let (_, graph, view) = &mut self.data[ix];
         let vm = &mut self.vms[ix];
-        Some(f(HeadDataMut { graph, view, vm }))
+        let instances = &mut self.instances[ix];
+        Some(f(HeadDataMut {
+            graph,
+            view,
+            vm,
+            instances,
+        }))
     }
 
     fn module(&self, head: &gantz_ca::Head) -> Option<&gantz_core::vm::Compiled> {
@@ -287,6 +296,8 @@ struct State {
     diagnostics: Vec<Vec<gantz_core::Diagnostic>>,
     /// Per-head VMs, indexed to match `heads`.
     vms: Vec<Engine>,
+    /// Per-head reified node instance caches, indexed to match `heads`.
+    instances: Vec<gantz_egui::node::NodeInstances>,
     /// Index of the currently focused head.
     focused_head: usize,
     /// The compile config used for all heads (session-only, not persisted).
@@ -420,6 +431,7 @@ impl App {
             modules.push(module);
             diagnostics.push(diags);
         }
+        let instances = heads.iter().map(|_| Default::default()).collect();
 
         // GUI setup.
         let ctx = &cc.egui_ctx;
@@ -434,6 +446,7 @@ impl App {
             modules,
             diagnostics,
             vms,
+            instances,
             focused_head: 0,
             compile_config,
         };
@@ -1199,6 +1212,7 @@ fn gui(ui: &mut egui::Ui, state: &mut State) -> gantz_egui::Responses {
                 &state.compile_errors,
                 &state.diagnostics,
                 &mut state.vms,
+                &mut state.instances,
             );
 
             let no_base_names = Default::default();
@@ -1360,6 +1374,7 @@ fn open_head(state: &mut State, new_head: gantz_ca::Head) {
     state.compile_errors.push(error);
     state.modules.push(module);
     state.diagnostics.push(diags);
+    state.instances.push(Default::default());
 
     // Initialize GUI state for the new head.
     state.gantz.open_heads.entry(new_head).or_default();
@@ -1382,8 +1397,10 @@ fn replace_head(ctx: &egui::Context, state: &mut State, new_head: gantz_ca::Head
     let new_graph = state.env.head_data_graph(&new_head).unwrap();
     let view = gantz_egui::SceneView::default();
 
-    // Replace at the focused index.
+    // Replace at the focused index. The graph is replaced wholesale, so
+    // drop the cached instances to bound memory.
     state.heads[ix] = (new_head.clone(), new_graph, view);
+    state.instances[ix].clear();
 
     // Reinitialize the VM from the reified cache at the committed address.
     let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
@@ -1437,6 +1454,7 @@ fn refresh_branch_head(state: &mut State) {
     let (ref head, ref mut graph, ref mut view) = state.heads[ix];
     *graph = state.env.head_data_graph(head).unwrap();
     *view = gantz_egui::SceneView::default();
+    state.instances[ix].clear();
     let get_node = |ca: &gantz_ca::ContentAddr| state.env.node(ca);
     let typed = state.env.head_graph(head).unwrap();
     let eps = push_pull_entrypoints(&get_node, typed);
@@ -1532,6 +1550,7 @@ fn close_head(state: &mut State, head: &gantz_ca::Head) {
     if let Some(ix) = state.heads.iter().position(|(h, _, _)| h == head) {
         state.heads.remove(ix);
         state.vms.remove(ix);
+        state.instances.remove(ix);
         state.compile_errors.remove(ix);
         state.modules.remove(ix);
         state.diagnostics.remove(ix);

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -1018,6 +1018,7 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
             vm,
             gv,
             &mut head_state.scene.interaction.selection,
+            &mut state.instances[ix],
             &nodes,
             &codec(),
         );

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -190,6 +190,10 @@ pub struct HeadDataMut<'a> {
     /// suffices (no path-keyed map).
     pub view: &'a mut crate::SceneView,
     pub vm: &'a mut Engine,
+    /// The head's cache of reified node instances, so steady-state passes
+    /// pay an equality check per node rather than a reify (see
+    /// [`node::NodeInstances`]).
+    pub instances: &'a mut node::NodeInstances,
 }
 
 /// A trait providing an egui `Ui` implementation for gantz nodes.

--- a/crates/gantz_egui/src/node.rs
+++ b/crates/gantz_egui/src/node.rs
@@ -5,7 +5,7 @@
 //! items for convenience.
 
 pub use comment::Comment;
-pub use dyn_node::{DynNode, NodeCodec, NormalizeNodeError, UiBuiltins, UiNodeInstance};
+pub use dyn_node::{DynNode, NodeCodec, NormalizeNodeError, UiBuiltins, NodeUiInstance};
 pub use fn_named_ref::FnNamedRef;
 #[doc(inline)]
 pub use gantz_core::node::{Id, state};

--- a/crates/gantz_egui/src/node.rs
+++ b/crates/gantz_egui/src/node.rs
@@ -7,10 +7,10 @@
 pub use comment::Comment;
 pub use dyn_node::{DynNode, NodeCodec, NodeUiInstance, NormalizeNodeError, UiBuiltins};
 pub use fn_named_ref::FnNamedRef;
-pub use instance_cache::{InstanceEntry, NodeInstances};
 #[doc(inline)]
 pub use gantz_core::node::{Id, state};
 pub use inspect::Inspect;
+pub use instance_cache::{InstanceEntry, NodeInstances};
 pub use named_ref::{NamedRef, missing_color, outdated_color};
 pub use plot::{Plot, PlotMode, PlotStyle};
 pub use ref_ext::RefExtUi;

--- a/crates/gantz_egui/src/node.rs
+++ b/crates/gantz_egui/src/node.rs
@@ -5,8 +5,9 @@
 //! items for convenience.
 
 pub use comment::Comment;
-pub use dyn_node::{DynNode, NodeCodec, NormalizeNodeError, UiBuiltins, NodeUiInstance};
+pub use dyn_node::{DynNode, NodeCodec, NodeUiInstance, NormalizeNodeError, UiBuiltins};
 pub use fn_named_ref::FnNamedRef;
+pub use instance_cache::{InstanceEntry, NodeInstances};
 #[doc(inline)]
 pub use gantz_core::node::{Id, state};
 pub use inspect::Inspect;
@@ -18,6 +19,7 @@ pub mod comment;
 pub mod dyn_node;
 pub mod fn_named_ref;
 pub mod inspect;
+pub mod instance_cache;
 pub mod named_ref;
 pub mod plot;
 pub mod ref_ext;

--- a/crates/gantz_egui/src/node/dyn_node.rs
+++ b/crates/gantz_egui/src/node/dyn_node.rs
@@ -31,7 +31,7 @@ pub type DynNode = Box<dyn NodeUi>;
 /// knows its concrete type, so it captures an eraser that downcasts and runs
 /// [`erase_node_typed`](gantz_core::data::erase_node_typed) - no trait-object
 /// serde involved.
-pub struct UiNodeInstance {
+pub struct NodeUiInstance {
     /// The reified node.
     pub node: DynNode,
     erase: fn(&dyn Any) -> Result<NodeData, EraseNodeError>,
@@ -44,7 +44,7 @@ pub struct UiNodeInstance {
 /// a `const`. Build one with [`ui_node_codec!`](crate::ui_node_codec).
 #[derive(Clone, Copy)]
 pub struct NodeCodec {
-    reify: fn(&NodeData) -> Result<UiNodeInstance, ReifyNodeError>,
+    reify: fn(&NodeData) -> Result<NodeUiInstance, ReifyNodeError>,
     sugars: fn() -> gantz_format::Sugars<'static>,
 }
 
@@ -85,7 +85,7 @@ impl gantz_core::node::AsRefNode for DynNode {
     }
 }
 
-impl UiNodeInstance {
+impl NodeUiInstance {
     /// Pair a reified node with its concrete type's eraser.
     ///
     /// `erase` receives the node upcast to `&dyn Any` and must downcast to
@@ -135,14 +135,14 @@ impl NodeCodec {
     /// source. See [`ui_node_codec!`](crate::ui_node_codec) for the standard
     /// construction.
     pub const fn new(
-        reify: fn(&NodeData) -> Result<UiNodeInstance, ReifyNodeError>,
+        reify: fn(&NodeData) -> Result<NodeUiInstance, ReifyNodeError>,
         sugars: fn() -> gantz_format::Sugars<'static>,
     ) -> Self {
         Self { reify, sugars }
     }
 
-    /// Reify one stored node to a typed [`UiNodeInstance`].
-    pub fn reify_ui(&self, node_data: &NodeData) -> Result<UiNodeInstance, ReifyNodeError> {
+    /// Reify one stored node to a typed [`NodeUiInstance`].
+    pub fn reify_ui(&self, node_data: &NodeData) -> Result<NodeUiInstance, ReifyNodeError> {
         (self.reify)(node_data)
     }
 
@@ -214,13 +214,13 @@ macro_rules! ui_node_codec {
         fn reify(
             node_data: &$crate::gantz_ca::NodeData,
         ) -> ::std::result::Result<
-            $crate::node::UiNodeInstance,
+            $crate::node::NodeUiInstance,
             $crate::gantz_core::data::ReifyNodeError,
         > {
             $(
                 if node_data.tag == <$ty as $crate::gantz_nodetag::NodeTag>::TAG {
                     return $crate::gantz_core::data::reify_node_concrete::<$ty>(node_data)
-                        .map(|node| $crate::node::UiNodeInstance::new(
+                        .map(|node| $crate::node::NodeUiInstance::new(
                             ::std::boxed::Box::new(node),
                             |any: &dyn ::std::any::Any| {
                                 let node = any

--- a/crates/gantz_egui/src/node/instance_cache.rs
+++ b/crates/gantz_egui/src/node/instance_cache.rs
@@ -1,0 +1,289 @@
+//! A per-head cache of reified working-graph node instances.
+//!
+//! The working graph stores nodes as [`NodeData`]. Rendering needs the typed
+//! form, so each pass reifies node weights through the app's
+//! [`NodeCodec`] - a datum clone, a serde decode and a box allocation per
+//! node. [`NodeInstances`] retains those instances between passes so the
+//! steady-state cost per node is one structural equality check.
+//!
+//! Correctness rests on the [`NodeUi`](crate::NodeUi) contract: an instance
+//! is a pure function of the `NodeData` it was reified from (all non-CA
+//! state lives in the VM or egui memory), so reusing a cached instance is
+//! indistinguishable from a fresh reify. Each entry therefore carries the
+//! `NodeData` it was reified from as its validity witness: the entry is
+//! valid exactly while the stored weight equals that witness. External
+//! mutations of the graph (undo, paste, collab edits, checkout) need no
+//! hooks - a rewritten weight simply misses and reifies fresh.
+
+use crate::node::{NodeCodec, NodeUiInstance};
+use gantz_ca::NodeData;
+use gantz_core::data::ReifyNodeError;
+use std::collections::HashMap;
+
+/// A cached reified instance paired with the weight it was reified from.
+pub struct InstanceEntry {
+    /// The `NodeData` this instance was reified from - the validity witness.
+    /// After an edit, set this to the newly erased data before
+    /// [`put`](NodeInstances::put)ting the entry back.
+    pub src: NodeData,
+    /// The reified instance and its eraser.
+    pub inst: NodeUiInstance,
+}
+
+/// A cache of reified node instances for one head's working graph, keyed by
+/// node index.
+///
+/// An entry is valid exactly while the stored weight equals its
+/// [`src`](InstanceEntry::src) witness. Index-keyed like the other per-node
+/// working-graph state (VM state, layout, selection), it must be migrated
+/// through the same [`Reindex`](crate::ops::Reindex) replay on node removal -
+/// see [`apply_reindex`](Self::apply_reindex). A missed migration is safe
+/// (the witness check catches it) but wastes a reify.
+#[derive(Default)]
+pub struct NodeInstances {
+    entries: HashMap<usize, InstanceEntry>,
+}
+
+impl NodeInstances {
+    /// Remove and return the entry for the node at index `n_ix`: the cached
+    /// entry when its witness equals `data`, otherwise a freshly reified one
+    /// (with `src` cloned from `data`). Any stale entry is dropped either
+    /// way.
+    ///
+    /// `Err` is the codec's decode failure (e.g. an unknown tag) - the
+    /// caller's placeholder path. No entry is retained on failure.
+    pub fn take(
+        &mut self,
+        codec: &NodeCodec,
+        n_ix: usize,
+        data: &NodeData,
+    ) -> Result<InstanceEntry, ReifyNodeError> {
+        if let Some(entry) = self.entries.remove(&n_ix) {
+            if entry.src == *data {
+                return Ok(entry);
+            }
+        }
+        let inst = codec.reify_ui(data)?;
+        Ok(InstanceEntry {
+            src: data.clone(),
+            inst,
+        })
+    }
+
+    /// Restore an entry after its pass, making it available to the next
+    /// [`take`](Self::take).
+    pub fn put(&mut self, n_ix: usize, entry: InstanceEntry) {
+        self.entries.insert(n_ix, entry);
+    }
+
+    /// A read-only lookup that hits only on a valid cached entry: `None` on
+    /// miss or stale witness. For probes that should not pay a reify - the
+    /// caller decides whether to fall back to a transient one.
+    pub fn peek(&self, n_ix: usize, data: &NodeData) -> Option<&NodeUiInstance> {
+        let entry = self.entries.get(&n_ix)?;
+        (entry.src == *data).then_some(&entry.inst)
+    }
+
+    /// Replay a [`remove_nodes`](crate::ops::remove_nodes) reindex onto the
+    /// cache keys: removed nodes' entries are dropped and swapped nodes'
+    /// entries follow them to their new index, mirroring
+    /// [`Reindex::apply_to_index`](crate::ops::Reindex::apply_to_index).
+    pub fn apply_reindex(&mut self, reindex: &crate::ops::Reindex) {
+        for op in &reindex.0 {
+            self.entries.remove(&op.removed);
+            if let Some(from) = op.moved_from {
+                if let Some(entry) = self.entries.remove(&from) {
+                    self.entries.insert(op.removed, entry);
+                }
+            }
+        }
+    }
+
+    /// Drop all entries. The next pass reifies every node fresh - use when
+    /// the whole graph is replaced (e.g. head checkout) to bound memory.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    /// The number of cached entries.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the cache holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ops::{Reindex, RemoveOp};
+
+    fn codec() -> NodeCodec {
+        crate::test_node::codec()
+    }
+
+    fn expr_data(src: &str) -> NodeData {
+        gantz_core::data::erase_node_typed(&gantz_core::node::Expr::new(src).unwrap()).unwrap()
+    }
+
+    /// The cached instance's heap address - stable across `Box` moves, so it
+    /// witnesses whether a take returned the same instance or a fresh one.
+    fn inst_ptr(entry: &InstanceEntry) -> *const () {
+        &*entry.inst.node as *const dyn crate::NodeUi as *const ()
+    }
+
+    // A take after a put with an equal witness returns the same instance.
+    #[test]
+    fn take_hits_on_equal_data() {
+        let codec = codec();
+        let data = expr_data("(+ $l $r)");
+        let mut cache = NodeInstances::default();
+        let entry = cache.take(&codec, 0, &data).unwrap();
+        let ptr = inst_ptr(&entry);
+        cache.put(0, entry);
+        let entry = cache.take(&codec, 0, &data).unwrap();
+        assert_eq!(inst_ptr(&entry), ptr);
+        // The instance still erases back to the witness.
+        assert_eq!(entry.inst.erase().unwrap(), data);
+    }
+
+    // A differing weight reifies fresh and drops the stale entry.
+    #[test]
+    fn take_misses_on_changed_data() {
+        let codec = codec();
+        let old = expr_data("(+ $l $r)");
+        let new = expr_data("(* $l $r)");
+        let mut cache = NodeInstances::default();
+        let entry = cache.take(&codec, 0, &old).unwrap();
+        cache.put(0, entry);
+        // Simulates any external mutation (undo, paste, collab, checkout):
+        // the stored weight changed out-of-band, no hooks involved. The
+        // fresh reify is witnessed semantically (the dropped stale box's
+        // address may be reused, so pointer inequality would be flaky).
+        let entry = cache.take(&codec, 0, &new).unwrap();
+        assert_eq!(entry.inst.erase().unwrap(), new);
+        assert_eq!(entry.src, new);
+        cache.put(0, entry);
+        assert_eq!(cache.len(), 1);
+    }
+
+    // An unknown tag fails without retaining anything; the slot still works
+    // for a later known tag.
+    #[test]
+    fn take_err_retains_nothing() {
+        let codec = codec();
+        let mut unknown = expr_data("(+ $l $r)");
+        unknown.tag = "NotInTheManifest".to_string();
+        let mut cache = NodeInstances::default();
+        assert!(cache.take(&codec, 0, &unknown).is_err());
+        assert!(cache.is_empty());
+        let known = expr_data("(+ $l $r)");
+        let entry = cache.take(&codec, 0, &known).unwrap();
+        cache.put(0, entry);
+        assert_eq!(cache.len(), 1);
+    }
+
+    // An unknown tag's failure also evicts a stale entry for that slot.
+    #[test]
+    fn take_err_drops_stale_entry() {
+        let codec = codec();
+        let known = expr_data("(+ $l $r)");
+        let mut cache = NodeInstances::default();
+        let entry = cache.take(&codec, 0, &known).unwrap();
+        cache.put(0, entry);
+        let mut unknown = expr_data("(+ $l $r)");
+        unknown.tag = "NotInTheManifest".to_string();
+        assert!(cache.take(&codec, 0, &unknown).is_err());
+        assert!(cache.is_empty());
+    }
+
+    // The edit path: erase to new data, update the witness, put. The entry
+    // then hits on the new data and misses on the old.
+    #[test]
+    fn edit_updates_witness() {
+        let codec = codec();
+        let old = expr_data("(+ $l $r)");
+        let new = expr_data("(* $l $r)");
+        let mut cache = NodeInstances::default();
+        let mut entry = cache.take(&codec, 0, &old).unwrap();
+        // Stand-in for an in-place UI edit of the instance.
+        entry.inst = codec.reify_ui(&new).unwrap();
+        entry.src = entry.inst.erase().unwrap();
+        let ptr = inst_ptr(&entry);
+        cache.put(0, entry);
+        // Hits on the new data with the same instance.
+        let entry = cache.take(&codec, 0, &new).unwrap();
+        assert_eq!(inst_ptr(&entry), ptr);
+        cache.put(0, entry);
+        // Misses on the old data: the fresh reify erases back to `old`,
+        // whereas the (now dropped) cached instance would have erased to
+        // `new`. Pointer inequality would be flaky under allocator reuse.
+        let entry = cache.take(&codec, 0, &old).unwrap();
+        assert_eq!(entry.inst.erase().unwrap(), old);
+    }
+
+    // `peek` hits only on a valid witness and never mutates the cache.
+    #[test]
+    fn peek_checks_witness() {
+        let codec = codec();
+        let data = expr_data("(+ $l $r)");
+        let other = expr_data("(* $l $r)");
+        let mut cache = NodeInstances::default();
+        assert!(cache.peek(0, &data).is_none());
+        let entry = cache.take(&codec, 0, &data).unwrap();
+        cache.put(0, entry);
+        assert!(cache.peek(0, &data).is_some());
+        assert!(cache.peek(0, &other).is_none());
+        assert!(cache.peek(1, &data).is_none());
+        assert_eq!(cache.len(), 1);
+    }
+
+    // Reindex replay: the removed slot's entry is dropped and the swapped
+    // node's entry follows it down, consistent with `Reindex::apply_to_index`.
+    #[test]
+    fn apply_reindex_migrates_entries() {
+        let codec = codec();
+        let datas: Vec<_> = ["(+ $l $r)", "(* $l $r)", "(- $l $r)"]
+            .iter()
+            .map(|s| expr_data(s))
+            .collect();
+        let mut cache = NodeInstances::default();
+        let mut ptrs = vec![];
+        for (i, d) in datas.iter().enumerate() {
+            let entry = cache.take(&codec, i, d).unwrap();
+            ptrs.push(inst_ptr(&entry));
+            cache.put(i, entry);
+        }
+        // Remove index 1 from a 3-node graph: node 2 swaps down into slot 1.
+        let reindex = Reindex(vec![RemoveOp {
+            removed: 1,
+            moved_from: Some(2),
+        }]);
+        cache.apply_reindex(&reindex);
+        assert_eq!(cache.len(), 2);
+        assert_eq!(reindex.apply_to_index(2), Some(1));
+        // Slot 1 now hits on node 2's data with node 2's instance.
+        let entry = cache.take(&codec, 1, &datas[2]).unwrap();
+        assert_eq!(inst_ptr(&entry), ptrs[2]);
+        cache.put(1, entry);
+        // Slot 0 is untouched, slot 2 is gone.
+        assert!(cache.peek(0, &datas[0]).is_some());
+        assert!(cache.peek(2, &datas[2]).is_none());
+    }
+
+    #[test]
+    fn clear_empties() {
+        let codec = codec();
+        let data = expr_data("(+ $l $r)");
+        let mut cache = NodeInstances::default();
+        let entry = cache.take(&codec, 0, &data).unwrap();
+        cache.put(0, entry);
+        assert!(!cache.is_empty());
+        cache.clear();
+        assert!(cache.is_empty());
+        assert_eq!(cache.len(), 0);
+    }
+}

--- a/crates/gantz_egui/src/ops.rs
+++ b/crates/gantz_egui/src/ops.rs
@@ -269,8 +269,8 @@ impl Reindex {
     }
 }
 
-/// Remove `nodes` from `graph`, migrating the per-node state, layout and
-/// selection that are keyed by node index.
+/// Remove `nodes` from `graph`, migrating the per-node state, layout,
+/// selection and cached instances that are keyed by node index.
 ///
 /// `petgraph::Graph::remove_node` swap-removes: the former-last node adopts the
 /// removed index, so exactly one surviving node changes index per removal.
@@ -291,6 +291,7 @@ pub fn remove_nodes(
     vm: &mut Engine,
     layout: &mut egui_graph::Layout,
     selection: &mut crate::widget::graph_scene::Selection,
+    instances: &mut crate::node::NodeInstances,
     nodes: impl IntoIterator<Item = NodeIndex>,
 ) -> Reindex {
     let node_id = |ix: usize| egui_graph::NodeId::from_u64(ix as u64);
@@ -327,7 +328,9 @@ pub fn remove_nodes(
     if !ops.is_empty() {
         selection.edges.clear();
     }
-    Reindex(ops)
+    let reindex = Reindex(ops);
+    instances.apply_reindex(&reindex);
+    reindex
 }
 
 /// Cut: serialize `nodes` to a `.gantz` clipboard payload, then remove them.
@@ -342,6 +345,7 @@ pub fn cut_nodes(
     vm: &mut Engine,
     head_view: &mut crate::SceneView,
     selection: &mut crate::widget::graph_scene::Selection,
+    instances: &mut crate::node::NodeInstances,
     nodes: &HashSet<NodeIndex>,
     codec: &NodeCodec,
 ) -> Option<String> {
@@ -351,6 +355,7 @@ pub fn cut_nodes(
         vm,
         &mut head_view.layout,
         selection,
+        instances,
         nodes.iter().copied(),
     );
     Some(text)
@@ -800,12 +805,31 @@ mod tests {
 
         let mut vm = Engine::new_base();
 
+        // Seed a cache entry per node so the instance migration is exercised
+        // too. The entries' weights are stand-ins (the `nd` weights aren't in
+        // the test codec's manifest); `apply_reindex` migrates by key alone.
+        let codec = crate::test_node::codec();
+        let mut instances = crate::node::NodeInstances::default();
+        let datas: Vec<_> = (0..5)
+            .map(|i| {
+                gantz_core::data::erase_node_typed(
+                    &gantz_core::node::Expr::new(format!("(+ $l {i})")).unwrap(),
+                )
+                .unwrap()
+            })
+            .collect();
+        for (i, d) in datas.iter().enumerate() {
+            let entry = instances.take(&codec, i, d).unwrap();
+            instances.put(i, entry);
+        }
+
         // Delete index 1: node 4 (weight 14) swap-removes into slot 1.
         let reindex = remove_nodes(
             &mut graph,
             &mut vm,
             &mut layout,
             &mut selection,
+            &mut instances,
             [NodeIx::new(1)],
         );
         assert!(!reindex.is_empty());
@@ -828,6 +852,13 @@ mod tests {
             selection.nodes.iter().copied().collect::<Vec<_>>(),
             vec![NodeIx::new(1)],
         );
+
+        // Cached instances followed the swap: node 4's entry now lives at
+        // index 1, the deleted and old-last slots are gone.
+        assert_eq!(instances.len(), 4);
+        assert!(instances.peek(1, &datas[4]).is_some());
+        assert!(instances.peek(1, &datas[1]).is_none());
+        assert!(instances.peek(4, &datas[4]).is_none());
     }
 
     // carry_layout maps live positions through the navigation matching, keeps

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -1494,7 +1494,13 @@ where
                 reindexes: &mut gantz_response.node_view_reindexes,
                 base_names,
                 base_immutable: gantz.base_immutable,
-                validate_change_tracking: gantz.validate_change_tracking.unwrap_or(false),
+                // With the instance cache, an unmarked weight mutation
+                // persists in the cached instance instead of visibly
+                // reverting next pass, so debug builds default the validator
+                // on to keep the contract violation loud.
+                validate_change_tracking: gantz
+                    .validate_change_tracking
+                    .unwrap_or(cfg!(debug_assertions)),
                 ext_panes: &ext_panes,
                 edge_styles: gantz.edge_styles,
             };
@@ -2212,6 +2218,7 @@ where
                 self.env,
                 self.codec,
                 data.graph,
+                data.instances,
                 pane_head,
                 head_state,
                 view_toggles,
@@ -3178,6 +3185,7 @@ fn graph_scene(
     registry: &Env<'_>,
     codec: &NodeCodec,
     graph: &mut gantz_ca::DataGraph,
+    instances: &mut crate::node::NodeInstances,
     head: &gantz_ca::Head,
     head_state: &mut OpenHeadState,
     view_toggles: &mut ViewToggles,
@@ -3222,7 +3230,7 @@ fn graph_scene(
         };
     }
 
-    let response = GraphScene::new(registry, codec, graph)
+    let response = GraphScene::new(registry, codec, graph, instances)
         .with_id(id)
         .layout_params(layout_params)
         .scene_config(scene_config)

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -804,6 +804,10 @@ impl<'a> Gantz<'a> {
     /// Provide the current change-tracking validation state so the Settings >
     /// Global pane shows its toggle. A change is reported via
     /// [`GantzResponse::validate_change_tracking`].
+    ///
+    /// When not provided, validation defaults on in debug builds (the node
+    /// instance cache would otherwise mask a missed `changed` flag) and off
+    /// in release.
     pub fn validate_change_tracking(mut self, enabled: bool) -> Self {
         self.validate_change_tracking = Some(enabled);
         self
@@ -3467,9 +3471,8 @@ fn node_inspector<'a>(
                         let path = [ix];
                         let ctx =
                             NodeCtx::new(registry, &path[..], &inlets, &outlets, ref_ext_uis, vm);
-                        let resp =
-                            widget::NodeInspector::new(&mut entry.inst.node, ctx, immutable)
-                                .show(ui);
+                        let resp = widget::NodeInspector::new(&mut entry.inst.node, ctx, immutable)
+                            .show(ui);
                         if resp.changed {
                             changed = true;
                             match entry.inst.erase() {

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -1711,6 +1711,7 @@ where
                         gantz.env,
                         codec,
                         data.graph,
+                        data.instances,
                         data.vm,
                         head_state,
                         &fh,
@@ -1745,8 +1746,12 @@ where
                     };
                     data.graph
                         .node_weight(graph_scene::NodeIndex::new(ix))
-                        .and_then(|w| codec.reify_ui(w).ok())
-                        .is_some_and(|inst| inst.node.view_no_margin())
+                        .is_some_and(|w| match data.instances.peek(ix, w) {
+                            Some(inst) => inst.node.view_no_margin(),
+                            None => codec
+                                .reify_ui(w)
+                                .is_ok_and(|inst| inst.node.view_no_margin()),
+                        })
                 })
                 .unwrap_or(false);
             let mut frame = egui::Frame::central_panel(ui.style());
@@ -1774,18 +1779,28 @@ where
                                 let (inlets, outlets) = crate::inlet_outlet_ids(env, data.graph);
                                 let n_id = graph_scene::NodeIndex::new(n_ix);
                                 let weight = data.graph.node_weight(n_id)?;
-                                // Reify the one node; erase back iff changed.
-                                let mut inst = codec.reify_ui(weight).ok()?;
+                                // Take the one node's cached instance (see
+                                // `graph_scene::nodes` - panes render
+                                // sequentially, so each take/put pair
+                                // completes within its site); erase back iff
+                                // changed, updating the witness.
+                                let mut entry = data.instances.take(codec, n_ix, weight).ok()?;
                                 let ctx = NodeCtx::new(env, &path, &inlets, &outlets, &[], data.vm);
-                                let r = inst.node.view_ui(ctx, ui);
+                                let r = entry.inst.node.view_ui(ctx, ui);
                                 if r.changed {
-                                    match inst.erase() {
-                                        Ok(node_data) => data.graph[n_id] = node_data,
+                                    match entry.inst.erase() {
+                                        Ok(node_data) => {
+                                            entry.src = node_data.clone();
+                                            data.graph[n_id] = node_data;
+                                            data.instances.put(n_ix, entry);
+                                        }
                                         Err(e) => log::error!(
                                             "node view {n_ix}: failed to erase edited node, \
                                              edit dropped: {e}"
                                         ),
                                     }
+                                } else {
+                                    data.instances.put(n_ix, entry);
                                 }
                                 Some((r.changed, r.payloads))
                             })
@@ -3410,6 +3425,7 @@ fn node_inspector<'a>(
     registry: &'a Env<'a>,
     codec: &NodeCodec,
     root: &mut gantz_ca::DataGraph,
+    instances: &mut crate::node::NodeInstances,
     vm: &mut Engine,
     head_state: &mut OpenHeadState,
     head: &gantz_ca::Head,
@@ -3439,27 +3455,36 @@ fn node_inspector<'a>(
                         let Some(weight) = graph.node_weight(id) else {
                             return;
                         };
-                        // Reify the one node; erase back below iff changed. An
-                        // unknown tag shows a weak placeholder row.
-                        let Ok(mut inst) = codec.reify_ui(weight) else {
+                        let ix = id.index();
+                        // Take the node's cached instance (see
+                        // `graph_scene::nodes`); erase back below iff changed,
+                        // updating the witness. An unknown tag shows a weak
+                        // placeholder row.
+                        let Ok(mut entry) = instances.take(codec, ix, weight) else {
                             ui.weak(format!("{} (unknown node type)", weight.tag));
                             return;
                         };
-                        let ix = id.index();
                         let path = [ix];
                         let ctx =
                             NodeCtx::new(registry, &path[..], &inlets, &outlets, ref_ext_uis, vm);
                         let resp =
-                            widget::NodeInspector::new(&mut inst.node, ctx, immutable).show(ui);
+                            widget::NodeInspector::new(&mut entry.inst.node, ctx, immutable)
+                                .show(ui);
                         if resp.changed {
                             changed = true;
-                            match inst.erase() {
-                                Ok(node_data) => graph[id] = node_data,
+                            match entry.inst.erase() {
+                                Ok(node_data) => {
+                                    entry.src = node_data.clone();
+                                    graph[id] = node_data;
+                                    instances.put(ix, entry);
+                                }
                                 Err(e) => log::error!(
                                     "inspector: failed to erase edited node {ix}, \
                                      edit dropped: {e}"
                                 ),
                             }
+                        } else {
+                            instances.put(ix, entry);
                         }
                         responses.extend(resp.payloads);
                         if resp.label_response.clicked() {

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -361,6 +361,7 @@ impl<'a> GraphScene<'a> {
             vm,
             &mut view.layout,
             &mut state.interaction.selection,
+            self.instances,
             to_delete,
         );
         if !reindex.is_empty() {

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -840,14 +840,14 @@ fn nodes(
                 // reifying transiently on a miss (e.g. this node's own entry,
                 // taken out for the duration of the iteration).
                 let stateful = target.iter().any(|&n| {
-                    graph.node_weight(n).is_some_and(|w| {
-                        match instances_ref.peek(n.index(), w) {
+                    graph
+                        .node_weight(n)
+                        .is_some_and(|w| match instances_ref.peek(n.index(), w) {
                             Some(inst) => inst.node.stateful(meta_ctx),
                             None => codec
                                 .reify_ui(w)
                                 .is_ok_and(|inst| inst.node.stateful(meta_ctx)),
-                        }
-                    })
+                        })
                 });
                 let reset_btn = ui.add_enabled(stateful, egui::Button::new("reset"));
                 if reset_btn

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -56,7 +56,7 @@ pub type NodeIndex = petgraph::graph::NodeIndex<usize>;
 /// gantz graph.
 ///
 /// Operates on the graph's stored data form: each node weight is reified to
-/// a typed [`crate::node::UiNodeInstance`] through the `codec` for the
+/// a typed [`crate::node::NodeUiInstance`] through the `codec` for the
 /// duration of its UI pass and erased back only when a response marks a
 /// CA-affecting change. Weights whose tag is unknown to the codec render as
 /// opaque placeholders whose data round-trips untouched.

--- a/crates/gantz_egui/src/widget/graph_scene.rs
+++ b/crates/gantz_egui/src/widget/graph_scene.rs
@@ -1,6 +1,8 @@
 use crate::{
     CopyNodes, Env, InspectEdge, NodeUi, OpenHead, OpenNodePalette, OpenNodeView, Paste, PastePos,
-    ResetTilesLayout, SocketDoc, node::NodeCodec, response::DynResponse,
+    ResetTilesLayout, SocketDoc,
+    node::{NodeCodec, NodeInstances},
+    response::DynResponse,
 };
 use egui::emath::GuiRounding;
 use egui_graph::{self, SocketKind, node::EdgeEvent};
@@ -58,12 +60,15 @@ pub type NodeIndex = petgraph::graph::NodeIndex<usize>;
 /// Operates on the graph's stored data form: each node weight is reified to
 /// a typed [`crate::node::NodeUiInstance`] through the `codec` for the
 /// duration of its UI pass and erased back only when a response marks a
-/// CA-affecting change. Weights whose tag is unknown to the codec render as
-/// opaque placeholders whose data round-trips untouched.
+/// CA-affecting change. Instances are retained between passes in the head's
+/// [`NodeInstances`] cache, so a steady-state pass pays an equality check
+/// per node rather than a reify. Weights whose tag is unknown to the codec
+/// render as opaque placeholders whose data round-trips untouched.
 pub struct GraphScene<'a> {
     registry: &'a Env<'a>,
     codec: &'a NodeCodec,
     graph: &'a mut DataGraph,
+    instances: &'a mut NodeInstances,
     id: egui::Id,
     layout_params: egui_graph::LayoutParams,
     /// Global dot-grid, snapping and snap-align options, applied to the
@@ -129,12 +134,18 @@ pub struct Selection {
 
 impl<'a> GraphScene<'a> {
     /// Create a graph scene for the given graph (a head's root graph; nested
-    /// graphs are separate heads).
-    pub fn new(registry: &'a Env<'a>, codec: &'a NodeCodec, graph: &'a mut DataGraph) -> Self {
+    /// graphs are separate heads) and its cache of reified node instances.
+    pub fn new(
+        registry: &'a Env<'a>,
+        codec: &'a NodeCodec,
+        graph: &'a mut DataGraph,
+        instances: &'a mut NodeInstances,
+    ) -> Self {
         Self {
             registry,
             codec,
             graph,
+            instances,
             id: egui::Id::new("gantz-graph-scene"),
             layout_params: egui_graph::LayoutParams::new(egui::Direction::TopDown),
             scene_config: Default::default(),
@@ -308,6 +319,7 @@ impl<'a> GraphScene<'a> {
                         self.registry,
                         self.codec,
                         self.graph,
+                        self.instances,
                         nctx,
                         state,
                         &mut responses,
@@ -648,6 +660,7 @@ fn nodes(
     registry: &Env<'_>,
     codec: &NodeCodec,
     graph: &mut DataGraph,
+    instances: &mut NodeInstances,
     nctx: &mut egui_graph::NodesCtx,
     state: &mut GraphSceneState,
     responses: &mut Vec<DynResponse>,
@@ -670,15 +683,17 @@ fn nodes(
     for n_id in node_ids {
         let n_ix = graph.to_index(n_id);
         let node_id = egui_graph::NodeId::from_u64(n_ix as u64);
-        // Reify once at the top of the iteration. An unknown tag renders as
-        // an opaque placeholder whose weight round-trips untouched -
-        // selection, movement, deletion and edge edits still work.
-        let mut instance = codec.reify_ui(&graph[n_id]).ok();
+        // Take the node's cached instance (or reify fresh when the stored
+        // weight differs from the cache entry's witness) for the duration of
+        // the iteration. An unknown tag renders as an opaque placeholder
+        // whose weight round-trips untouched - selection, movement, deletion
+        // and edge edits still work.
+        let mut instance = instances.take(codec, n_ix, &graph[n_id]).ok();
         let (inputs, outputs, flow) = match &instance {
-            Some(inst) => (
-                inst.node.n_inputs(meta_ctx),
-                inst.node.n_outputs(meta_ctx),
-                inst.node.flow(registry),
+            Some(entry) => (
+                entry.inst.node.n_inputs(meta_ctx),
+                entry.inst.node.n_outputs(meta_ctx),
+                entry.inst.node.flow(registry),
             ),
             None => {
                 let (inputs, outputs) = placeholder_socket_counts(graph, n_id);
@@ -694,13 +709,13 @@ fn nodes(
             .flow(flow)
             .max_width(f32::INFINITY)
             .show(nctx, ui, |nui_ctx| match instance.as_mut() {
-                Some(inst) => {
+                Some(entry) => {
                     // A node at this (root) level has the single-element state
                     // path `[n_ix]`.
                     let node_path = [n_ix];
                     let node_ctx =
                         crate::NodeCtx::new(registry, &node_path, &inlets, &outlets, &[], vm);
-                    let r = inst.node.ui(node_ctx, nui_ctx);
+                    let r = entry.inst.node.ui(node_ctx, nui_ctx);
                     node_changed |= r.changed;
                     responses.extend(r.payloads);
                     r.framed
@@ -711,14 +726,14 @@ fn nodes(
         // Attach on-hover docs to each socket. Each node describes its own
         // sockets (markers read their stored docs; references resolve the
         // referenced graph's marker docs via the registry).
-        if let Some(inst) = &instance {
+        if let Some(entry) = &instance {
             for (ix, sock) in response.sockets().inputs() {
-                if let Some(doc) = inst.node.socket_doc(registry, SocketKind::Input, ix) {
+                if let Some(doc) = entry.inst.node.socket_doc(registry, SocketKind::Input, ix) {
                     socket_hover(sock, &doc);
                 }
             }
             for (ix, sock) in response.sockets().outputs() {
-                if let Some(doc) = inst.node.socket_doc(registry, SocketKind::Output, ix) {
+                if let Some(doc) = entry.inst.node.socket_doc(registry, SocketKind::Output, ix) {
                     socket_hover(sock, &doc);
                 }
             }
@@ -758,7 +773,10 @@ fn nodes(
             }
         }
 
-        // Node context menu.
+        // Node context menu. Reborrowed shared so the stateful probe below
+        // can peek other nodes' cached instances (the mutable uses - take
+        // above, put below - sit outside this borrow).
+        let instances_ref: &NodeInstances = instances;
         response.context_menu(|ui| {
             let selected = &state.interaction.selection.nodes;
             let target: HashSet<NodeIndex> = if selected.contains(&n_id) {
@@ -773,9 +791,9 @@ fn nodes(
                 responses.push(DynResponse::new(CopyNodes(target.clone())));
                 ui.close();
             }
-            if let Some(inst) = &instance {
+            if let Some(entry) = &instance {
                 // Demo graph, if the node has one.
-                let demo_name = inst.node.demo_graph(registry);
+                let demo_name = entry.inst.node.demo_graph(registry);
                 let demo_btn = ui.add_enabled(demo_name.is_some(), egui::Button::new("demo"));
                 if let Some(name) = demo_name {
                     if demo_btn.on_hover_text(format!("opens {name}")).clicked() {
@@ -788,7 +806,7 @@ fn nodes(
                     demo_btn.on_disabled_hover_text("no associated demo");
                 }
                 // "open in new tab" for nodes that reference a named graph.
-                if let Some(head) = inst.node.nav_head(registry) {
+                if let Some(head) = entry.inst.node.nav_head(registry) {
                     if ui
                         .button("open tab")
                         .on_hover_text("open the referenced graph in a new tab")
@@ -807,7 +825,7 @@ fn nodes(
                     .on_hover_text("open this node's view in the Node Views pane")
                     .clicked()
                 {
-                    let ty_name = inst.node.name(registry).to_string();
+                    let ty_name = entry.inst.node.name(registry).to_string();
                     responses.push(DynResponse::new(OpenNodeView {
                         path: vec![n_ix],
                         ty_name,
@@ -816,13 +834,18 @@ fn nodes(
                 }
             }
             if !immutable {
-                // The reset target may include other selected nodes; reify
-                // each transiently to ask whether any is stateful.
+                // The reset target may include other selected nodes; peek
+                // each one's cached instance to ask whether any is stateful,
+                // reifying transiently on a miss (e.g. this node's own entry,
+                // taken out for the duration of the iteration).
                 let stateful = target.iter().any(|&n| {
                     graph.node_weight(n).is_some_and(|w| {
-                        codec
-                            .reify_ui(w)
-                            .is_ok_and(|inst| inst.node.stateful(meta_ctx))
+                        match instances_ref.peek(n.index(), w) {
+                            Some(inst) => inst.node.stateful(meta_ctx),
+                            None => codec
+                                .reify_ui(w)
+                                .is_ok_and(|inst| inst.node.stateful(meta_ctx)),
+                        }
                     })
                 });
                 let reset_btn = ui.add_enabled(stateful, egui::Button::new("reset"));
@@ -880,32 +903,43 @@ fn nodes(
                 }
             }
             // Node-specific items (e.g. the log node's "open logs").
-            if let Some(inst) = instance.as_mut() {
+            if let Some(entry) = instance.as_mut() {
                 let node_path = [n_ix];
                 let mut node_ctx =
                     crate::NodeCtx::new(registry, &node_path, &inlets, &outlets, &[], vm);
-                let cm = inst.node.context_menu(&mut node_ctx, ui);
+                let cm = entry.inst.node.context_menu(&mut node_ctx, ui);
                 node_changed |= cm.changed;
                 responses.extend(cm.payloads);
             }
         });
 
-        // Erase the instance back into the weight iff a response marked a
-        // CA-affecting change (the commit signal - see `NodeUi`). Unchanged
-        // instances drop: non-CA state lives in VM/egui memory by contract.
-        if let Some(inst) = &instance {
+        // Return the instance to the cache, erasing it back into the weight
+        // iff a response marked a CA-affecting change (the commit signal -
+        // see `NodeUi`). The entry's witness is updated in the same breath,
+        // so the cache hits exactly while the stored weight is untouched.
+        // Non-CA state lives in VM/egui memory by contract.
+        if let Some(mut entry) = instance {
             if node_changed {
                 *changed = true;
-                match inst.erase() {
-                    Ok(node_data) => graph[n_id] = node_data,
+                match entry.inst.erase() {
+                    Ok(node_data) => {
+                        entry.src = node_data.clone();
+                        graph[n_id] = node_data;
+                        instances.put(n_ix, entry);
+                    }
                     Err(e) => {
+                        // Dropping the entry restores the uncached semantics:
+                        // the edit is lost and the next pass reifies from the
+                        // unchanged stored weight.
                         log::error!("node {n_ix}: failed to erase edited node, edit dropped: {e}");
                     }
                 }
             } else if validate {
                 // Change-tracking validator: an unmarked weight mutation
-                // would silently drop with the instance - make it loud.
-                match inst.erase() {
+                // would otherwise persist invisibly in the cached instance -
+                // make it loud, and evict so the mutation drops exactly as
+                // it would uncached.
+                match entry.inst.erase() {
                     Ok(node_data) => {
                         if node_data.content_addr() != graph[n_id].content_addr() {
                             log::warn!(
@@ -913,12 +947,16 @@ fn nodes(
                                  `changed` response; the edit was dropped (see `NodeUi`)",
                                 graph[n_id].tag,
                             );
+                        } else {
+                            instances.put(n_ix, entry);
                         }
                     }
                     Err(e) => {
                         log::warn!("node {n_ix}: change-tracking validation failed to erase: {e}");
                     }
                 }
+            } else {
+                instances.put(n_ix, entry);
             }
         }
 


### PR DESCRIPTION
Follow-up to #341.

The editor was reifying every node in every visible graph pane on every frame (a datum clone, a serde decode and a box allocation per node), then dropping the instance unused. This was the documented deferred escape hatch in the editor data model design ("reify per pass, seam allows a cache later"). This PR adds that cache.

## Approach

Each open head now carries a `NodeInstances` cache (`gantz_egui::node::instance_cache`), keyed by node index. Each entry pairs the reified `NodeUiInstance` with the `NodeData` it was reified from, which acts as a validity witness. A pass takes the entry for each node, reuses it when the stored weight equals the witness and reifies fresh otherwise, then puts it back with the witness updated on erase-back.

Because instances are pure functions of their `NodeData` (all non-CA state lives in the VM or egui memory by the `NodeUi` contract), witness equality makes the cache self-heal against every external graph mutation (undo, paste, collab edits, checkout) with no hooks in those systems. Steady-state frames pay one structural equality check per visible node instead of a reify.

A per-node-index cache was chosen over a shared content-addr pool (like `UiBuiltins`) because `NodeUi::ui` takes `&mut self`. Same-addr nodes would alias a shared entry, and a contract-violating transient mutation would corrupt every node sharing the address.

## Changes

- `UiNodeInstance` renamed to `NodeUiInstance`, aligning with the `NodeUi` trait.
- New `gantz_egui::node::NodeInstances` with `take`/`put`/`peek`/`apply_reindex`, plus unit tests covering hit identity, stale misses, unknown tags, edit commits, external-mutation self-healing and reindex migration.
- `HeadDataMut` gains an `instances` field. The bevy adapter stores it as a `HeadNodeInstances` component (reset on head navigation to bound memory, dropped with the entity on close). The demo example keeps a parallel `Vec`.
- The `graph_scene` hot loop, NodeView panes and node inspector take/put through the cache. The context-menu stateful probe and the no-margin probe use read-only `peek` with a transient-reify fallback. One-shot paths (layout socket counts, reset re-register, palette, log labels) stay transient.
- `remove_nodes`/`cut_nodes` replay their `Reindex` onto the cache keys, matching the existing state/layout/selection migration.
- On an erase failure, or when the change-tracking validator detects an unmarked mutation, the entry is evicted, restoring the uncached drop-the-edit semantics exactly.

## Behavioural note

Change-tracking validation now defaults on in debug builds (the widget fallback and `bevy_gantz::ValidateCommitted`'s default). With the cache, a node that mutates CA-affecting state without flagging `changed` would persist visually instead of reverting next frame, so debug builds keep that contract violation loud. Release builds are unchanged (off), and the setting remains toggleable at runtime.