### PR TITLE
feat(gantz_egui): egui Style configuration via Settings > Style

### DIFF
--- a/crates/bevy_gantz_egui/src/lib.rs
+++ b/crates/bevy_gantz_egui/src/lib.rs
@@ -131,7 +131,9 @@ impl Plugin for GantzEguiPlugin {
             .register_response_with::<gantz_egui::OpenHead>(dispatch_open_head)
             .register_response_with::<gantz_egui::ReplaceHead>(dispatch_replace_head)
             .register_response_with::<gantz_egui::ExportHead>(dispatch_export_head)
-            .register_response_with::<gantz_egui::ExportAllNamed>(dispatch_export_all_named);
+            .register_response_with::<gantz_egui::ExportAllNamed>(dispatch_export_all_named)
+            .register_response_with::<gantz_egui::ExportStyle>(dispatch_export_style)
+            .register_response_with::<gantz_egui::ImportStyle>(dispatch_import_style);
 
         app.insert_resource(BaseImmutable(self.base_immutable))
             .init_resource::<GraphCache>()
@@ -176,6 +178,8 @@ impl Plugin for GantzEguiPlugin {
             .add_observer(on_redo)
             .add_observer(on_export_head)
             .add_observer(on_export_all_named)
+            .add_observer(on_export_style)
+            .add_observer(on_import_style)
             .add_observer(on_import_file)
             .add_observer(on_reset_base_graph)
             // Systems. `drive_update_bangs` evaluates head VMs, so it must not
@@ -217,6 +221,7 @@ impl Plugin for GantzEguiPlugin {
                         .after(persist_camera_and_seed)
                         .run_if(on_message::<bevy_gantz::debounced_input::DebouncedInputEvent>),
                     poll_import_task,
+                    poll_style_import_task,
                 ),
             )
             .add_systems(First, clear_ui_providers)
@@ -347,6 +352,10 @@ pub struct HostNativePaneWindows;
 #[derive(Resource)]
 pub struct ImportTask(bevy_tasks::Task<Option<Vec<u8>>>);
 
+/// In-flight style import file dialog task.
+#[derive(Resource)]
+pub struct StyleImportTask(bevy_tasks::Task<Option<Vec<u8>>>);
+
 /// Settings subtabs contributed by domains (see
 /// [`SettingsTab`][gantz_egui::widget::SettingsTab]).
 ///
@@ -419,6 +428,14 @@ pub struct ExportHeadEvent {
 /// Event emitted when the user requests exporting all named graphs.
 #[derive(Event)]
 pub struct ExportAllNamedEvent;
+
+/// Event emitted when the user requests exporting the GUI style.
+#[derive(Event)]
+pub struct ExportStyleEvent;
+
+/// Event emitted when the user requests importing a GUI style.
+#[derive(Event)]
+pub struct ImportStyleEvent;
 
 /// Event emitted when a `.gantz` file is dropped onto a pane.
 #[derive(Event)]
@@ -1756,6 +1773,61 @@ pub fn on_export_all_named(
         .detach();
 }
 
+/// Handle style export events.
+///
+/// Writes the GUI's [`gantz_egui::StyleConfig`] to a `.ron` file chosen via an
+/// `rfd` file dialog.
+pub fn on_export_style(_trigger: On<ExportStyleEvent>, gui_state: Res<GuiState>) {
+    let text = match gantz_egui::style::to_ron(&gui_state.style) {
+        Ok(s) => s,
+        Err(e) => {
+            log::error!("ExportStyle: failed to serialize: {e}");
+            return;
+        }
+    };
+
+    let ext = gantz_egui::style::FILE_EXTENSION;
+    let dialog = rfd::AsyncFileDialog::new()
+        .set_title("Export Style")
+        .set_file_name(&format!("gantz-style.{ext}"))
+        .add_filter("Gantz Style", &[ext]);
+    bevy_tasks::AsyncComputeTaskPool::get()
+        .spawn(async move {
+            if let Some(handle) = dialog.save_file().await {
+                if let Err(e) = handle.write(text.as_bytes()).await {
+                    log::error!("ExportStyle: failed to write: {e}");
+                } else {
+                    log::info!("Exported style to {}", handle.file_name());
+                }
+            }
+        })
+        .detach();
+}
+
+/// Handle style import events by opening a file dialog.
+///
+/// The chosen file's bytes return to the main world via [`StyleImportTask`],
+/// polled by `poll_style_import_task`.
+pub fn on_import_style(
+    _trigger: On<ImportStyleEvent>,
+    task: Option<Res<StyleImportTask>>,
+    mut cmds: Commands,
+) {
+    // Only one dialog at a time.
+    if task.is_some() {
+        return;
+    }
+    let ext = gantz_egui::style::FILE_EXTENSION;
+    let dialog = rfd::AsyncFileDialog::new()
+        .set_title("Import Style")
+        .add_filter("Gantz Style", &[ext]);
+    let task = bevy_tasks::AsyncComputeTaskPool::get().spawn(async move {
+        let handle = dialog.pick_file().await?;
+        Some(handle.read().await)
+    });
+    cmds.insert_resource(StyleImportTask(task));
+}
+
 /// Handle import file events (dropped `.gantz` files).
 ///
 /// Deserializes the export, optionally computes root names, merges into the
@@ -1958,6 +2030,32 @@ fn poll_import_task(task: Option<ResMut<ImportTask>>, mut cmds: Commands) {
                 open_head: true,
             });
         }
+    }
+}
+
+/// Poll the in-flight style import file dialog task.
+///
+/// When the task completes with file bytes, replaces the GUI's style config;
+/// `gantz_egui::style::apply` picks it up on the next pass. The resource is
+/// removed regardless of whether a file was selected.
+fn poll_style_import_task(
+    task: Option<ResMut<StyleImportTask>>,
+    mut gui_state: ResMut<GuiState>,
+    mut cmds: Commands,
+) {
+    let Some(mut task) = task else { return };
+    let Some(result) = bevy_tasks::futures::check_ready(&mut task.0) else {
+        return;
+    };
+    cmds.remove_resource::<StyleImportTask>();
+    let Some(bytes) = result else { return };
+    match std::str::from_utf8(&bytes).map(gantz_egui::style::from_ron) {
+        Ok(Ok(style)) => {
+            gui_state.style = style;
+            log::info!("Imported style");
+        }
+        Ok(Err(e)) => log::error!("ImportStyle: failed to parse: {e}"),
+        Err(e) => log::error!("ImportStyle: invalid UTF-8: {e}"),
     }
 }
 
@@ -2448,6 +2546,18 @@ fn dispatch_export_head(entity: Option<Entity>, payload: DynResponse, cmds: &mut
 fn dispatch_export_all_named(_: Option<Entity>, payload: DynResponse, cmds: &mut Commands) {
     let gantz_egui::ExportAllNamed = downcast_payload(payload);
     cmds.trigger(ExportAllNamedEvent);
+}
+
+/// Dispatch a [`gantz_egui::ExportStyle`] payload as an [`ExportStyleEvent`].
+fn dispatch_export_style(_: Option<Entity>, payload: DynResponse, cmds: &mut Commands) {
+    let gantz_egui::ExportStyle = downcast_payload(payload);
+    cmds.trigger(ExportStyleEvent);
+}
+
+/// Dispatch a [`gantz_egui::ImportStyle`] payload as an [`ImportStyleEvent`].
+fn dispatch_import_style(_: Option<Entity>, payload: DynResponse, cmds: &mut Commands) {
+    let gantz_egui::ImportStyle = downcast_payload(payload);
+    cmds.trigger(ImportStyleEvent);
 }
 
 /// Trigger the appropriate event to move a head to a target commit.

--- a/crates/gantz_egui/examples/demo.rs
+++ b/crates/gantz_egui/examples/demo.rs
@@ -1240,6 +1240,47 @@ fn process_responses(ctx: &egui::Context, state: &mut State, mut responses: gant
         }
     }
 
+    for (_, gantz_egui::ExportStyle) in responses.take() {
+        let text = match gantz_egui::style::to_ron(&state.gantz.style) {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!("ExportStyle: failed to serialize: {e}");
+                continue;
+            }
+        };
+        let ext = gantz_egui::style::FILE_EXTENSION;
+        let dialog = rfd::AsyncFileDialog::new()
+            .set_title("Export Style")
+            .set_file_name(&format!("gantz-style.{ext}"))
+            .add_filter("Gantz Style", &[ext]);
+        if let Some(handle) = pollster::block_on(dialog.save_file()) {
+            if let Err(e) = pollster::block_on(handle.write(text.as_bytes())) {
+                log::error!("ExportStyle: failed to write: {e}");
+            } else {
+                log::info!("Exported style to {}", handle.file_name());
+            }
+        }
+    }
+
+    for (_, gantz_egui::ImportStyle) in responses.take() {
+        let ext = gantz_egui::style::FILE_EXTENSION;
+        let dialog = rfd::AsyncFileDialog::new()
+            .set_title("Import Style")
+            .add_filter("Gantz Style", &[ext]);
+        let Some(handle) = pollster::block_on(dialog.pick_file()) else {
+            continue;
+        };
+        let bytes = pollster::block_on(handle.read());
+        match std::str::from_utf8(&bytes).map(gantz_egui::style::from_ron) {
+            Ok(Ok(style)) => {
+                state.gantz.style = style;
+                log::info!("Imported style from {}", handle.file_name());
+            }
+            Ok(Err(e)) => log::error!("ImportStyle: failed to parse: {e}"),
+            Err(e) => log::error!("ImportStyle: invalid UTF-8: {e}"),
+        }
+    }
+
     // Recorded VM-state writes exist for collaborative sessions (see
     // `gantz_egui::StateWritten`); the demo has none, so drop them silently.
     responses.take::<gantz_egui::StateWritten>();

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -22,6 +22,7 @@ pub mod ops;
 pub mod reg;
 pub mod response;
 pub mod section;
+pub mod style;
 pub mod sugar;
 pub mod sync;
 #[cfg(test)]
@@ -50,6 +51,7 @@ pub use response::{
     ContextMenuResponse, DynResponse, InspectorRowsResponse, InspectorUiResponse, NodeUiResponse,
     NodeViewResponse, ResponseData, Responses,
 };
+pub use style::StyleConfig;
 pub use sugar::EguiSugar;
 pub use view::{Camera, SceneView};
 

--- a/crates/gantz_egui/src/lib.rs
+++ b/crates/gantz_egui/src/lib.rs
@@ -501,6 +501,16 @@ pub struct ExportAllNamed;
 #[derive(Clone, Copy, Debug)]
 pub struct ExportHead;
 
+/// Export the GUI's [`StyleConfig`] to a file (see [`style`]). Emitted without
+/// an associated head.
+#[derive(Clone, Copy, Debug)]
+pub struct ExportStyle;
+
+/// Replace the GUI's [`StyleConfig`] with one loaded from a file (see
+/// [`style`]). Emitted without an associated head.
+#[derive(Clone, Copy, Debug)]
+pub struct ImportStyle;
+
 /// Insert an inspect node on the given edge at the given position.
 #[derive(Clone, Debug)]
 pub struct InspectEdge {

--- a/crates/gantz_egui/src/style.rs
+++ b/crates/gantz_egui/src/style.rs
@@ -134,7 +134,7 @@ fn slot(cfg: &StyleConfig, theme: egui::Theme) -> &Option<egui::Style> {
 /// `Arc` identity, so styles that are otherwise identical - a deserialized one
 /// against a fresh default, say - never compare equal. The formatter is neither
 /// editable nor serialized, so normalise it out of the comparison.
-fn eq_style(a: &egui::Style, b: &egui::Style) -> bool {
+pub(crate) fn eq_style(a: &egui::Style, b: &egui::Style) -> bool {
     let mut b = b.clone();
     b.number_formatter = a.number_formatter.clone();
     *a == b

--- a/crates/gantz_egui/src/style.rs
+++ b/crates/gantz_egui/src/style.rs
@@ -1,0 +1,176 @@
+//! Global egui appearance: the theme preference and the per-theme
+//! [`egui::Style`], edited in `Settings -> Style`.
+//!
+//! egui omits its own styles when serializing its `Options` (`dark_style` and
+//! `light_style` are `#[serde(skip)]`), so gantz owns them: [`StyleConfig`]
+//! rides [`GantzState`][crate::widget::GantzState] - which both hosts already
+//! persist - and is applied to a context by [`apply`]. Owning the preference
+//! also keeps pop-out pane windows in step, as each is a separate
+//! `egui::Context` with its own options.
+
+/// File extension for exported style files (without the leading dot).
+pub const FILE_EXTENSION: &str = "ron";
+
+/// The id under which a context tracks the config last applied to it.
+const APPLIED_ID: &str = "gantz-applied-style";
+
+/// The theme preference and per-theme style overrides.
+///
+/// A `None` style means egui's default for that theme, so an untouched config
+/// costs nothing to store and follows egui's defaults across version bumps.
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct StyleConfig {
+    /// Whether to use the dark style, the light style, or follow the system.
+    #[serde(default = "default_theme")]
+    pub theme: egui::ThemePreference,
+    /// The dark style, when customised.
+    #[serde(default)]
+    pub dark: Option<egui::Style>,
+    /// The light style, when customised.
+    #[serde(default)]
+    pub light: Option<egui::Style>,
+}
+
+impl Default for StyleConfig {
+    fn default() -> Self {
+        Self {
+            theme: default_theme(),
+            dark: None,
+            light: None,
+        }
+    }
+}
+
+impl PartialEq for StyleConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.theme == other.theme
+            && [egui::Theme::Dark, egui::Theme::Light]
+                .into_iter()
+                .all(|theme| match (slot(self, theme), slot(other, theme)) {
+                    (None, None) => true,
+                    (Some(a), Some(b)) => eq_style(a, b),
+                    _ => false,
+                })
+    }
+}
+
+/// gantz's default theme preference.
+///
+/// Dark rather than egui's `System`: gantz's remaining hand-picked colours are
+/// dark-tuned (#203), and `bevy_egui` reports no system theme, so following the
+/// system would leave the app and the `gantz_egui` demo disagreeing.
+fn default_theme() -> egui::ThemePreference {
+    egui::ThemePreference::Dark
+}
+
+/// The style `cfg` specifies for `theme`, or egui's default for it.
+pub fn style_of(cfg: &StyleConfig, theme: egui::Theme) -> egui::Style {
+    slot(cfg, theme)
+        .clone()
+        .unwrap_or_else(|| theme.default_style())
+}
+
+/// Customise `theme`'s style.
+///
+/// A style equal to egui's default for the theme clears the customisation
+/// rather than storing a redundant copy.
+pub fn set_style_of(cfg: &mut StyleConfig, theme: egui::Theme, style: egui::Style) {
+    let custom = (!eq_style(&style, &theme.default_style())).then_some(style);
+    match theme {
+        egui::Theme::Dark => cfg.dark = custom,
+        egui::Theme::Light => cfg.light = custom,
+    }
+}
+
+/// Drop `theme`'s customisation, restoring egui's default style for it.
+pub fn reset_theme(cfg: &mut StyleConfig, theme: egui::Theme) {
+    match theme {
+        egui::Theme::Dark => cfg.dark = None,
+        egui::Theme::Light => cfg.light = None,
+    }
+}
+
+/// Apply `cfg` to `ctx`, unless it is already what was last applied to it.
+///
+/// Cheap enough to call every frame. The last-applied config is tracked in the
+/// context's *temporary* data, so a context without one - a freshly spawned
+/// pop-out window, or the primary context after a wholesale `Memory` restore -
+/// is brought back into line on its next frame.
+pub fn apply(ctx: &egui::Context, cfg: &StyleConfig) {
+    let id = egui::Id::new(APPLIED_ID);
+    if ctx.data(|d| d.get_temp::<StyleConfig>(id)).as_ref() == Some(cfg) {
+        return;
+    }
+    ctx.set_theme(cfg.theme);
+    for theme in [egui::Theme::Dark, egui::Theme::Light] {
+        ctx.set_style_of(theme, style_of(cfg, theme));
+    }
+    ctx.data_mut(|d| d.insert_temp(id, cfg.clone()));
+    // The `Ui`s built so far this pass carry the old style.
+    ctx.request_repaint();
+}
+
+/// Serialize a config as the text of an exported style file.
+pub fn to_ron(cfg: &StyleConfig) -> Result<String, ron::Error> {
+    ron::ser::to_string_pretty(cfg, ron::ser::PrettyConfig::default())
+}
+
+/// Parse the text of an exported style file.
+pub fn from_ron(s: &str) -> Result<StyleConfig, ron::de::SpannedError> {
+    ron::de::from_str(s)
+}
+
+/// The slot holding `theme`'s customisation.
+fn slot(cfg: &StyleConfig, theme: egui::Theme) -> &Option<egui::Style> {
+    match theme {
+        egui::Theme::Dark => &cfg.dark,
+        egui::Theme::Light => &cfg.light,
+    }
+}
+
+/// Whether two styles are equal in everything a user can edit or store.
+///
+/// `egui::Style`'s own `PartialEq` compares its `number_formatter` callback by
+/// `Arc` identity, so styles that are otherwise identical - a deserialized one
+/// against a fresh default, say - never compare equal. The formatter is neither
+/// editable nor serialized, so normalise it out of the comparison.
+fn eq_style(a: &egui::Style, b: &egui::Style) -> bool {
+    let mut b = b.clone();
+    b.number_formatter = a.number_formatter.clone();
+    *a == b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{StyleConfig, from_ron, set_style_of, style_of, to_ron};
+
+    /// A customised config must survive the RON round-trip used by
+    /// export/import and by GUI-state persistence. Guards against an egui bump
+    /// breaking `Style`'s serde.
+    #[test]
+    fn style_config_round_trips_through_ron() {
+        let mut cfg = StyleConfig::default();
+        for theme in [egui::Theme::Dark, egui::Theme::Light] {
+            let mut style = style_of(&cfg, theme);
+            style.spacing.item_spacing.x += 3.0;
+            style.visuals.window_corner_radius = egui::CornerRadius::same(9);
+            set_style_of(&mut cfg, theme, style);
+        }
+        assert!(cfg.dark.is_some() && cfg.light.is_some());
+        let text = to_ron(&cfg).expect("serialize StyleConfig");
+        assert_eq!(cfg, from_ron(&text).expect("deserialize StyleConfig"));
+    }
+
+    /// Storing egui's default style for a theme leaves the config untouched, so
+    /// an unmodified theme never bloats persisted state.
+    #[test]
+    fn default_style_clears_customisation() {
+        let mut cfg = StyleConfig::default();
+        set_style_of(
+            &mut cfg,
+            egui::Theme::Dark,
+            egui::Theme::Dark.default_style(),
+        );
+        assert!(cfg.dark.is_none());
+    }
+}

--- a/crates/gantz_egui/src/style.rs
+++ b/crates/gantz_egui/src/style.rs
@@ -142,20 +142,25 @@ fn eq_style(a: &egui::Style, b: &egui::Style) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{StyleConfig, from_ron, set_style_of, style_of, to_ron};
+    use super::{StyleConfig, apply, eq_style, from_ron, set_style_of, style_of, to_ron};
+
+    /// A config with both themes customised, distinguishably.
+    fn customised() -> StyleConfig {
+        let mut cfg = StyleConfig::default();
+        for (theme, gap) in [(egui::Theme::Dark, 3.0), (egui::Theme::Light, 7.0)] {
+            let mut style = style_of(&cfg, theme);
+            style.spacing.item_spacing.x = gap;
+            set_style_of(&mut cfg, theme, style);
+        }
+        cfg
+    }
 
     /// A customised config must survive the RON round-trip used by
     /// export/import and by GUI-state persistence. Guards against an egui bump
     /// breaking `Style`'s serde.
     #[test]
     fn style_config_round_trips_through_ron() {
-        let mut cfg = StyleConfig::default();
-        for theme in [egui::Theme::Dark, egui::Theme::Light] {
-            let mut style = style_of(&cfg, theme);
-            style.spacing.item_spacing.x += 3.0;
-            style.visuals.window_corner_radius = egui::CornerRadius::same(9);
-            set_style_of(&mut cfg, theme, style);
-        }
+        let cfg = customised();
         assert!(cfg.dark.is_some() && cfg.light.is_some());
         let text = to_ron(&cfg).expect("serialize StyleConfig");
         assert_eq!(cfg, from_ron(&text).expect("deserialize StyleConfig"));
@@ -172,5 +177,43 @@ mod tests {
             egui::Theme::Dark.default_style(),
         );
         assert!(cfg.dark.is_none());
+    }
+
+    /// Applying installs both themes' styles and the preference, whichever
+    /// theme is active - so a pop-out window's fresh context matches the
+    /// primary's after a single call.
+    #[test]
+    fn apply_installs_theme_and_both_styles() {
+        let mut cfg = customised();
+        cfg.theme = egui::ThemePreference::Light;
+        let ctx = egui::Context::default();
+        apply(&ctx, &cfg);
+        assert_eq!(ctx.theme(), egui::Theme::Light);
+        for theme in [egui::Theme::Dark, egui::Theme::Light] {
+            assert!(eq_style(&ctx.style_of(theme), &style_of(&cfg, theme)));
+        }
+    }
+
+    /// Re-applying an unchanged config is a no-op, so the per-frame call costs
+    /// nothing and does not fight a style set elsewhere in the same session.
+    #[test]
+    fn apply_skips_an_unchanged_config() {
+        let mut cfg = customised();
+        let ctx = egui::Context::default();
+        apply(&ctx, &cfg);
+
+        let mut meddled = ctx.style_of(egui::Theme::Dark).as_ref().clone();
+        meddled.spacing.item_spacing.x = 99.0;
+        ctx.set_style_of(egui::Theme::Dark, meddled.clone());
+        apply(&ctx, &cfg);
+        assert!(eq_style(&ctx.style_of(egui::Theme::Dark), &meddled));
+
+        // A changed config applies again, restoring what it specifies.
+        cfg.theme = egui::ThemePreference::Light;
+        apply(&ctx, &cfg);
+        assert!(eq_style(
+            &ctx.style_of(egui::Theme::Dark),
+            &style_of(&cfg, egui::Theme::Dark)
+        ));
     }
 }

--- a/crates/gantz_egui/src/widget.rs
+++ b/crates/gantz_egui/src/widget.rs
@@ -28,7 +28,7 @@ pub use perf_view::{PerfCapture, PerfView};
 pub use settings::{SettingsResponse, SettingsTab, settings};
 pub use status_dot::status_dot;
 pub use steel_view::SteelView;
-pub use style_config::style_config;
+pub use style_config::{StyleConfigResponse, style_config};
 pub use tab::{Tab, TabResponse};
 
 pub mod checkbox_enabled;

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -113,6 +113,10 @@ pub struct GantzState {
     /// apply to every open head.
     #[serde(default)]
     pub scene_config: SceneConfig,
+    /// The egui theme preference and per-theme style overrides, applied to
+    /// every gantz context (see [`crate::style`]); edited in Settings -> Style.
+    #[serde(default)]
+    pub style: crate::StyleConfig,
     /// The command keyboard shortcuts. The single source of truth for editor
     /// command bindings (see [`crate::keybind`]); edited in Settings -> Keybinds.
     #[serde(default)]
@@ -951,6 +955,8 @@ impl<'a> Gantz<'a> {
             ui.ctx().memory_mut(|m| m.data.clear());
         }
 
+        crate::style::apply(ui.ctx(), &state.style);
+
         // The persisted outer tree. The version suffix invalidates any tree
         // persisted before the latest default-layout change (v4: perf panes
         // side by side at half height), forcing a rebuild via `create_tree`.
@@ -1143,6 +1149,7 @@ impl<'a> Gantz<'a> {
         's: 'a,
         Access: HeadAccess,
     {
+        crate::style::apply(ui.ctx(), &state.style);
         let mut response = GantzResponse::new(focused_head);
         let base_names = self.base_names;
         let mut cx = PaneCtx {
@@ -1174,6 +1181,7 @@ impl GantzState {
             view_toggles: ViewToggles::default(),
             layout_config: LayoutConfig::default(),
             scene_config: SceneConfig::default(),
+            style: Default::default(),
             keymap: Keymap::default(),
             collab: Default::default(),
             merge_resolutions: Default::default(),

--- a/crates/gantz_egui/src/widget/gantz.rs
+++ b/crates/gantz_egui/src/widget/gantz.rs
@@ -1,7 +1,8 @@
 use crate::{
     Action, CopyNodes, CreateNestedGraph, CreateNode, CutNodes, DuplicateNodes, Env,
-    ExportAllNamed, ExportHead, HeadAccess, Keymap, NodeCtx, NodeUi, OpenLogs, OpenNodePalette,
-    OpenNodeView, Paste, Redo, ReplaceHead, ResetTilesLayout, Undo, export,
+    ExportAllNamed, ExportHead, ExportStyle, HeadAccess, ImportStyle, Keymap, NodeCtx, NodeUi,
+    OpenLogs, OpenNodePalette, OpenNodeView, Paste, Redo, ReplaceHead, ResetTilesLayout, Undo,
+    export,
     node::NodeCodec,
     response::{DynResponse, Responses},
     widget::{self, GraphScene, GraphSceneState, graph_scene},
@@ -2173,6 +2174,7 @@ where
                     validate_change_tracking,
                     &mut state.layout_config,
                     &mut state.scene_config,
+                    &mut state.style,
                     &mut state.keymap,
                     ext_tabs,
                     &ext_panes,
@@ -2190,6 +2192,12 @@ where
             }
             if res.inner.reset_layout {
                 gantz_response.responses.push(None, ResetTilesLayout);
+            }
+            if res.inner.export_style {
+                gantz_response.responses.push(None, ExportStyle);
+            }
+            if res.inner.import_style {
+                gantz_response.responses.push(None, ImportStyle);
             }
             let mut ext_responses = res.inner.responses;
             gantz_response

--- a/crates/gantz_egui/src/widget/global_config.rs
+++ b/crates/gantz_egui/src/widget/global_config.rs
@@ -37,7 +37,7 @@ pub fn global_config(
     let mut changed_config = None;
     let mut changed_validate = None;
     if compile_config.is_some() || validate_change_tracking.is_some() {
-        ui.label("Compile:");
+        ui.strong("Compile");
     }
     if let Some(mut cfg) = compile_config {
         let mut changed = false;
@@ -83,7 +83,7 @@ pub fn global_config(
 
     // Auto-layout parameters (the non-flow `egui_graph` layout params; flow is
     // per-head, in the Graph Config pane). Applied on the next auto-layout.
-    ui.label("Layout:");
+    ui.strong("Layout");
     let gap = |ui: &mut egui::Ui, label: &str, value: &mut f32, hover: &str| {
         ui.horizontal(|ui| {
             ui.add(
@@ -124,7 +124,7 @@ pub fn global_config(
 
     // Drag snapping. Point snaps to unit points (effectively free); Grid snaps
     // to a fraction of the dot grid (the grid step is set in Style).
-    ui.label("Snap:");
+    ui.strong("Snap");
     ui.horizontal(|ui| {
         ui.radio_value(&mut snap.mode, SnapMode::Point, "Point")
             .on_hover_text("Snap to the nearest unit point - effectively free movement.");
@@ -149,7 +149,7 @@ pub fn global_config(
 
     // Drag-time snap-align: snap a dragged node to its neighbours' edges /
     // centres and draw guides.
-    ui.label("Snap-align:");
+    ui.strong("Snap-align");
     ui.checkbox(&mut align.enabled, "Align to neighbours")
         .on_hover_text(
             "While dragging, align a node to its neighbours' edges or centres \
@@ -166,7 +166,7 @@ pub fn global_config(
     // Maintenance: a recovery tool to drop egui's persisted UI memory if it
     // accumulates stale state (e.g. tile-layout snapshots from old builds),
     // without touching the graph registry.
-    ui.label("Maintenance:");
+    ui.strong("Maintenance");
     if ui
         .button("Clear egui memory")
         .on_hover_text(

--- a/crates/gantz_egui/src/widget/settings.rs
+++ b/crates/gantz_egui/src/widget/settings.rs
@@ -3,7 +3,7 @@
 //! extension subtabs (see [`SettingsTab`]).
 
 use super::gantz::{LayoutConfig, SceneConfig, ViewToggles};
-use crate::{Keymap, Responses};
+use crate::{Keymap, Responses, StyleConfig};
 
 /// An application-supplied settings subtab.
 ///
@@ -43,6 +43,10 @@ pub struct SettingsResponse {
     pub validate_change_tracking: Option<bool>,
     /// The "Reset all demos" button was clicked (Global subtab).
     pub reset_all_demos: bool,
+    /// The "Export" style button was clicked (Style subtab).
+    pub export_style: bool,
+    /// The "Import" style button was clicked (Style subtab).
+    pub import_style: bool,
     /// The "reset all" layout button was clicked (Panes subtab).
     pub reset_layout: bool,
     /// Payloads emitted by extension subtabs.
@@ -60,6 +64,7 @@ pub fn settings(
     validate_change_tracking: Option<bool>,
     layout_config: &mut LayoutConfig,
     scene_config: &mut SceneConfig,
+    style: &mut StyleConfig,
     keymap: &mut Keymap,
     ext_tabs: &mut [&mut dyn SettingsTab],
     ext_panes: &[super::ExtPaneEntry],
@@ -128,9 +133,14 @@ pub fn settings(
                 });
         }
         SubTab::Style => {
-            egui::ScrollArea::vertical()
+            let s = egui::ScrollArea::vertical()
                 .auto_shrink([false, false])
-                .show(ui, |ui| super::style_config(&mut scene_config.grid, ui));
+                .show(ui, |ui| {
+                    super::style_config(style, &mut scene_config.grid, ui)
+                })
+                .inner;
+            res.export_style = s.export;
+            res.import_style = s.import;
         }
         SubTab::Keybinds => {
             egui::ScrollArea::vertical()

--- a/crates/gantz_egui/src/widget/style_config.rs
+++ b/crates/gantz_egui/src/widget/style_config.rs
@@ -13,7 +13,7 @@
 use super::gantz::GridConfig;
 use crate::{
     StyleConfig,
-    style::{reset_theme, set_style_of, style_of},
+    style::{eq_style, reset_theme, set_style_of, style_of},
 };
 
 /// Response from [`style_config`].
@@ -76,6 +76,12 @@ pub fn style_config(
     // has hand-reverted every value.
     let mut edited = style_of(style, edit);
     edited.ui(ui);
+    // egui's "Reset style" button at the bottom of the tree resets to
+    // `Style::default()`, whose visuals are dark whichever theme is edited.
+    // Treat it as a reset to the edited theme's own default.
+    if eq_style(&edited, &egui::Style::default()) {
+        edited = edit.default_style();
+    }
     set_style_of(style, edit, edited);
     ui.separator();
 

--- a/crates/gantz_egui/src/widget/style_config.rs
+++ b/crates/gantz_egui/src/widget/style_config.rs
@@ -1,14 +1,84 @@
-//! The "Style" settings subtab: visual configuration of the graph scene.
+//! The "Style" settings subtab: the egui theme and style, plus the visual
+//! configuration of the graph scene.
 //!
-//! Currently hosts the dot-grid controls (show/hide and base step). The grid
-//! step also feeds snap-to-grid (see `Global > Snap`), so it stays editable even
-//! when the grid is hidden.
+//! The theme preference and the per-theme [`egui::Style`] live in a
+//! [`StyleConfig`] on [`GantzState`][super::GantzState] (see [`crate::style`]);
+//! this only edits it, and [`crate::style::apply`] does the applying. Either
+//! theme's style can be edited, whichever one is active.
+//!
+//! Also hosts the dot-grid controls (show/hide and base step). The grid step
+//! feeds snap-to-grid (see `Global > Snap`), so it stays editable even when the
+//! grid is hidden.
 
 use super::gantz::GridConfig;
+use crate::{
+    StyleConfig,
+    style::{reset_theme, set_style_of, style_of},
+};
 
-/// Render the style configuration controls. `grid` is mutated in place; the
-/// config applies to all open heads.
-pub fn style_config(grid: &mut GridConfig, ui: &mut egui::Ui) {
+/// Response from [`style_config`].
+#[derive(Default)]
+pub struct StyleConfigResponse {
+    /// The "Export" button was clicked.
+    pub export: bool,
+    /// The "Import" button was clicked.
+    pub import: bool,
+}
+
+/// Render the style configuration controls. `style` and `grid` are mutated in
+/// place; both apply to the whole UI, including all open heads.
+pub fn style_config(
+    style: &mut StyleConfig,
+    grid: &mut GridConfig,
+    ui: &mut egui::Ui,
+) -> StyleConfigResponse {
+    ui.label("Theme:");
+    style.theme.radio_buttons(ui);
+    ui.separator();
+
+    // Which theme's style the editor below edits - not necessarily the active
+    // one, so a theme can be styled before switching to it.
+    let edit_id = ui.id().with("edit_theme");
+    let mut edit = ui
+        .data(|d| d.get_temp::<egui::Theme>(edit_id))
+        .unwrap_or_else(|| ui.ctx().theme());
+
+    ui.label("Style:");
+    let mut res = StyleConfigResponse::default();
+    let mut reset = false;
+    ui.horizontal(|ui| {
+        ui.radio_value(&mut edit, egui::Theme::Dark, "Dark");
+        ui.radio_value(&mut edit, egui::Theme::Light, "Light")
+            .on_hover_text(
+                "Which theme's style the controls below edit. Either can be \
+                 edited, whichever theme is active.",
+            );
+        reset = ui
+            .button("Reset")
+            .on_hover_text("Discard this theme's edits, restoring egui's default style.")
+            .clicked();
+        res.export = ui
+            .button("Export…")
+            .on_hover_text("Save both themes' styles to a file.")
+            .clicked();
+        res.import = ui
+            .button("Import…")
+            .on_hover_text("Load both themes' styles from an exported file.")
+            .clicked();
+    });
+    ui.data_mut(|d| d.insert_temp(edit_id, edit));
+    if reset {
+        reset_theme(style, edit);
+    }
+
+    // egui's own style editor, as seen in its demo. It edits a copy of the
+    // effective style; storing that back drops the override again if the user
+    // has hand-reverted every value.
+    let mut edited = style_of(style, edit);
+    edited.ui(ui);
+    set_style_of(style, edit, edited);
+    ui.separator();
+
     ui.label("Grid:");
     ui.checkbox(&mut grid.show, "Show grid")
         .on_hover_text("Draw the dot grid behind the graph.");
@@ -26,4 +96,6 @@ pub fn style_config(grid: &mut GridConfig, ui: &mut egui::Ui) {
         );
         ui.label("Grid step");
     });
+
+    res
 }

--- a/crates/gantz_egui/src/widget/style_config.rs
+++ b/crates/gantz_egui/src/widget/style_config.rs
@@ -3,8 +3,8 @@
 //!
 //! The theme preference and the per-theme [`egui::Style`] live in a
 //! [`StyleConfig`] on [`GantzState`][super::GantzState] (see [`crate::style`]);
-//! this only edits it, and [`crate::style::apply`] does the applying. Either
-//! theme's style can be edited, whichever one is active.
+//! this only edits it, and [`crate::style::apply`] does the applying. The
+//! editor edits the selected theme's style.
 //!
 //! Also hosts the dot-grid controls (show/hide and base step). The grid step
 //! feeds snap-to-grid (see `Global > Snap`), so it stays editable even when the
@@ -36,23 +36,18 @@ pub fn style_config(
     style.theme.radio_buttons(ui);
     ui.separator();
 
-    // Which theme's style the editor below edits - not necessarily the active
-    // one, so a theme can be styled before switching to it.
-    let edit_id = ui.id().with("edit_theme");
-    let mut edit = ui
-        .data(|d| d.get_temp::<egui::Theme>(edit_id))
-        .unwrap_or_else(|| ui.ctx().theme());
+    // The editor below edits the selected theme's style. `ctx.theme()` only
+    // reflects a preference change on the next frame, so resolve directly.
+    let edit = match style.theme {
+        egui::ThemePreference::Dark => egui::Theme::Dark,
+        egui::ThemePreference::Light => egui::Theme::Light,
+        egui::ThemePreference::System => ui.ctx().theme(),
+    };
 
     ui.label("Style:");
     let mut res = StyleConfigResponse::default();
     let mut reset = false;
     ui.horizontal(|ui| {
-        ui.radio_value(&mut edit, egui::Theme::Dark, "Dark");
-        ui.radio_value(&mut edit, egui::Theme::Light, "Light")
-            .on_hover_text(
-                "Which theme's style the controls below edit. Either can be \
-                 edited, whichever theme is active.",
-            );
         reset = ui
             .button("Reset")
             .on_hover_text("Discard this theme's edits, restoring egui's default style.")
@@ -66,7 +61,6 @@ pub fn style_config(
             .on_hover_text("Load both themes' styles from an exported file.")
             .clicked();
     });
-    ui.data_mut(|d| d.insert_temp(edit_id, edit));
     if reset {
         reset_theme(style, edit);
     }

--- a/crates/gantz_egui/src/widget/style_config.rs
+++ b/crates/gantz_egui/src/widget/style_config.rs
@@ -32,7 +32,7 @@ pub fn style_config(
     grid: &mut GridConfig,
     ui: &mut egui::Ui,
 ) -> StyleConfigResponse {
-    ui.label("Theme:");
+    ui.strong("Theme");
     style.theme.radio_buttons(ui);
     ui.separator();
 
@@ -44,7 +44,7 @@ pub fn style_config(
         egui::ThemePreference::System => ui.ctx().theme(),
     };
 
-    ui.label("Style:");
+    ui.strong("Style");
     let mut res = StyleConfigResponse::default();
     let mut reset = false;
     ui.horizontal(|ui| {
@@ -79,7 +79,7 @@ pub fn style_config(
     set_style_of(style, edit, edited);
     ui.separator();
 
-    ui.label("Grid:");
+    ui.strong("Grid");
     ui.checkbox(&mut grid.show, "Show grid")
         .on_hover_text("Draw the dot grid behind the graph.");
     ui.horizontal(|ui| {

--- a/crates/gantz_plyphon/src/egui/settings.rs
+++ b/crates/gantz_plyphon/src/egui/settings.rs
@@ -29,7 +29,7 @@ impl gantz_egui::widget::SettingsTab for DspSettingsTab {
     fn ui(&mut self, ui: &mut egui::Ui) -> Responses {
         let mut responses = Responses::default();
 
-        ui.label("Status:");
+        ui.strong("Status");
         if self.status.present {
             egui::Grid::new("dsp_status_grid")
                 .num_columns(2)
@@ -96,7 +96,7 @@ impl gantz_egui::widget::SettingsTab for DspSettingsTab {
         // head's in full).
         if !self.heads.is_empty() {
             ui.separator();
-            ui.label("Graphs:");
+            ui.strong("Graphs");
             egui::Grid::new("dsp_heads_grid")
                 .num_columns(2)
                 .spacing([12.0, 4.0])


### PR DESCRIPTION
Closes #306.

Adds egui style configuration to the Settings > Style subtab. The editor is egui's own `Style::ui` tree, the same one its demo uses, alongside a Dark/Light/System theme selector and Reset, Export and Import buttons. The style can be exported to and imported from a RON file in both the bevy app and the `gantz_egui` demo.