### PR TITLE
feat: lazily-compiled per-domain steel modules (#307)

### DIFF
--- a/crates/bevy_gantz/src/lib.rs
+++ b/crates/bevy_gantz/src/lib.rs
@@ -104,6 +104,7 @@ impl Plugin for GantzPlugin {
             .init_resource::<HeadTabOrder>()
             .init_resource::<Registry>()
             .init_resource::<vm::CompileConfig>()
+            .init_resource::<vm::SteelModules>()
             .init_resource::<vm::ValidateCommitted>()
             .insert_resource(EvalEpoch(web_time::Instant::now()))
             .init_non_send::<HeadVms>()

--- a/crates/bevy_gantz/src/vm.rs
+++ b/crates/bevy_gantz/src/vm.rs
@@ -21,6 +21,22 @@ use std::time::Duration;
 #[derive(Default, Resource)]
 pub struct CompileConfig(pub core_compile::Config);
 
+/// Resource collecting the domain-provided [`SteelModule`]s registered on
+/// every freshly created head VM.
+///
+/// Domain plugins contribute via `get_resource_or_init` + push (never
+/// `insert_resource`), so plugin order does not matter. `gantz_core`'s own
+/// modules are baked into engine creation (`gantz_core::vm::new_engine`)
+/// and need no entry here.
+///
+/// Contributions must land during plugin construction: an engine only sees
+/// the modules present when its head is first compiled, and the in-place
+/// recompile path never re-registers.
+///
+/// [`SteelModule`]: gantz_core::vm::SteelModule
+#[derive(Default, Resource)]
+pub struct SteelModules(pub Vec<gantz_core::vm::SteelModule>);
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------

--- a/crates/bevy_gantz_egui/src/vm.rs
+++ b/crates/bevy_gantz_egui/src/vm.rs
@@ -7,7 +7,7 @@ use crate::reg::{BuiltinNodes, GraphCache, lookup_node};
 use bevy_ecs::prelude::*;
 use bevy_gantz::Registry;
 use bevy_gantz::head;
-use bevy_gantz::vm::{CompileConfig, Inputs};
+use bevy_gantz::vm::{CompileConfig, Inputs, SteelModules};
 use bevy_log as log;
 use gantz_ca as ca;
 use gantz_core::node::{GetNode, graph::Graph};
@@ -92,6 +92,7 @@ pub fn sync(
     codec: Res<NodeCodecRes>,
     ep_fns: Res<EntrypointFns>,
     config: Res<CompileConfig>,
+    modules: Res<SteelModules>,
     mut vms: NonSendMut<head::HeadVms>,
     mut heads_query: Query<head::OpenHeadData, With<head::OpenHead>>,
 ) {
@@ -154,12 +155,17 @@ pub fn sync(
         let get_node = |ca: &ca::ContentAddr| lookup_node(&cache, &builtins.instances, ca);
         let entrypoints = collect_entrypoints(&ep_fns, &get_node, graph);
         let result = match vms.get_mut(&data.entity) {
-            None => gantz_core::vm::init(&get_node, graph, &entrypoints, &config.0).map(
-                |(vm, module)| {
-                    vms.insert(data.entity, vm);
-                    module
-                },
-            ),
+            None => gantz_core::vm::init_with_modules(
+                &get_node,
+                graph,
+                &entrypoints,
+                &config.0,
+                &modules.0,
+            )
+            .map(|(vm, module)| {
+                vms.insert(data.entity, vm);
+                module
+            }),
             Some(vm) => {
                 gantz_core::graph::register(&get_node, graph, &[], vm);
                 gantz_core::vm::compile(&get_node, graph, vm, &entrypoints, &config.0)
@@ -194,5 +200,23 @@ mod tests {
             4,
             "the pre-pushed provider and the plugin's three seeds must survive",
         );
+    }
+
+    /// Steel modules pushed into `SteelModules` before `GantzPlugin` is
+    /// added must survive its build (same shared-collection convention as
+    /// `EntrypointFns`).
+    #[test]
+    fn steel_modules_survive_plugin_order() {
+        let mut app = bevy_app::App::new();
+        app.world_mut()
+            .get_resource_or_init::<SteelModules>()
+            .0
+            .push(gantz_core::vm::SteelModule {
+                name: "test/module",
+                src: "(provide nothing) (define nothing '())",
+            });
+        app.add_plugins(bevy_gantz::GantzPlugin);
+        let modules = app.world().resource::<SteelModules>();
+        assert_eq!(modules.0.len(), 1, "the pre-pushed module must survive");
     }
 }

--- a/crates/gantz/src/node.rs
+++ b/crates/gantz/src/node.rs
@@ -1912,6 +1912,48 @@ mod tests {
         }
     }
 
+    /// The full app pipeline for `#:require`: a `.gantz` snippet declaring a
+    /// steel module dep on an expr parses through the app codec, compiles via
+    /// `vm::init` (which registers `gantz/option`), emits the `(require ...)`
+    /// and evaluates the module's bindings.
+    #[test]
+    fn expr_require_sugar_compiles_and_evaluates() {
+        use std::time::Duration;
+
+        let text = "\
+(graph opt-demo
+  (b bang)
+  (u (expr (begin $push (unwrap-or (None) 42)) #:require \"gantz/option\"))
+  (c (expr (assert! (equal? $x 42))))
+  (-> b u)
+  (-> u c))";
+        let registry: DataReg =
+            gantz_egui::format::from_str(text, Duration::from_secs(0), &super::codec())
+                .expect("from_str");
+        let reified = reify_all(&registry);
+        let builtins = builtins_with_instances();
+        let codec = super::codec();
+        let reg_env = env(&registry, &reified, &builtins, &codec);
+        let get_node = |ca: &gantz_ca::ContentAddr| reg_env.node(ca);
+
+        let head = gantz_ca::Head::Branch(name("opt-demo"));
+        let graph = head_graph(&reified, &registry, &head).expect("head graph");
+        let entrypoints = gantz_core::compile::push_pull_entrypoints(&get_node, graph);
+        assert_eq!(entrypoints.len(), 1, "the bang provides one entrypoint");
+
+        let (mut vm, compiled) =
+            gantz_core::vm::init(&get_node, graph, &entrypoints, &Default::default())
+                .expect("init");
+        assert!(
+            compiled.src.starts_with("(require"),
+            "the declared module leads the emitted module:\n{}",
+            compiled.src,
+        );
+        let fn_name = gantz_core::compile::entry_fn_name(&entrypoints[0].id());
+        vm.call_function_by_name_with_args(&fn_name, vec![])
+            .expect("the required binding evaluates");
+    }
+
     /// Every `ref` in `base.gantz` is auto-syncing, so the demos track the latest
     /// primitive commits automatically. Verified through a load + re-serialize
     /// round-trip (the `update-base` export path): a loaded `NamedRef` whose

--- a/crates/gantz_core/src/compile.rs
+++ b/crates/gantz_core/src/compile.rs
@@ -549,11 +549,42 @@ where
             .map(|(depth, f)| (depth, 1, f)),
     );
     fns.sort_by(|(d1, k1, _), (d2, k2, _)| d2.cmp(d1).then(k1.cmp(k2)));
-    Ok(fns
+
+    // One `(require ...)` per Steel module named by any node in the meta
+    // tree, ahead of every definition. Steel resolves the free identifiers
+    // of every emitted fn at definition time, so module bindings must be
+    // required even for nodes outside any eval path. The `BTreeSet` union
+    // keeps emission order deterministic.
+    let requires = collect_requires(&meta_tree)
         .into_iter()
-        .map(|(_, _, f)| f)
+        .map(|name| {
+            // Node-declared names reach a string literal in emitted Steel, so
+            // restrict them to a conservative charset rather than escaping.
+            let valid = !name.is_empty()
+                && name
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || "/-_.".contains(c));
+            if !valid {
+                return Err(ModuleError::InvalidModuleName { name });
+            }
+            Ok(emit::parse_one(&format!("(require \"{name}\")")))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(requires
+        .into_iter()
+        .chain(fns.into_iter().map(|(_, _, f)| f))
         .chain(builder.fns)
         .collect())
+}
+
+/// The union of [`Meta::requires`] over every level of the meta tree.
+fn collect_requires(tree: &RoseTree<Meta>) -> std::collections::BTreeSet<String> {
+    let mut set = tree.elem.requires.clone();
+    for sub in tree.nested.values() {
+        set.extend(collect_requires(sub));
+    }
+    set
 }
 
 /// Insert the all-connected variant conf of every node at every level of the

--- a/crates/gantz_core/src/compile/error.rs
+++ b/crates/gantz_core/src/compile/error.rs
@@ -141,6 +141,10 @@ pub enum ModuleError {
     /// so it surfaces as a compile error rather than emitting malformed Steel.
     #[error("internal compiler error: invalid IR for {}: {detail}", level(path))]
     InvalidIr { path: Vec<node::Id>, detail: String },
+    /// A node declared a required Steel module under a name that cannot be
+    /// emitted as a `(require ...)` string literal.
+    #[error("invalid steel module name {name:?}")]
+    InvalidModuleName { name: String },
 }
 
 impl fmt::Display for MetaError {

--- a/crates/gantz_core/src/compile/meta.rs
+++ b/crates/gantz_core/src/compile/meta.rs
@@ -37,6 +37,9 @@ pub struct Meta {
     pub inputs: BTreeMap<node::Id, usize>,
     /// The total number of outputs on node (whether or not they're connected).
     pub outputs: BTreeMap<node::Id, usize>,
+    /// The names of the registered Steel modules required by this graph's
+    /// nodes (see [`Node::required_modules`]).
+    pub requires: BTreeSet<String>,
 }
 
 /// Whether an edge is known to always be traversed, or whether it is
@@ -147,6 +150,7 @@ impl Meta {
         if node.stateful(ctx) {
             self.stateful.insert(id);
         }
+        self.requires.extend(node.required_modules(ctx));
         Ok(())
     }
 }

--- a/crates/gantz_core/src/diagnostic.rs
+++ b/crates/gantz_core/src/diagnostic.rs
@@ -93,6 +93,11 @@ pub fn from_module_error(err: &ModuleError) -> Vec<Diagnostic> {
         ModuleError::InvalidIr { path, .. } => {
             vec![Diagnostic::compile(path.clone(), err.to_string())]
         }
+        // Module requirements are collected graph-wide, so no single node
+        // path can be attributed.
+        ModuleError::InvalidModuleName { .. } => {
+            vec![Diagnostic::compile(vec![], err.to_string())]
+        }
     }
 }
 

--- a/crates/gantz_core/src/node.rs
+++ b/crates/gantz_core/src/node.rs
@@ -194,6 +194,22 @@ pub trait Node: std::any::Any {
         vec![]
     }
 
+    /// The names of the registered Steel modules this node's [`expr`]
+    /// depends on (see [`crate::vm::SteelModule`]).
+    ///
+    /// Compilation emits one `(require ...)` per module named by any node
+    /// in the graph. Steel resolves the free identifiers in every emitted
+    /// node fn at module definition time, so a node whose expression
+    /// references a module binding must declare the module here even if
+    /// no eval path reaches it.
+    ///
+    /// By default, returns an empty vec (no module dependencies).
+    ///
+    /// [`expr`]: Self::expr
+    fn required_modules(&self, _ctx: MetaCtx) -> Vec<String> {
+        vec![]
+    }
+
     /// Traverse all nested nodes, depth-first, with the given [`Visitor`].
     ///
     /// For each nested node:
@@ -453,6 +469,10 @@ macro_rules! impl_node_for_ptr {
 
             fn required_blobs(&self) -> Vec<(gantz_ca::SectionId, gantz_ca::ContentAddr)> {
                 (**self).required_blobs()
+            }
+
+            fn required_modules(&self, ctx: MetaCtx) -> Vec<String> {
+                (**self).required_modules(ctx)
             }
 
             fn visit(&self, ctx: visit::Ctx<'_, '_>, visitor: &mut dyn Visitor) {

--- a/crates/gantz_core/src/node/expr.rs
+++ b/crates/gantz_core/src/node/expr.rs
@@ -42,6 +42,11 @@ pub struct Expr {
     src: String,
     #[serde(skip_serializing_if = "is_default_outputs")]
     outputs: u8,
+    /// The registered Steel modules the expression depends on. Omitted from
+    /// serialization when empty so pre-existing nodes keep their content
+    /// addresses.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    requires: Vec<String>,
     /// Unique `$` variable names in order of first appearance (cached).
     /// Skipped during serialization and recomputed on deserialization.
     #[serde(skip)]
@@ -58,6 +63,8 @@ impl<'de> Deserialize<'de> for Expr {
             src: String,
             #[serde(default = "default_outputs")]
             outputs: u8,
+            #[serde(default)]
+            requires: Vec<String>,
         }
         let data = ExprData::deserialize(deserializer)?;
         if data.outputs < 1 || data.outputs > 16 {
@@ -70,6 +77,7 @@ impl<'de> Deserialize<'de> for Expr {
         Ok(Expr {
             src: data.src,
             outputs: data.outputs,
+            requires: data.requires,
             vars,
         })
     }
@@ -111,6 +119,7 @@ impl Expr {
         Ok(Expr {
             src,
             outputs: 1,
+            requires: vec![],
             vars,
         })
     }
@@ -146,6 +155,25 @@ impl Expr {
     /// The source string that was used to create this node.
     pub fn src(&self) -> &str {
         &self.src
+    }
+
+    /// Set the registered Steel modules the expression depends on (see
+    /// [`Node::required_modules`]).
+    ///
+    /// Compilation emits a `(require ...)` for each named module, making
+    /// its provided bindings available to the expression.
+    pub fn with_requires<I>(mut self, requires: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<String>,
+    {
+        self.requires = requires.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// The names of the registered Steel modules the expression depends on.
+    pub fn requires(&self) -> &[String] {
+        &self.requires
     }
 
     /// The unique `$` variable names, in order of first appearance.
@@ -286,6 +314,10 @@ impl Node for Expr {
         let (_, path, vm) = ctx.into_parts();
         node::state::init_value_if_absent(vm, path, || steel::SteelVal::Void).unwrap();
     }
+
+    fn required_modules(&self, _ctx: node::MetaCtx) -> Vec<String> {
+        self.requires.clone()
+    }
 }
 
 impl fmt::Display for Expr {
@@ -399,6 +431,26 @@ fn test_set_outputs() {
     let mut e = Expr::new("(values $a $b $c)").unwrap();
     e.set_outputs(3);
     assert_eq!(e.outputs(), 3);
+}
+
+// An `Expr` without requires must serialize exactly as before the field
+// existed (content addresses hash the serialized form), and the requires
+// round-trip when present.
+#[test]
+fn test_requires_serde() {
+    let e = Expr::new("(+ $a 1)").unwrap();
+    let json = serde_json::to_string(&e).unwrap();
+    assert!(!json.contains("requires"));
+    let de: Expr = serde_json::from_str(&json).unwrap();
+    assert_eq!(e, de);
+
+    let e = Expr::new("(unwrap-or $?a 0)")
+        .unwrap()
+        .with_requires(["gantz/option"]);
+    assert_eq!(e.requires(), ["gantz/option"]);
+    let json = serde_json::to_string(&e).unwrap();
+    let de: Expr = serde_json::from_str(&json).unwrap();
+    assert_eq!(e, de);
 }
 
 #[test]

--- a/crates/gantz_core/src/node/fn_.rs
+++ b/crates/gantz_core/src/node/fn_.rs
@@ -104,6 +104,12 @@ impl<N: Node> Node for Fn<N> {
         self.0.required_blobs()
     }
 
+    /// Forwarded from the inner node: the emitted lambda inlines the inner
+    /// node's expression, so its module bindings are load-bearing.
+    fn required_modules(&self, ctx: node::MetaCtx) -> Vec<String> {
+        self.0.required_modules(ctx)
+    }
+
     fn visit(&self, ctx: visit::Ctx<'_, '_>, visitor: &mut dyn node::Visitor) {
         self.0.visit(ctx, visitor);
     }

--- a/crates/gantz_core/src/node/pull.rs
+++ b/crates/gantz_core/src/node/pull.rs
@@ -91,4 +91,8 @@ impl<N: Node> Node for Pull<N> {
     fn required_blobs(&self) -> Vec<(gantz_ca::SectionId, gantz_ca::ContentAddr)> {
         self.node.required_blobs()
     }
+
+    fn required_modules(&self, ctx: node::MetaCtx) -> Vec<String> {
+        self.node.required_modules(ctx)
+    }
 }

--- a/crates/gantz_core/src/node/push.rs
+++ b/crates/gantz_core/src/node/push.rs
@@ -89,4 +89,8 @@ impl<N: Node> Node for Push<N> {
     fn required_blobs(&self) -> Vec<(gantz_ca::SectionId, gantz_ca::ContentAddr)> {
         self.node.required_blobs()
     }
+
+    fn required_modules(&self, ctx: node::MetaCtx) -> Vec<String> {
+        self.node.required_modules(ctx)
+    }
 }

--- a/crates/gantz_core/src/node/ref_.rs
+++ b/crates/gantz_core/src/node/ref_.rs
@@ -269,6 +269,12 @@ impl Node for Ref {
         vec![self.addr]
     }
 
+    fn required_modules(&self, ctx: node::MetaCtx) -> Vec<String> {
+        ctx.node(&self.addr)
+            .map(|n| n.required_modules(ctx))
+            .unwrap_or_default()
+    }
+
     fn visit(&self, ctx: visit::Ctx<'_, '_>, visitor: &mut dyn node::Visitor) {
         if let Some(n) = ctx.node(&self.addr) {
             n.visit(ctx, visitor);

--- a/crates/gantz_core/src/node/state.rs
+++ b/crates/gantz_core/src/node/state.rs
@@ -140,6 +140,10 @@ where
     fn required_blobs(&self) -> Vec<(gantz_ca::SectionId, gantz_ca::ContentAddr)> {
         self.node.required_blobs()
     }
+
+    fn required_modules(&self, ctx: node::MetaCtx) -> Vec<String> {
+        self.node.required_modules(ctx)
+    }
 }
 
 /// Sets the given node's state to the given value.

--- a/crates/gantz_core/src/vm.rs
+++ b/crates/gantz_core/src/vm.rs
@@ -46,6 +46,33 @@ pub enum CompileError {
     },
 }
 
+/// A named Steel source module that can be registered with an [`Engine`].
+///
+/// Registration is cheap: the engine stores the source text and only
+/// compiles the module when a program first `(require ...)`s it by name,
+/// caching the result for the engine's lifetime. Graphs that never
+/// require a module never pay for it.
+///
+/// Modules must be registered via [`new_engine`], which installs a
+/// minimal prelude string first. Steel prepends its prelude string to a
+/// module's source *at registration time*, and the default prelude would
+/// drag the entire steel stdlib into the module's first `(require ...)`.
+#[derive(Clone, Copy, Debug)]
+pub struct SteelModule {
+    /// The name used to `(require ...)` the module.
+    pub name: &'static str,
+    /// The module's Steel source.
+    pub src: &'static str,
+}
+
+/// The Steel modules provided by `gantz_core` itself.
+///
+/// Always registered by [`new_engine`], ahead of any domain modules.
+const CORE_MODULES: &[SteelModule] = &[SteelModule {
+    name: "gantz/option",
+    src: include_str!("vm/option.scm"),
+}];
+
 impl CompileError {
     /// The generated module, when compilation got far enough to produce one
     /// (steel rejecting the module still yields the artifact, so its source
@@ -58,7 +85,39 @@ impl CompileError {
     }
 }
 
+/// The Steel modules provided by `gantz_core` itself.
+///
+/// [`new_engine`] registers these on every engine, so their bindings are
+/// available to any graph via `(require ...)` regardless of which domains
+/// are present.
+pub fn modules() -> &'static [SteelModule] {
+    CORE_MODULES
+}
+
+/// Create a new base [`Engine`] with gantz's core Steel [`modules`] and
+/// the given domain modules registered, plus the root state and args
+/// globals.
+///
+/// The prelude string is reduced to `(require-builtin steel/base)` before
+/// any module is registered (see [`SteelModule`]): module sources get the
+/// base primitives and must `(require-builtin ...)` anything further
+/// themselves.
+pub fn new_engine(extra_modules: &[SteelModule]) -> Engine {
+    let mut vm = Engine::new_base();
+    vm.set_prelude_string(std::borrow::Cow::Borrowed("(require-builtin steel/base)\n"));
+    for m in modules().iter().chain(extra_modules) {
+        vm.register_steel_module(m.name.to_string(), m.src.to_string());
+    }
+    vm.register_value(crate::ROOT_STATE, SteelVal::empty_hashmap());
+    vm.register_value(crate::ARGS, crate::args::default());
+    vm
+}
+
 /// Initialize a new VM with root state and register the given graph.
+///
+/// The VM is created via [`new_engine`] with no domain modules, so
+/// gantz_core's own [`modules`] are available. To register additional
+/// domain modules, use [`init_with_modules`].
 ///
 /// Returns the initialized VM and the compiled module.
 pub fn init<'a, G>(
@@ -76,9 +135,28 @@ where
         + Copy,
     G::NodeWeight: Node,
 {
-    let mut vm = Engine::new_base();
-    vm.register_value(crate::ROOT_STATE, SteelVal::empty_hashmap());
-    vm.register_value(crate::ARGS, crate::args::default());
+    init_with_modules(get_node, graph, entrypoints, config, &[])
+}
+
+/// The same as [`init`], but with additional domain [`SteelModule`]s
+/// registered on the freshly created engine (see [`new_engine`]).
+pub fn init_with_modules<'a, G>(
+    get_node: node::GetNode<'a>,
+    graph: G,
+    entrypoints: &[crate::compile::Entrypoint],
+    config: &crate::compile::Config,
+    extra_modules: &[SteelModule],
+) -> Result<(Engine, Compiled), CompileError>
+where
+    G: Data<EdgeWeight = Edge>
+        + IntoEdgesDirected
+        + IntoNodeReferences
+        + NodeIndexable
+        + Visitable
+        + Copy,
+    G::NodeWeight: Node,
+{
+    let mut vm = new_engine(extra_modules);
     crate::graph::register(get_node, graph, &[], &mut vm);
     let compiled = compile(get_node, graph, &mut vm, entrypoints, config)?;
     Ok((vm, compiled))

--- a/crates/gantz_core/src/vm/option.scm
+++ b/crates/gantz_core/src/vm/option.scm
@@ -1,0 +1,23 @@
+;; Ergonomic helpers over steel's builtin Option type.
+;;
+;; Steel's own `option.scm` library is unavailable on the prelude-free
+;; base engine (it depends on the contract modules), so gantz provides
+;; the small subset that makes `$?` optional inputs pleasant to use.
+;;
+;; Written for the base engine: primitive special forms only (no `and`,
+;; `or`, `cond`).
+(require-builtin steel/core/option)
+
+(provide option? unwrap-or map-option)
+
+;; Whether the value is an Option (`Some` or `None`).
+(define (option? v)
+  (if (Some? v) #t (None? v)))
+
+;; The value inside `Some`, or `default` when `None`.
+(define (unwrap-or opt default)
+  (if (Some? opt) (Some->value opt) default))
+
+;; Apply `f` to the value inside `Some`, passing `None` through.
+(define (map-option f opt)
+  (if (Some? opt) (Some (f (Some->value opt))) opt))

--- a/crates/gantz_core/tests/modules.rs
+++ b/crates/gantz_core/tests/modules.rs
@@ -1,0 +1,185 @@
+//! Tests for per-node Steel module requirements: `(require ...)` emission
+//! from `Node::required_modules` declarations, and evaluation against the
+//! modules registered by `vm::new_engine`.
+
+use gantz_core::{
+    Edge,
+    compile::{Config, ModuleError, SourceMap, entry_fn_name, push_pull_entrypoints},
+    node::{self, ExprCtx, ExprResult, MetaCtx, Node, RegCtx, WithPushEval},
+};
+use std::fmt::Debug;
+
+trait DebugNode: Debug + Node {}
+impl<T> DebugNode for T where T: Debug + Node {}
+
+// A no-op node lookup function for tests that don't need it.
+fn no_lookup(_: &gantz_ca::ContentAddr) -> Option<&'static dyn Node> {
+    None
+}
+
+fn node_push() -> node::Push<node::Expr> {
+    node::expr("'()").unwrap().with_push_eval()
+}
+
+/// An expr node declaring a dependency on the named Steel modules.
+#[derive(Debug)]
+struct RequiresNode {
+    expr: node::Expr,
+    modules: Vec<String>,
+}
+
+fn node_requires(src: &str, modules: &[&str]) -> RequiresNode {
+    RequiresNode {
+        expr: node::expr(src).unwrap(),
+        modules: modules.iter().map(|m| m.to_string()).collect(),
+    }
+}
+
+impl Node for RequiresNode {
+    fn n_inputs(&self, ctx: MetaCtx) -> usize {
+        self.expr.n_inputs(ctx)
+    }
+
+    fn n_outputs(&self, ctx: MetaCtx) -> usize {
+        self.expr.n_outputs(ctx)
+    }
+
+    fn expr(&self, ctx: ExprCtx<'_, '_>) -> ExprResult {
+        self.expr.expr(ctx)
+    }
+
+    fn stateful(&self, ctx: MetaCtx) -> bool {
+        self.expr.stateful(ctx)
+    }
+
+    fn register(&self, ctx: RegCtx<'_, '_>) {
+        self.expr.register(ctx)
+    }
+
+    fn required_modules(&self, _ctx: MetaCtx) -> Vec<String> {
+        self.modules.clone()
+    }
+}
+
+// A graph with no module declarations emits no `(require ...)` forms.
+#[test]
+fn no_requires_without_declarations() {
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let int = g.add_node(Box::new(node::expr("(begin $push 6)").unwrap()) as Box<_>);
+    g.add_edge(push, int, Edge::from((0, 0)));
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Config::default()).unwrap();
+    let src = gantz_core::vm::fmt_module(&module);
+    assert!(!src.contains("(require"));
+}
+
+// Multiple declarations of the same module emit exactly one leading
+// `(require ...)`, and the SourceMap still resolves every node def around
+// the (nameless) require form.
+#[test]
+fn requires_deduped_and_lead_the_module() {
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let a = g.add_node(Box::new(node_requires(
+        "(begin $push (unwrap-or (Some 1) 0))",
+        &["gantz/option"],
+    )) as Box<_>);
+    let b =
+        g.add_node(Box::new(node_requires("(unwrap-or (Some $x) 0)", &["gantz/option"])) as Box<_>);
+    g.add_edge(push, a, Edge::from((0, 0)));
+    g.add_edge(a, b, Edge::from((0, 0)));
+
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let module = gantz_core::compile::module(&no_lookup, &g, &eps, &Config::default()).unwrap();
+    let src = gantz_core::vm::fmt_module(&module);
+    assert_eq!(src.matches("gantz/option").count(), 1);
+    assert!(src.starts_with("(require"));
+
+    // One def per module expression. The require's def carries no name;
+    // every other def remains a recognised define.
+    let map = SourceMap::parse(&src);
+    assert_eq!(map.defs().len(), module.len());
+    let named = map.defs().iter().filter(|d| d.name.is_some()).count();
+    assert_eq!(named, module.len() - 1);
+
+    // Node defs and refs still resolve to their paths.
+    for n in [a, b] {
+        let path = vec![n.index()];
+        let spans = map.node_spans(&path);
+        assert!(!spans.defs.is_empty(), "no defs for {path:?}");
+        for range in spans.defs.iter().chain(&spans.refs) {
+            assert_eq!(map.node_at(range.clone()), Some(path.clone()));
+        }
+    }
+}
+
+// A declaring node outside every eval path still gets its require: steel
+// resolves the free identifiers of every emitted fn at definition time, so
+// the module bindings must exist even for fns nothing calls. Pinned under
+// both configs (`emit_all_node_fns` emits the orphan's fn unconditionally).
+#[test]
+fn off_eval_path_node_still_requires_its_module() {
+    for config in [
+        Config::default(),
+        Config {
+            emit_all_node_fns: true,
+            ..Config::default()
+        },
+    ] {
+        let mut g = petgraph::graph::DiGraph::new();
+        let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+        let int = g.add_node(Box::new(node::expr("(begin $push 6)").unwrap()) as Box<_>);
+        g.add_edge(push, int, Edge::from((0, 0)));
+        // No edges: the orphan is outside every eval path.
+        let _orphan = g
+            .add_node(
+                Box::new(node_requires("(unwrap-or (Some $x) 0)", &["gantz/option"])) as Box<_>,
+            );
+
+        let eps = push_pull_entrypoints(&no_lookup, &g);
+        let module = gantz_core::compile::module(&no_lookup, &g, &eps, &config).unwrap();
+        let src = gantz_core::vm::fmt_module(&module);
+        assert_eq!(src.matches("gantz/option").count(), 1);
+
+        // The module must also run: `vm::init` registers `gantz/option` so
+        // the emitted require resolves.
+        gantz_core::vm::init(&no_lookup, &g, &eps, &config).unwrap();
+    }
+}
+
+// End-to-end: a node whose expr uses a `gantz/option` binding compiles and
+// evaluates through `vm::init`.
+#[test]
+fn required_module_bindings_evaluate() {
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let unwrap = g.add_node(Box::new(node_requires(
+        "(begin $push (unwrap-or (Some 40) 2))",
+        &["gantz/option"],
+    )) as Box<_>);
+    let check = g.add_node(Box::new(node::expr("(assert! (equal? $x 40))").unwrap()) as Box<_>);
+    g.add_edge(push, unwrap, Edge::from((0, 0)));
+    g.add_edge(unwrap, check, Edge::from((0, 0)));
+
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let (mut vm, _compiled) =
+        gantz_core::vm::init(&no_lookup, &g, &eps, &Config::default()).unwrap();
+    let fn_name = entry_fn_name(&eps[0].id());
+    vm.call_function_by_name_with_args(&fn_name, vec![])
+        .unwrap();
+}
+
+// A declared name that cannot be emitted as a `(require ...)` string
+// literal surfaces as a compile error rather than emitting broken Steel.
+#[test]
+fn invalid_module_name_errors() {
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let bad = g.add_node(Box::new(node_requires("(begin $push 1)", &["bad\"name"])) as Box<_>);
+    g.add_edge(push, bad, Edge::from((0, 0)));
+
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let err = gantz_core::compile::module(&no_lookup, &g, &eps, &Config::default()).unwrap_err();
+    assert!(matches!(err, ModuleError::InvalidModuleName { .. }));
+}

--- a/crates/gantz_core/tests/modules.rs
+++ b/crates/gantz_core/tests/modules.rs
@@ -170,6 +170,31 @@ fn required_module_bindings_evaluate() {
         .unwrap();
 }
 
+// The `Expr` node's own `requires` field drives emission end-to-end: an
+// expr using a `gantz/option` binding compiles and evaluates via `vm::init`
+// with no custom node type involved.
+#[test]
+fn expr_requires_field_evaluates() {
+    let mut g = petgraph::graph::DiGraph::new();
+    let push = g.add_node(Box::new(node_push()) as Box<dyn DebugNode>);
+    let unwrap = g.add_node(Box::new(
+        node::expr("(begin $push (unwrap-or (None) 42))")
+            .unwrap()
+            .with_requires(["gantz/option"]),
+    ) as Box<_>);
+    let check = g.add_node(Box::new(node::expr("(assert! (equal? $x 42))").unwrap()) as Box<_>);
+    g.add_edge(push, unwrap, Edge::from((0, 0)));
+    g.add_edge(unwrap, check, Edge::from((0, 0)));
+
+    let eps = push_pull_entrypoints(&no_lookup, &g);
+    let (mut vm, compiled) =
+        gantz_core::vm::init(&no_lookup, &g, &eps, &Config::default()).unwrap();
+    assert!(compiled.src.starts_with("(require"));
+    let fn_name = entry_fn_name(&eps[0].id());
+    vm.call_function_by_name_with_args(&fn_name, vec![])
+        .unwrap();
+}
+
 // A declared name that cannot be emitted as a `(require ...)` string
 // literal surfaces as a compile error rather than emitting broken Steel.
 #[test]

--- a/crates/gantz_core/tests/steel_target.rs
+++ b/crates/gantz_core/tests/steel_target.rs
@@ -94,3 +94,71 @@ fn define_after_expression_in_body() {
                (top)";
     assert_eq!(run_int(src), 3);
 }
+
+// ----------------------------------------------------------------------------
+// Pins for the registered-steel-module semantics `vm::new_engine` relies on:
+// registration is lazy (no compilation until the first `require`), compiled
+// modules are cached for the engine's lifetime, and provided names bind
+// unmangled in the requiring program.
+
+fn run_int_vm(vm: &mut Engine, src: &str) -> isize {
+    let vals = vm.run(src.to_string()).unwrap();
+    match vals.last() {
+        Some(SteelVal::IntV(i)) => *i,
+        other => panic!("expected IntV, got {other:?}"),
+    }
+}
+
+/// A module registered via `new_engine` resolves through `require`, and its
+/// provided names bind unmangled in the requiring program.
+#[test]
+fn required_module_provides_bind_unmangled() {
+    let mut vm = gantz_core::vm::new_engine(&[]);
+    let src = "(require \"gantz/option\")
+               (+ (unwrap-or (Some 5) 0)
+                  (unwrap-or (None) 2)
+                  (if (option? (Some 1)) 10 0)
+                  (unwrap-or (map-option (lambda (x) (* x 10)) (Some 4)) 0))";
+    assert_eq!(run_int_vm(&mut vm, src), 57);
+}
+
+/// Registration performs no compilation: a syntactically invalid module is
+/// accepted silently, and the error surfaces only at the first `require`.
+#[test]
+fn module_registration_is_lazy() {
+    let broken = gantz_core::vm::SteelModule {
+        name: "gantz/test-broken",
+        src: "(define (broken",
+    };
+    let mut vm = gantz_core::vm::new_engine(&[broken]);
+    assert_eq!(run_int_vm(&mut vm, "(+ 1 2)"), 3);
+    assert!(
+        vm.run("(require \"gantz/test-broken\")".to_string())
+            .is_err()
+    );
+}
+
+/// A second program containing the same `require` hits the engine's module
+/// cache: the module's top-level defines run once per engine, not per run.
+#[test]
+fn required_module_is_cached_across_runs() {
+    let counting = gantz_core::vm::SteelModule {
+        name: "gantz/test-counting",
+        src: "(provide get-count)
+              (define count (box 0))
+              (set-box! count (+ (unbox count) 1))
+              (define (get-count) (unbox count))",
+    };
+    let mut vm = gantz_core::vm::new_engine(&[counting]);
+    let src = "(require \"gantz/test-counting\") (get-count)";
+    assert_eq!(run_int_vm(&mut vm, src), 1);
+    assert_eq!(run_int_vm(&mut vm, src), 1);
+}
+
+/// Requiring a name that was never registered errors rather than silently
+/// binding nothing.
+#[test]
+fn require_of_unregistered_module_errors() {
+    let mut vm = gantz_core::vm::new_engine(&[]);
+    assert!(vm.run("(require \"gantz/nope\")".to_string()).is_err());
+}

--- a/crates/gantz_egui/src/node/named_ref.rs
+++ b/crates/gantz_egui/src/node/named_ref.rs
@@ -201,6 +201,10 @@ impl Node for NamedRef {
         vec![self.ref_.content_addr()]
     }
 
+    fn required_modules(&self, ctx: MetaCtx) -> Vec<String> {
+        self.ref_.required_modules(ctx)
+    }
+
     fn visit(&self, ctx: gantz_core::visit::Ctx<'_, '_>, visitor: &mut dyn node::Visitor) {
         self.ref_.visit(ctx, visitor)
     }

--- a/crates/gantz_egui/src/widget/gui_debug.rs
+++ b/crates/gantz_egui/src/widget/gui_debug.rs
@@ -14,8 +14,8 @@ use std::sync::Arc;
 
 /// The tree seeded into a fresh editor: self-contained layout/display
 /// elements plus a couple of bindings into the focused graph (nodes 0 and 1)
-/// to demonstrate the live harness. Evaluated by `Engine::new_base` (no
-/// prelude), hence the quote.
+/// to demonstrate the live harness. Evaluated by the same prelude-free base
+/// engine the runtime uses, hence the quote.
 const SEED: &str = r#"'(col
   (frame (@ (title "gui debug"))
     (label "edit this tree - it renders live")
@@ -81,7 +81,7 @@ pub fn tree_editor(id: egui::Id, ui: &mut egui::Ui) -> TreeEditOutput {
         .on_hover_text(
             "A quoted tree literal, evaluated by a scratch Steel engine on \
              the UI thread whenever the text changes (no prelude - primitive \
-             forms only)",
+             forms plus gantz's core modules via require)",
         );
 
     // Re-evaluate only when the text changes.
@@ -106,8 +106,12 @@ pub fn tree_editor(id: egui::Id, ui: &mut egui::Ui) -> TreeEditOutput {
 
 /// Evaluate the editor text in a scratch base engine and decode the last
 /// yielded value into an element tree.
+///
+/// The engine comes from `gantz_core::vm::new_engine` for parity with node
+/// exprs: gantz's core steel modules are requirable, though domain modules
+/// are not plumbed through to this scratch pane (yet).
 fn evaluate(text_hash: u64, code: &str) -> Cache {
-    let mut engine = steel::steel_vm::engine::Engine::new_base();
+    let mut engine = gantz_core::vm::new_engine(&[]);
     let (eval_err, decoded) = match engine.run(code.to_string()) {
         Err(e) => (Some(e.to_string()), None),
         Ok(vals) => match vals.last() {

--- a/crates/gantz_format/src/sugar.rs
+++ b/crates/gantz_format/src/sugar.rs
@@ -102,6 +102,28 @@ impl<'a> SugarArgs<'a> {
         }
     }
 
+    /// Find every `#:<key>` keyword and return the string value following
+    /// each occurrence.
+    ///
+    /// Returns an empty vec when the keyword is absent. Errors when an
+    /// occurrence lacks a following string.
+    pub fn keyword_strs(&self, key: &str) -> Result<Vec<String>, FormatError> {
+        self.args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| as_keyword(a).as_deref() == Some(key))
+            .map(|(i, kw)| {
+                self.args.get(i + 1).and_then(as_string).ok_or_else(|| {
+                    err_at(
+                        kw,
+                        self.src,
+                        ErrorKind::Malformed(format!("#:{key} requires a string")),
+                    )
+                })
+            })
+            .collect()
+    }
+
     /// Whether a bare `#:<key>` flag keyword is present.
     pub fn has_flag(&self, key: &str) -> bool {
         self.args
@@ -347,6 +369,11 @@ fn expr_spec(args: SugarArgs<'_>) -> Result<Datum, FormatError> {
     if let Some(out) = args.keyword_int("out")? {
         fields.push(("outputs", Datum::U64(out.max(0) as u64)));
     }
+    let requires = args.keyword_strs("require")?;
+    if !requires.is_empty() {
+        let seq = requires.into_iter().map(Datum::Str).collect();
+        fields.push(("requires", Datum::Seq(seq)));
+    }
     Ok(node_datum("Expr", fields))
 }
 
@@ -375,9 +402,19 @@ fn branch_spec(args: SugarArgs<'_>) -> Result<Datum, FormatError> {
 
 fn write_expr(node: &Datum) -> String {
     let src = node.get("src").and_then(Datum::as_str).unwrap_or("'()");
+    let requires = node
+        .get("requires")
+        .and_then(Datum::as_seq)
+        .map(|seq| {
+            seq.iter()
+                .filter_map(Datum::as_str)
+                .map(|name| format!(" #:require {}", quote(name)))
+                .collect::<String>()
+        })
+        .unwrap_or_default();
     match node.get("outputs").and_then(Datum::as_i64) {
-        Some(n) if n != 1 => format!("(expr {src} #:out {n})"),
-        _ => format!("(expr {src})"),
+        Some(n) if n != 1 => format!("(expr {src} #:out {n}{requires})"),
+        _ => format!("(expr {src}{requires})"),
     }
 }
 
@@ -494,6 +531,75 @@ mod tests {
         with_args("(osc #:rate 5)", |args| {
             assert!(args.keyword_symbol("rate").is_err(), "5 is not a symbol");
         });
+    }
+
+    /// `(expr <code> [#:out n] [#:require "name"]...)` round-trips the
+    /// requires: repeated occurrences read in order, a non-string value
+    /// errors, and a `#:require` nested inside the code slice is ignored.
+    #[test]
+    fn expr_requires_round_trip() {
+        let s = CoreSugar;
+
+        // A single require.
+        let d = read_spec(&s, r#"(expr (unwrap-or $?a 0) #:require "gantz/option")"#)
+            .expect("recognised");
+        let requires: Vec<_> = d
+            .get("requires")
+            .and_then(Datum::as_seq)
+            .expect("requires seq")
+            .iter()
+            .filter_map(Datum::as_str)
+            .collect();
+        assert_eq!(requires, ["gantz/option"]);
+        assert_eq!(
+            s.write_spec("Expr", &d).as_deref(),
+            Some(r#"(expr (unwrap-or $?a 0) #:require "gantz/option")"#),
+        );
+
+        // Repeated requires keep their order, composing with #:out.
+        let d = read_spec(
+            &s,
+            r#"(expr (list (f $x) (g $x)) #:out 2 #:require "b/mod" #:require "a/mod")"#,
+        )
+        .expect("recognised");
+        let requires: Vec<_> = d
+            .get("requires")
+            .and_then(Datum::as_seq)
+            .expect("requires seq")
+            .iter()
+            .filter_map(Datum::as_str)
+            .collect();
+        assert_eq!(requires, ["b/mod", "a/mod"]);
+        assert_eq!(
+            s.write_spec("Expr", &d).as_deref(),
+            Some(r#"(expr (list (f $x) (g $x)) #:out 2 #:require "b/mod" #:require "a/mod")"#),
+        );
+
+        // No requires: the field is absent and the written form unchanged.
+        let d = read_spec(&s, "(expr (+ 1 2))").expect("recognised");
+        assert!(d.get("requires").is_none());
+        assert_eq!(s.write_spec("Expr", &d).as_deref(), Some("(expr (+ 1 2))"));
+
+        // A non-string value errors.
+        let exprs = sexpr::read("(expr (+ 1 2) #:require 5)").expect("read");
+        let args = sexpr::list_args(&exprs[0]).expect("list");
+        assert!(
+            CoreSugar
+                .read_spec(
+                    "expr",
+                    SugarArgs::new(&args[1..], "(expr (+ 1 2) #:require 5)")
+                )
+                .is_err()
+        );
+
+        // A keyword inside the code s-expression is not a require: the
+        // keyword scan only covers top-level args.
+        let d = read_spec(&s, r#"(expr (foo #:require "x"))"#).expect("recognised");
+        assert!(d.get("requires").is_none());
+        assert_eq!(
+            d.get("src").and_then(Datum::as_str),
+            Some(r#"(foo #:require "x")"#),
+        );
     }
 
     #[test]

--- a/pkgs/workspace-src.nix
+++ b/pkgs/workspace-src.nix
@@ -1,12 +1,14 @@
 # Workspace source for crane derivations: cargo-relevant files (Cargo.toml,
 # Cargo.lock, *.rs, *.toml - including .cargo/config.toml and Trunk.toml) plus
-# the .gantz assets that gantz_base and gantz_plyphon include at compile time.
+# the .gantz assets that gantz_base and gantz_plyphon include at compile time
+# and the .scm steel modules that gantz_core includes at compile time.
 { craneLib, lib }:
 rec {
   root = ../.;
   fileset = lib.fileset.unions [
     (craneLib.fileset.commonCargoSources root)
     (lib.fileset.fileFilter (file: file.hasExt "gantz") root)
+    (lib.fileset.fileFilter (file: file.hasExt "scm") root)
   ];
   src = lib.fileset.toSource { inherit root fileset; };
 }


### PR DESCRIPTION
Closes #307.

Gives each domain a way to ship Steel definitions to node exprs without bloating `Engine::new_base()` startup. Named source modules registered at engine creation, compiled lazily by steel at their first `(require ...)` and cached per engine.

## Included

- `gantz_core::vm::SteelModule` and a `new_engine(extra_modules)` constructor. It reduces steel's prelude string to `(require-builtin steel/base)` before registering anything: steel prepends the prelude string to a module's source at registration time, and the default prelude would drag the entire stdlib into the first require. `vm::init` builds through the factory (delegating to the new `init_with_modules`), so every existing call site is unchanged and `base_graphs_all_compile` covers the new bindings automatically.
- `Node::required_modules`, a defaulted metadata method naming the modules a node's expr depends on. Declarations are collected in the existing Meta pass and codegen emits one deduped `(require ...)` at the front of the compiled module. Collection spans the whole meta tree rather than just eval paths because steel resolves every emitted fn's free identifiers at definition time (pinned by a test with an orphan node under `emit_all_node_fns`).
- `Expr` gains a `requires` field (omitted from serialization when empty, so existing content addresses are untouched) and the `.gantz` format gains `(expr <code> [#:out n] [#:require "name"]...)` sugar. Repeated single-string occurrences are the only unambiguous parse next to the verbatim code slice.
- Bevy seam: a `SteelModules` resource mirroring the `BaseSources` convention (`get_resource_or_init` + push from domain plugins), passed to `init_with_modules` when a head VM is first created.
- First real module: `gantz/option` (`option?`, `unwrap-or`, `map-option` over the `steel/core/option` builtins), addressing the option-ergonomics item from #307. The GuiDebug scratch engine now builds through the same factory for parity.

This is the enabling step for the pattern domain (see #373).
