### PR TITLE
Port Rust packages to crane, swap CI cache to cachix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
       - uses: cachix/cachix-action@v17
         with:
           name: mitchmindtree-gantz
-          # Absent on fork PRs: the public cache is still readable, pushes are skipped.
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - uses: Swatinem/rust-cache@v2
       - run: nix ${{ matrix.command }}
@@ -64,7 +63,6 @@ jobs:
       - uses: cachix/cachix-action@v17
         with:
           name: mitchmindtree-gantz
-          # Absent on fork PRs: the public cache is still readable, pushes are skipped.
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix build --print-build-logs .#gantz-website
       - name: Prepare artifact
@@ -90,7 +88,6 @@ jobs:
       - uses: cachix/cachix-action@v17
         with:
           name: mitchmindtree-gantz
-          # Absent on fork PRs: the public cache is still readable, pushes are skipped.
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix build --print-build-logs .#gantz-website
       - uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: cachix/cachix-action@v17
+        with:
+          name: mitchmindtree-gantz
+          # Absent on fork PRs: the public cache is still readable, pushes are skipped.
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - uses: Swatinem/rust-cache@v2
       - run: nix ${{ matrix.command }}
 
@@ -57,7 +61,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: cachix/cachix-action@v17
+        with:
+          name: mitchmindtree-gantz
+          # Absent on fork PRs: the public cache is still readable, pushes are skipped.
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix build --print-build-logs .#gantz-website
       - name: Prepare artifact
         run: |
@@ -79,7 +87,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: cachix/cachix-action@v17
+        with:
+          name: mitchmindtree-gantz
+          # Absent on fork PRs: the public cache is still readable, pushes are skipped.
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix build --print-build-logs .#gantz-website
       - uses: peaceiris/actions-gh-pages@v4
         with:

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1785284101,
+        "narHash": "sha256-ghcXEpYEM4a7pbEkoqbn8c0ptJJqgGzuFiG3T6W5g4I=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "756d6d07c3818ea95d1e2cdac63fa7d02fe3e61b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1781577229,
@@ -18,6 +33,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay",
         "systems": "systems"

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,9 @@
           craneLib = final.gantzCraneLib;
         };
         gantz = final.callPackage ./pkgs/gantz.nix { };
-        gantz-website = final.callPackage ./pkgs/gantz-website.nix { };
+        gantz-website = final.callPackage ./pkgs/gantz-website.nix {
+          craneLib = final.gantzCraneLibWasm;
+        };
         serve-gantz-website = final.callPackage ./pkgs/serve-gantz-website.nix { };
         wasm-bindgen-cli = prev.callPackage ./pkgs/wasm-bindgen-cli.nix { };
         # Nightly wasm toolchain for the AudioWorklet website build: `-Z build-std`

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,9 @@
         # website's `-Z build-std` build.
         gantzCraneLibWasm = final.gantzCraneLib.overrideToolchain (p: p.rustToolchainWasmNightly);
 
-        gantz-unwrapped = prev.callPackage ./pkgs/gantz-unwrapped.nix { };
+        gantz-unwrapped = prev.callPackage ./pkgs/gantz-unwrapped.nix {
+          craneLib = final.gantzCraneLib;
+        };
         gantz = final.callPackage ./pkgs/gantz.nix { };
         gantz-website = final.callPackage ./pkgs/gantz-website.nix { };
         serve-gantz-website = final.callPackage ./pkgs/serve-gantz-website.nix { };

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,6 @@
   description = "An environment for creative systems.";
 
   inputs = {
-    # No `follows` for crane: it has no inputs of its own.
     crane.url = "github:ipetkov/crane";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     rust-overlay = {
@@ -27,12 +26,7 @@
     in
     {
       overlays.default = final: prev: {
-        # crane with nixpkgs' stable rustc: the same toolchain `buildRustPackage`
-        # used, now driving a deps-only artifact derivation so source edits stop
-        # rebuilding the whole dependency closure.
         gantzCraneLib = inputs.crane.mkLib final;
-        # crane with the nightly wasm toolchain (rust-src + wasm32) for the
-        # website's `-Z build-std` build.
         gantzCraneLibWasm = final.gantzCraneLib.overrideToolchain (p: p.rustToolchainWasmNightly);
 
         gantz-unwrapped = prev.callPackage ./pkgs/gantz-unwrapped.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,8 @@
   description = "An environment for creative systems.";
 
   inputs = {
+    # No `follows` for crane: it has no inputs of its own.
+    crane.url = "github:ipetkov/crane";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     rust-overlay = {
       inputs.nixpkgs.follows = "nixpkgs";
@@ -25,6 +27,14 @@
     in
     {
       overlays.default = final: prev: {
+        # crane with nixpkgs' stable rustc: the same toolchain `buildRustPackage`
+        # used, now driving a deps-only artifact derivation so source edits stop
+        # rebuilding the whole dependency closure.
+        gantzCraneLib = inputs.crane.mkLib final;
+        # crane with the nightly wasm toolchain (rust-src + wasm32) for the
+        # website's `-Z build-std` build.
+        gantzCraneLibWasm = final.gantzCraneLib.overrideToolchain (p: p.rustToolchainWasmNightly);
+
         gantz-unwrapped = prev.callPackage ./pkgs/gantz-unwrapped.nix { };
         gantz = final.callPackage ./pkgs/gantz.nix { };
         gantz-website = final.callPackage ./pkgs/gantz-website.nix { };

--- a/pkgs/gantz-unwrapped.nix
+++ b/pkgs/gantz-unwrapped.nix
@@ -10,14 +10,7 @@
   wayland,
 }:
 let
-  root = ../.;
-  src = lib.fileset.toSource {
-    inherit root;
-    fileset = lib.fileset.unions [
-      (craneLib.fileset.commonCargoSources root)
-      (lib.fileset.fileFilter (file: file.hasExt "gantz") root)
-    ];
-  };
+  inherit (import ./workspace-src.nix { inherit craneLib lib; }) src;
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib

--- a/pkgs/gantz-unwrapped.nix
+++ b/pkgs/gantz-unwrapped.nix
@@ -1,7 +1,3 @@
-# Built with crane rather than `buildRustPackage` so that the dependency
-# closure compiles once into a deps-only artifact derivation (`buildDepsOnly`,
-# built against stubbed sources) that survives workspace source edits - only
-# the workspace crates recompile on change.
 {
   alsa-lib,
   craneLib,
@@ -15,9 +11,6 @@
 }:
 let
   root = ../.;
-  # Cargo-relevant files (Cargo.toml/lock, *.rs, *.toml - including
-  # .cargo/config.toml) plus the .gantz assets that gantz_base and
-  # gantz_plyphon include at compile time.
   src = lib.fileset.toSource {
     inherit root;
     fileset = lib.fileset.unions [
@@ -27,7 +20,6 @@ let
   };
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
-    # `cpal` (via `bevy_gantz_plyphon`) links ALSA on Linux for audio output.
     alsa-lib
     libxkbcommon
     vulkan-loader
@@ -39,10 +31,6 @@ let
     LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
   };
 
-  # Shared verbatim between the deps and package derivations: any divergence in
-  # cargo flags, RUSTFLAGS or profile between the two invalidates cargo's
-  # fingerprints and silently recompiles the whole dep closure in the final
-  # derivation.
   commonArgs = {
     inherit src buildInputs env;
     inherit (craneLib.crateNameFromCargoToml { cargoToml = ../crates/gantz/Cargo.toml; })
@@ -51,7 +39,6 @@ let
       ;
     strictDeps = true;
     nativeBuildInputs = [ pkg-config ];
-    # crane's default is just "--locked"; keep it when overriding.
     cargoExtraArgs = "--locked -p gantz --bin gantz";
     doCheck = false;
   };

--- a/pkgs/gantz-unwrapped.nix
+++ b/pkgs/gantz-unwrapped.nix
@@ -1,25 +1,30 @@
+# Built with crane rather than `buildRustPackage` so that the dependency
+# closure compiles once into a deps-only artifact derivation (`buildDepsOnly`,
+# built against stubbed sources) that survives workspace source edits - only
+# the workspace crates recompile on change.
 {
   alsa-lib,
+  craneLib,
   lib,
   libxkbcommon,
-  makeWrapper,
   pkg-config,
-  rustPlatform,
   stdenv,
   vulkan-loader,
   vulkan-validation-layers,
   wayland,
 }:
 let
-  src = lib.sourceFilesBySuffices ../. [
-    ".gantz"
-    ".lock"
-    ".rs"
-    ".toml"
-  ];
-  buildAndTestSubdir = "crates/gantz";
-  manifestPath = "${src}/${buildAndTestSubdir}/Cargo.toml";
-  manifest = builtins.fromTOML (builtins.readFile manifestPath);
+  root = ../.;
+  # Cargo-relevant files (Cargo.toml/lock, *.rs, *.toml - including
+  # .cargo/config.toml) plus the .gantz assets that gantz_base and
+  # gantz_plyphon include at compile time.
+  src = lib.fileset.toSource {
+    inherit root;
+    fileset = lib.fileset.unions [
+      (craneLib.fileset.commonCargoSources root)
+      (lib.fileset.fileFilter (file: file.hasExt "gantz") root)
+    ];
+  };
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     # `cpal` (via `bevy_gantz_plyphon`) links ALSA on Linux for audio output.
@@ -34,20 +39,26 @@ let
     LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
   };
 
+  # Shared verbatim between the deps and package derivations: any divergence in
+  # cargo flags, RUSTFLAGS or profile between the two invalidates cargo's
+  # fingerprints and silently recompiles the whole dep closure in the final
+  # derivation.
+  commonArgs = {
+    inherit src buildInputs env;
+    inherit (craneLib.crateNameFromCargoToml { cargoToml = ../crates/gantz/Cargo.toml; })
+      pname
+      version
+      ;
+    strictDeps = true;
+    nativeBuildInputs = [ pkg-config ];
+    # crane's default is just "--locked"; keep it when overriding.
+    cargoExtraArgs = "--locked -p gantz --bin gantz";
+    doCheck = false;
+  };
 in
-rustPlatform.buildRustPackage {
-  inherit src buildAndTestSubdir;
-  pname = manifest.package.name;
-  version = manifest.package.version;
-  cargoLock.lockFile = ../Cargo.lock;
-  cargoBuildFlags = [
-    "--bin"
-    "gantz"
-  ];
-  doCheck = false;
-  nativeBuildInputs = [
-    makeWrapper
-    pkg-config
-  ];
-  inherit buildInputs env;
-}
+craneLib.buildPackage (
+  commonArgs
+  // {
+    cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+  }
+)

--- a/pkgs/gantz-website.nix
+++ b/pkgs/gantz-website.nix
@@ -17,12 +17,12 @@
   wasm-bindgen-cli,
 }:
 let
-  root = ../.;
+  workspace = import ./workspace-src.nix { inherit craneLib lib; };
+  # The workspace source plus the web page assets and hooks.
   src = lib.fileset.toSource {
-    inherit root;
+    inherit (workspace) root;
     fileset = lib.fileset.unions [
-      (craneLib.fileset.commonCargoSources root)
-      (lib.fileset.fileFilter (file: file.hasExt "gantz") root)
+      workspace.fileset
       ../crates/gantz/web
     ];
   };

--- a/pkgs/gantz-website.nix
+++ b/pkgs/gantz-website.nix
@@ -18,8 +18,6 @@
 }:
 let
   root = ../.;
-  # Cargo-relevant files (incl. Trunk.toml and .cargo/config.toml via the *.toml
-  # rule), the compile-time .gantz assets, and the web page assets/hooks.
   src = lib.fileset.toSource {
     inherit root;
     fileset = lib.fileset.unions [
@@ -29,9 +27,6 @@ let
     ];
   };
 
-  # Shared verbatim between the deps and website derivations: any divergence in
-  # cargo flags, RUSTFLAGS or profile between the two invalidates cargo's
-  # fingerprints and silently recompiles everything in the final derivation.
   commonArgs =
     # RUSTFLAGS (atomics + shared memory), CARGO_UNSTABLE_BUILD_STD, and the
     # wasm-capable CC/AR for `ring`.
@@ -48,7 +43,6 @@ let
         inherit (craneLib.findCargoFiles src) cargoConfigs;
         cargoLockList = [
           ../Cargo.lock
-          # `std`'s own lock, from the rust-src component `build-std` rebuilds from.
           "${rustToolchainWasmNightly.passthru.availableComponents.rust-src}/lib/rustlib/src/rust/library/Cargo.lock"
         ];
       };
@@ -69,8 +63,6 @@ craneLib.buildTrunkPackage (
   // {
     inherit cargoArtifacts wasm-bindgen-cli;
     trunkIndexPath = "crates/gantz/web/index.html";
-    # buildTrunkPackage installs "$(dirname trunkIndexPath)/dist"; Trunk.toml
-    # lives at the root so trunk's default dist would land there instead.
     trunkExtraBuildArgs = "--dist crates/gantz/web/dist";
   }
 )

--- a/pkgs/gantz-website.nix
+++ b/pkgs/gantz-website.nix
@@ -3,98 +3,74 @@
 # *nightly* toolchain (`-Z build-std` to recompile `std` with atomics) and the shared-memory
 # build flags from `wasm-threads-env.nix`.
 #
-# This is a plain `mkDerivation` rather than `buildRustPackage` because `-Z build-std`
-# recompiles `std` from the rust-src component, so `std`'s own crates.io deps must be vendored
-# alongside the app's - the sandbox has no network and `buildRustPackage` only vendors the
-# workspace lock.
+# Built with crane's `buildTrunkPackage` plus an explicit deps-only artifact derivation, so the
+# dependency closure AND the build-std `std` rebuild compile once and survive workspace source
+# edits. `-Z build-std` recompiles `std` from the rust-src component, so `std`'s own crates.io
+# deps must be vendored alongside the app's (the sandbox has no network) - crane's
+# `vendorMultipleCargoDeps` merges both lockfiles into one vendor dir.
 {
-  binaryen,
+  craneLib,
   lib,
   lld,
   llvmPackages,
-  runCommand,
-  rustPlatform,
   rustToolchainWasmNightly,
-  stdenv,
-  trunk,
   wasm-bindgen-cli,
 }:
 let
-  # Everything except build artifacts.
-  src = lib.cleanSourceWith {
-    src = ../.;
-    filter =
-      path: type:
-      let
-        base = baseNameOf (toString path);
-      in
-      !(builtins.elem base [
-        "target"
-        "result"
-        "dist"
-        ".direnv"
-      ])
-      && lib.cleanSourceFilter path type;
-  };
-
-  # Vendor both the workspace deps and `std`'s deps (from the rust-src component the nightly
-  # toolchain ships), then merge them into one source-replacement tree so build-std resolves
-  # everything offline. Neither lock has git deps, so no `outputHashes` are needed.
-  appDeps = rustPlatform.importCargoLock { lockFile = ../Cargo.lock; };
-  stdDeps = rustPlatform.importCargoLock {
-    lockFile = "${rustToolchainWasmNightly}/lib/rustlib/src/rust/library/Cargo.lock";
-  };
-  cargoVendor = runCommand "gantz-website-vendor" { } ''
-    mkdir -p $out
-    cp -r ${appDeps}/. $out/
-    # Shared crate+version dirs are byte-identical, so skipping collisions is safe.
-    cp -rn ${stdDeps}/. $out/
-  '';
-in
-stdenv.mkDerivation (
-  {
-    pname = "gantz-website";
-    version = "0.1.0";
-    inherit src;
-
-    nativeBuildInputs = [
-      rustToolchainWasmNightly
-      binaryen
-      lld
-      trunk
-      wasm-bindgen-cli
+  root = ../.;
+  # Cargo-relevant files (incl. Trunk.toml and .cargo/config.toml via the *.toml
+  # rule), the compile-time .gantz assets, and the web page assets/hooks.
+  src = lib.fileset.toSource {
+    inherit root;
+    fileset = lib.fileset.unions [
+      (craneLib.fileset.commonCargoSources root)
+      (lib.fileset.fileFilter (file: file.hasExt "gantz") root)
+      ../crates/gantz/web
     ];
+  };
 
-    # Tell trunk to use Nix-provided tools, not download its own; resolve everything from the vendor.
-    TRUNK_SKIP_VERSION_CHECK = "true";
-    CARGO_NET_OFFLINE = "true";
+  # Shared verbatim between the deps and website derivations: any divergence in
+  # cargo flags, RUSTFLAGS or profile between the two invalidates cargo's
+  # fingerprints and silently recompiles everything in the final derivation.
+  commonArgs =
+    # RUSTFLAGS (atomics + shared memory), CARGO_UNSTABLE_BUILD_STD, and the
+    # wasm-capable CC/AR for `ring`.
+    (import ./wasm-threads-env.nix { inherit llvmPackages; }) // {
+      inherit src;
+      pname = "gantz-website";
+      inherit (craneLib.crateNameFromCargoToml { cargoToml = ../crates/gantz/Cargo.toml; })
+        version
+        ;
+      strictDeps = true;
+      CARGO_BUILD_TARGET = "wasm32-unknown-unknown";
+      cargoExtraArgs = "--locked -p gantz --bin gantz";
+      cargoVendorDir = craneLib.vendorMultipleCargoDeps {
+        inherit (craneLib.findCargoFiles src) cargoConfigs;
+        cargoLockList = [
+          ../Cargo.lock
+          # `std`'s own lock, from the rust-src component `build-std` rebuilds from.
+          "${rustToolchainWasmNightly.passthru.availableComponents.rust-src}/lib/rustlib/src/rust/library/Cargo.lock"
+        ];
+      };
+      doCheck = false;
+      # trunk, binaryen and the pinned wasm-bindgen-cli come via buildTrunkPackage.
+      nativeBuildInputs = [ lld ];
+    };
 
-    configurePhase = ''
-      runHook preConfigure
-      # trunk (via wasm-bindgen) and cargo need writable home/cache dirs in the sandbox.
-      export HOME=$(mktemp -d)
-      export CARGO_HOME=$HOME/.cargo
-      mkdir -p $CARGO_HOME
-      cat > $CARGO_HOME/config.toml <<EOF
-      [source.crates-io]
-      replace-with = "vendored-sources"
-      [source.vendored-sources]
-      directory = "${cargoVendor}"
-      EOF
-      runHook postConfigure
-    '';
-
-    buildPhase = ''
-      runHook preBuild
-      # The page (crates/gantz/web/index.html) builds on cpal's AudioWorklet backend (the
-      # `audioworklet` feature, now the app's default); the shared build flags (atomics +
-      # build-std) come from the derivation env below.
-      trunk build --release --dist $out
-      runHook postBuild
-    '';
-
-    dontInstall = true;
-    dontFixup = true;
+  # Trunk compiles with `--profile wasm_release` (index.html's
+  # data-cargo-profile-release), so deps must be compiled under the same
+  # profile. Only here: buildTrunkPackage passes `--release` to trunk exactly
+  # when CARGO_PROFILE is the default "release", and trunk applies
+  # data-cargo-profile-release only under `--release`.
+  cargoArtifacts = craneLib.buildDepsOnly (commonArgs // { CARGO_PROFILE = "wasm_release"; });
+in
+craneLib.buildTrunkPackage (
+  commonArgs
+  // {
+    inherit cargoArtifacts wasm-bindgen-cli;
+    trunkIndexPath = "crates/gantz/web/index.html";
+    # buildTrunkPackage installs "$(dirname trunkIndexPath)/dist"; Trunk.toml
+    # lives at the root so trunk's default dist would land there instead.
+    trunkExtraBuildArgs = "--dist crates/gantz/web/dist";
   }
-  // (import ./wasm-threads-env.nix { inherit llvmPackages; })
 )

--- a/pkgs/workspace-src.nix
+++ b/pkgs/workspace-src.nix
@@ -1,0 +1,12 @@
+# Workspace source for crane derivations: cargo-relevant files (Cargo.toml,
+# Cargo.lock, *.rs, *.toml - including .cargo/config.toml and Trunk.toml) plus
+# the .gantz assets that gantz_base and gantz_plyphon include at compile time.
+{ craneLib, lib }:
+rec {
+  root = ../.;
+  fileset = lib.fileset.unions [
+    (craneLib.fileset.commonCargoSources root)
+    (lib.fileset.fileFilter (file: file.hasExt "gantz") root)
+  ];
+  src = lib.fileset.toSource { inherit root fileset; };
+}


### PR DESCRIPTION
Ports `gantz-unwrapped` and `gantz-website` from `buildRustPackage` / a hand-rolled `mkDerivation` to [crane](https://github.com/ipetkov/crane). Each build is now split into a deps-only artifact derivation (built once against stubbed sources) and a workspace build that inherits its `target/`, so source edits no longer recompile the ~880-crate dependency closure.

For the website this includes the `-Z build-std` rebuild of `std`: its lock is vendored alongside the workspace lock via crane's `vendorMultipleCargoDeps`, replacing the previous double `importCargoLock` merge and hand-written cargo source-replacement config.

## Use cachix

Also replaces `magic-nix-cache-action` with `cachix/cachix-action`. GitHub's Jan 2026 Actions cache rate limit (200 entry uploads/min per repo) targets magic-nix-cache's one-entry-per-store-path pattern and the upstream fix remains unmerged. The public `mitchmindtree-gantz` cache avoids the GitHub cache quota and branch scoping, gives fork PRs read access, and lets dev machines substitute the deps artifacts with `cachix use mitchmindtree-gantz`.

## Rebuild-time benchmark

Wall time of `nix build` after appending a comment to `crates/gantz/src/main.rs`, deps already realized. Same machine and store (Ryzen 9 5950X, 64 GB), identical nixpkgs revs, 3 iterations, median.

| Rebuild after a 1-line source edit | master | this branch | speedup | crates recompiled |
|---|---|---|---|---|
| `nix build .#gantz` | 230.5s | 48.4s | 4.8x | 668 -> 17 |
| `nix build .#gantz-website` | 294.8s | 222.1s | 1.3x | 583 + std -> 17 |

The website's win is bounded by its `wasm_release` profile: fat LTO, `codegen-units = 1` and wasm-opt rerun on any edit and dominate its build time. The native win is understated on a 16-core machine. On 2-core CI runners the avoided work is far larger, and with the deps derivations substituted from cachix a CI build starts directly at the 17-crate case.

Cold builds are near parity (one extra dummy-source deps pass). The final derivations were verified to recompile only the 17 workspace crates on every iteration, confirming the deps artifacts stay fingerprint-aligned.