### PR TITLE
feat: `await` node + bevy task integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,6 +1052,7 @@ dependencies = [
  "gantz_egui",
  "gantz_format",
  "gantz_nodetag",
+ "petgraph",
  "rfd",
  "serde",
  "steel-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,7 @@ dependencies = [
  "bevy_ecs",
  "bevy_input",
  "bevy_log",
+ "bevy_tasks",
  "bevy_time",
  "bevy_window",
  "gantz_ca",

--- a/crates/bevy_gantz/Cargo.toml
+++ b/crates/bevy_gantz/Cargo.toml
@@ -14,6 +14,7 @@ bevy_app.workspace = true
 bevy_ecs.workspace = true
 bevy_input.workspace = true
 bevy_log.workspace = true
+bevy_tasks.workspace = true
 bevy_time.workspace = true
 bevy_window.workspace = true
 gantz_ca.workspace = true

--- a/crates/bevy_gantz/src/lib.rs
+++ b/crates/bevy_gantz/src/lib.rs
@@ -25,6 +25,7 @@ pub mod debounced_input;
 pub mod head;
 pub mod reg;
 pub mod storage;
+pub mod task;
 pub mod vm;
 
 use bevy_app::{App, Plugin, Update};

--- a/crates/bevy_gantz/src/task.rs
+++ b/crates/bevy_gantz/src/task.rs
@@ -1,0 +1,217 @@
+//! Opaque task values for asynchronous work in gantz graphs.
+//!
+//! A [`GantzTask`] represents work whose result arrives at some unknown later
+//! time (a network response, a DB query, a timer). Producer nodes construct
+//! one (usually via [`GantzTask::spawn`]) and emit it wrapped in a
+//! [`TaskHandle`] as an opaque steel value. An `await` node downstream stashes
+//! the handle in its state, and a driver system polls the task each frame via
+//! [`GantzTask::check`], delivering the result back into the graph with a push
+//! evaluation.
+//!
+//! Steel values are not `Send`, so a spawned task's future must produce a
+//! `Send` output. The conversion to a [`SteelVal`] happens on the main thread
+//! when the task completes, via a closure that may itself capture non-`Send`
+//! steel values.
+
+use bevy_tasks::{AsyncComputeTaskPool, Task, TaskPool};
+use std::{any::Any, cell::RefCell, future::Future, rc::Rc};
+use steel::{
+    SteelVal,
+    rvals::{Custom, IntoSteelVal},
+    steel_vm::engine::Engine,
+};
+
+/// A unit of asynchronous work resolving to a steel value or an error string.
+///
+/// Dropping a `GantzTask` cancels it: a task spawned via [`GantzTask::spawn`]
+/// detaches from its pool and stops, and a [`GantzTask::poll_fn`] closure is
+/// simply never called again.
+pub struct GantzTask {
+    kind: Kind,
+}
+
+/// A cloneable, shareable handle to an optional [`GantzTask`], suitable for
+/// storage in node state or transfer along graph edges as an opaque
+/// [`SteelVal`].
+///
+/// Cloning shares the underlying cell: steel's `FromSteelVal` for custom
+/// types clones, so a handle extracted from the VM still refers to the same
+/// task. The task is delivered exactly once via [`TaskHandle::take`] - the
+/// first taker wins, and every other holder of the handle observes `None`.
+/// In particular, wiring one task value into several `await` nodes fires
+/// only one of them.
+#[derive(Clone)]
+pub struct TaskHandle(Rc<RefCell<Option<GantzTask>>>);
+
+enum Kind {
+    /// Work running on the async compute task pool.
+    Spawned {
+        task: Task<Box<dyn Any + Send>>,
+        /// Converts the future's `Send` output to a steel value on the main
+        /// thread. `None` once the result has been delivered.
+        convert: Option<Box<dyn FnOnce(Box<dyn Any + Send>) -> Result<SteelVal, String>>>,
+    },
+    /// Work checked by a plain closure each frame, with no executor involved.
+    Poll(Box<dyn FnMut() -> Option<Result<SteelVal, String>>>),
+}
+
+/// The name under which the [`TaskHandle`] type predicate is registered in
+/// node VMs, allowing generated code to test `(gantz-task? x)`.
+pub const TASK_PREDICATE: &str = "gantz-task?";
+
+impl GantzTask {
+    /// Spawn the given future on the async compute task pool.
+    ///
+    /// The future's output is converted to a steel value by `convert`, which
+    /// runs on the main thread once the task completes and so may capture
+    /// non-`Send` values (including [`SteelVal`]s).
+    pub fn spawn<T, F, C>(fut: F, convert: C) -> Self
+    where
+        T: Send + 'static,
+        F: Future<Output = T> + Send + 'static,
+        C: FnOnce(T) -> Result<SteelVal, String> + 'static,
+    {
+        let task = AsyncComputeTaskPool::get_or_init(TaskPool::default)
+            .spawn(async move { Box::new(fut.await) as Box<dyn Any + Send> });
+        let convert = Box::new(move |out: Box<dyn Any + Send>| {
+            let t = out.downcast::<T>().expect("spawned task output is `T`");
+            convert(*t)
+        });
+        let kind = Kind::Spawned {
+            task,
+            convert: Some(convert),
+        };
+        Self { kind }
+    }
+
+    /// Spawn a future whose output converts directly to a steel value.
+    ///
+    /// See [`GantzTask::spawn`] for the threading contract.
+    pub fn spawn_value<T, F>(fut: F) -> Self
+    where
+        T: Send + IntoSteelVal + 'static,
+        F: Future<Output = T> + Send + 'static,
+    {
+        Self::spawn(fut, |t| t.into_steelval().map_err(|e| e.to_string()))
+    }
+
+    /// A task backed by a closure checked once per frame by the driver,
+    /// rather than a future running on an executor.
+    ///
+    /// Suited to work that only needs the passage of frames (e.g. timers):
+    /// an executor-driven future would need to wake itself to be re-polled,
+    /// busy-spinning a pool thread, whereas the driver checks this closure
+    /// each update anyway.
+    pub fn poll_fn<F>(f: F) -> Self
+    where
+        F: FnMut() -> Option<Result<SteelVal, String>> + 'static,
+    {
+        Self {
+            kind: Kind::Poll(Box::new(f)),
+        }
+    }
+
+    /// Check whether the task has resolved, returning its result if so.
+    ///
+    /// Returns `None` while still pending, and also on any check after the
+    /// one that delivered the result.
+    pub fn check(&mut self) -> Option<Result<SteelVal, String>> {
+        match &mut self.kind {
+            Kind::Spawned { task, convert } => {
+                let out = bevy_tasks::futures::check_ready(task)?;
+                let convert = convert.take()?;
+                Some(convert(out))
+            }
+            Kind::Poll(f) => f(),
+        }
+    }
+}
+
+impl TaskHandle {
+    /// Wrap a task in a fresh shareable handle.
+    pub fn new(task: GantzTask) -> Self {
+        Self(Rc::new(RefCell::new(Some(task))))
+    }
+
+    /// Take the task out of the handle, leaving `None` for every clone.
+    pub fn take(&self) -> Option<GantzTask> {
+        self.0.borrow_mut().take()
+    }
+}
+
+impl Custom for TaskHandle {
+    fn fmt(&self) -> Option<Result<String, std::fmt::Error>> {
+        let state = match self.0.borrow().is_some() {
+            true => "pending",
+            false => "taken",
+        };
+        Some(Ok(format!("#<gantz-task {state}>")))
+    }
+}
+
+/// Register the [`TaskHandle`] type and its [`TASK_PREDICATE`] predicate in
+/// the given VM if not already present.
+///
+/// Guarded so that repeated registration (e.g. on every recompile) doesn't
+/// leak fresh global slots.
+pub fn register_task_type(vm: &mut Engine) {
+    if vm.extract_value(TASK_PREDICATE).is_err() {
+        vm.register_type::<TaskHandle>(TASK_PREDICATE);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ready(val: SteelVal) -> GantzTask {
+        let mut val = Some(val);
+        GantzTask::poll_fn(move || val.take().map(Ok))
+    }
+
+    #[test]
+    fn predicate_distinguishes_task_handles() {
+        let mut vm = Engine::new_base();
+        register_task_type(&mut vm);
+        let handle = TaskHandle::new(ready(SteelVal::IntV(1)));
+        let val = handle.into_steelval().unwrap();
+        vm.register_value("t", val);
+        vm.register_value("n", SteelVal::IntV(42));
+        let res = vm.run(format!("({TASK_PREDICATE} t)")).unwrap();
+        assert_eq!(res.last(), Some(&SteelVal::BoolV(true)));
+        let res = vm.run(format!("({TASK_PREDICATE} n)")).unwrap();
+        assert_eq!(res.last(), Some(&SteelVal::BoolV(false)));
+    }
+
+    #[test]
+    fn clones_share_the_cell() {
+        let handle = TaskHandle::new(ready(SteelVal::IntV(7)));
+        let clone = handle.clone();
+        let mut task = clone.take().expect("first take yields the task");
+        assert!(handle.take().is_none());
+        assert_eq!(task.check(), Some(Ok(SteelVal::IntV(7))));
+        assert_eq!(task.check(), None);
+    }
+
+    #[test]
+    fn round_trips_through_steelval() {
+        use steel::rvals::FromSteelVal;
+        let handle = TaskHandle::new(ready(SteelVal::IntV(3)));
+        let val = handle.clone().into_steelval().unwrap();
+        let extracted = TaskHandle::from_steelval(&val).unwrap();
+        assert!(extracted.take().is_some());
+        assert!(handle.take().is_none());
+    }
+
+    #[test]
+    fn poll_fn_pends_until_ready() {
+        let mut count = 0;
+        let mut task = GantzTask::poll_fn(move || {
+            count += 1;
+            (count >= 3).then(|| Ok(SteelVal::IntV(9)))
+        });
+        assert_eq!(task.check(), None);
+        assert_eq!(task.check(), None);
+        assert_eq!(task.check(), Some(Ok(SteelVal::IntV(9))));
+    }
+}

--- a/crates/bevy_gantz/src/task.rs
+++ b/crates/bevy_gantz/src/task.rs
@@ -4,9 +4,11 @@
 //! time (a network response, a DB query, a timer). Producer nodes construct
 //! one (usually via [`GantzTask::spawn`]) and emit it wrapped in a
 //! [`TaskHandle`] as an opaque steel value. An `await` node downstream stashes
-//! the handle in its state, and a driver system polls the task each frame via
-//! [`GantzTask::check`], delivering the result back into the graph with a push
-//! evaluation.
+//! the handle in its state, and a driver system polls it in place each frame
+//! via [`TaskHandle::check`], delivering the result back into the graph with a
+//! push evaluation. Keeping the pending task inside node state means the
+//! state-migration machinery (editor deletes, undo/redo, merges) carries
+//! in-flight work wherever its node goes.
 //!
 //! Steel values are not `Send`, so a spawned task's future must produce a
 //! `Send` output. The conversion to a [`SteelVal`] happens on the main thread
@@ -17,8 +19,9 @@ use bevy_tasks::{AsyncComputeTaskPool, Task, TaskPool};
 use std::{any::Any, cell::RefCell, future::Future, rc::Rc};
 use steel::{
     SteelVal,
-    rvals::{Custom, IntoSteelVal},
+    rvals::{Custom, FromSteelVal, IntoSteelVal},
     steel_vm::engine::Engine,
+    steel_vm::register_fn::RegisterFn,
 };
 
 /// A unit of asynchronous work resolving to a steel value or an error string.
@@ -36,10 +39,12 @@ pub struct GantzTask {
 ///
 /// Cloning shares the underlying cell: steel's `FromSteelVal` for custom
 /// types clones, so a handle extracted from the VM still refers to the same
-/// task. The task is delivered exactly once via [`TaskHandle::take`] - the
-/// first taker wins, and every other holder of the handle observes `None`.
-/// In particular, wiring one task value into several `await` nodes fires
-/// only one of them.
+/// task. The result is delivered exactly once: [`TaskHandle::check`] consumes
+/// the underlying result on completion, so when several holders share the
+/// cell (e.g. one task value wired into several `await` nodes) only the first
+/// holder checked after completion delivers, and the rest observe `None`.
+/// [`TaskHandle::take`] and [`TaskHandle::cancel`] remove the task from every
+/// clone at once.
 #[derive(Clone)]
 pub struct TaskHandle(Rc<RefCell<Option<GantzTask>>>);
 
@@ -58,6 +63,11 @@ enum Kind {
 /// The name under which the [`TaskHandle`] type predicate is registered in
 /// node VMs, allowing generated code to test `(gantz-task? x)`.
 pub const TASK_PREDICATE: &str = "gantz-task?";
+
+/// The name of the registered fn cancelling a pending task, allowing
+/// generated code to call `(gantz-task-cancel! x)` where `x` is a task handle
+/// or a list whose second element is one (the `await` node's state pair).
+pub const TASK_CANCEL_FN: &str = "gantz-task-cancel!";
 
 impl GantzTask {
     /// Spawn the given future on the async compute task pool.
@@ -137,6 +147,21 @@ impl TaskHandle {
     pub fn take(&self) -> Option<GantzTask> {
         self.0.borrow_mut().take()
     }
+
+    /// Check the contained task in place, leaving it in the handle.
+    ///
+    /// Returns `None` while pending, after the result has been delivered, or
+    /// when the handle is empty (taken or cancelled).
+    pub fn check(&self) -> Option<Result<SteelVal, String>> {
+        self.0.borrow_mut().as_mut()?.check()
+    }
+
+    /// Drop the contained task, cancelling it for every clone.
+    ///
+    /// Returns whether a task was present to cancel.
+    pub fn cancel(&self) -> bool {
+        self.0.borrow_mut().take().is_some()
+    }
 }
 
 impl Custom for TaskHandle {
@@ -149,15 +174,39 @@ impl Custom for TaskHandle {
     }
 }
 
-/// Register the [`TaskHandle`] type and its [`TASK_PREDICATE`] predicate in
-/// the given VM if not already present.
+/// Register the [`TaskHandle`] type, its [`TASK_PREDICATE`] predicate and the
+/// [`TASK_CANCEL_FN`] fn in the given VM if not already present.
 ///
 /// Guarded so that repeated registration (e.g. on every recompile) doesn't
 /// leak fresh global slots.
 pub fn register_task_type(vm: &mut Engine) {
     if vm.extract_value(TASK_PREDICATE).is_err() {
         vm.register_type::<TaskHandle>(TASK_PREDICATE);
+        vm.register_fn(TASK_CANCEL_FN, cancel_task_value);
     }
+}
+
+/// Cancel the task in `val`, a task handle or a list whose second element is
+/// one (the `await` node's state pair). No-op on anything else.
+///
+/// Returns whether a task was present to cancel. Cancellation must be
+/// explicit rather than relying on the replaced value being dropped: steel
+/// heap-boxes `set!`-mutated state, so a superseded value may linger until
+/// its slot is recycled.
+fn cancel_task_value(val: SteelVal) -> bool {
+    task_handle_of(&val).is_some_and(|handle| handle.cancel())
+}
+
+/// The task handle in `val`: either `val` itself, or the second element of a
+/// list (the `await` node's `(list arm payload)` state pair).
+fn task_handle_of(val: &SteelVal) -> Option<TaskHandle> {
+    if let Ok(handle) = TaskHandle::from_steelval(val) {
+        return Some(handle);
+    }
+    let SteelVal::ListV(list) = val else {
+        return None;
+    };
+    TaskHandle::from_steelval(list.iter().nth(1)?).ok()
 }
 
 #[cfg(test)]
@@ -213,5 +262,72 @@ mod tests {
         assert_eq!(task.check(), None);
         assert_eq!(task.check(), None);
         assert_eq!(task.check(), Some(Ok(SteelVal::IntV(9))));
+    }
+
+    /// Sets its flag when dropped, proving a task was actually released.
+    struct DropFlag(Rc<std::cell::Cell<bool>>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.set(true);
+        }
+    }
+
+    /// A never-resolving task whose drop sets the given flag.
+    fn flagged_task(flag: &Rc<std::cell::Cell<bool>>) -> GantzTask {
+        let guard = DropFlag(flag.clone());
+        GantzTask::poll_fn(move || {
+            let _ = &guard;
+            None
+        })
+    }
+
+    #[test]
+    fn check_in_place_leaves_the_task_until_delivery() {
+        let mut count = 0;
+        let task = GantzTask::poll_fn(move || {
+            count += 1;
+            (count == 2).then(|| Ok(SteelVal::IntV(4)))
+        });
+        let handle = TaskHandle::new(task);
+        let clone = handle.clone();
+        // Still pending: the task stays in the handle for the next check.
+        assert_eq!(clone.check(), None);
+        assert_eq!(handle.check(), Some(Ok(SteelVal::IntV(4))));
+        // Delivered: the task remains but yields nothing further.
+        assert_eq!(clone.check(), None);
+    }
+
+    #[test]
+    fn cancel_drops_the_task() {
+        let flag = Rc::new(std::cell::Cell::new(false));
+        let handle = TaskHandle::new(flagged_task(&flag));
+        assert!(!flag.get());
+        assert!(handle.cancel());
+        assert!(flag.get());
+        assert!(!handle.cancel());
+    }
+
+    #[test]
+    fn cancel_fn_cancels_pending_pairs() {
+        let mut vm = Engine::new_base();
+        register_task_type(&mut vm);
+        let flag = Rc::new(std::cell::Cell::new(false));
+        let handle = TaskHandle::new(flagged_task(&flag));
+        let pair = SteelVal::ListV(
+            [SteelVal::IntV(2), handle.into_steelval().unwrap()]
+                .into_iter()
+                .collect(),
+        );
+        vm.register_value("p", pair);
+        vm.register_value("n", SteelVal::IntV(1));
+        // A non-pair, non-handle value is a no-op.
+        let res = vm.run(format!("({TASK_CANCEL_FN} n)")).unwrap();
+        assert_eq!(res.last(), Some(&SteelVal::BoolV(false)));
+        assert!(!flag.get());
+        // A pending pair's task is dropped.
+        let res = vm.run(format!("({TASK_CANCEL_FN} p)")).unwrap();
+        assert_eq!(res.last(), Some(&SteelVal::BoolV(true)));
+        assert!(flag.get());
     }
 }

--- a/crates/bevy_gantz_egui/Cargo.toml
+++ b/crates/bevy_gantz_egui/Cargo.toml
@@ -37,3 +37,6 @@ web-time.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bevy_camera.workspace = true
 bevy_window.workspace = true
+
+[dev-dependencies]
+petgraph.workspace = true

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -133,8 +133,6 @@ impl Plugin for GantzEguiPlugin {
             .register_response_with::<gantz_egui::ExportHead>(dispatch_export_head)
             .register_response_with::<gantz_egui::ExportAllNamed>(dispatch_export_all_named);
 
-        app.init_non_send::<node::await_::AwaitTasks>();
-
         app.insert_resource(BaseImmutable(self.base_immutable))
             .init_resource::<GraphCache>()
             .init_resource::<BuiltinNodes>()

--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -133,6 +133,8 @@ impl Plugin for GantzEguiPlugin {
             .register_response_with::<gantz_egui::ExportHead>(dispatch_export_head)
             .register_response_with::<gantz_egui::ExportAllNamed>(dispatch_export_all_named);
 
+        app.init_non_send::<node::await_::AwaitTasks>();
+
         app.insert_resource(BaseImmutable(self.base_immutable))
             .init_resource::<GraphCache>()
             .init_resource::<BuiltinNodes>()
@@ -190,6 +192,9 @@ impl Plugin for GantzEguiPlugin {
                         .after(bevy_gantz::VmSet)
                         .in_set(bevy_gantz::EntrypointSet),
                     node::tick_bang::drive_tick_bangs
+                        .after(bevy_gantz::VmSet)
+                        .in_set(bevy_gantz::EntrypointSet),
+                    node::await_::drive_awaits
                         .after(bevy_gantz::VmSet)
                         .in_set(bevy_gantz::EntrypointSet),
                     persist_camera_and_seed.in_set(ViewPersistSet),

--- a/crates/bevy_gantz_egui/src/node/await_.rs
+++ b/crates/bevy_gantz_egui/src/node/await_.rs
@@ -1,23 +1,30 @@
 //! The `await` node: receive a gantz task, swallow evaluation, and fire a
 //! push evaluation with the task's result once it resolves.
 //!
-//! On receiving a [`TaskHandle`] the node
-//! stashes it in its state and selects a dead branch arm, so evaluation stops
-//! at the node. The [`drive_awaits`] Bevy system moves the task out of VM
-//! state, polls it each update, and on completion writes the result back into
-//! the node's state and triggers the node's push entrypoint - the value output
-//! fires on success, the error output on failure. A non-task input value
-//! passes straight through the value output in the same evaluation.
+//! On receiving a [`TaskHandle`] the node stashes it in its state and selects
+//! a dead branch arm, so evaluation stops at the node. The [`drive_awaits`]
+//! Bevy system polls the stashed task in place each update, and on completion
+//! writes the result pair into the node's state and triggers the node's push
+//! entrypoint - the value output fires on success, the error output on
+//! failure. A non-task input value passes straight through the value output
+//! in the same evaluation.
+//!
+//! Pending tasks never leave the node's VM state, so the state-maintenance
+//! machinery carries in-flight work everywhere the node goes: editor deletes
+//! reindex it via `remove_value`/`move_value`, and head navigation, merges and
+//! collab sync migrate it via `remap_root` (dropping - and thereby cancelling
+//! - the tasks of deleted nodes). The one corner where a pending task is
+//! deliberately dropped is nesting, which removes rather than relocates the
+//! nested nodes' state.
 
 use bevy_ecs::prelude::*;
 use bevy_egui::egui;
-use bevy_gantz::task::{GantzTask, TASK_PREDICATE, TaskHandle};
+use bevy_gantz::task::{TASK_CANCEL_FN, TASK_PREDICATE, TaskHandle};
 use gantz_core::node::{self, Conns, EvalConf, ExprCtx, ExprResult, MetaCtx, RegCtx};
 use gantz_core::visit;
 use gantz_egui::node::DynNode;
 use gantz_nodetag::NodeTag;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
 use steel::SteelVal;
 use steel::rvals::FromSteelVal;
 
@@ -81,10 +88,15 @@ impl gantz_core::Node for Await {
         let expr = match ctx.inputs().first() {
             // A value arrived: stash tasks in state for the driver and select
             // the dead arm; pass anything else straight through the value
-            // output.
+            // output. Any pending predecessor is cancelled explicitly (latest
+            // wins) - relying on the replaced pair being dropped would be
+            // best-effort timing, since steel heap-boxes `set!` state.
             Some(Some(input)) => format!(
                 "(if ({TASK_PREDICATE} {input}) \
-                     (begin (set! state (list {PENDING_ARM} {input})) (list {PENDING_ARM} '())) \
+                     (begin \
+                         ({TASK_CANCEL_FN} state) \
+                         (set! state (list {PENDING_ARM} {input})) \
+                         (list {PENDING_ARM} '())) \
                      (list {VALUE_ARM} {input}))"
             ),
             // Entered via the push entry fn: the driver wrote the result pair
@@ -176,11 +188,13 @@ fn pair(arm: isize, payload: SteelVal) -> SteelVal {
     SteelVal::ListV([SteelVal::IntV(arm), payload].into_iter().collect())
 }
 
-/// The stashed task, if the given state value is a pending pair holding one.
+/// The stashed task's handle, if the given state value is a pending pair
+/// holding one.
 ///
-/// Extraction leaves the handle's shared cell empty, so a subsequent read of
-/// the same state yields `None`.
-fn take_stashed_task(state: &SteelVal) -> Option<GantzTask> {
+/// The returned handle shares the cell of the one in state, so checking it
+/// polls the task in place. A dead pair's `'()` payload simply fails the
+/// handle conversion.
+pub fn pending_handle(state: &SteelVal) -> Option<TaskHandle> {
     let SteelVal::ListV(list) = state else {
         return None;
     };
@@ -191,7 +205,7 @@ fn take_stashed_task(state: &SteelVal) -> Option<GantzTask> {
     if *arm != SteelVal::IntV(PENDING_ARM) {
         return None;
     }
-    TaskHandle::from_steelval(payload).ok()?.take()
+    TaskHandle::from_steelval(payload).ok()
 }
 
 // ---------------------------------------------------------------------------
@@ -217,50 +231,26 @@ impl visit::TypedVisitor<DynNode> for AwaitCollector {
 // Bevy system
 // ---------------------------------------------------------------------------
 
-/// The pending tasks taken out of `await` node state, keyed by head entity
-/// and node path.
-///
-/// Dropping an entry cancels its task, so pruning (head closed, node removed)
-/// and latest-wins replacement cancel superseded work for free.
-///
-/// Known limitation: unlike VM state, the map is not remapped when a graph
-/// edit reindexes nodes, so such an edit cancels the in-flight task of any
-/// awaiting node whose path changed.
-#[derive(Default)]
-pub struct AwaitTasks(pub HashMap<(Entity, Vec<usize>), GantzTask>);
-
 /// Drives `await` nodes every update, independent of GUI visibility.
 ///
-/// For each open head and each `await` node: moves any task stashed in the
-/// node's state into [`AwaitTasks`] (replacing - and thereby cancelling - a
-/// previously pending task at the same node), polls the pending tasks, and on
-/// completion writes the result pair into the node's state and triggers the
-/// node's push entrypoint. Pending entries whose head or node has gone are
-/// dropped.
+/// For each open head and each `await` node whose state is a pending pair,
+/// checks the stashed task in place. On completion it writes the result pair
+/// into the node's state - overwriting the pair releases the handle - and
+/// triggers the node's push entrypoint.
+///
+/// Pending tasks live entirely in node state, so nothing here needs pruning
+/// or remapping: deleting a node, closing a head, or navigating to a graph
+/// without the node drops the state (cancelling the task), while reindexing
+/// edits and head navigation migrate it with the node.
 pub fn drive_awaits(
     registry: Res<crate::Registry>,
     cache: Res<crate::GraphCache>,
     builtins: Res<crate::BuiltinNodes>,
     mut vms: NonSendMut<bevy_gantz::head::HeadVms>,
-    mut tasks: NonSendMut<AwaitTasks>,
     heads: Query<(Entity, &bevy_gantz::head::HeadRef), With<bevy_gantz::head::OpenHead>>,
     mut cmds: Commands,
 ) {
-    // Prune bookkeeping. `open`: every open head. `walked`: heads whose graph
-    // was traversed this update. `live`: every (head, path) with a
-    // still-pending task at a present await node. An entry is dropped - which
-    // cancels its task - when its head is closed, or when its head was walked
-    // but the entry is not live (the node is gone, or its task was delivered).
-    // Entries of open heads that could not be walked this update (e.g. the
-    // reified graph is not cached yet) are kept rather than spuriously
-    // cancelled.
-    let mut open: HashSet<Entity> = HashSet::new();
-    let mut walked: HashSet<Entity> = HashSet::new();
-    let mut live: HashSet<(Entity, Vec<usize>)> = HashSet::new();
-
     for (entity, head_ref) in heads.iter() {
-        open.insert(entity);
-
         // The head's committed graph, read from the reified cache (the
         // working graph equals it by the `WorkingGraph` invariant).
         let Some(graph_ca) = registry.head_commit(&head_ref.0).map(|c| c.graph) else {
@@ -274,7 +264,6 @@ pub fn drive_awaits(
 
         let mut collector = AwaitCollector { paths: vec![] };
         gantz_core::graph::visit_typed(&get_node, graph, &[], &mut collector);
-        walked.insert(entity);
 
         if collector.paths.is_empty() {
             continue;
@@ -285,32 +274,20 @@ pub fn drive_awaits(
         };
 
         for path in collector.paths {
-            // Stash: move a newly received task out of the node's state,
-            // replacing (and thereby cancelling) any pending predecessor.
-            match node::state::extract_value(vm, &path) {
-                Ok(Some(state)) => {
-                    if let Some(task) = take_stashed_task(&state) {
-                        tasks.0.insert((entity, path.clone()), task);
-                        if let Err(e) = node::state::update_value(vm, &path, dead_pair()) {
-                            bevy_log::error!("await state reset failed: {e}");
-                        }
-                    }
+            let state = match node::state::extract_value(vm, &path) {
+                Ok(Some(state)) => state,
+                Ok(None) => continue,
+                Err(e) => {
+                    bevy_log::error!("await state read failed: {e}");
+                    continue;
                 }
-                Ok(None) => {}
-                Err(e) => bevy_log::error!("await state read failed: {e}"),
-            }
-
-            // Poll: deliver a resolved task's result and fire the entrypoint.
-            let key = (entity, path);
-            let Some(task) = tasks.0.get_mut(&key) else {
+            };
+            let Some(handle) = pending_handle(&state) else {
                 continue;
             };
-            let Some(result) = task.check() else {
-                live.insert(key);
+            let Some(result) = handle.check() else {
                 continue;
             };
-            tasks.0.remove(&key);
-            let (_, path) = key;
             let pair = match result {
                 Ok(val) => value_pair(val),
                 Err(err) => error_pair(err),
@@ -336,8 +313,4 @@ pub fn drive_awaits(
             });
         }
     }
-
-    tasks
-        .0
-        .retain(|key, _| open.contains(&key.0) && (!walked.contains(&key.0) || live.contains(key)));
 }

--- a/crates/bevy_gantz_egui/src/node/await_.rs
+++ b/crates/bevy_gantz_egui/src/node/await_.rs
@@ -1,0 +1,343 @@
+//! The `await` node: receive a gantz task, swallow evaluation, and fire a
+//! push evaluation with the task's result once it resolves.
+//!
+//! On receiving a [`TaskHandle`] the node
+//! stashes it in its state and selects a dead branch arm, so evaluation stops
+//! at the node. The [`drive_awaits`] Bevy system moves the task out of VM
+//! state, polls it each update, and on completion writes the result back into
+//! the node's state and triggers the node's push entrypoint - the value output
+//! fires on success, the error output on failure. A non-task input value
+//! passes straight through the value output in the same evaluation.
+
+use bevy_ecs::prelude::*;
+use bevy_egui::egui;
+use bevy_gantz::task::{GantzTask, TASK_PREDICATE, TaskHandle};
+use gantz_core::node::{self, Conns, EvalConf, ExprCtx, ExprResult, MetaCtx, RegCtx};
+use gantz_core::visit;
+use gantz_egui::node::DynNode;
+use gantz_nodetag::NodeTag;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use steel::SteelVal;
+use steel::rvals::FromSteelVal;
+
+/// The branch arm firing the value output on task success.
+const VALUE_ARM: isize = 0;
+
+/// The branch arm firing the error output on task failure.
+const ERROR_ARM: isize = 1;
+
+/// The dead branch arm selected while a task is pending: no output fires.
+const PENDING_ARM: isize = 2;
+
+// ---------------------------------------------------------------------------
+// Await node
+// ---------------------------------------------------------------------------
+
+/// A node that awaits a gantz task received on its input.
+///
+/// Receiving a task swallows the evaluation (nothing fires downstream) until
+/// the task resolves, at which point [`drive_awaits`] fires the node's push
+/// entrypoint: output 0 carries the resolved value, output 1 the error string
+/// if the task failed. Any non-task input value passes straight through
+/// output 0 in the same evaluation.
+///
+/// The node's state is always a `(list arm payload)` branch pair: the pending
+/// arm holding the stashed task (or nothing), or the value/error arm written
+/// by the driver just before it fires the entrypoint.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize, NodeTag)]
+pub struct Await;
+
+impl gantz_core::Node for Await {
+    fn n_inputs(&self, _ctx: MetaCtx) -> usize {
+        1
+    }
+
+    fn n_outputs(&self, _ctx: MetaCtx) -> usize {
+        // Output 0 = the resolved value; output 1 = the error string.
+        2
+    }
+
+    fn branches(&self, _ctx: MetaCtx) -> Vec<EvalConf> {
+        // Arm 0 fires the value output, arm 1 the error output, arm 2 neither
+        // (a task was received or is still pending - evaluation stops here).
+        vec![
+            EvalConf::Set(Conns::try_from([true, false]).unwrap()),
+            EvalConf::Set(Conns::try_from([false, true]).unwrap()),
+            EvalConf::Set(Conns::try_from([false, false]).unwrap()),
+        ]
+    }
+
+    fn push_eval(&self, _ctx: MetaCtx) -> Vec<EvalConf> {
+        // The entry fn through which `drive_awaits` delivers task results.
+        vec![EvalConf::All]
+    }
+
+    fn stateful(&self, _ctx: MetaCtx) -> bool {
+        true
+    }
+
+    fn expr(&self, ctx: ExprCtx<'_, '_>) -> ExprResult {
+        let expr = match ctx.inputs().first() {
+            // A value arrived: stash tasks in state for the driver and select
+            // the dead arm; pass anything else straight through the value
+            // output.
+            Some(Some(input)) => format!(
+                "(if ({TASK_PREDICATE} {input}) \
+                     (begin (set! state (list {PENDING_ARM} {input})) (list {PENDING_ARM} '())) \
+                     (list {VALUE_ARM} {input}))"
+            ),
+            // Entered via the push entry fn: the driver wrote the result pair
+            // into state, which is exactly the branch pair to return.
+            _ => "(begin state)".to_string(),
+        };
+        node::parse_expr(&expr)
+    }
+
+    fn register(&self, mut ctx: RegCtx<'_, '_>) {
+        let path = ctx.path();
+        bevy_gantz::task::register_task_type(ctx.vm());
+        node::state::init_value_if_absent(ctx.vm(), path, dead_pair).unwrap()
+    }
+}
+
+impl gantz_egui::NodeUi for Await {
+    fn name(&self, _: &gantz_egui::Env<'_>) -> std::borrow::Cow<'_, str> {
+        std::borrow::Cow::Borrowed("await")
+    }
+
+    fn description(&self) -> Option<&'static str> {
+        Some(
+            "Awaits a gantz task (e.g. produced by `sleep`), swallowing \
+             evaluation until the task resolves, then fires its result through \
+             the value output - or the error message through the error output \
+             if the task failed. A non-task input value passes straight \
+             through the value output. A task arriving while another is \
+             pending replaces it, cancelling the earlier task.",
+        )
+    }
+
+    fn ui(
+        &mut self,
+        _ctx: gantz_egui::NodeCtx,
+        uictx: egui_graph::NodeCtx,
+    ) -> gantz_egui::NodeUiResponse {
+        let framed =
+            uictx.framed(|ui, _sockets| ui.add(egui::Label::new("await").selectable(false)));
+        gantz_egui::NodeUiResponse::new(framed)
+    }
+
+    fn socket_doc(
+        &self,
+        _: &gantz_egui::Env<'_>,
+        kind: gantz_egui::SocketKind,
+        ix: usize,
+    ) -> Option<gantz_egui::SocketDoc> {
+        match (kind, ix) {
+            (gantz_egui::SocketKind::Input, 0) => Some(
+                gantz_egui::SocketDoc::ty("task | any")
+                    .with_description("a gantz task to await, or any value to pass through"),
+            ),
+            (gantz_egui::SocketKind::Output, 0) => Some(
+                gantz_egui::SocketDoc::ty("any")
+                    .with_description("the resolved value, once the task completes"),
+            ),
+            (gantz_egui::SocketKind::Output, 1) => Some(
+                gantz_egui::SocketDoc::ty("string")
+                    .with_description("the error message, if the task failed"),
+            ),
+            _ => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// State pairs
+// ---------------------------------------------------------------------------
+
+/// The state pair while no result is pending delivery: the dead arm with an
+/// empty payload.
+pub fn dead_pair() -> SteelVal {
+    pair(PENDING_ARM, SteelVal::ListV(Default::default()))
+}
+
+/// The state pair delivering a resolved value through the value output.
+pub fn value_pair(val: SteelVal) -> SteelVal {
+    pair(VALUE_ARM, val)
+}
+
+/// The state pair delivering an error message through the error output.
+pub fn error_pair(err: String) -> SteelVal {
+    pair(ERROR_ARM, SteelVal::StringV(err.into()))
+}
+
+/// A `(list arm payload)` branch pair.
+fn pair(arm: isize, payload: SteelVal) -> SteelVal {
+    SteelVal::ListV([SteelVal::IntV(arm), payload].into_iter().collect())
+}
+
+/// The stashed task, if the given state value is a pending pair holding one.
+///
+/// Extraction leaves the handle's shared cell empty, so a subsequent read of
+/// the same state yields `None`.
+fn take_stashed_task(state: &SteelVal) -> Option<GantzTask> {
+    let SteelVal::ListV(list) = state else {
+        return None;
+    };
+    let mut items = list.iter();
+    let (Some(arm), Some(payload)) = (items.next(), items.next()) else {
+        return None;
+    };
+    if *arm != SteelVal::IntV(PENDING_ARM) {
+        return None;
+    }
+    TaskHandle::from_steelval(payload).ok()?.take()
+}
+
+// ---------------------------------------------------------------------------
+// AwaitCollector
+// ---------------------------------------------------------------------------
+
+/// Collects the path of every [`Await`] node found during graph traversal,
+/// discovered by [`Any`](std::any::Any) downcast within the erased UI node.
+struct AwaitCollector {
+    pub paths: Vec<Vec<usize>>,
+}
+
+impl visit::TypedVisitor<DynNode> for AwaitCollector {
+    fn visit_pre(&mut self, ctx: visit::Ctx<'_, '_>, node: &DynNode) {
+        let n: &dyn gantz_core::Node = &**node;
+        if (n as &dyn std::any::Any).downcast_ref::<Await>().is_some() {
+            self.paths.push(ctx.path().to_vec());
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bevy system
+// ---------------------------------------------------------------------------
+
+/// The pending tasks taken out of `await` node state, keyed by head entity
+/// and node path.
+///
+/// Dropping an entry cancels its task, so pruning (head closed, node removed)
+/// and latest-wins replacement cancel superseded work for free.
+///
+/// Known limitation: unlike VM state, the map is not remapped when a graph
+/// edit reindexes nodes, so such an edit cancels the in-flight task of any
+/// awaiting node whose path changed.
+#[derive(Default)]
+pub struct AwaitTasks(pub HashMap<(Entity, Vec<usize>), GantzTask>);
+
+/// Drives `await` nodes every update, independent of GUI visibility.
+///
+/// For each open head and each `await` node: moves any task stashed in the
+/// node's state into [`AwaitTasks`] (replacing - and thereby cancelling - a
+/// previously pending task at the same node), polls the pending tasks, and on
+/// completion writes the result pair into the node's state and triggers the
+/// node's push entrypoint. Pending entries whose head or node has gone are
+/// dropped.
+pub fn drive_awaits(
+    registry: Res<crate::Registry>,
+    cache: Res<crate::GraphCache>,
+    builtins: Res<crate::BuiltinNodes>,
+    mut vms: NonSendMut<bevy_gantz::head::HeadVms>,
+    mut tasks: NonSendMut<AwaitTasks>,
+    heads: Query<(Entity, &bevy_gantz::head::HeadRef), With<bevy_gantz::head::OpenHead>>,
+    mut cmds: Commands,
+) {
+    // Prune bookkeeping. `open`: every open head. `walked`: heads whose graph
+    // was traversed this update. `live`: every (head, path) with a
+    // still-pending task at a present await node. An entry is dropped - which
+    // cancels its task - when its head is closed, or when its head was walked
+    // but the entry is not live (the node is gone, or its task was delivered).
+    // Entries of open heads that could not be walked this update (e.g. the
+    // reified graph is not cached yet) are kept rather than spuriously
+    // cancelled.
+    let mut open: HashSet<Entity> = HashSet::new();
+    let mut walked: HashSet<Entity> = HashSet::new();
+    let mut live: HashSet<(Entity, Vec<usize>)> = HashSet::new();
+
+    for (entity, head_ref) in heads.iter() {
+        open.insert(entity);
+
+        // The head's committed graph, read from the reified cache (the
+        // working graph equals it by the `WorkingGraph` invariant).
+        let Some(graph_ca) = registry.head_commit(&head_ref.0).map(|c| c.graph) else {
+            continue;
+        };
+        let Some(graph) = cache.get(&graph_ca) else {
+            continue;
+        };
+        let get_node =
+            |ca: &gantz_ca::ContentAddr| crate::lookup_node(&cache, &builtins.instances, ca);
+
+        let mut collector = AwaitCollector { paths: vec![] };
+        gantz_core::graph::visit_typed(&get_node, graph, &[], &mut collector);
+        walked.insert(entity);
+
+        if collector.paths.is_empty() {
+            continue;
+        }
+
+        let Some(vm) = vms.get_mut(&entity) else {
+            continue;
+        };
+
+        for path in collector.paths {
+            // Stash: move a newly received task out of the node's state,
+            // replacing (and thereby cancelling) any pending predecessor.
+            match node::state::extract_value(vm, &path) {
+                Ok(Some(state)) => {
+                    if let Some(task) = take_stashed_task(&state) {
+                        tasks.0.insert((entity, path.clone()), task);
+                        if let Err(e) = node::state::update_value(vm, &path, dead_pair()) {
+                            bevy_log::error!("await state reset failed: {e}");
+                        }
+                    }
+                }
+                Ok(None) => {}
+                Err(e) => bevy_log::error!("await state read failed: {e}"),
+            }
+
+            // Poll: deliver a resolved task's result and fire the entrypoint.
+            let key = (entity, path);
+            let Some(task) = tasks.0.get_mut(&key) else {
+                continue;
+            };
+            let Some(result) = task.check() else {
+                live.insert(key);
+                continue;
+            };
+            tasks.0.remove(&key);
+            let (_, path) = key;
+            let pair = match result {
+                Ok(val) => value_pair(val),
+                Err(err) => error_pair(err),
+            };
+            if let Err(e) = node::state::update_value(vm, &path, pair) {
+                bevy_log::error!("await result write failed: {e}");
+                continue;
+            }
+            let n_outputs = 2;
+            let entrypoint = gantz_core::compile::entrypoint::push(path, n_outputs);
+            // Guard against delivering through an entry fn the current module
+            // no longer compiles (e.g. the task resolved in the same update
+            // as a graph edit).
+            let fn_name = gantz_core::compile::entry_fn_name(&entrypoint.id());
+            if vm.extract_value(&fn_name).is_err() {
+                bevy_log::debug!("await eval skipped: entry fn {fn_name} not compiled");
+                continue;
+            }
+            cmds.trigger(bevy_gantz::vm::EvalEntryEvent {
+                head: entity,
+                entrypoint,
+                time: None,
+            });
+        }
+    }
+
+    tasks
+        .0
+        .retain(|key, _| open.contains(&key.0) && (!walked.contains(&key.0) || live.contains(key)));
+}

--- a/crates/bevy_gantz_egui/src/node/mod.rs
+++ b/crates/bevy_gantz_egui/src/node/mod.rs
@@ -1,6 +1,10 @@
+pub use await_::Await;
+pub use sleep::Sleep;
 pub use tick_bang::{Interval, TickBang};
 pub use update_bang::UpdateBang;
 
+pub mod await_;
+pub mod sleep;
 pub mod tick_bang;
 pub mod update_bang;
 
@@ -8,6 +12,8 @@ pub mod update_bang;
 pub fn builtins() -> Vec<gantz_core::Builtin> {
     use gantz_core::Builtin;
     vec![
+        Builtin::new("await", &Await),
+        Builtin::new("sleep", &Sleep::default()),
         Builtin::new("tick!", &TickBang::default()),
         Builtin::new("update!", &UpdateBang),
     ]

--- a/crates/bevy_gantz_egui/src/node/sleep.rs
+++ b/crates/bevy_gantz_egui/src/node/sleep.rs
@@ -1,0 +1,240 @@
+//! The `sleep` node: produce a gantz task that resolves to the input value
+//! after a configurable duration.
+//!
+//! The simplest task producer, useful for testing and demonstrating `await`.
+//! The task is a driver-polled deadline check (see
+//! [`GantzTask::poll_fn`](bevy_gantz::task::GantzTask::poll_fn)) rather than
+//! an executor-driven future, so it is portable to single-threaded targets
+//! and costs nothing while pending.
+
+use bevy_egui::egui;
+use bevy_gantz::task::{GantzTask, TaskHandle};
+use gantz_core::node::{self, EvalConf, ExprCtx, ExprResult, MetaCtx, RegCtx};
+use gantz_format::{Datum, FormatError, SugarArgs, node_datum};
+use gantz_nodetag::NodeTag;
+use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
+use steel::SteelVal;
+use steel::steel_vm::register_fn::RegisterFn;
+
+/// The default sleep duration in seconds when unconfigured.
+const DEFAULT_DURATION: f64 = 1.0;
+
+/// The smallest sleep duration the inspector allows, in seconds.
+const MIN_DURATION: f64 = 0.0;
+
+/// The name of the registered fn producing the sleep task.
+const SLEEP_FN: &str = "gantz-sleep";
+
+// ---------------------------------------------------------------------------
+// Sleep node
+// ---------------------------------------------------------------------------
+
+/// A node producing a gantz task that resolves to the received input value
+/// after the configured duration.
+///
+/// Push a value into it (e.g. from a `bang`) and wire the task output into an
+/// `await` node to receive the value once the duration elapses.
+#[derive(Clone, Debug, Serialize, Deserialize, NodeTag)]
+pub struct Sleep {
+    #[serde(
+        default = "default_duration",
+        skip_serializing_if = "is_default_duration"
+    )]
+    duration: f64,
+}
+
+fn default_duration() -> f64 {
+    DEFAULT_DURATION
+}
+
+fn is_default_duration(duration: &f64) -> bool {
+    *duration == DEFAULT_DURATION
+}
+
+impl Sleep {
+    /// The sleep duration in seconds.
+    pub fn duration(&self) -> f64 {
+        self.duration
+    }
+
+    /// Set the sleep duration in seconds (content-address affecting).
+    pub fn set_duration(&mut self, duration: f64) {
+        self.duration = duration.max(MIN_DURATION);
+    }
+}
+
+impl Default for Sleep {
+    fn default() -> Self {
+        Sleep {
+            duration: DEFAULT_DURATION,
+        }
+    }
+}
+
+impl PartialEq for Sleep {
+    fn eq(&self, other: &Self) -> bool {
+        self.duration.to_bits() == other.duration.to_bits()
+    }
+}
+
+impl Eq for Sleep {}
+
+impl Hash for Sleep {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Hash::hash(&self.duration.to_bits(), state);
+    }
+}
+
+impl gantz_core::Node for Sleep {
+    fn n_inputs(&self, _ctx: MetaCtx) -> usize {
+        1
+    }
+
+    fn n_outputs(&self, _ctx: MetaCtx) -> usize {
+        1
+    }
+
+    fn push_eval(&self, _ctx: MetaCtx) -> Vec<EvalConf> {
+        vec![EvalConf::All]
+    }
+
+    fn expr(&self, ctx: ExprCtx<'_, '_>) -> ExprResult {
+        // The forwarded value is the input when connected, else `'()`.
+        // `{:?}` formats the float with a guaranteed `.`/exponent so Steel
+        // parses it as a number rather than an integer.
+        let val = match ctx.inputs().first() {
+            Some(Some(input)) => input.as_str(),
+            _ => "'()",
+        };
+        node::parse_expr(&format!("({SLEEP_FN} {:?} {val})", self.duration))
+    }
+
+    fn register(&self, mut ctx: RegCtx<'_, '_>) {
+        let vm = ctx.vm();
+        bevy_gantz::task::register_task_type(vm);
+        // Register the producer fn only once: `register_fn` allocates a new
+        // global slot and shadows the previous binding rather than
+        // overwriting it, so re-running this on every recompile would leak.
+        if vm.extract_value(SLEEP_FN).is_err() {
+            vm.register_fn(SLEEP_FN, gantz_sleep);
+        }
+    }
+}
+
+impl gantz_egui::NodeUi for Sleep {
+    fn name(&self, _: &gantz_egui::Env<'_>) -> std::borrow::Cow<'_, str> {
+        std::borrow::Cow::Borrowed("sleep")
+    }
+
+    fn description(&self) -> Option<&'static str> {
+        Some(
+            "Produces a gantz task that resolves to the received input value \
+             after the configured duration. Wire the output into an `await` \
+             node to receive the value once the duration elapses.",
+        )
+    }
+
+    fn ui(
+        &mut self,
+        _ctx: gantz_egui::NodeCtx,
+        uictx: egui_graph::NodeCtx,
+    ) -> gantz_egui::NodeUiResponse {
+        let framed =
+            uictx.framed(|ui, _sockets| ui.add(egui::Label::new("sleep").selectable(false)));
+        gantz_egui::NodeUiResponse::new(framed)
+    }
+
+    fn inspector_rows(
+        &mut self,
+        _ctx: &mut gantz_egui::NodeCtx,
+        body: &mut egui_extras::TableBody,
+    ) -> gantz_egui::InspectorRowsResponse {
+        let row_h = gantz_egui::widget::node_inspector::table_row_h(body.ui_mut());
+        let mut changed = false;
+        body.row(row_h, |mut row| {
+            row.col(|ui| {
+                ui.label("dur.")
+                    .on_hover_text("seconds until the task resolves");
+            });
+            row.col(|ui| {
+                let mut v = self.duration;
+                let resp = ui.add(
+                    egui::DragValue::new(&mut v)
+                        .speed(0.01)
+                        .range(MIN_DURATION..=f64::INFINITY)
+                        .suffix(" s"),
+                );
+                if resp.changed() {
+                    self.set_duration(v);
+                    changed = true;
+                }
+            });
+        });
+        let mut resp = gantz_egui::InspectorRowsResponse::default();
+        if changed {
+            resp.mark_changed();
+        }
+        resp
+    }
+
+    fn socket_doc(
+        &self,
+        _: &gantz_egui::Env<'_>,
+        kind: gantz_egui::SocketKind,
+        _ix: usize,
+    ) -> Option<gantz_egui::SocketDoc> {
+        match kind {
+            gantz_egui::SocketKind::Input => Some(
+                gantz_egui::SocketDoc::ty("any")
+                    .with_description("value the task resolves to after the duration"),
+            ),
+            gantz_egui::SocketKind::Output => Some(
+                gantz_egui::SocketDoc::ty("task")
+                    .with_description("gantz task resolving to the input after the duration"),
+            ),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.gantz` keyword sugar
+// ---------------------------------------------------------------------------
+
+/// Read a `(sleep [#:duration secs])` form into a [`Sleep`] datum. No
+/// `#:duration` yields the default. Dispatched by [`crate::sugar::BevySugar`].
+pub(crate) fn read_sugar(args: SugarArgs<'_>) -> Result<Datum, FormatError> {
+    let fields = match args.keyword_f64("duration")? {
+        Some(secs) => vec![("duration", Datum::F64(secs))],
+        None => vec![],
+    };
+    Ok(node_datum("Sleep", fields))
+}
+
+/// Write a [`Sleep`] as bare `sleep` for the default duration, else as
+/// `(sleep #:duration secs)`.
+pub(crate) fn write_sugar(node: &Datum) -> String {
+    match node.get("duration").and_then(Datum::as_f64) {
+        Some(secs) if secs != DEFAULT_DURATION => format!("(sleep #:duration {secs})"),
+        _ => "sleep".to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Registered fns
+// ---------------------------------------------------------------------------
+
+/// Produce a task resolving to `val` once `secs` seconds have passed.
+///
+/// Non-finite or negative durations resolve immediately.
+fn gantz_sleep(secs: f64, val: SteelVal) -> TaskHandle {
+    let secs = if secs.is_finite() { secs.max(0.0) } else { 0.0 };
+    let deadline = web_time::Instant::now() + std::time::Duration::from_secs_f64(secs);
+    let mut val = Some(val);
+    TaskHandle::new(GantzTask::poll_fn(move || {
+        if web_time::Instant::now() < deadline {
+            return None;
+        }
+        val.take().map(Ok)
+    }))
+}

--- a/crates/bevy_gantz_egui/src/sugar.rs
+++ b/crates/bevy_gantz_egui/src/sugar.rs
@@ -6,11 +6,11 @@
 //! [`gantz_format::CoreSugar`] (and the other crates' sugars) via
 //! [`gantz_format::Sugars`].
 
-use crate::node::{TickBang, UpdateBang, tick_bang};
+use crate::node::{Await, Sleep, TickBang, UpdateBang, sleep, tick_bang};
 use gantz_format::{Datum, FormatError, Sugar, SugarArgs, node_datum};
 use gantz_nodetag::NodeTag;
 
-/// Keyword sugar for [`UpdateBang`] and [`TickBang`].
+/// Keyword sugar for [`UpdateBang`], [`TickBang`], [`Await`] and [`Sleep`].
 #[derive(Clone, Copy, Debug, Default)]
 pub struct BevySugar;
 
@@ -19,6 +19,8 @@ pub struct BevySugar;
 const KEYWORD_TAG: &[(&str, &str)] = &[
     ("update-bang", UpdateBang::TAG),
     ("tick-bang", TickBang::TAG),
+    ("await", Await::TAG),
+    ("sleep", Sleep::TAG),
 ];
 
 /// The node tag for a sugar keyword.
@@ -41,6 +43,7 @@ impl Sugar for BevySugar {
     fn read_spec(&self, head: &str, args: SugarArgs<'_>) -> Result<Option<Datum>, FormatError> {
         let datum = match head {
             "tick-bang" => tick_bang::read_sugar(args)?,
+            "sleep" => sleep::read_sugar(args)?,
             _ => return Ok(None),
         };
         Ok(Some(datum))
@@ -53,6 +56,7 @@ impl Sugar for BevySugar {
     fn write_spec(&self, tag: &str, node: &Datum) -> Option<String> {
         match tag {
             "TickBang" => Some(tick_bang::write_sugar(node)),
+            "Sleep" => Some(sleep::write_sugar(node)),
             other => keyword_for_tag(other).map(str::to_string),
         }
     }
@@ -126,5 +130,35 @@ mod tests {
             s.read_spec("tick-bang", SugarArgs::new(&args[1..], text))
                 .is_err()
         );
+    }
+
+    #[test]
+    fn await_round_trips() {
+        let bare = BevySugar.read_bare("await").expect("bare await");
+        assert_eq!(bare.get("type").and_then(Datum::as_str), Some("Await"));
+        assert_eq!(
+            BevySugar.write_spec("Await", &bare).as_deref(),
+            Some("await")
+        );
+    }
+
+    #[test]
+    fn sleep_config_round_trips() {
+        let s = BevySugar;
+
+        // A bare (default-duration) sleep stays bare, read as keyword or spec.
+        let bare = s.read_bare("sleep").expect("bare sleep");
+        assert_eq!(s.write_spec("Sleep", &bare).as_deref(), Some("sleep"));
+
+        // A custom duration round-trips via the `#:duration` keyword (seconds).
+        let d = read_spec("(sleep #:duration 0.5)").expect("duration");
+        assert_eq!(
+            s.write_spec("Sleep", &d).as_deref(),
+            Some("(sleep #:duration 0.5)"),
+        );
+
+        // An explicit default duration also writes as the bare keyword.
+        let one = read_spec("(sleep #:duration 1)").expect("default duration");
+        assert_eq!(s.write_spec("Sleep", &one).as_deref(), Some("sleep"));
     }
 }

--- a/crates/bevy_gantz_egui/tests/await.rs
+++ b/crates/bevy_gantz_egui/tests/await.rs
@@ -1,0 +1,254 @@
+//! End-to-end tests for the `await` node: the state/branch protocol in a bare
+//! VM, and result delivery through the bevy driver in a headless app.
+
+use bevy_gantz::task::TaskHandle;
+use bevy_gantz_egui::node::{Await, Sleep, await_};
+use gantz_core::{
+    Edge, Node,
+    compile::{Entrypoint, EvalKind, entry_fn_name, push_pull_entrypoints},
+    node::{self, WithPushEval},
+};
+use std::fmt::Debug;
+use steel::SteelVal;
+use steel::rvals::FromSteelVal;
+use steel::steel_vm::engine::Engine;
+
+trait DebugNode: Debug + Node {}
+impl<T> DebugNode for T where T: Debug + Node {}
+
+// A no-op node lookup function for tests that don't need it.
+fn no_lookup(_: &gantz_ca::ContentAddr) -> Option<&'static dyn Node> {
+    None
+}
+
+/// The push entrypoint whose single source is the node at `path`.
+fn push_entry<'a>(eps: &'a [Entrypoint], path: &[usize]) -> &'a Entrypoint {
+    eps.iter()
+        .find(|ep| {
+            ep.0.iter()
+                .any(|s| s.kind == EvalKind::Push && s.path == path)
+        })
+        .expect("push entrypoint")
+}
+
+/// Call the given entrypoint's generated entry fn.
+fn call(vm: &mut Engine, ep: &Entrypoint) {
+    vm.call_function_by_name_with_args(&entry_fn_name(&ep.id()), vec![])
+        .expect("entry fn errored");
+}
+
+/// The state of the node at the given root index.
+fn state(vm: &Engine, ix: usize) -> SteelVal {
+    node::state::extract_value(vm, &[ix])
+        .expect("state read")
+        .expect("state present")
+}
+
+/// Take the task stashed in an await node's pending state pair, as the
+/// driver's stash step does.
+fn take_stashed(vm: &Engine, ix: usize) -> bevy_gantz::task::GantzTask {
+    let st = state(vm, ix);
+    let SteelVal::ListV(list) = &st else {
+        panic!("await state is not a pair: {st:?}");
+    };
+    let mut items = list.iter();
+    let (Some(arm), Some(payload)) = (items.next(), items.next()) else {
+        panic!("await state is not a pair: {st:?}");
+    };
+    assert_eq!(*arm, SteelVal::IntV(2), "await state should be pending");
+    TaskHandle::from_steelval(payload)
+        .expect("pending payload is a task handle")
+        .take()
+        .expect("task present")
+}
+
+/// The whole state/branch protocol in a bare VM, under both compile configs:
+/// a received task is stashed and swallows the push; a driver-written value
+/// pair fires only the value output; an error pair only the error output; and
+/// a non-task input passes straight through.
+#[test]
+fn await_delivers_value_error_and_passthrough() {
+    for config in [
+        gantz_core::compile::Config::default(),
+        gantz_core::compile::Config {
+            validate_ir: true,
+            emit_all_node_fns: true,
+        },
+    ] {
+        let mut g = petgraph::graph::DiGraph::new();
+        let mut sleep_node = Sleep::default();
+        sleep_node.set_duration(0.0);
+        let push =
+            g.add_node(Box::new(node::expr("7").unwrap().with_push_eval()) as Box<dyn DebugNode>);
+        let sleep = g.add_node(Box::new(sleep_node) as Box<_>);
+        let await_n = g.add_node(Box::new(Await) as Box<_>);
+        let val_sink = g.add_node(Box::new(gantz_egui::node::Inspect) as Box<_>);
+        let err_sink = g.add_node(Box::new(gantz_egui::node::Inspect) as Box<_>);
+        let push2 =
+            g.add_node(Box::new(node::expr("9").unwrap().with_push_eval()) as Box<dyn DebugNode>);
+        g.add_edge(push, sleep, Edge::from((0, 0)));
+        g.add_edge(sleep, await_n, Edge::from((0, 0)));
+        g.add_edge(push2, await_n, Edge::from((0, 0)));
+        g.add_edge(await_n, val_sink, Edge::from((0, 0)));
+        g.add_edge(await_n, err_sink, Edge::from((1, 0)));
+
+        let eps = push_pull_entrypoints(&no_lookup, &g);
+        let (mut vm, _compiled) = gantz_core::vm::init(&no_lookup, &g, &eps, &config)
+            .unwrap_or_else(|e| panic!("init: {}", gantz_core::vm::error_chain(&e)));
+
+        // Push a value through `sleep`: the task reaches `await`, which
+        // stashes it and swallows the evaluation - neither sink fires.
+        call(&mut vm, push_entry(&eps, &[push.index()]));
+        assert_eq!(state(&vm, val_sink.index()), SteelVal::Void);
+        assert_eq!(state(&vm, err_sink.index()), SteelVal::Void);
+
+        // The stashed zero-duration task resolves to the pushed value on the
+        // first check.
+        let mut task = take_stashed(&vm, await_n.index());
+        let result = task.check().expect("ready").expect("resolves ok");
+        assert_eq!(result, SteelVal::IntV(7));
+
+        // Driver delivery: write the value pair, fire the await entry fn -
+        // only the value output fires.
+        node::state::update_value(&mut vm, &[await_n.index()], await_::value_pair(result))
+            .expect("state write");
+        call(&mut vm, push_entry(&eps, &[await_n.index()]));
+        assert_eq!(state(&vm, val_sink.index()), SteelVal::IntV(7));
+        assert_eq!(state(&vm, err_sink.index()), SteelVal::Void);
+
+        // An error pair fires only the error output.
+        node::state::update_value(
+            &mut vm,
+            &[await_n.index()],
+            await_::error_pair("boom".to_string()),
+        )
+        .expect("state write");
+        call(&mut vm, push_entry(&eps, &[await_n.index()]));
+        assert_eq!(state(&vm, val_sink.index()), SteelVal::IntV(7));
+        assert_eq!(
+            state(&vm, err_sink.index()),
+            SteelVal::StringV("boom".into())
+        );
+
+        // A non-task input passes straight through the value output.
+        call(&mut vm, push_entry(&eps, &[push2.index()]));
+        assert_eq!(state(&vm, val_sink.index()), SteelVal::IntV(9));
+    }
+}
+
+/// The test app's `.gantz` sugar carrier (required by the codec macro; this
+/// test never parses text).
+struct NodeSet;
+
+impl gantz_format::NodeSugar for NodeSet {
+    fn sugar() -> gantz_format::Sugars<'static> {
+        gantz_format::Sugars(vec![&gantz_format::CoreSugar])
+    }
+}
+
+/// The codec over the test's node set, through which the runtime's
+/// reified-graph cache serves the stored graph as typed nodes.
+fn codec() -> gantz_egui::node::NodeCodec {
+    gantz_egui::ui_node_codec! {
+        NodeSet {
+            bevy_gantz_egui::node::Await,
+            bevy_gantz_egui::node::Sleep,
+            gantz_egui::node::Inspect,
+        }
+    }
+}
+
+/// The full bevy plumbing, headless: `sleep -> await -> inspect` built in
+/// code, compiled by `vm::sync`, the sleep entrypoint fired, and the result
+/// delivered by `drive_awaits` once the duration elapses.
+#[test]
+fn driver_delivers_sleep_result_through_app() {
+    use bevy_app::{App, TaskPoolPlugin, Update};
+    use bevy_ecs::prelude::*;
+    use bevy_gantz::{EntrypointSet, GantzPlugin, Registry, VmSet, head, timestamp};
+    use std::time::{Duration, Instant};
+
+    let mut app = App::new();
+    app.add_plugins(TaskPoolPlugin::default())
+        .add_plugins(GantzPlugin)
+        .insert_resource(bevy_gantz_egui::NodeCodecRes(codec()))
+        .init_resource::<bevy_gantz_egui::GraphCache>()
+        .init_resource::<bevy_gantz_egui::BuiltinNodes>()
+        .init_non_send::<await_::AwaitTasks>()
+        .add_systems(
+            Update,
+            (
+                bevy_gantz_egui::vm::sync.in_set(VmSet),
+                await_::drive_awaits.after(VmSet).in_set(EntrypointSet),
+            ),
+        );
+    app.world_mut()
+        .get_resource_or_init::<bevy_gantz_egui::vm::EntrypointFns>()
+        .0
+        .push(Box::new(|get_node, graph| {
+            gantz_core::compile::push_pull_entrypoints(get_node, graph)
+        }));
+
+    // Build `sleep(0.05) -> await -> inspect` as stored (erased) data.
+    let mut sleep_node = Sleep::default();
+    sleep_node.set_duration(0.05);
+    let mut dg = gantz_ca::DataGraph::default();
+    let sleep = dg.add_node(gantz_core::data::erase_node_typed(&sleep_node).unwrap());
+    let await_n = dg.add_node(gantz_core::data::erase_node_typed(&Await).unwrap());
+    let inspect =
+        dg.add_node(gantz_core::data::erase_node_typed(&gantz_egui::node::Inspect).unwrap());
+    dg.add_edge(sleep, await_n, gantz_ca::Edge::from((0, 0)));
+    dg.add_edge(await_n, inspect, gantz_ca::Edge::from((0, 0)));
+
+    // Commit it, reify it into the cache, and open it as a head.
+    let graph_ca = gantz_ca::graph_addr(&dg);
+    let commit = {
+        let mut registry = app.world_mut().resource_mut::<Registry>();
+        registry.commit_graph(timestamp(), None, graph_ca, move || dg)
+    };
+    app.world_mut()
+        .resource_scope::<bevy_gantz_egui::GraphCache, _>(|world, mut cache| {
+            let registry = world.resource::<Registry>();
+            bevy_gantz_egui::refresh_cache(registry, &mut cache, &codec());
+        });
+    app.world_mut()
+        .trigger(head::OpenEvent(gantz_ca::Head::Commit(commit)));
+
+    // First update: `vm::sync` compiles the head's VM.
+    app.update();
+    let mut q = app
+        .world_mut()
+        .query_filtered::<Entity, With<head::OpenHead>>();
+    let head_entity = q.single(app.world()).expect("one open head");
+
+    // Fire the sleep node: its task flows into `await`, which swallows the
+    // evaluation; `drive_awaits` stashes and polls it across updates.
+    app.world_mut().trigger(bevy_gantz::vm::EvalEntryEvent {
+        head: head_entity,
+        entrypoint: gantz_core::compile::entrypoint::push(vec![sleep.index()], 1),
+        time: None,
+    });
+
+    // `sleep` forwards its (unconnected, so `'()`) input value once the
+    // duration elapses: the inspect sink's state flips from `Void` to `'()`.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        app.update();
+        let vms = app.world().non_send::<head::HeadVms>();
+        let vm = vms.0.get(&head_entity).expect("head VM");
+        let st = state(vm, inspect.index());
+        if st != SteelVal::Void {
+            assert_eq!(st, SteelVal::ListV(Default::default()));
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "await result was not delivered in time",
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+
+    // The delivered task is removed from the pending map.
+    let tasks = app.world().non_send::<await_::AwaitTasks>();
+    assert!(tasks.0.is_empty());
+}

--- a/crates/bevy_gantz_egui/tests/await.rs
+++ b/crates/bevy_gantz_egui/tests/await.rs
@@ -1,7 +1,7 @@
 //! End-to-end tests for the `await` node: the state/branch protocol in a bare
 //! VM, and result delivery through the bevy driver in a headless app.
 
-use bevy_gantz::task::TaskHandle;
+use bevy_gantz::task::{GantzTask, TaskHandle};
 use bevy_gantz_egui::node::{Await, Sleep, await_};
 use gantz_core::{
     Edge, Node,
@@ -10,7 +10,7 @@ use gantz_core::{
 };
 use std::fmt::Debug;
 use steel::SteelVal;
-use steel::rvals::FromSteelVal;
+use steel::rvals::IntoSteelVal;
 use steel::steel_vm::engine::Engine;
 
 trait DebugNode: Debug + Node {}
@@ -44,22 +44,25 @@ fn state(vm: &Engine, ix: usize) -> SteelVal {
         .expect("state present")
 }
 
-/// Take the task stashed in an await node's pending state pair, as the
-/// driver's stash step does.
-fn take_stashed(vm: &Engine, ix: usize) -> bevy_gantz::task::GantzTask {
-    let st = state(vm, ix);
-    let SteelVal::ListV(list) = &st else {
-        panic!("await state is not a pair: {st:?}");
-    };
-    let mut items = list.iter();
-    let (Some(arm), Some(payload)) = (items.next(), items.next()) else {
-        panic!("await state is not a pair: {st:?}");
-    };
-    assert_eq!(*arm, SteelVal::IntV(2), "await state should be pending");
-    TaskHandle::from_steelval(payload)
-        .expect("pending payload is a task handle")
-        .take()
-        .expect("task present")
+/// The handle stashed in an await node's pending state pair, sharing the cell
+/// of the one in state (the driver polls through such a handle in place).
+fn stashed_handle(vm: &Engine, ix: usize) -> TaskHandle {
+    await_::pending_handle(&state(vm, ix)).expect("await state should be a pending pair")
+}
+
+/// A `(list 2 <handle>)` pending pair over a fresh handle for the given task,
+/// as the await expr stashes. Returns the pair and a clone of the handle.
+fn pending_pair(task: GantzTask) -> (SteelVal, TaskHandle) {
+    let handle = TaskHandle::new(task);
+    let pair = SteelVal::ListV(
+        [
+            SteelVal::IntV(2),
+            handle.clone().into_steelval().expect("handle to steelval"),
+        ]
+        .into_iter()
+        .collect(),
+    );
+    (pair, handle)
 }
 
 /// The whole state/branch protocol in a bare VM, under both compile configs:
@@ -103,9 +106,11 @@ fn await_delivers_value_error_and_passthrough() {
         assert_eq!(state(&vm, err_sink.index()), SteelVal::Void);
 
         // The stashed zero-duration task resolves to the pushed value on the
-        // first check.
-        let mut task = take_stashed(&vm, await_n.index());
-        let result = task.check().expect("ready").expect("resolves ok");
+        // first in-place check, leaving the handle in state.
+        let result = stashed_handle(&vm, await_n.index())
+            .check()
+            .expect("ready")
+            .expect("resolves ok");
         assert_eq!(result, SteelVal::IntV(7));
 
         // Driver delivery: write the value pair, fire the await entry fn -
@@ -158,15 +163,12 @@ fn codec() -> gantz_egui::node::NodeCodec {
     }
 }
 
-/// The full bevy plumbing, headless: `sleep -> await -> inspect` built in
-/// code, compiled by `vm::sync`, the sleep entrypoint fired, and the result
-/// delivered by `drive_awaits` once the duration elapses.
-#[test]
-fn driver_delivers_sleep_result_through_app() {
+/// A headless app with the gantz plugin, the test codec, and the `vm::sync` +
+/// `drive_awaits` systems - the minimal plumbing the await driver needs.
+fn task_test_app() -> bevy_app::App {
     use bevy_app::{App, TaskPoolPlugin, Update};
-    use bevy_ecs::prelude::*;
-    use bevy_gantz::{EntrypointSet, GantzPlugin, Registry, VmSet, head, timestamp};
-    use std::time::{Duration, Instant};
+    use bevy_ecs::prelude::IntoScheduleConfigs;
+    use bevy_gantz::{EntrypointSet, GantzPlugin, VmSet};
 
     let mut app = App::new();
     app.add_plugins(TaskPoolPlugin::default())
@@ -174,7 +176,6 @@ fn driver_delivers_sleep_result_through_app() {
         .insert_resource(bevy_gantz_egui::NodeCodecRes(codec()))
         .init_resource::<bevy_gantz_egui::GraphCache>()
         .init_resource::<bevy_gantz_egui::BuiltinNodes>()
-        .init_non_send::<await_::AwaitTasks>()
         .add_systems(
             Update,
             (
@@ -188,6 +189,28 @@ fn driver_delivers_sleep_result_through_app() {
         .push(Box::new(|get_node, graph| {
             gantz_core::compile::push_pull_entrypoints(get_node, graph)
         }));
+    app
+}
+
+/// Reify the registry's committed graphs into the app's graph cache.
+fn refresh_app_cache(app: &mut bevy_app::App) {
+    app.world_mut()
+        .resource_scope::<bevy_gantz_egui::GraphCache, _>(|world, mut cache| {
+            let registry = world.resource::<bevy_gantz::Registry>();
+            bevy_gantz_egui::refresh_cache(registry, &mut cache, &codec());
+        });
+}
+
+/// The full bevy plumbing, headless: `sleep -> await -> inspect` built in
+/// code, compiled by `vm::sync`, the sleep entrypoint fired, and the result
+/// delivered by `drive_awaits` once the duration elapses.
+#[test]
+fn driver_delivers_sleep_result_through_app() {
+    use bevy_ecs::prelude::*;
+    use bevy_gantz::{Registry, head, timestamp};
+    use std::time::{Duration, Instant};
+
+    let mut app = task_test_app();
 
     // Build `sleep(0.05) -> await -> inspect` as stored (erased) data.
     let mut sleep_node = Sleep::default();
@@ -206,11 +229,7 @@ fn driver_delivers_sleep_result_through_app() {
         let mut registry = app.world_mut().resource_mut::<Registry>();
         registry.commit_graph(timestamp(), None, graph_ca, move || dg)
     };
-    app.world_mut()
-        .resource_scope::<bevy_gantz_egui::GraphCache, _>(|world, mut cache| {
-            let registry = world.resource::<Registry>();
-            bevy_gantz_egui::refresh_cache(registry, &mut cache, &codec());
-        });
+    refresh_app_cache(&mut app);
     app.world_mut()
         .trigger(head::OpenEvent(gantz_ca::Head::Commit(commit)));
 
@@ -222,7 +241,7 @@ fn driver_delivers_sleep_result_through_app() {
     let head_entity = q.single(app.world()).expect("one open head");
 
     // Fire the sleep node: its task flows into `await`, which swallows the
-    // evaluation; `drive_awaits` stashes and polls it across updates.
+    // evaluation; `drive_awaits` polls it in place across updates.
     app.world_mut().trigger(bevy_gantz::vm::EvalEntryEvent {
         head: head_entity,
         entrypoint: gantz_core::compile::entrypoint::push(vec![sleep.index()], 1),
@@ -248,7 +267,163 @@ fn driver_delivers_sleep_result_through_app() {
         std::thread::sleep(Duration::from_millis(5));
     }
 
-    // The delivered task is removed from the pending map.
-    let tasks = app.world().non_send::<await_::AwaitTasks>();
-    assert!(tasks.0.is_empty());
+    // Delivery replaced the pending pair, releasing the handle from state.
+    let vms = app.world().non_send::<head::HeadVms>();
+    let vm = vms.0.get(&head_entity).expect("head VM");
+    assert!(await_::pending_handle(&state(vm, await_n.index())).is_none());
+}
+
+/// Deleting a node reindexes its successors via swap-remove: the editor's
+/// delete flow (`remove_value` + `move_value`) must carry a pending task with
+/// the await node's state, and dropping an unmapped key must cancel its task.
+#[test]
+fn state_migration_carries_and_cancels_pending_tasks() {
+    use std::cell::Cell;
+    use std::collections::BTreeMap;
+    use std::rc::Rc;
+
+    /// Sets its flag when dropped, proving the task was released.
+    struct DropFlag(Rc<Cell<bool>>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.set(true);
+        }
+    }
+
+    let mut vm = Engine::new_base();
+    vm.register_value(gantz_core::ROOT_STATE, SteelVal::empty_hashmap());
+
+    // A pending await at index 2 whose task resolves on first check.
+    let mut val = Some(SteelVal::IntV(11));
+    let (pair, _) = pending_pair(GantzTask::poll_fn(move || val.take().map(Ok)));
+    node::state::update_value(&mut vm, &[2], pair).expect("state write");
+    node::state::update_value(&mut vm, &[0], SteelVal::IntV(0)).expect("state write");
+
+    // The editor's delete flow: drop node 0's state, swap the last node (2)
+    // into its index.
+    node::state::remove_value(&mut vm, &[0]).expect("remove");
+    node::state::move_value(&mut vm, &[2], &[0]).expect("move");
+
+    // The pending task followed the node and still delivers.
+    assert!(
+        node::state::extract_value(&vm, &[2])
+            .expect("read")
+            .is_none()
+    );
+    let handle = stashed_handle(&vm, 0);
+    assert_eq!(handle.check(), Some(Ok(SteelVal::IntV(11))));
+
+    // A `remap_root` whose mapping omits the node drops its state, cancelling
+    // the task.
+    let flag = Rc::new(Cell::new(false));
+    let guard = DropFlag(flag.clone());
+    let (pair, _) = pending_pair(GantzTask::poll_fn(move || {
+        let _ = &guard;
+        None
+    }));
+    node::state::update_value(&mut vm, &[3], pair).expect("state write");
+    node::state::remap_root(&mut vm, &BTreeMap::from([(0, 1)])).expect("remap");
+    assert!(
+        node::state::extract_value(&vm, &[3])
+            .expect("read")
+            .is_none()
+    );
+    assert!(flag.get(), "dropped state should cancel the pending task");
+}
+
+/// Regression test for in-flight awaits surviving a reindexing graph change:
+/// replace the head with a child commit in which every node's index shifted
+/// (a leading node removed). `migrate_vm_state` remaps the node state - and
+/// with it the pending task - so the result still delivers at the new path.
+#[test]
+fn pending_await_survives_reindexing_replace() {
+    use bevy_ecs::prelude::*;
+    use bevy_gantz::{Registry, head, timestamp};
+    use std::time::{Duration, Instant};
+
+    let mut app = task_test_app();
+
+    // Base graph: `filler, sleep(0.5) -> await -> inspect`. The filler is a
+    // content-distinct sleep (the migration matcher pairs nodes by content
+    // address, so duplicates would match arbitrarily).
+    let mut filler_node = Sleep::default();
+    filler_node.set_duration(9.0);
+    let mut sleep_node = Sleep::default();
+    sleep_node.set_duration(0.5);
+    let mut base_dg = gantz_ca::DataGraph::default();
+    let _filler = base_dg.add_node(gantz_core::data::erase_node_typed(&filler_node).unwrap());
+    let sleep = base_dg.add_node(gantz_core::data::erase_node_typed(&sleep_node).unwrap());
+    let await_n = base_dg.add_node(gantz_core::data::erase_node_typed(&Await).unwrap());
+    let _inspect =
+        base_dg.add_node(gantz_core::data::erase_node_typed(&gantz_egui::node::Inspect).unwrap());
+    base_dg.add_edge(sleep, await_n, gantz_ca::Edge::from((0, 0)));
+    base_dg.add_edge(await_n, _inspect, gantz_ca::Edge::from((0, 0)));
+
+    // The child graph: identical but without the filler, so every index
+    // shifts down by one.
+    let mut child_dg = gantz_ca::DataGraph::default();
+    let c_sleep = child_dg.add_node(gantz_core::data::erase_node_typed(&sleep_node).unwrap());
+    let c_await = child_dg.add_node(gantz_core::data::erase_node_typed(&Await).unwrap());
+    let c_inspect =
+        child_dg.add_node(gantz_core::data::erase_node_typed(&gantz_egui::node::Inspect).unwrap());
+    child_dg.add_edge(c_sleep, c_await, gantz_ca::Edge::from((0, 0)));
+    child_dg.add_edge(c_await, c_inspect, gantz_ca::Edge::from((0, 0)));
+
+    // Commit the base, open it, compile.
+    let base_ca = gantz_ca::graph_addr(&base_dg);
+    let base_commit = {
+        let mut registry = app.world_mut().resource_mut::<Registry>();
+        registry.commit_graph(timestamp(), None, base_ca, move || base_dg)
+    };
+    refresh_app_cache(&mut app);
+    app.world_mut()
+        .trigger(head::OpenEvent(gantz_ca::Head::Commit(base_commit)));
+    app.update();
+    let mut q = app
+        .world_mut()
+        .query_filtered::<Entity, With<head::OpenHead>>();
+    let head_entity = q.single(app.world()).expect("one open head");
+
+    // Fire the sleep so a task is pending at the await node.
+    app.world_mut().trigger(bevy_gantz::vm::EvalEntryEvent {
+        head: head_entity,
+        entrypoint: gantz_core::compile::entrypoint::push(vec![sleep.index()], 1),
+        time: None,
+    });
+    app.update();
+    {
+        let vms = app.world().non_send::<head::HeadVms>();
+        let vm = vms.0.get(&head_entity).expect("head VM");
+        assert!(await_::pending_handle(&state(vm, await_n.index())).is_some());
+    }
+
+    // Replace the head with the child commit while the task is pending. The
+    // chain-tracked matching remaps node state (await 2 -> 1, inspect 3 -> 2).
+    let child_ca = gantz_ca::graph_addr(&child_dg);
+    let child_commit = {
+        let mut registry = app.world_mut().resource_mut::<Registry>();
+        registry.commit_graph(timestamp(), Some(base_commit), child_ca, move || child_dg)
+    };
+    refresh_app_cache(&mut app);
+    app.world_mut()
+        .trigger(head::ReplaceEvent(gantz_ca::Head::Commit(child_commit)));
+
+    // The result must deliver to the inspect sink at its NEW index.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        app.update();
+        let vms = app.world().non_send::<head::HeadVms>();
+        let vm = vms.0.get(&head_entity).expect("head VM");
+        let st = state(vm, c_inspect.index());
+        if st != SteelVal::Void {
+            assert_eq!(st, SteelVal::ListV(Default::default()));
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "await result was not delivered after the reindexing replace",
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
 }

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -39,6 +39,8 @@ pub fn codec() -> gantz_egui::node::NodeCodec {
             gantz_egui::node::Comment,
             bevy_gantz_egui::node::UpdateBang,
             bevy_gantz_egui::node::TickBang,
+            bevy_gantz_egui::node::Await,
+            bevy_gantz_egui::node::Sleep,
             gantz_egui::node::Inspect,
             gantz_egui::node::Plot,
             gantz_plyphon::UnitNode,
@@ -184,6 +186,7 @@ mod tests {
     fn builtins_match_expected_name_set() {
         let mut expected = vec![
             "apply",
+            "await",
             "bang",
             "branch",
             "comment",
@@ -197,6 +200,7 @@ mod tests {
             "number",
             "outlet",
             "plot",
+            "sleep",
             "tick!",
             "update!",
             "~bus",
@@ -257,6 +261,9 @@ mod tests {
             node_datum("Bang", vec![]),
             node_datum("Inspect", vec![]),
             node_datum("UpdateBang", vec![]),
+            node_datum("Await", vec![]),
+            node_datum("Sleep", vec![]),
+            node_datum("Sleep", vec![("duration", Datum::F64(0.25))]),
             node_datum(
                 "TickBang",
                 vec![(
@@ -512,6 +519,10 @@ mod tests {
                 "7efc434b814bf22f86e51c95a525c335b050cefe38a37598dd45bce0f1ebfde4",
             ),
             (
+                "Await",
+                "ae7e6f2aa5a151e730875311da2eaddb271ccf2b21b8043e5a2dc2a36b036e08",
+            ),
+            (
                 "Bang",
                 "ac2f4e3d47c7b69a188da461568e9c9c013d1458f68a259ad3c64c3e4055c825",
             ),
@@ -586,6 +597,10 @@ mod tests {
             (
                 "ScopeOut",
                 "f52e55d37ad94f3c6bd37c78f55282f8b8e934c8f26e075cd1afb32a5eee133c",
+            ),
+            (
+                "Sleep",
+                "c2b64d4e118478d3be0f7c5eca933105fafbd788e8ca05e0736e28d9d4e317eb",
             ),
             (
                 "Sum",


### PR DESCRIPTION
Closes #363.

Adds a generic `await` node that receives an opaque task value, swallows evaluation until the task resolves, and then fires the result through a push evaluation. Built entirely on existing primitives (branches, state, push entrypoints, an entrypoint driver system). No `gantz_core` changes.

## `bevy_gantz::task`

- `GantzTask`: a unit of asynchronous work resolving to a `SteelVal` or an error string with two backing kinds:
    1. a future spawned on bevy's `AsyncComputeTaskPool` (its `Send` output is converted to a `SteelVal` on the main thread on completion, via a closure that may capture non-`Send` values), and
    2. a driver-polled closure (`poll_fn`) for frame-paced work such as timers, where an executor-driven future would have to busy-wake itself to be re-polled (and would spin the main thread on wasm, where `tick_global_task_pools` is compiled out).
- `TaskHandle`: a cloneable `Rc<RefCell<Option<GantzTask>>>` implementing steel's `Custom`, so tasks can live in node state and travel along graph edges as opaque values. This is the first `SteelVal::Custom` use in the tree. It works without a `Send` bound because the `sync` feature is off and head VMs are `NonSend`. A `(gantz-task? x)` predicate is registered for generated code, guarded so recompiles do not leak global slots.
- Dropping a `GantzTask` cancels it, so pruning and replacement cancel superseded work for free.

## The `await` node

1 input, 2 outputs (value, error), stateful, three branch arms: `[t f]` fires the value output, `[f t]` the error output, `[f f]` fires nothing (the dead-arm pattern established by `~scopeout`). Its state is always a valid `(list arm payload)` branch pair, with the stashed task riding as the pending arm's payload, so the push-entry expr is simply `(begin state)` and a spurious entry fire is harmless.

A non-task input value passes straight through the value output in the same evaluation (awaiting a plain value acts as identity). It implements `push_eval`, so the generic `push_pull_entrypoints` provider compiles its delivery entry fn with no custom `EntrypointFns` contribution.

The `drive_awaits` system (scheduled with the other entrypoint drivers) moves stashed tasks into a `NonSend` pending map keyed by `(head, node path)`, polls them each update, and on completion writes the result pair into node state and triggers the node's push entrypoint, guarded on the entry fn existing in the compiled module. Entries are pruned (cancelling their task) when the head closes or the node disappears, while a head that merely cannot be walked this update (e.g. a transient cache gap) keeps its entries. A task arriving while another is pending replaces it, latest wins.

Known v1 limitations: the pending map is not remapped when a graph edit reindexes nodes, so such an edit cancels the in-flight task. Task values do not replicate over collab, and peers replaying an eval spawn their own tasks (flagged as an open question on #363).

## The `sleep` node

The simplest producer, mainly for testing and demonstrating `await`. It forwards its input value through a `poll_fn` deadline task after a configurable duration (inspector drag value, `(sleep #:duration secs)` sugar).

---

Both nodes are registered in the app codec, the builtin name gate, the node-set wire cases and two deliberate new content-address pins (all existing pins unchanged).
