### PR TITLE
fix(egui,app)!: session-restored heads missed the instance cache component

### DIFF
--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -221,7 +221,13 @@ fn clear_ui_providers(
 pub struct HeadGuiState(pub gantz_egui::widget::gantz::OpenHeadState);
 
 /// Views for a single head's graphs (keyed by subgraph path).
+///
+/// Requires the rest of the per-head GUI state so every spawn path (including
+/// app-side session restore, which bypasses the [`on_head_opened`] observer)
+/// gets the full trio: the `OpenHeadViews` query silently skips entities
+/// missing any of them.
 #[derive(Component, Default, Clone)]
+#[require(HeadGuiState, HeadNodeInstances)]
 pub struct GraphView(pub gantz_egui::SceneView);
 
 /// Per-head cache of reified node instances for the working graph.
@@ -473,10 +479,19 @@ impl<'q, 'w, 's> HeadAccess<'q, 'w, 's> {
         let mut head_to_entity = HashMap::new();
 
         for &entity in tab_order.iter() {
-            if let Ok(data) = query.get(entity) {
-                let head: ca::Head = (**data.core.head_ref).clone();
-                heads.push(head.clone());
-                head_to_entity.insert(head, entity);
+            match query.get(entity) {
+                Ok(data) => {
+                    let head: ca::Head = (**data.core.head_ref).clone();
+                    heads.push(head.clone());
+                    head_to_entity.insert(head, entity);
+                }
+                // A tab-order entity outside the query means a spawn path
+                // missed one of the per-head GUI components. Dropping it here
+                // would hide the head from the UI (no tab, blank panes) while
+                // its VM keeps running - make it loud instead.
+                Err(e) => {
+                    log::error!("open head {entity} missing from the views query: {e}");
+                }
             }
         }
 

--- a/crates/gantz/src/main.rs
+++ b/crates/gantz/src/main.rs
@@ -8,7 +8,7 @@ use bevy_gantz::{
     debounced_input::{DebouncedInputEvent, DebouncedInputPlugin},
     timestamp,
 };
-use bevy_gantz_egui::{BuiltinNodes, GantzEguiPlugin, HeadGuiState, TraceCapture};
+use bevy_gantz_egui::{BuiltinNodes, GantzEguiPlugin, TraceCapture};
 use bevy_pkv::PkvStore;
 use storage::Pkv;
 
@@ -129,18 +129,12 @@ fn setup_open(
     let focused_head = bevy_gantz::storage::load_focused_head(&*storage);
 
     // Spawn entities for each open head. `OpenHead`'s required components
-    // cover the compile outcome; `vm::sync` initializes the VMs on the first
-    // `Update`.
+    // cover the compile outcome, `GraphView`'s the rest of the per-head GUI
+    // state. `vm::sync` initializes the VMs on the first `Update`.
     for (head, graph, head_view) in loaded {
         let is_focused = focused_head.as_ref() == Some(&head);
         let entity = cmds
-            .spawn((
-                OpenHead,
-                HeadRef(head),
-                WorkingGraph(graph),
-                head_view,
-                HeadGuiState::default(),
-            ))
+            .spawn((OpenHead, HeadRef(head), WorkingGraph(graph), head_view))
             .id();
 
         tab_order.push(entity);

--- a/crates/gantz/src/main_update_base.rs
+++ b/crates/gantz/src/main_update_base.rs
@@ -15,7 +15,7 @@ use bevy_gantz::{
     debounced_input::{DebouncedInputEvent, DebouncedInputPlugin},
     timestamp,
 };
-use bevy_gantz_egui::{BuiltinNodes, GantzEguiPlugin, GuiState, HeadGuiState, TraceCapture};
+use bevy_gantz_egui::{BuiltinNodes, GantzEguiPlugin, GuiState, TraceCapture};
 use bevy_pkv::PkvStore;
 use storage::Pkv;
 
@@ -124,18 +124,13 @@ fn setup_open(
     let loaded = bevy_gantz_egui::storage::load_open(&*storage, &mut *registry, timestamp());
     let focused_head = bevy_gantz::storage::load_focused_head(&*storage);
 
-    // `OpenHead`'s required components cover the compile outcome; `vm::sync`
-    // initializes the VMs on the first `Update`.
+    // `OpenHead`'s required components cover the compile outcome, `GraphView`'s
+    // the rest of the per-head GUI state. `vm::sync` initializes the VMs on
+    // the first `Update`.
     for (head, graph, head_view) in loaded {
         let is_focused = focused_head.as_ref() == Some(&head);
         let entity = cmds
-            .spawn((
-                OpenHead,
-                HeadRef(head),
-                WorkingGraph(graph),
-                head_view,
-                HeadGuiState::default(),
-            ))
+            .spawn((OpenHead, HeadRef(head), WorkingGraph(graph), head_view))
             .id();
 
         tab_order.push(entity);


### PR DESCRIPTION
The node-instance cache (#342) added `HeadNodeInstances` to the `OpenHeadViews` query, but the component was only inserted by the on_head_opened/on_head_changed observers. The app's session-restore path (setup_open) spawns open-head entities directly without firing `OpenedEvent`, so restored heads lacked the component and Bevy silently dropped them from the query: no tab, blank `GraphScene` and `NodeInspector` panes, opens of an already-restored head appearing to do nothing, and ghost VMs that kept evaluating (audible for DSP heads) with no way to close them from the UI.

Make `HeadNodeInstances` (and `HeadGuiState`) required components of `GraphView`, mirroring `OpenHead`'s required compile-outcome components, so every spawn path that attaches a graph view structurally gets the full per-head GUI trio. Drop the now-redundant explicit `HeadGuiState` insert from the restore paths.

Also log an error in `HeadAccess::new` when a tab-order entity is missing from the views query instead of silently skipping it - the silent drop is what made this failure invisible while the head's VM kept running.